### PR TITLE
chore: release-drafter + auto-label PRs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,60 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: '🚀 Новые функции'
+    labels:
+      - 'feature'
+      - 'feat'
+  - title: '🐛 Исправления'
+    labels:
+      - 'bug'
+      - 'fix'
+  - title: '♻️ Рефакторинг'
+    labels:
+      - 'refactor'
+  - title: '🧪 Тесты'
+    labels:
+      - 'test'
+  - title: '🔧 Инфраструктура'
+    labels:
+      - 'chore'
+      - 'ci'
+  - title: '📚 Документация'
+    labels:
+      - 'docs'
+  - title: '⚠️ Ломающие изменения'
+    labels:
+      - 'breaking'
+
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - 'breaking'
+  minor:
+    labels:
+      - 'feature'
+      - 'feat'
+  patch:
+    labels:
+      - 'bug'
+      - 'fix'
+      - 'refactor'
+      - 'chore'
+      - 'ci'
+      - 'docs'
+      - 'test'
+  default: patch
+
+exclude-labels:
+  - 'skip-changelog'
+
+template: |
+  ## Что нового
+
+  $CHANGES
+
+  **Полный changelog:** $PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,9 @@ categories:
   - title: '🧪 Тесты'
     labels:
       - 'test'
+  - title: '⚡ Производительность'
+    labels:
+      - 'perf'
   - title: '🔧 Инфраструктура'
     labels:
       - 'chore'
@@ -47,6 +50,7 @@ version-resolver:
       - 'ci'
       - 'docs'
       - 'test'
+      - 'perf'
   default: patch
 
 exclude-labels:

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const title = context.payload.pull_request.title.toLowerCase();
+            const title = context.payload.pull_request.title;
             const prNumber = context.payload.pull_request.number;
 
             const typeMap = [
@@ -25,12 +25,15 @@ jobs:
               { prefix: 'docs',     label: 'docs'     },
               { prefix: 'chore',    label: 'chore'    },
               { prefix: 'ci',       label: 'ci'       },
-              { prefix: 'perf',     label: 'feat'     },
+              { prefix: 'perf',     label: 'perf'     },
             ];
 
             const autoLabels = typeMap.map(t => t.label);
 
-            const matched = typeMap.find(t => title.startsWith(t.prefix + ':') || title.startsWith(t.prefix + '('));
+            // Match: feat: / feat(scope): / feat!: / feat(scope)!:
+            const matched = typeMap.find(t =>
+              new RegExp(`^${t.prefix}(\\([^)]+\\))?!?:`).test(title)
+            );
             if (!matched) return;
 
             // Получить текущие лейблы PR
@@ -43,22 +46,18 @@ jobs:
             // Убрать старые авто-лейблы, добавить новый
             const toKeep = currentLabels
               .map(l => l.name)
-              .filter(name => !autoLabels.includes(name));
+              .filter(name => !autoLabels.includes(name) && name !== 'breaking');
+
+            const newLabels = [...toKeep, matched.label];
+
+            // Добавить breaking если есть "!" после типа
+            if (/^[a-z]+(\([^)]+\))?!:/.test(title)) {
+              newLabels.push('breaking');
+            }
 
             await github.rest.issues.setLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              labels: [...toKeep, matched.label],
+              labels: newLabels,
             });
-
-            // Добавить breaking если есть "!" после типа
-            const rawTitle = context.payload.pull_request.title;
-            if (rawTitle.match(/^[a-z]+(\([^)]+\))?!:/)) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                labels: ['breaking'],
-              });
-            }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,64 @@
+name: Auto Label PR
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title.toLowerCase();
+            const prNumber = context.payload.pull_request.number;
+
+            const typeMap = [
+              { prefix: 'feat',     label: 'feat'     },
+              { prefix: 'fix',      label: 'fix'      },
+              { prefix: 'refactor', label: 'refactor' },
+              { prefix: 'test',     label: 'test'     },
+              { prefix: 'docs',     label: 'docs'     },
+              { prefix: 'chore',    label: 'chore'    },
+              { prefix: 'ci',       label: 'ci'       },
+              { prefix: 'perf',     label: 'feat'     },
+            ];
+
+            const autoLabels = typeMap.map(t => t.label);
+
+            const matched = typeMap.find(t => title.startsWith(t.prefix + ':') || title.startsWith(t.prefix + '('));
+            if (!matched) return;
+
+            // Получить текущие лейблы PR
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            // Убрать старые авто-лейблы, добавить новый
+            const toKeep = currentLabels
+              .map(l => l.name)
+              .filter(name => !autoLabels.includes(name));
+
+            await github.rest.issues.setLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: [...toKeep, matched.label],
+            });
+
+            // Добавить breaking если есть "!" после типа
+            const rawTitle = context.payload.pull_request.title;
+            if (rawTitle.match(/^[a-z]+(\([^)]+\))?!:/)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: ['breaking'],
+              });
+            }

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: write

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Добавлен `release-drafter` — автоматически ведёт черновик релиза, группируя PR по лейблам
- Добавлен `auto-label` — автоматически ставит лейбл на PR по conventional commit префиксу в заголовке
- Созданы лейблы: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `ci`, `breaking`, `skip-changelog`

## Как пользоваться

1. Открыть PR с заголовком по конвенции (`feat:`, `fix:` и т.д.) — лейбл встанет автоматически
2. После merge в `main` — release-drafter обновит черновик релиза в GitHub Releases
3. При выпуске версии — опубликовать черновик

## Test plan

- [ ] Открыть тестовый PR с `feat: ...` — проверить что появился лейбл `feat`
- [ ] Переименовать PR в `fix: ...` — проверить что лейбл сменился на `fix`
- [ ] Смержить PR в `main` — проверить что в Releases появился черновик

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated release draft generation with categorized changelogs (features, fixes, refactors, tests, perf, docs, breaking) and semantic version resolution.
  * Added automatic PR labeling based on conventional commit-style titles, including detection of breaking changes, to streamline release preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->