### PR TITLE
feat: admin reset-password endpoint

### DIFF
--- a/backend/src/modules/admin/admin.router.ts
+++ b/backend/src/modules/admin/admin.router.ts
@@ -207,16 +207,18 @@ router.get(
   }
 );
 
-router.post('/admin/users/by-email/:email/reset-password', requireRole('SUPER_ADMIN', 'ADMIN'), async (req, res, next) => {
+router.post('/admin/users/reset-password', requireRole('SUPER_ADMIN', 'ADMIN'), async (req, res, next) => {
   try {
-    const { email } = req.params;
-<<<<<<< HEAD
-    const { newPassword } = req.body as { newPassword?: unknown };
+    const { email, newPassword } = req.body as { email?: unknown; newPassword?: unknown };
+    if (typeof email !== 'string' || email.trim().length === 0) {
+      res.status(400).json({ error: 'email is required and must be a non-empty string' });
+      return;
+    }
     if (typeof newPassword !== 'string' || newPassword.trim().length === 0) {
       res.status(400).json({ error: 'newPassword is required and must be a non-empty string' });
       return;
     }
-    const user = await rotateUserPassword({ email, newPassword: newPassword.trim() });
+    const user = await rotateUserPassword({ email: email.trim(), newPassword: newPassword.trim() });
     res.json({ success: true, userId: user.id, email: user.email });
   } catch (err) {
     next(err);

--- a/backend/src/modules/admin/admin.router.ts
+++ b/backend/src/modules/admin/admin.router.ts
@@ -6,6 +6,7 @@ import * as adminService from './admin.service.js';
 import { createUserDto, updateUserAdminDto, assignProjectRoleDto } from './admin.dto.js';
 import { logAudit } from '../../shared/middleware/audit.js';
 import type { AuthRequest } from '../../shared/types/index.js';
+import { rotateUserPassword } from '../users/password-rotation.service.js';
 import type { UatRole } from './uat-tests.data.js';
 
 const router = Router();
@@ -205,5 +206,20 @@ router.get(
     }
   }
 );
+
+router.post('/admin/users/by-email/:email/reset-password', requireRole('SUPER_ADMIN', 'ADMIN'), async (req, res, next) => {
+  try {
+    const { email } = req.params;
+    const { newPassword } = req.body as { newPassword?: string };
+    if (typeof newPassword !== 'string' || !newPassword) {
+      res.status(400).json({ error: 'newPassword is required' });
+      return;
+    }
+    const user = await rotateUserPassword({ email, newPassword });
+    res.json({ success: true, userId: user.id, email: user.email });
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/backend/src/modules/admin/admin.router.ts
+++ b/backend/src/modules/admin/admin.router.ts
@@ -210,12 +210,13 @@ router.get(
 router.post('/admin/users/by-email/:email/reset-password', requireRole('SUPER_ADMIN', 'ADMIN'), async (req, res, next) => {
   try {
     const { email } = req.params;
-    const { newPassword } = req.body as { newPassword?: string };
-    if (typeof newPassword !== 'string' || !newPassword) {
-      res.status(400).json({ error: 'newPassword is required' });
+<<<<<<< HEAD
+    const { newPassword } = req.body as { newPassword?: unknown };
+    if (typeof newPassword !== 'string' || newPassword.trim().length === 0) {
+      res.status(400).json({ error: 'newPassword is required and must be a non-empty string' });
       return;
     }
-    const user = await rotateUserPassword({ email, newPassword });
+    const user = await rotateUserPassword({ email, newPassword: newPassword.trim() });
     res.json({ success: true, userId: user.id, email: user.email });
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- `POST /api/admin/users/:email/reset-password` — сброс пароля пользователя (SUPER_ADMIN/ADMIN)
- Использует существующий `rotateUserPassword` сервис (инвалидирует refresh tokens + Redis сессию)
- `mustChangePassword` устанавливается через сервис при необходимости

## Зачем
Нет возможности сбросить пароль пользователю через API без SSH-доступа к серверу.

## Test plan
- [ ] POST /api/admin/users/d.demidova%40tasktime.ru/reset-password с телом `{"newPassword":"..."}` от SUPERADMIN → 200 `{success: true}`
- [ ] Попытка без авторизации → 401
- [ ] Попытка от USER → 403
- [ ] Несуществующий email → 404