### PR TITLE
fix: remove MOEX prefix from browser tab title

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MOEX Flow Universe</title>
+    <title>Flow Universe</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700;800&family=Inter:wght@300;400;500&display=swap" rel="stylesheet" />


### PR DESCRIPTION
Убрал MOEX из заголовка вкладки браузера. Было: «MOEX Flow Universe», стало: «Flow Universe».

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the page title displayed in the browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->