### PR TITLE
feat(pipeline): batch-gated deploy flow — TBD + Staging Gate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'FILE=$(echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get(\\\"file_path\\\",d.get(\\\"path\\\",\\\"\\\")))\" 2>/dev/null); if [ -n \"$FILE\" ]; then MAIN_REPO=$(git worktree list --porcelain 2>/dev/null | awk \"/^worktree/{print \\$2; exit}\"); [ -z \"$MAIN_REPO\" ] && MAIN_REPO=$(git rev-parse --show-toplevel 2>/dev/null); bash \"$MAIN_REPO/scripts/doc-reminder.sh\" \"$FILE\"; fi || true'"
+            "command": "bash -c 'FILE=$(echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get(\\\"file_path\\\",d.get(\\\"path\\\",\\\"\\\")))\" 2>/dev/null); if [ -n \"$FILE\" ]; then MAIN_REPO=$(git worktree list --porcelain 2>/dev/null | awk \"/^worktree/{sub(/^worktree /, \\\"\\\"); print; exit}\"); [ -z \"$MAIN_REPO\" ] && MAIN_REPO=$(git rev-parse --show-toplevel 2>/dev/null); bash \"$MAIN_REPO/scripts/doc-reminder.sh\" \"$FILE\"; fi || true'"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'FILE=$(echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get(\\\"file_path\\\",d.get(\\\"path\\\",\\\"\\\")))\" 2>/dev/null); if [ -n \"$FILE\" ]; then REPO=$(git rev-parse --show-toplevel 2>/dev/null || echo \".\"); bash \"$REPO/scripts/doc-reminder.sh\" \"$FILE\"; fi || true'"
+            "command": "bash -c 'FILE=$(echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get(\\\"file_path\\\",d.get(\\\"path\\\",\\\"\\\")))\" 2>/dev/null); if [ -n \"$FILE\" ]; then MAIN_REPO=$(git worktree list --porcelain 2>/dev/null | awk \"/^worktree/{print \\$2; exit}\"); [ -z \"$MAIN_REPO\" ] && MAIN_REPO=$(git rev-parse --show-toplevel 2>/dev/null); bash \"$MAIN_REPO/scripts/doc-reminder.sh\" \"$FILE\"; fi || true'"
           }
         ]
       }

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -67,4 +67,4 @@ jobs:
           curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
             -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
             -H "Content-Type: application/json" \
-            -d "{\"status\":\"${DEPLOY_STATUS}\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" || true
+            -d "{\"status\":\"${DEPLOY_STATUS}\",\"target\":\"PRODUCTION\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" || true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,14 +16,13 @@ permissions:
   contents: read
   packages: read
 
-concurrency:
-  group: deploy-production
-  cancel-in-progress: false
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
 
@@ -55,18 +54,17 @@ jobs:
           "
 
       - name: Run remote deploy
+        id: remote_deploy
         run: |
           ssh "${{ secrets.PRODUCTION_DEPLOY_USER }}@${{ secrets.PRODUCTION_DEPLOY_HOST }}" \
             "cd '${{ secrets.PRODUCTION_DEPLOY_PATH }}' && chmod +x deploy/scripts/*.sh && ./deploy/scripts/deploy.sh production '${{ inputs.image_tag }}'"
 
-      - name: Callback
+      - name: Callback to Pipeline Service
         if: always() && inputs.batch_id != ''
         env:
-          JOB_STATUS: ${{ job.status }}
+          DEPLOY_STATUS: ${{ steps.remote_deploy.outcome == 'success' && 'SUCCESS' || 'FAILURE' }}
         run: |
-          STATUS=$([[ "$JOB_STATUS" == "success" ]] && echo "SUCCESS" || echo "FAILURE")
           curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
             -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
             -H "Content-Type: application/json" \
-            -d "{\"status\":\"$STATUS\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
-            || echo "WARNING: callback delivery failed — batch ${{ inputs.batch_id }} may need manual status update"
+            -d "{\"status\":\"${DEPLOY_STATUS}\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" || true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,6 +16,10 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -55,18 +59,11 @@ jobs:
           ssh "${{ secrets.PRODUCTION_DEPLOY_USER }}@${{ secrets.PRODUCTION_DEPLOY_HOST }}" \
             "cd '${{ secrets.PRODUCTION_DEPLOY_PATH }}' && chmod +x deploy/scripts/*.sh && ./deploy/scripts/deploy.sh production '${{ inputs.image_tag }}'"
 
-      - name: Callback — success
-        if: success() && inputs.batch_id != ''
+      - name: Callback
+        if: always() && inputs.batch_id != ''
         run: |
+          STATUS=$([[ "${{ job.status }}" == "success" ]] && echo "SUCCESS" || echo "FAILURE")
           curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
             -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
             -H "Content-Type: application/json" \
-            -d "{\"status\":\"SUCCESS\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
-
-      - name: Callback — failure
-        if: failure() && inputs.batch_id != ''
-        run: |
-          curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
-            -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"status\":\"FAILURE\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",\"errorMessage\":\"Deploy failed\"}" || true
+            -d "{\"status\":\"$STATUS\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" || true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -61,9 +61,12 @@ jobs:
 
       - name: Callback
         if: always() && inputs.batch_id != ''
+        env:
+          JOB_STATUS: ${{ job.status }}
         run: |
-          STATUS=$([[ "${{ job.status }}" == "success" ]] && echo "SUCCESS" || echo "FAILURE")
+          STATUS=$([[ "$JOB_STATUS" == "success" ]] && echo "SUCCESS" || echo "FAILURE")
           curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
             -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
             -H "Content-Type: application/json" \
-            -d "{\"status\":\"$STATUS\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" || true
+            -d "{\"status\":\"$STATUS\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
+            || echo "WARNING: callback delivery failed — batch ${{ inputs.batch_id }} may need manual status update"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -16,6 +16,10 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -55,18 +59,11 @@ jobs:
           ssh "${{ secrets.STAGING_DEPLOY_USER }}@${{ secrets.STAGING_DEPLOY_HOST }}" \
             "cd '${{ secrets.STAGING_DEPLOY_PATH }}' && chmod +x deploy/scripts/*.sh && ./deploy/scripts/deploy.sh staging '${{ inputs.image_tag }}'"
 
-      - name: Callback — success
-        if: success() && inputs.batch_id != ''
+      - name: Callback
+        if: always() && inputs.batch_id != ''
         run: |
+          STATUS=$([[ "${{ job.status }}" == "success" ]] && echo "SUCCESS" || echo "FAILURE")
           curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
             -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
             -H "Content-Type: application/json" \
-            -d "{\"status\":\"SUCCESS\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
-
-      - name: Callback — failure
-        if: failure() && inputs.batch_id != ''
-        run: |
-          curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
-            -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"status\":\"FAILURE\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",\"errorMessage\":\"Deploy failed\"}" || true
+            -d "{\"status\":\"$STATUS\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" || true

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -16,14 +16,13 @@ permissions:
   contents: read
   packages: read
 
-concurrency:
-  group: deploy-staging
-  cancel-in-progress: false
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: staging
+    concurrency:
+      group: deploy-staging
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
 
@@ -55,18 +54,17 @@ jobs:
           "
 
       - name: Run remote deploy
+        id: remote_deploy
         run: |
           ssh "${{ secrets.STAGING_DEPLOY_USER }}@${{ secrets.STAGING_DEPLOY_HOST }}" \
             "cd '${{ secrets.STAGING_DEPLOY_PATH }}' && chmod +x deploy/scripts/*.sh && ./deploy/scripts/deploy.sh staging '${{ inputs.image_tag }}'"
 
-      - name: Callback
+      - name: Callback to Pipeline Service
         if: always() && inputs.batch_id != ''
         env:
-          JOB_STATUS: ${{ job.status }}
+          DEPLOY_STATUS: ${{ steps.remote_deploy.outcome == 'success' && 'SUCCESS' || 'FAILURE' }}
         run: |
-          STATUS=$([[ "$JOB_STATUS" == "success" ]] && echo "SUCCESS" || echo "FAILURE")
           curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
             -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
             -H "Content-Type: application/json" \
-            -d "{\"status\":\"$STATUS\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
-            || echo "WARNING: callback delivery failed — batch ${{ inputs.batch_id }} may need manual status update"
+            -d "{\"status\":\"${DEPLOY_STATUS}\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" || true

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,4 +1,4 @@
-name: Deploy Production
+name: Deploy Staging
 
 on:
   workflow_dispatch:
@@ -19,32 +19,32 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: production
+    environment: staging
     steps:
       - uses: actions/checkout@v6
 
       - name: Prepare SSH key
         run: |
           install -m 700 -d ~/.ssh
-          printf '%s\n' "${{ secrets.PRODUCTION_DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
+          printf '%s\n' "${{ secrets.STAGING_DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "${{ secrets.PRODUCTION_DEPLOY_HOST }}" >> ~/.ssh/known_hosts
+          ssh-keyscan -H "${{ secrets.STAGING_DEPLOY_HOST }}" >> ~/.ssh/known_hosts
 
       - name: Sync deploy assets
         run: |
-          rsync -az deploy/ "${{ secrets.PRODUCTION_DEPLOY_USER }}@${{ secrets.PRODUCTION_DEPLOY_HOST }}:${{ secrets.PRODUCTION_DEPLOY_PATH }}/deploy/"
+          rsync -az deploy/ "${{ secrets.STAGING_DEPLOY_USER }}@${{ secrets.STAGING_DEPLOY_HOST }}:${{ secrets.STAGING_DEPLOY_PATH }}/deploy/"
 
       - name: Docker login on server
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ssh "${{ secrets.PRODUCTION_DEPLOY_USER }}@${{ secrets.PRODUCTION_DEPLOY_HOST }}" \
+          ssh "${{ secrets.STAGING_DEPLOY_USER }}@${{ secrets.STAGING_DEPLOY_HOST }}" \
             "echo '$GHCR_TOKEN' | docker login ghcr.io -u ${{ github.actor }} --password-stdin"
 
       - name: Inject secrets into backend env
         run: |
-          ssh "${{ secrets.PRODUCTION_DEPLOY_USER }}@${{ secrets.PRODUCTION_DEPLOY_HOST }}" "
-            ENV_FILE='${{ secrets.PRODUCTION_DEPLOY_PATH }}/deploy/env/backend.production.env'
+          ssh "${{ secrets.STAGING_DEPLOY_USER }}@${{ secrets.STAGING_DEPLOY_HOST }}" "
+            ENV_FILE='${{ secrets.STAGING_DEPLOY_PATH }}/deploy/env/backend.staging.env'
             sed -i '/^AI_PROVIDER=/d; /^ANTHROPIC_API_KEY=/d' \"\$ENV_FILE\"
             echo 'AI_PROVIDER=${{ secrets.AI_PROVIDER }}' >> \"\$ENV_FILE\"
             echo 'ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}' >> \"\$ENV_FILE\"
@@ -52,8 +52,8 @@ jobs:
 
       - name: Run remote deploy
         run: |
-          ssh "${{ secrets.PRODUCTION_DEPLOY_USER }}@${{ secrets.PRODUCTION_DEPLOY_HOST }}" \
-            "cd '${{ secrets.PRODUCTION_DEPLOY_PATH }}' && chmod +x deploy/scripts/*.sh && ./deploy/scripts/deploy.sh production '${{ inputs.image_tag }}'"
+          ssh "${{ secrets.STAGING_DEPLOY_USER }}@${{ secrets.STAGING_DEPLOY_HOST }}" \
+            "cd '${{ secrets.STAGING_DEPLOY_PATH }}' && chmod +x deploy/scripts/*.sh && ./deploy/scripts/deploy.sh staging '${{ inputs.image_tag }}'"
 
       - name: Callback — success
         if: success() && inputs.batch_id != ''

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -67,4 +67,4 @@ jobs:
           curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
             -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
             -H "Content-Type: application/json" \
-            -d "{\"status\":\"${DEPLOY_STATUS}\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" || true
+            -d "{\"status\":\"${DEPLOY_STATUS}\",\"target\":\"STAGING\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" || true

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -61,9 +61,12 @@ jobs:
 
       - name: Callback
         if: always() && inputs.batch_id != ''
+        env:
+          JOB_STATUS: ${{ job.status }}
         run: |
-          STATUS=$([[ "${{ job.status }}" == "success" ]] && echo "SUCCESS" || echo "FAILURE")
+          STATUS=$([[ "$JOB_STATUS" == "success" ]] && echo "SUCCESS" || echo "FAILURE")
           curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
             -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
             -H "Content-Type: application/json" \
-            -d "{\"status\":\"$STATUS\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" || true
+            -d "{\"status\":\"$STATUS\",\"workflowRunId\":${{ github.run_id }},\"workflowRunUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
+            || echo "WARNING: callback delivery failed — batch ${{ inputs.batch_id }} may need manual status update"

--- a/docs/plans/pipeline-deploy-flow.md
+++ b/docs/plans/pipeline-deploy-flow.md
@@ -1,0 +1,621 @@
+# Pipeline Deploy Flow — План реализации
+
+> Документ описывает AS-IS состояние CI/CD, целевой TO-BE флоу с управлением батчами,
+> стейт-машину StagingBatch, компонентную схему и GAP-анализ с фазами реализации.
+
+---
+
+## 1. Текущее состояние (AS-IS)
+
+### Что происходит сейчас
+
+```
+Developer merges PR to main
+        │
+        ▼
+CI workflow (ci.yml)
+  • TypeScript build
+  • ESLint
+  • Vitest tests
+  • Redis service container
+        │ (on success, only main branch)
+        ▼
+Build and Publish (build-and-publish.yml)
+  • Triggered via workflow_run: ["CI"] completed
+  • Builds Docker images: tasktime-backend, tasktime-web
+  • Tags: <sha>, main (+ optional custom tag via workflow_dispatch)
+  • Pushes to ghcr.io
+        │
+        ▼
+Deploy Production (deploy-production.yml)
+  • ТОЛЬКО workflow_dispatch — ручной запуск
+  • Requires: image_tag input
+  • SSH → rsync deploy/ assets → docker login → inject secrets → run deploy.sh
+```
+
+### Ключевые наблюдения
+
+- **`deploy-staging.yml` не существует** — workflow файл отсутствует в репозитории.
+- Deploy Production — только ручной запуск через `workflow_dispatch` с явным `image_tag`.
+- Нет автоматического деплоя на staging при merge в main.
+- Pipeline Service уже существует (`pipeline-service/`) с моделью батчей и роутерами.
+- Frontend `PipelineDashboardPage` уже рендерит батчи и кнопку "→ Deploy Staging",
+  но кнопка только переводит батч в состояние `DEPLOYING` в БД — реального деплоя
+  на staging-сервер **не происходит**.
+- `pipelineApi.transitionState()` вызывает `PATCH /api/batches/:id/state` — это чисто
+  локальная операция в Pipeline Service DB. GitHub Actions не вызывается.
+
+---
+
+## 2. Целевой флоу (TO-BE)
+
+### Полная диаграмма
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  DEVELOPER                                                                │
+│  1. Создаёт ветку, пишет код                                             │
+│  2. Открывает PR → CI запускается автоматически                          │
+│  3. Получает code review + аппрув                                        │
+│  4. Мёрджит PR в main                                                    │
+└───────────────────────────┬──────────────────────────────────────────────┘
+                            │ merge to main
+                            ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  GITHUB ACTIONS — CI (ci.yml)                                            │
+│  • tsc + eslint + vitest                                                 │
+│  При успехе → Build and Publish                                          │
+└───────────────────────────┬──────────────────────────────────────────────┘
+                            │ workflow_run trigger (CI success, main)
+                            ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  GITHUB ACTIONS — Build and Publish (build-and-publish.yml)             │
+│  • Сборка Docker образов backend + web                                  │
+│  • Тэг: <sha>, main                                                      │
+│  • Push в ghcr.io                                                        │
+└───────────────────────────┬──────────────────────────────────────────────┘
+                            │ (после успешной сборки)
+                            │ GitHub → webhook / polling
+                            ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  PIPELINE SERVICE — АВТОМАТИЧЕСКАЯ СИНХРОНИЗАЦИЯ                        │
+│  POST /api/github/sync (по расписанию или webhook)                      │
+│  • Находит новые merged PRs через GitHub API                            │
+│  • Upsert → PullRequestSnapshot в БД                                    │
+│  • Автоматически добавляет в активный COLLECTING батч                   │
+│  (если COLLECTING батча нет — создаёт новый)                            │
+└───────────────────────────┬──────────────────────────────────────────────┘
+                            │ PR попадает в батч
+                            ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  PIPELINE DASHBOARD — PM видит батч в статусе COLLECTING                │
+│                                                                          │
+│  Батч "2026-04-01" [COLLECTING]                                         │
+│  ┌─────────────────────────────────────────────────────────┐            │
+│  │  #142  feat: новый дашборд          ✓ CI   ✓ Approved  │            │
+│  │  #143  fix: исправить таймер        ✓ CI   ✓ Approved  │            │
+│  │  #144  chore: обновить зависимости  ⟳ CI   — Pending   │            │
+│  └─────────────────────────────────────────────────────────┘            │
+│                                                                          │
+│  PM проверяет: все ли PR готовы к деплою?                               │
+│  • CI зелёный у всех?                                                   │
+│  • Все заапрувлены?                                                     │
+│  • Нет конфликтов?                                                      │
+└───────────────────────────┬──────────────────────────────────────────────┘
+                            │ PM нажимает "→ Deploy Staging"
+                            ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  PIPELINE SERVICE — DEPLOYING                                            │
+│  PATCH /api/batches/:id/state → { state: "DEPLOYING" }                 │
+│  + POST /api/batches/:id/deploy-staging                                 │
+│    → GitHub API: POST /repos/.../actions/workflows/deploy-staging.yml/  │
+│                        dispatches { ref: "main", inputs: { batch_id,    │
+│                        image_tag: <sha> } }                              │
+│  + Создаёт DeployEvent { target: STAGING, status: RUNNING }            │
+└───────────────────────────┬──────────────────────────────────────────────┘
+                            │ GitHub Actions запускается
+                            ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  GITHUB ACTIONS — Deploy Staging (deploy-staging.yml) [НОВЫЙ]           │
+│  Trigger: workflow_dispatch                                              │
+│    inputs: image_tag (required), batch_id (optional)                   │
+│  Steps:                                                                  │
+│  • SSH prepare                                                           │
+│  • rsync deploy/ assets                                                 │
+│  • docker login on staging server                                       │
+│  • inject secrets                                                        │
+│  • run deploy.sh staging <image_tag>                                    │
+│  • health check (retry 12×5s)                                           │
+│  • POST /api/batches/:batch_id/deploy-callback                          │
+│    { status: "SUCCESS"|"FAILURE", workflowRunId, workflowRunUrl }       │
+└───────────────────────────┬──────────────────────────────────────────────┘
+                            │ деплой завершён
+                            ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  PIPELINE SERVICE — получает callback / polling                         │
+│  DeployEvent обновляется: status → SUCCESS / FAILURE                   │
+│  StagingBatch переходит:                                                │
+│    SUCCESS → TESTING                                                    │
+│    FAILURE → FAILED                                                     │
+└───────────────────────────┬──────────┬───────────────────────────────────┘
+                            │ TESTING  │ FAILED
+                            ▼          ▼
+              ┌─────────────┐    ┌─────────────┐
+              │  PM проводит│    │  PM видит   │
+              │  ручное QA  │    │  лог ошибки │
+              │  на staging │    │  и нажимает │
+              └──────┬──────┘    │  ↩ Restart  │
+                     │           └──────┬───────┘
+          ┌──────────┴────┐             │
+          │               │             ▼
+          ▼               ▼     [COLLECTING снова]
+      [✓ Passed]      [✗ Failed]  (фикс → новый PR)
+          │               │
+          ▼               ▼
+      PASSED           FAILED
+          │
+          │  PM нажимает "🚀 Deploy to Production"
+          ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  PIPELINE SERVICE — инициирует деплой в Production                      │
+│  POST /api/batches/:id/deploy-production                                │
+│  → GitHub API: workflow_dispatch deploy-production.yml                  │
+│    { image_tag: <sha_from_batch> }                                      │
+│  + Создаёт DeployEvent { target: PRODUCTION, status: RUNNING }         │
+└───────────────────────────┬──────────────────────────────────────────────┘
+                            │ GitHub Actions запускается
+                            ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  GITHUB ACTIONS — Deploy Production (deploy-production.yml)             │
+│  (существующий, без изменений)                                          │
+│  • SSH → deploy.sh production <image_tag>                               │
+│  • callback → Pipeline Service                                          │
+└───────────────────────────┬──────────────────────────────────────────────┘
+                            │
+                            ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  PIPELINE SERVICE — финализация                                         │
+│  StagingBatch.state → RELEASED                                          │
+│  DeployEvent.status → SUCCESS                                           │
+│  Dashboard показывает релиз с тэгом, SHA, временем                     │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Стейт-машина StagingBatch
+
+### Схема переходов
+
+```
+                    ┌─────────────┐
+                    │  COLLECTING │ ◄──────────────────────────────┐
+                    └──────┬──────┘                                │
+                           │                                       │
+                    PM нажимает                                     │
+                  "→ Deploy Staging"                               │
+                  + GitHub dispatch                                │
+                           │                                       │
+                           ▼                                       │
+                    ┌─────────────┐                                │
+                    │   MERGING   │ (зарезервировано для будущего) │
+                    └──────┬──────┘                                │
+                           │ (опционально, сейчас пропускается)    │
+                           ▼                                       │
+                    ┌─────────────┐       deploy failure           │
+                    │  DEPLOYING  │ ─────────────────────────────► │
+                    └──────┬──────┘                                │
+                           │ deploy success                        │
+                           ▼                                       │
+                    ┌─────────────┐       testing fails            │
+                    │   TESTING   │ ─────────────────────────────► │
+                    └──────┬──────┘                                │
+                           │ PM подтверждает QA                    │
+                           ▼                              ┌────────┴──────┐
+                    ┌─────────────┐                       │    FAILED     │
+                    │   PASSED    │                       └───────────────┘
+                    └──────┬──────┘
+                           │ PM нажимает
+                      "🚀 Deploy to Production"
+                           │
+                           ▼
+                    ┌─────────────┐
+                    │  RELEASED   │  (терминальный, без выхода)
+                    └─────────────┘
+```
+
+### Таблица допустимых переходов
+
+| Из \ В      | COLLECTING | MERGING | DEPLOYING | TESTING | PASSED | FAILED | RELEASED |
+|-------------|:----------:|:-------:|:---------:|:-------:|:------:|:------:|:--------:|
+| COLLECTING  |            |         |     ✓     |         |        |   ✓    |          |
+| MERGING     |            |         |     ✓     |         |        |   ✓    |          |
+| DEPLOYING   |            |         |           |    ✓    |        |   ✓    |          |
+| TESTING     |            |         |           |         |   ✓    |   ✓    |          |
+| PASSED      |            |         |           |         |        |        |    ✓     |
+| FAILED      |     ✓      |         |           |         |        |        |          |
+| RELEASED    |  (нет выхода)                                                          |
+
+> Реализовано в `batches.router.ts` → `VALID_TRANSITIONS`. Нужно добавить side-effect:
+> переход COLLECTING → DEPLOYING должен тригерить GitHub workflow_dispatch.
+
+---
+
+## 4. Компонентная схема
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  BROWSER (React)                                                             │
+│                                                                              │
+│  PipelineDashboardPage                                                       │
+│  ├── pipelineApi.getBatches()          GET  /pipeline/api/batches           │
+│  ├── pipelineApi.transitionState()     PATCH /pipeline/api/batches/:id/state│
+│  ├── pipelineApi.syncGitHub()          POST /pipeline/api/github/sync       │
+│  ├── [нужно] pipelineApi.deployStat() POST /pipeline/api/batches/:id/       │
+│  │                                          deploy-staging                   │
+│  └── [нужно] pipelineApi.deployProd() POST /pipeline/api/batches/:id/       │
+│                                             deploy-production                │
+└───────────────────────────────┬─────────────────────────────────────────────┘
+                                │ HTTPS (nginx proxy /pipeline/ → :3100)
+                                ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  PIPELINE SERVICE (pipeline-service/, port 3100)                            │
+│  Express + Prisma + PostgreSQL                                              │
+│                                                                              │
+│  Модули:                                                                     │
+│  ├── /api/health          health.router.ts                                  │
+│  ├── /api/pipelines       pipelines.router.ts                               │
+│  │     GET  /prs          — список PR снапшотов                            │
+│  │     GET  /deploys      — история деплоев                                │
+│  │     POST /sync         — запуск синхронизации с GitHub                  │
+│  │     GET  /sync-state   — статус последней синхронизации                 │
+│  │     GET  /batches      — список батчей (дублирует /api/batches)         │
+│  ├── /api/batches         batches.router.ts                                 │
+│  │     POST /             — создать батч                                   │
+│  │     GET  /             — список батчей (с фильтрацией)                  │
+│  │     GET  /:id          — батч по ID                                     │
+│  │     PATCH /:id/state   — переход состояния (стейт-машина)              │
+│  │     POST /:id/prs      — добавить PRs в батч                           │
+│  │     DELETE /:id/prs/:prId — убрать PR из батча                         │
+│  │     [нужно] POST /:id/deploy-staging    — тригер staging деплоя        │
+│  │     [нужно] POST /:id/deploy-production — тригер prod деплоя           │
+│  │     [нужно] POST /:id/deploy-callback   — callback от GitHub Actions    │
+│  └── /api/github          github.router.ts                                  │
+│        POST /sync         — синхронизация merged PRs из GitHub             │
+│        GET  /prs          — merged PRs с batch info                        │
+└───────────────────┬───────────────────────────────────────────────────────-─┘
+                    │ GitHub REST API (Bearer token)
+                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  GITHUB ACTIONS                                                              │
+│                                                                              │
+│  ci.yml                build-and-publish.yml    deploy-production.yml       │
+│  • push / PR           • workflow_run (CI ok)   • workflow_dispatch         │
+│  • tsc+lint+test       • docker build+push      • SSH → deploy.sh prod      │
+│                                                                              │
+│  [нужно]                                                                     │
+│  deploy-staging.yml                                                          │
+│  • workflow_dispatch (inputs: image_tag, batch_id)                          │
+│  • SSH → deploy.sh staging                                                  │
+│  • POST callback → Pipeline Service                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Модели данных (Prisma schema)
+
+```
+PullRequestSnapshot
+  id, externalId (PR number), source, repo, title, author
+  branch, baseBranch, hasConflicts
+  ciStatus: PENDING | RUNNING | SUCCESS | FAILURE | CANCELLED
+  reviewStatus: PENDING | APPROVED | CHANGES_REQUESTED
+  mergedAt, mergedSha
+  stagingBatchId → StagingBatch (optional, null = не в батче)
+
+StagingBatch
+  id, name, state: COLLECTING | MERGING | DEPLOYING | TESTING | PASSED | FAILED | RELEASED
+  createdById, notes
+  releaseId, releaseName        ← заполняется при RELEASED
+  healthCheckResult             ← результат health-check после деплоя
+  pullRequests → PullRequestSnapshot[]
+  deployEvents → DeployEvent[]
+
+DeployEvent
+  id, target: STAGING | PRODUCTION
+  status: PENDING | RUNNING | SUCCESS | FAILURE | ROLLED_BACK
+  imageTag, gitSha
+  triggeredById
+  stagingBatchId → StagingBatch
+  workflowRunId, workflowRunUrl ← заполняется после dispatch
+  startedAt, finishedAt, durationMs
+  healthCheckResult, errorMessage
+```
+
+---
+
+## 5. GAP анализ — Что нужно построить
+
+### 5.1 GitHub Actions — создать deploy-staging.yml
+
+**Статус:** файл **отсутствует**. `deploy-staging.yml` не существует в `.github/workflows/`.
+
+Нужно создать по образцу `deploy-production.yml`:
+
+```yaml
+name: Deploy Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Docker image tag to deploy
+        required: true
+        type: string
+      batch_id:
+        description: Pipeline Service batch ID (for callback)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v6
+      - name: Prepare SSH key
+        # ... (аналогично deploy-production.yml)
+      - name: Sync deploy assets
+        # rsync deploy/ → staging server
+      - name: Docker login on server
+        # ...
+      - name: Inject secrets into backend env
+        # ... (backend.staging.env)
+      - name: Run remote deploy
+        # deploy.sh staging <image_tag>
+      - name: Callback to Pipeline Service (success)
+        if: success()
+        run: |
+          curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
+            -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{"status":"SUCCESS","workflowRunId":${{ github.run_id }},"workflowRunUrl":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+      - name: Callback to Pipeline Service (failure)
+        if: failure()
+        run: |
+          curl -sf -X POST "${{ secrets.PIPELINE_SERVICE_URL }}/api/batches/${{ inputs.batch_id }}/deploy-callback" \
+            -H "x-pipeline-api-key: ${{ secrets.PIPELINE_SERVICE_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{"status":"FAILURE","workflowRunId":${{ github.run_id }},"errorMessage":"Deploy failed"}'
+```
+
+**Новые GitHub Secrets для staging environment:**
+- `STAGING_DEPLOY_SSH_KEY`
+- `STAGING_DEPLOY_HOST`
+- `STAGING_DEPLOY_USER`
+- `STAGING_DEPLOY_PATH`
+- `PIPELINE_SERVICE_URL` (например `http://5.129.242.171:3100`)
+- `PIPELINE_SERVICE_API_KEY`
+
+**Изменение в deploy-production.yml:**
+Добавить аналогичные callback-шаги (success/failure) для замыкания стейт-машины батча.
+
+### 5.2 Pipeline Service — новые эндпоинты
+
+**a) POST /api/batches/:id/deploy-staging**
+
+Логика:
+1. Найти батч, проверить state == COLLECTING или MERGING
+2. Взять `imageTag` (из последнего merged PR в батче → mergedSha, либо передать явно)
+3. Вызвать `github.client.ts` → `triggerWorkflowDispatch('deploy-staging.yml', { image_tag, batch_id })`
+4. Создать `DeployEvent { target: STAGING, status: RUNNING, imageTag, workflowRunId? }`
+5. Перевести батч в DEPLOYING
+6. Вернуть `{ batch, deployEvent }`
+
+**b) POST /api/batches/:id/deploy-production**
+
+Логика:
+1. Найти батч, проверить state == PASSED
+2. Вызвать `triggerWorkflowDispatch('deploy-production.yml', { image_tag })`
+3. Создать `DeployEvent { target: PRODUCTION, status: RUNNING }`
+4. Вернуть `{ batch, deployEvent }` (state остаётся PASSED до callback)
+
+**c) POST /api/batches/:id/deploy-callback**
+
+Используется GitHub Actions для уведомления об окончании деплоя.
+
+Тело: `{ status: "SUCCESS"|"FAILURE", workflowRunId?: number, workflowRunUrl?: string, errorMessage?: string }`
+
+Логика:
+- Найти самый последний `DeployEvent` с `status: RUNNING` для этого батча
+- Обновить DeployEvent: `status`, `finishedAt`, `durationMs`, `workflowRunId`, `workflowRunUrl`, `errorMessage`
+- Автоматический переход батча:
+  - DEPLOYING + SUCCESS → TESTING
+  - DEPLOYING + FAILURE → FAILED
+  - (PASSED батч при деплое в прод) + SUCCESS → RELEASED
+  - (PASSED батч при деплое в прод) + FAILURE → FAILED
+
+**d) Новая функция в github.client.ts**
+
+```typescript
+export async function triggerWorkflowDispatch(
+  owner: string,
+  repo: string,
+  workflowFile: string,
+  ref: string,
+  inputs: Record<string, string>,
+): Promise<void>
+```
+
+Вызывает `POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches`.
+
+### 5.3 Frontend — новые вызовы API
+
+**Текущее поведение кнопки "→ Deploy Staging"** (строка 358 PipelineDashboardPage.tsx):
+```typescript
+onClick={() => handleTransition(selected.id, 'DEPLOYING')}
+```
+Вызывает только `PATCH /api/batches/:id/state` → переводит батч в DEPLOYING локально.
+**GitHub Actions не запускается.**
+
+**Нужно заменить** на вызов нового эндпоинта:
+```typescript
+onClick={() => handleDeployStaging(selected.id)}
+
+const handleDeployStaging = async (batchId: string) => {
+  try {
+    await pipelineApi.deployStagingBatch(batchId);  // POST /api/batches/:id/deploy-staging
+    await load();
+  } catch (e) {
+    setError(e instanceof Error ? e.message : 'Ошибка запуска деплоя');
+  }
+};
+```
+
+**Кнопка "🚀 Deploy to Production"** (строка 373):
+```typescript
+onClick={() => handleTransition(selected.id, 'RELEASED')}
+```
+Аналогично заменить на `pipelineApi.deployProductionBatch(batchId)`.
+
+**Новые методы в `frontend/src/api/pipeline.ts`:**
+```typescript
+deployStagingBatch: async (batchId: string): Promise<StagingBatch> => { ... }
+deployProductionBatch: async (batchId: string): Promise<StagingBatch> => { ... }
+```
+
+**Дополнительно:** добавить поллинг (каждые 10с) когда батч в состоянии DEPLOYING,
+чтобы PM видел обновление статуса без ручного обновления страницы.
+
+### 5.4 Создание продакшн батчей (prod batch collection)
+
+После того как батч получил статус `RELEASED`, следующие PR-ы мёрджатся в main и
+автоматически попадают в **новый** COLLECTING батч (логика уже реализована в
+`getOrCreateCollectingBatchId()` в `github.router.ts`).
+
+Никаких изменений не требуется — логика корректная.
+
+---
+
+## 6. Фазы реализации
+
+### Фаза 1 — GitHub Actions + Secrets (1-2 дня)
+
+**Задачи:**
+1. Создать `.github/workflows/deploy-staging.yml` по шаблону deploy-production.yml
+   - `workflow_dispatch` с inputs: `image_tag`, `batch_id`
+   - environment: `staging`
+   - SSH + rsync + deploy.sh staging
+   - callback step (success + failure)
+2. Настроить в GitHub → Settings → Environments → `staging`:
+   - `STAGING_DEPLOY_SSH_KEY`
+   - `STAGING_DEPLOY_HOST`
+   - `STAGING_DEPLOY_USER`
+   - `STAGING_DEPLOY_PATH`
+3. Добавить в оба environments (staging + production):
+   - `PIPELINE_SERVICE_URL`
+   - `PIPELINE_SERVICE_API_KEY`
+4. Добавить callback шаги в существующий `deploy-production.yml`
+
+**Проверка:** ручной `workflow_dispatch` deploy-staging.yml из GitHub UI успешно деплоит на staging.
+
+---
+
+### Фаза 2 — Pipeline Service: GitHub dispatch + callback (2-3 дня)
+
+**Задачи:**
+1. `github.client.ts` → добавить `triggerWorkflowDispatch()`
+2. `batches.router.ts` → добавить:
+   - `POST /api/batches/:id/deploy-staging`
+   - `POST /api/batches/:id/deploy-production`
+   - `POST /api/batches/:id/deploy-callback`
+3. Обновить `VALID_TRANSITIONS` если нужно (PASSED → RELEASED только через deploy-production callback)
+4. Добавить `PIPELINE_GITHUB_OWNER`, `PIPELINE_GITHUB_REPO` в `config.ts`
+5. Добавить тесты для новых эндпоинтов (Supertest)
+
+**Проверка:** curl в Pipeline Service → запускается GitHub Actions job, callback получен, батч переходит в TESTING.
+
+---
+
+### Фаза 3 — Frontend: wire up кнопки (1 день)
+
+**Задачи:**
+1. `frontend/src/api/pipeline.ts` → добавить `deployStagingBatch()`, `deployProductionBatch()`
+2. `PipelineDashboardPage.tsx`:
+   - Заменить onClick "→ Deploy Staging" → `handleDeployStaging()`
+   - Заменить onClick "🚀 Deploy to Production" → `handleDeployProd()`
+   - Добавить поллинг `useEffect` (интервал 10с) когда batch.state === 'DEPLOYING'
+   - Показывать `workflowRunUrl` как кликабельную ссылку на GitHub Actions run
+3. Добавить отображение `DeployEvent` с реальным временем выполнения и статусом
+
+**Проверка:** нажатие "→ Deploy Staging" в UI → деплой идёт на staging → статус обновляется автоматически.
+
+---
+
+### Фаза 4 — Polish + авто-поллинг GitHub статусов (1-2 дня)
+
+**Задачи:**
+1. Периодический sync PR статусов (CI checks, review status) — крон каждые 5 минут
+   или GitHub webhook
+2. Добавить `DeployEvent.workflowRunId` polling: Pipeline Service проверяет статус
+   GitHub Actions run через `GET /repos/.../actions/runs/:run_id` и автоматически
+   закрывает `DeployEvent` без ожидания callback (resilience против потери callback)
+3. Уведомления: при переходе DEPLOYING → TESTING / FAILED отправить Telegram уведомление
+   через существующий Telegram-бот
+4. Добавить страницу истории деплоев с фильтрацией по target/status
+
+---
+
+## 7. Новые / изменённые API эндпоинты
+
+### Pipeline Service (новые)
+
+| Метод | Путь | Описание |
+|-------|------|----------|
+| `POST` | `/api/batches/:id/deploy-staging` | Запустить деплой батча на staging (GitHub dispatch + DeployEvent) |
+| `POST` | `/api/batches/:id/deploy-production` | Запустить деплой батча в production |
+| `POST` | `/api/batches/:id/deploy-callback` | Webhook от GitHub Actions: обновить DeployEvent и переключить состояние батча |
+
+### Pipeline Service (изменения в существующих)
+
+| Метод | Путь | Изменение |
+|-------|------|-----------|
+| `PATCH` | `/api/batches/:id/state` | Добавить side-effect: переход COLLECTING→DEPLOYING должен вызывать GitHub dispatch (альтернатива — убрать прямой вызов, использовать только `/deploy-staging`) |
+
+### Frontend API (новые методы в `pipeline.ts`)
+
+| Метод | Описание |
+|-------|----------|
+| `pipelineApi.deployStagingBatch(batchId)` | POST /api/batches/:id/deploy-staging |
+| `pipelineApi.deployProductionBatch(batchId)` | POST /api/batches/:id/deploy-production |
+
+### GitHub Actions (новый workflow)
+
+| Workflow | Trigger | Inputs |
+|----------|---------|--------|
+| `deploy-staging.yml` | `workflow_dispatch` | `image_tag` (required), `batch_id` (optional) |
+
+---
+
+## 8. Нерешённые вопросы (открыто)
+
+1. **image_tag для батча:** какой SHA брать если в батче несколько PR с разными `mergedSha`?
+   Варианты: последний merged SHA, SHA самого последнего build-and-publish job для main.
+   Рекомендация: хранить `latestMainSha` в SyncState, обновлять при каждом sync.
+
+2. **MERGING состояние:** сейчас `VALID_TRANSITIONS` разрешает COLLECTING→DEPLOYING напрямую,
+   минуя MERGING. Это корректно пока нет merge queue. В будущем MERGING потребует
+   автоматической проверки merge conflicts перед деплоем.
+
+3. **Callback надёжность:** GitHub Actions может не отправить callback при падении runner.
+   Нужен fallback polling DeployEvent через GitHub API (Фаза 4).
+
+4. **Staging secrets (P1 блокер из истории):** `STAGING_DEPLOY_SSH_KEY` и другие secrets
+   для staging environment должны быть настроены в GitHub Settings до запуска Фазы 1.
+
+5. **Авторизация callback:** `POST /api/batches/:id/deploy-callback` открыт для любого,
+   кто знает `PIPELINE_SERVICE_API_KEY`. В будущем добавить проверку источника (GitHub
+   Actions IP ranges или HMAC подпись).

--- a/frontend/src/api/pipeline.ts
+++ b/frontend/src/api/pipeline.ts
@@ -176,7 +176,7 @@ export const pipelineApi = {
       method: 'POST',
       body: JSON.stringify(imageTag ? { imageTag } : {}),
     });
-    return mapBatch((raw as any)?.data ?? unwrap(raw));
+    return mapBatch(unwrap(raw));
   },
 
   deployProductionBatch: async (batchId: string, imageTag?: string): Promise<StagingBatch> => {
@@ -184,6 +184,6 @@ export const pipelineApi = {
       method: 'POST',
       body: JSON.stringify(imageTag ? { imageTag } : {}),
     });
-    return mapBatch((raw as any)?.data ?? unwrap(raw));
+    return mapBatch(unwrap(raw));
   },
 };

--- a/frontend/src/api/pipeline.ts
+++ b/frontend/src/api/pipeline.ts
@@ -170,4 +170,20 @@ export const pipelineApi = {
     pipelineFetch<void>(`/api/batches/${batchId}/prs/${prId}`, { method: 'DELETE' }),
 
   syncGitHub: () => pipelineFetch<{ synced: number; repo: string; truncated: boolean }>('/api/github/sync', { method: 'POST' }),
+
+  deployStagingBatch: async (batchId: string, imageTag?: string): Promise<StagingBatch> => {
+    const raw = await pipelineFetch<unknown>(`/api/batches/${batchId}/deploy-staging`, {
+      method: 'POST',
+      body: JSON.stringify(imageTag ? { imageTag } : {}),
+    });
+    return mapBatch((raw as any)?.data ?? unwrap(raw));
+  },
+
+  deployProductionBatch: async (batchId: string, imageTag?: string): Promise<StagingBatch> => {
+    const raw = await pipelineFetch<unknown>(`/api/batches/${batchId}/deploy-production`, {
+      method: 'POST',
+      body: JSON.stringify(imageTag ? { imageTag } : {}),
+    });
+    return mapBatch((raw as any)?.data ?? unwrap(raw));
+  },
 };

--- a/frontend/src/api/pipeline.ts
+++ b/frontend/src/api/pipeline.ts
@@ -1,7 +1,7 @@
 // In production nginx proxies /pipeline/ → pipeline-service:3100/ and injects the API key server-side.
 // In development set VITE_PIPELINE_URL=http://localhost:3100 and VITE_PIPELINE_API_KEY in .env.local.
 const BASE = import.meta.env.VITE_PIPELINE_URL ?? '/pipeline';
-const DEV_KEY = import.meta.env.VITE_PIPELINE_API_KEY;
+const DEV_KEY = import.meta.env.DEV ? (import.meta.env.VITE_PIPELINE_API_KEY as string | undefined) : undefined;
 
 async function pipelineFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json', ...options?.headers as Record<string, string> };

--- a/frontend/src/api/pipeline.ts
+++ b/frontend/src/api/pipeline.ts
@@ -78,7 +78,7 @@ function mapPr(raw: any): PrSnapshot {
     prTitle: raw.title ?? raw.prTitle ?? '',
     prUrl: raw.htmlUrl ?? raw.prUrl ?? '',
     author: raw.author ?? '',
-    headSha: raw.mergedSha ?? raw.branch ?? raw.headSha ?? '',
+    headSha: raw.mergedSha ?? raw.headSha ?? '',
     mergedAt: raw.mergedAt ?? null,
     ciStatus: raw.ciStatus ?? 'PENDING',
     batchId: raw.stagingBatchId ?? raw.batchId ?? '',

--- a/frontend/src/api/pipeline.ts
+++ b/frontend/src/api/pipeline.ts
@@ -78,7 +78,7 @@ function mapPr(raw: any): PrSnapshot {
     prTitle: raw.title ?? raw.prTitle ?? '',
     prUrl: raw.htmlUrl ?? raw.prUrl ?? '',
     author: raw.author ?? '',
-    headSha: raw.mergedSha ?? raw.headSha ?? '',
+    headSha: raw.mergedSha ?? raw.branch ?? raw.headSha ?? '',
     mergedAt: raw.mergedAt ?? null,
     ciStatus: raw.ciStatus ?? 'PENDING',
     batchId: raw.stagingBatchId ?? raw.batchId ?? '',

--- a/frontend/src/pages/PipelineDashboardPage.tsx
+++ b/frontend/src/pages/PipelineDashboardPage.tsx
@@ -346,7 +346,7 @@ export default function PipelineDashboardPage() {
                     tabIndex={0}
                     aria-pressed={isSelected}
                     onClick={() => setSelectedBatch(isSelected ? null : batch.id)}
-                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSelectedBatch(isSelected ? null : batch.id); }}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedBatch(isSelected ? null : batch.id); } }}
                     style={{ padding: '10px 16px', borderBottom: `1px solid ${C.border}`, cursor: 'pointer', backgroundColor: isSelected ? C.accBg : 'transparent', display: 'flex', alignItems: 'center', gap: 12 }}
                   >
                     <div style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: cfg.dot, flexShrink: 0 }} />

--- a/frontend/src/pages/PipelineDashboardPage.tsx
+++ b/frontend/src/pages/PipelineDashboardPage.tsx
@@ -161,6 +161,8 @@ export default function PipelineDashboardPage() {
     }
   };
 
+  const [deploying, setDeploying] = useState(false);
+
   const handleTransition = async (batchId: string, state: BatchState) => {
     try {
       await pipelineApi.transitionState(batchId, state);
@@ -169,6 +171,40 @@ export default function PipelineDashboardPage() {
       setError(e instanceof Error ? e.message : 'Ошибка перехода');
     }
   };
+
+  const handleDeployStaging = async (batchId: string) => {
+    setDeploying(true);
+    setError(null);
+    try {
+      await pipelineApi.deployStagingBatch(batchId);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Ошибка запуска деплоя на стейдж');
+    } finally {
+      setDeploying(false);
+    }
+  };
+
+  const handleDeployProd = async (batchId: string) => {
+    setDeploying(true);
+    setError(null);
+    try {
+      await pipelineApi.deployProductionBatch(batchId);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Ошибка запуска деплоя в прод');
+    } finally {
+      setDeploying(false);
+    }
+  };
+
+  // Poll every 10s when a batch is actively deploying
+  useEffect(() => {
+    const hasActive = batches.some(b => ['DEPLOYING'].includes(b.state));
+    if (!hasActive) return;
+    const id = setInterval(() => load(), 10_000);
+    return () => clearInterval(id);
+  }, [batches, load]);
 
   // Derived stats
   const activeBatch = batches.find(b => ['COLLECTING','DEPLOYING','TESTING','PASSED'].includes(b.state));
@@ -355,7 +391,7 @@ export default function PipelineDashboardPage() {
                 {/* Actions */}
                 <div style={{ padding: '12px 16px', borderTop: `1px solid ${C.border}`, display: 'flex', flexWrap: 'wrap', gap: 8 }}>
                   {selected.state === 'COLLECTING' && (
-                    <ActionBtn label="→ Deploy Staging" color={C.acc} onClick={() => handleTransition(selected.id, 'DEPLOYING')} />
+                    <ActionBtn label={deploying ? 'Запуск...' : '→ Deploy Staging'} color={C.acc} onClick={() => handleDeployStaging(selected.id)} disabled={deploying} />
                   )}
                   {selected.state === 'DEPLOYING' && (
                     <>
@@ -370,7 +406,7 @@ export default function PipelineDashboardPage() {
                     </>
                   )}
                   {selected.state === 'PASSED' && (
-                    <ActionBtn label="🚀 Deploy to Production" color={C.acc} onClick={() => handleTransition(selected.id, 'RELEASED')} />
+                    <ActionBtn label={deploying ? 'Запуск...' : '🚀 Deploy to Production'} color={C.acc} onClick={() => handleDeployProd(selected.id)} disabled={deploying} />
                   )}
                   {selected.state === 'FAILED' && (
                     <ActionBtn label="↩ Restart" color={C.muted} onClick={() => handleTransition(selected.id, 'COLLECTING')} />
@@ -411,11 +447,12 @@ export default function PipelineDashboardPage() {
 }
 
 // ── Small helper ──────────────────────────────────────────────────────────────
-function ActionBtn({ label, color, onClick }: { label: string; color: string; onClick: () => void }) {
+function ActionBtn({ label, color, onClick, disabled }: { label: string; color: string; onClick: () => void; disabled?: boolean }) {
   return (
     <button
       onClick={onClick}
-      style={{ fontSize: 12, fontWeight: 600, color: '#FFF', backgroundColor: color, border: 'none', borderRadius: 6, padding: '5px 12px', cursor: 'pointer', fontFamily: '"Inter", system-ui, sans-serif' }}
+      disabled={disabled}
+      style={{ fontSize: 12, fontWeight: 600, color: '#FFF', backgroundColor: color, border: 'none', borderRadius: 6, padding: '5px 12px', cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.6 : 1, fontFamily: '"Inter", system-ui, sans-serif' }}
     >
       {label}
     </button>

--- a/frontend/src/pages/PipelineDashboardPage.tsx
+++ b/frontend/src/pages/PipelineDashboardPage.tsx
@@ -394,10 +394,7 @@ export default function PipelineDashboardPage() {
                     <ActionBtn label={deploying ? 'Запуск...' : '→ Deploy Staging'} color={C.acc} onClick={() => handleDeployStaging(selected.id)} disabled={deploying} />
                   )}
                   {selected.state === 'DEPLOYING' && (
-                    <>
-                      <ActionBtn label="→ Testing" color={C.warn} onClick={() => handleTransition(selected.id, 'TESTING')} />
-                      <ActionBtn label="✗ Failed" color={C.error} onClick={() => handleTransition(selected.id, 'FAILED')} />
-                    </>
+                    <span style={{ fontSize: 12, color: C.warn, fontStyle: 'italic' }}>⟳ Деплой в процессе...</span>
                   )}
                   {selected.state === 'TESTING' && (
                     <>

--- a/frontend/src/pages/PipelineDashboardPage.tsx
+++ b/frontend/src/pages/PipelineDashboardPage.tsx
@@ -200,7 +200,7 @@ export default function PipelineDashboardPage() {
 
   // Poll every 10s when a batch is actively deploying
   useEffect(() => {
-    const hasActive = batches.some(b => ['DEPLOYING'].includes(b.state));
+    const hasActive = batches.some(b => b.state === 'DEPLOYING');
     if (!hasActive) return;
     const id = setInterval(() => load(), 10_000);
     return () => clearInterval(id);

--- a/frontend/src/pages/PipelineDashboardPage.tsx
+++ b/frontend/src/pages/PipelineDashboardPage.tsx
@@ -161,7 +161,8 @@ export default function PipelineDashboardPage() {
     }
   };
 
-  const [deploying, setDeploying] = useState(false);
+  const [stagingDeploying, setStagingDeploying] = useState<string | null>(null);
+  const [prodDeploying, setProdDeploying] = useState<string | null>(null);
 
   const handleTransition = async (batchId: string, state: BatchState) => {
     try {
@@ -173,7 +174,7 @@ export default function PipelineDashboardPage() {
   };
 
   const handleDeployStaging = async (batchId: string) => {
-    setDeploying(true);
+    setStagingDeploying(batchId);
     setError(null);
     try {
       await pipelineApi.deployStagingBatch(batchId);
@@ -181,12 +182,12 @@ export default function PipelineDashboardPage() {
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Ошибка запуска деплоя на стейдж');
     } finally {
-      setDeploying(false);
+      setStagingDeploying(null);
     }
   };
 
   const handleDeployProd = async (batchId: string) => {
-    setDeploying(true);
+    setProdDeploying(batchId);
     setError(null);
     try {
       await pipelineApi.deployProductionBatch(batchId);
@@ -194,17 +195,17 @@ export default function PipelineDashboardPage() {
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Ошибка запуска деплоя в прод');
     } finally {
-      setDeploying(false);
+      setProdDeploying(null);
     }
   };
 
-  // Poll every 10s when a batch is actively deploying
+  // Poll every 10s when staging deploy active OR production dispatch in flight
   useEffect(() => {
-    const hasActive = batches.some(b => b.state === 'DEPLOYING');
+    const hasActive = batches.some(b => b.state === 'DEPLOYING') || prodDeploying !== null;
     if (!hasActive) return;
     const id = setInterval(() => load(), 10_000);
     return () => clearInterval(id);
-  }, [batches, load]);
+  }, [batches, prodDeploying, load]);
 
   // Derived stats
   const activeBatch = batches.find(b => ['COLLECTING','DEPLOYING','TESTING','PASSED'].includes(b.state));
@@ -391,7 +392,7 @@ export default function PipelineDashboardPage() {
                 {/* Actions */}
                 <div style={{ padding: '12px 16px', borderTop: `1px solid ${C.border}`, display: 'flex', flexWrap: 'wrap', gap: 8 }}>
                   {selected.state === 'COLLECTING' && (
-                    <ActionBtn label={deploying ? 'Запуск...' : '→ Deploy Staging'} color={C.acc} onClick={() => handleDeployStaging(selected.id)} disabled={deploying} />
+                    <ActionBtn label={stagingDeploying === selected.id ? 'Запуск...' : '→ Deploy Staging'} color={C.acc} onClick={() => handleDeployStaging(selected.id)} disabled={stagingDeploying !== null} />
                   )}
                   {selected.state === 'DEPLOYING' && (
                     <span style={{ fontSize: 12, color: C.warn, fontStyle: 'italic' }}>⟳ Деплой в процессе...</span>
@@ -403,7 +404,7 @@ export default function PipelineDashboardPage() {
                     </>
                   )}
                   {selected.state === 'PASSED' && (
-                    <ActionBtn label={deploying ? 'Запуск...' : '🚀 Deploy to Production'} color={C.acc} onClick={() => handleDeployProd(selected.id)} disabled={deploying} />
+                    <ActionBtn label={prodDeploying === selected.id ? 'Запуск...' : '🚀 Deploy to Production'} color={C.acc} onClick={() => handleDeployProd(selected.id)} disabled={prodDeploying !== null} />
                   )}
                   {selected.state === 'FAILED' && (
                     <ActionBtn label="↩ Restart" color={C.muted} onClick={() => handleTransition(selected.id, 'COLLECTING')} />

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -52,7 +52,7 @@
   --space-6: 16px;
   --space-7: 20px;
   --space-8: 24px;
-  --font-display: "Space Grotesk", Inter, system-ui, sans-serif;
+  --font-display: Space Grotesk, Inter, system-ui, sans-serif;
   --font-sans: Inter, system-ui, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --fs-xs: 12px;

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -52,8 +52,8 @@
   --space-6: 16px;
   --space-7: 20px;
   --space-8: 24px;
-  --font-display: "Space Grotesk", Inter, system-ui, sans-serif;
-  --font-sans: Inter, system-ui, sans-serif;
+  --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
+  --font-sans: "Inter", system-ui, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --fs-xs: 12px;
   --fs-sm: 13px;

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -52,7 +52,7 @@
   --space-6: 16px;
   --space-7: 20px;
   --space-8: 24px;
-  --font-display: Space Grotesk, Inter, system-ui, sans-serif;
+  --font-display: "Space Grotesk", Inter, system-ui, sans-serif;
   --font-sans: Inter, system-ui, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --fs-xs: 12px;

--- a/pipeline-service/src/config.ts
+++ b/pipeline-service/src/config.ts
@@ -20,6 +20,9 @@ const envSchema = z.object({
   // Polling interval in seconds (min 30s to respect GitHub rate limits)
   SYNC_INTERVAL_SEC: z.coerce.number().min(30).max(3600).default(60),
 
+  // GitHub Actions dispatch — owner/repo derived from APP_GITHUB_REPOS, override if needed
+  PIPELINE_GITHUB_REF: z.string().default('main'),
+
   // Flow Universe API (for issue/release resolution)
   FU_API_URL: z.string().optional(),
   FU_API_KEY: z.string().optional(),

--- a/pipeline-service/src/modules/batches/batches.router.ts
+++ b/pipeline-service/src/modules/batches/batches.router.ts
@@ -228,7 +228,7 @@ async function getImageTag(batchId: string): Promise<string> {
     where: { id: batchId },
     include: { pullRequests: { orderBy: { mergedAt: 'desc' }, take: 1 } },
   });
-  return batch?.pullRequests[0]?.mergedSha?.slice(0, 7) ?? '';
+  return batch?.pullRequests[0]?.mergedSha ?? '';
 }
 
 // ─── POST /api/batches/:id/deploy-staging ─────────────────────────────────────
@@ -250,10 +250,6 @@ router.post('/:id/deploy-staging', async (req, res, next) => {
     }
 
     const [owner, repo] = getOwnerRepo();
-    await triggerWorkflowDispatch(owner, repo, 'deploy-staging.yml', config.PIPELINE_GITHUB_REF, {
-      image_tag: imageTag,
-      batch_id: batchId,
-    });
 
     const [deployEvent, updatedBatch] = await prisma.$transaction([
       prisma.deployEvent.create({
@@ -265,6 +261,16 @@ router.post('/:id/deploy-staging', async (req, res, next) => {
         include: { pullRequests: { select: { id: true, externalId: true, title: true, ciStatus: true } }, deployEvents: { orderBy: { startedAt: 'desc' }, take: 5 } },
       }),
     ]);
+
+    try {
+      await triggerWorkflowDispatch(owner, repo, 'deploy-staging.yml', config.PIPELINE_GITHUB_REF, {
+        image_tag: imageTag,
+        batch_id: batchId,
+      });
+    } catch (dispatchErr) {
+      await prisma.deployEvent.update({ where: { id: deployEvent.id }, data: { status: 'FAILURE', finishedAt: new Date() } });
+      throw dispatchErr;
+    }
 
     res.json({ data: updatedBatch, deployEvent });
   } catch (err) {
@@ -284,6 +290,14 @@ router.post('/:id/deploy-production', async (req, res, next) => {
       return;
     }
 
+    const runningProd = await prisma.deployEvent.findFirst({
+      where: { stagingBatchId: batchId, target: 'PRODUCTION', status: 'RUNNING' },
+    });
+    if (runningProd) {
+      res.status(409).json({ error: 'A production deploy is already in progress for this batch' });
+      return;
+    }
+
     const imageTag = (req.body?.imageTag as string | undefined) || await getImageTag(batchId);
     if (!imageTag) {
       res.status(422).json({ error: 'No imageTag available — batch has no merged PRs with a SHA' });
@@ -291,10 +305,6 @@ router.post('/:id/deploy-production', async (req, res, next) => {
     }
 
     const [owner, repo] = getOwnerRepo();
-    await triggerWorkflowDispatch(owner, repo, 'deploy-production.yml', config.PIPELINE_GITHUB_REF, {
-      image_tag: imageTag,
-      batch_id: batchId,
-    });
 
     const [deployEvent, updatedBatch] = await prisma.$transaction([
       prisma.deployEvent.create({
@@ -306,6 +316,16 @@ router.post('/:id/deploy-production', async (req, res, next) => {
         include: { pullRequests: { select: { id: true, externalId: true, title: true, ciStatus: true } }, deployEvents: { orderBy: { startedAt: 'desc' }, take: 5 } },
       }),
     ]);
+
+    try {
+      await triggerWorkflowDispatch(owner, repo, 'deploy-production.yml', config.PIPELINE_GITHUB_REF, {
+        image_tag: imageTag,
+        batch_id: batchId,
+      });
+    } catch (dispatchErr) {
+      await prisma.deployEvent.update({ where: { id: deployEvent.id }, data: { status: 'FAILURE', finishedAt: new Date() } });
+      throw dispatchErr;
+    }
 
     res.json({ data: updatedBatch, deployEvent });
   } catch (err) {

--- a/pipeline-service/src/modules/batches/batches.router.ts
+++ b/pipeline-service/src/modules/batches/batches.router.ts
@@ -215,11 +215,13 @@ export { router as batchesRouter };
 
 /** Parse APP_GITHUB_REPOS → [owner, repo] or throw */
 function getOwnerRepo(): [string, string] {
-  const ownerRepo = config.APP_GITHUB_REPOS.split(',').map((s: string) => s.trim()).find(Boolean);
-  if (!ownerRepo) throw new Error('APP_GITHUB_REPOS is not configured');
-  const parts = ownerRepo.split('/');
-  if (parts.length !== 2 || !parts[0] || !parts[1]) throw new Error(`Invalid APP_GITHUB_REPOS: ${ownerRepo}`);
-  return [parts[0], parts[1]];
+  const ownerRepo = config.APP_GITHUB_REPOS
+    .split(',')
+    .map((s: string) => s.trim())
+    .find(r => /^[^/\s]+\/[^/\s]+$/.test(r));
+  if (!ownerRepo) throw new Error('APP_GITHUB_REPOS is empty or contains no valid "owner/repo" entry');
+  const [owner, repo] = ownerRepo.split('/');
+  return [owner, repo];
 }
 
 /** Latest mergedSha from batch PRs, or '' */
@@ -290,14 +292,6 @@ router.post('/:id/deploy-production', async (req, res, next) => {
       return;
     }
 
-    const runningProd = await prisma.deployEvent.findFirst({
-      where: { stagingBatchId: batchId, target: 'PRODUCTION', status: 'RUNNING' },
-    });
-    if (runningProd) {
-      res.status(409).json({ error: 'A production deploy is already in progress for this batch' });
-      return;
-    }
-
     const imageTag = (req.body?.imageTag as string | undefined) || await getImageTag(batchId);
     if (!imageTag) {
       res.status(422).json({ error: 'No imageTag available — batch has no merged PRs with a SHA' });
@@ -306,16 +300,34 @@ router.post('/:id/deploy-production', async (req, res, next) => {
 
     const [owner, repo] = getOwnerRepo();
 
-    const [deployEvent, updatedBatch] = await prisma.$transaction([
-      prisma.deployEvent.create({
-        data: { target: 'PRODUCTION', status: 'RUNNING', imageTag, gitSha: imageTag, triggeredById: req.caller?.userId ?? 'unknown', stagingBatchId: batchId },
-      }),
-      prisma.stagingBatch.update({
-        where: { id: batchId },
-        data: {},  // state stays PASSED until callback confirms success
-        include: { pullRequests: { select: { id: true, externalId: true, title: true, ciStatus: true } }, deployEvents: { orderBy: { startedAt: 'desc' }, take: 5 } },
-      }),
-    ]);
+    // Duplicate-protection + event creation in a single interactive transaction
+    // to close the check-then-insert race window.
+    let deployEvent: import('@prisma/client').DeployEvent;
+    let updatedBatch: import('@prisma/client').StagingBatch & { pullRequests: { id: string; externalId: number; title: string; ciStatus: string }[]; deployEvents: import('@prisma/client').DeployEvent[] };
+    try {
+      [deployEvent, updatedBatch] = await prisma.$transaction(async (tx) => {
+        const running = await tx.deployEvent.findFirst({
+          where: { stagingBatchId: batchId, target: 'PRODUCTION', status: 'RUNNING' },
+        });
+        if (running) throw Object.assign(new Error('ALREADY_RUNNING'), { code: 'ALREADY_RUNNING' });
+
+        const event = await tx.deployEvent.create({
+          data: { target: 'PRODUCTION', status: 'RUNNING', imageTag, gitSha: imageTag, triggeredById: req.caller?.userId ?? 'unknown', stagingBatchId: batchId },
+        });
+        const btch = await tx.stagingBatch.update({
+          where: { id: batchId },
+          data: {},  // state stays PASSED until callback confirms success
+          include: { pullRequests: { select: { id: true, externalId: true, title: true, ciStatus: true } }, deployEvents: { orderBy: { startedAt: 'desc' }, take: 5 } },
+        });
+        return [event, btch];
+      });
+    } catch (txErr: unknown) {
+      if ((txErr as { code?: string }).code === 'ALREADY_RUNNING') {
+        res.status(409).json({ error: 'A production deploy is already in progress for this batch' });
+        return;
+      }
+      throw txErr;
+    }
 
     try {
       await triggerWorkflowDispatch(owner, repo, 'deploy-production.yml', config.PIPELINE_GITHUB_REF, {

--- a/pipeline-service/src/modules/batches/batches.router.ts
+++ b/pipeline-service/src/modules/batches/batches.router.ts
@@ -349,6 +349,7 @@ router.post('/:id/deploy-production', async (req, res, next) => {
 
 const callbackBody = z.object({
   status: z.enum(['SUCCESS', 'FAILURE']),
+  target: z.enum(['STAGING', 'PRODUCTION']).optional(),
   workflowRunId: z.number().optional(),
   workflowRunUrl: z.string().url().optional(),
   errorMessage: z.string().optional(),
@@ -357,7 +358,7 @@ const callbackBody = z.object({
 router.post('/:id/deploy-callback', validate(callbackBody), async (req, res, next) => {
   try {
     const batchId = req.params.id as string;
-    const { status, workflowRunId, workflowRunUrl, errorMessage } = req.body as z.infer<typeof callbackBody>;
+    const { status, target: callbackTarget, workflowRunId, workflowRunUrl, errorMessage } = req.body as z.infer<typeof callbackBody>;
 
     const batch = await prisma.stagingBatch.findUnique({
       where: { id: batchId },
@@ -374,7 +375,9 @@ router.post('/:id/deploy-callback', validate(callbackBody), async (req, res, nex
       if (runningEvent.target === 'STAGING') {
         newBatchState = status === 'SUCCESS' ? 'TESTING' : 'FAILED';
       } else if (runningEvent.target === 'PRODUCTION') {
-        newBatchState = status === 'SUCCESS' ? 'RELEASED' : 'FAILED';
+        // On production failure, keep batch in PASSED state so deploy can be retried
+        // (PASSED → FAILED is not a valid transition)
+        newBatchState = status === 'SUCCESS' ? 'RELEASED' : null;
       }
     }
 
@@ -392,7 +395,7 @@ router.post('/:id/deploy-callback', validate(callbackBody), async (req, res, nex
             },
           })
         : prisma.deployEvent.create({
-            data: { target: 'STAGING', status: 'FAILURE', imageTag: 'unknown', triggeredById: 'callback', stagingBatchId: batchId, errorMessage: 'No running deploy found' },
+            data: { target: callbackTarget ?? 'STAGING', status: 'FAILURE', imageTag: 'unknown', triggeredById: 'callback', stagingBatchId: batchId, errorMessage: 'No running deploy found' },
           }),
       prisma.stagingBatch.update({
         where: { id: batchId },

--- a/pipeline-service/src/modules/batches/batches.router.ts
+++ b/pipeline-service/src/modules/batches/batches.router.ts
@@ -4,6 +4,8 @@ import { prisma } from '../../prisma/client.js';
 import { apiKeyAuth } from '../../shared/middleware/api-key-auth.js';
 import { validate } from '../../shared/middleware/validate.js';
 import type { StagingBatchState } from '@prisma/client';
+import { triggerWorkflowDispatch } from '../github/github.client.js';
+import { config } from '../../config.js';
 
 const router = Router();
 router.use(apiKeyAuth);
@@ -208,3 +210,167 @@ router.delete('/:id/prs/:prId', async (req, res, next) => {
 });
 
 export { router as batchesRouter };
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Parse APP_GITHUB_REPOS → [owner, repo] or throw */
+function getOwnerRepo(): [string, string] {
+  const ownerRepo = config.APP_GITHUB_REPOS.split(',').map((s: string) => s.trim()).find(Boolean);
+  if (!ownerRepo) throw new Error('APP_GITHUB_REPOS is not configured');
+  const parts = ownerRepo.split('/');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) throw new Error(`Invalid APP_GITHUB_REPOS: ${ownerRepo}`);
+  return [parts[0], parts[1]];
+}
+
+/** Latest mergedSha from batch PRs, or '' */
+async function getImageTag(batchId: string): Promise<string> {
+  const batch = await prisma.stagingBatch.findUnique({
+    where: { id: batchId },
+    include: { pullRequests: { orderBy: { mergedAt: 'desc' }, take: 1 } },
+  });
+  return batch?.pullRequests[0]?.mergedSha?.slice(0, 7) ?? '';
+}
+
+// ─── POST /api/batches/:id/deploy-staging ─────────────────────────────────────
+
+router.post('/:id/deploy-staging', async (req, res, next) => {
+  try {
+    const batchId = req.params.id as string;
+    const batch = await prisma.stagingBatch.findUnique({ where: { id: batchId } });
+    if (!batch) { res.status(404).json({ error: 'Batch not found' }); return; }
+    if (!['COLLECTING', 'MERGING'].includes(batch.state)) {
+      res.status(422).json({ error: `Batch must be COLLECTING or MERGING to deploy staging (current: ${batch.state})` });
+      return;
+    }
+
+    const imageTag = (req.body?.imageTag as string | undefined) || await getImageTag(batchId);
+    if (!imageTag) {
+      res.status(422).json({ error: 'No imageTag available — batch has no merged PRs with a SHA' });
+      return;
+    }
+
+    const [owner, repo] = getOwnerRepo();
+    await triggerWorkflowDispatch(owner, repo, 'deploy-staging.yml', config.PIPELINE_GITHUB_REF, {
+      image_tag: imageTag,
+      batch_id: batchId,
+    });
+
+    const [deployEvent, updatedBatch] = await prisma.$transaction([
+      prisma.deployEvent.create({
+        data: { target: 'STAGING', status: 'RUNNING', imageTag, gitSha: imageTag, triggeredById: req.caller?.userId ?? 'unknown', stagingBatchId: batchId },
+      }),
+      prisma.stagingBatch.update({
+        where: { id: batchId },
+        data: { state: 'DEPLOYING' },
+        include: { pullRequests: { select: { id: true, externalId: true, title: true, ciStatus: true } }, deployEvents: { orderBy: { startedAt: 'desc' }, take: 5 } },
+      }),
+    ]);
+
+    res.json({ data: updatedBatch, deployEvent });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── POST /api/batches/:id/deploy-production ──────────────────────────────────
+
+router.post('/:id/deploy-production', async (req, res, next) => {
+  try {
+    const batchId = req.params.id as string;
+    const batch = await prisma.stagingBatch.findUnique({ where: { id: batchId } });
+    if (!batch) { res.status(404).json({ error: 'Batch not found' }); return; }
+    if (batch.state !== 'PASSED') {
+      res.status(422).json({ error: `Batch must be PASSED to deploy production (current: ${batch.state})` });
+      return;
+    }
+
+    const imageTag = (req.body?.imageTag as string | undefined) || await getImageTag(batchId);
+    if (!imageTag) {
+      res.status(422).json({ error: 'No imageTag available — batch has no merged PRs with a SHA' });
+      return;
+    }
+
+    const [owner, repo] = getOwnerRepo();
+    await triggerWorkflowDispatch(owner, repo, 'deploy-production.yml', config.PIPELINE_GITHUB_REF, {
+      image_tag: imageTag,
+      batch_id: batchId,
+    });
+
+    const [deployEvent, updatedBatch] = await prisma.$transaction([
+      prisma.deployEvent.create({
+        data: { target: 'PRODUCTION', status: 'RUNNING', imageTag, gitSha: imageTag, triggeredById: req.caller?.userId ?? 'unknown', stagingBatchId: batchId },
+      }),
+      prisma.stagingBatch.update({
+        where: { id: batchId },
+        data: {},  // state stays PASSED until callback confirms success
+        include: { pullRequests: { select: { id: true, externalId: true, title: true, ciStatus: true } }, deployEvents: { orderBy: { startedAt: 'desc' }, take: 5 } },
+      }),
+    ]);
+
+    res.json({ data: updatedBatch, deployEvent });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── POST /api/batches/:id/deploy-callback ────────────────────────────────────
+
+const callbackBody = z.object({
+  status: z.enum(['SUCCESS', 'FAILURE']),
+  workflowRunId: z.number().optional(),
+  workflowRunUrl: z.string().url().optional(),
+  errorMessage: z.string().optional(),
+});
+
+router.post('/:id/deploy-callback', validate(callbackBody), async (req, res, next) => {
+  try {
+    const batchId = req.params.id as string;
+    const { status, workflowRunId, workflowRunUrl, errorMessage } = req.body as z.infer<typeof callbackBody>;
+
+    const batch = await prisma.stagingBatch.findUnique({
+      where: { id: batchId },
+      include: { deployEvents: { where: { status: 'RUNNING' }, orderBy: { startedAt: 'desc' }, take: 1 } },
+    });
+    if (!batch) { res.status(404).json({ error: 'Batch not found' }); return; }
+
+    const runningEvent = batch.deployEvents[0];
+    const finishedAt = new Date();
+
+    // Determine new batch state based on deploy target + result
+    let newBatchState: import('@prisma/client').StagingBatchState | null = null;
+    if (runningEvent) {
+      if (runningEvent.target === 'STAGING') {
+        newBatchState = status === 'SUCCESS' ? 'TESTING' : 'FAILED';
+      } else if (runningEvent.target === 'PRODUCTION') {
+        newBatchState = status === 'SUCCESS' ? 'RELEASED' : 'FAILED';
+      }
+    }
+
+    const [updatedEvent, updatedBatch] = await prisma.$transaction([
+      runningEvent
+        ? prisma.deployEvent.update({
+            where: { id: runningEvent.id },
+            data: {
+              status: status === 'SUCCESS' ? 'SUCCESS' : 'FAILURE',
+              finishedAt,
+              durationMs: runningEvent.startedAt ? finishedAt.getTime() - runningEvent.startedAt.getTime() : null,
+              workflowRunId: workflowRunId ?? null,
+              workflowRunUrl: workflowRunUrl ?? null,
+              errorMessage: errorMessage ?? null,
+            },
+          })
+        : prisma.deployEvent.create({
+            data: { target: 'STAGING', status: 'FAILURE', imageTag: 'unknown', triggeredById: 'callback', stagingBatchId: batchId, errorMessage: 'No running deploy found' },
+          }),
+      prisma.stagingBatch.update({
+        where: { id: batchId },
+        data: newBatchState ? { state: newBatchState } : {},
+        include: { pullRequests: { select: { id: true, externalId: true, title: true, ciStatus: true } }, deployEvents: { orderBy: { startedAt: 'desc' }, take: 5 } },
+      }),
+    ]);
+
+    res.json({ data: updatedBatch, deployEvent: updatedEvent });
+  } catch (err) {
+    next(err);
+  }
+});

--- a/pipeline-service/src/modules/github/github.client.ts
+++ b/pipeline-service/src/modules/github/github.client.ts
@@ -138,3 +138,27 @@ export async function listCheckRunsForCommit(
   );
   return check_runs;
 }
+
+export async function triggerWorkflowDispatch(
+  owner: string,
+  repo: string,
+  workflowFile: string,
+  ref: string,
+  inputs: Record<string, string>,
+): Promise<void> {
+  const res = await fetch(`${BASE}/repos/${owner}/${repo}/actions/workflows/${workflowFile}/dispatches`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ ref, inputs }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`GitHub workflow dispatch failed (${res.status}): ${text}`);
+  }
+}

--- a/pipeline-service/src/modules/github/github.client.ts
+++ b/pipeline-service/src/modules/github/github.client.ts
@@ -150,16 +150,25 @@ export async function triggerWorkflowDispatch(
     throw new Error('GITHUB_TOKEN is not configured — cannot trigger workflow dispatch');
   }
 
-  const res = await fetch(`${BASE}/repos/${owner}/${repo}/actions/workflows/${workflowFile}/dispatches`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${config.GITHUB_TOKEN}`,
-      Accept: 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ ref, inputs }),
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  let res: Response;
+  try {
+    res = await fetch(`${BASE}/repos/${owner}/${repo}/actions/workflows/${workflowFile}/dispatches`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ref, inputs }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
 
   if (!res.ok) {
     const text = await res.text().catch(() => '');

--- a/pipeline-service/src/modules/github/github.client.ts
+++ b/pipeline-service/src/modules/github/github.client.ts
@@ -146,6 +146,10 @@ export async function triggerWorkflowDispatch(
   ref: string,
   inputs: Record<string, string>,
 ): Promise<void> {
+  if (!config.GITHUB_TOKEN) {
+    throw new Error('GITHUB_TOKEN is not configured — cannot trigger workflow dispatch');
+  }
+
   const res = await fetch(`${BASE}/repos/${owner}/${repo}/actions/workflows/${workflowFile}/dispatches`, {
     method: 'POST',
     headers: {
@@ -159,6 +163,7 @@ export async function triggerWorkflowDispatch(
 
   if (!res.ok) {
     const text = await res.text().catch(() => '');
-    throw new Error(`GitHub workflow dispatch failed (${res.status}): ${text}`);
+    const hint = res.status === 403 ? ' — check that GITHUB_TOKEN has Actions: write permission on this repo' : '';
+    throw new Error(`GitHub workflow dispatch failed (${res.status})${hint}: ${text}`);
   }
 }

--- a/pipeline-service/src/modules/github/github.router.ts
+++ b/pipeline-service/src/modules/github/github.router.ts
@@ -12,12 +12,15 @@ const SYNC_TYPE = 'github-merged-prs';
 // POST /api/github/sync — pull merged PRs from configured repo
 githubRouter.post('/sync', async (_req, res, next) => {
   try {
-    const repo = config.APP_GITHUB_REPOS
-      .split(',')
-      .map(r => r.trim())
-      .find(r => /^[^/\s]+\/[^/\s]+$/.test(r));
+    const repos = config.APP_GITHUB_REPOS.split(',').map(r => r.trim()).filter(Boolean);
+    const invalid = repos.find(r => !/^[^/\s]+\/[^/\s]+$/.test(r));
+    if (invalid) {
+      res.status(422).json({ error: `Invalid APP_GITHUB_REPOS entry: "${invalid}" (expected "owner/repo")` });
+      return;
+    }
+    const repo = repos[0];
     if (!repo) {
-      res.status(422).json({ error: 'APP_GITHUB_REPOS not configured or invalid (expected "owner/repo")' });
+      res.status(422).json({ error: 'APP_GITHUB_REPOS not configured (expected "owner/repo")' });
       return;
     }
 

--- a/pipeline-service/src/modules/github/github.router.ts
+++ b/pipeline-service/src/modules/github/github.router.ts
@@ -65,6 +65,12 @@ githubRouter.post('/sync', async (_req, res, next) => {
           stagingBatchId: collectingBatchId,
         },
       });
+
+      // If the PR existed as an open PR (batchId=null), assign it to collecting batch now
+      await prisma.pullRequestSnapshot.updateMany({
+        where: { source: 'GITHUB', repo, externalId: pr.number, stagingBatchId: null },
+        data: { stagingBatchId: collectingBatchId },
+      });
     }
 
     // Do NOT advance the sync cursor when results were truncated — next sync will re-fetch the same range

--- a/pipeline-service/src/modules/github/github.router.ts
+++ b/pipeline-service/src/modules/github/github.router.ts
@@ -114,17 +114,19 @@ githubRouter.get('/prs', async (req, res, next) => {
 
 // ── Helper: get or create COLLECTING batch ────────────────────────────────────
 async function getOrCreateCollectingBatchId(): Promise<string> {
-  const existing = await prisma.stagingBatch.findFirst({
-    where: { state: 'COLLECTING' },
-    orderBy: { createdAt: 'desc' },
-  });
-  if (existing) return existing.id;
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.stagingBatch.findFirst({
+      where: { state: 'COLLECTING' },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (existing) return existing.id;
 
-  const created = await prisma.stagingBatch.create({
-    data: {
-      name: `Batch ${new Date().toISOString().slice(0, 10)}`,
-      createdById: 'system',
-    },
+    const created = await tx.stagingBatch.create({
+      data: {
+        name: `Batch ${new Date().toISOString().slice(0, 10)}`,
+        createdById: 'system',
+      },
+    });
+    return created.id;
   });
-  return created.id;
 }

--- a/pipeline-service/src/modules/github/github.router.ts
+++ b/pipeline-service/src/modules/github/github.router.ts
@@ -18,6 +18,10 @@ githubRouter.post('/sync', async (_req, res, next) => {
       res.status(422).json({ error: `Invalid APP_GITHUB_REPOS entry: "${invalid}" (expected "owner/repo")` });
       return;
     }
+    if (repos.length > 1) {
+      res.status(422).json({ error: 'Multiple repositories not supported; supply a single "owner/repo" in APP_GITHUB_REPOS' });
+      return;
+    }
     const repo = repos[0];
     if (!repo) {
       res.status(422).json({ error: 'APP_GITHUB_REPOS not configured (expected "owner/repo")' });

--- a/pipeline-service/src/modules/sync/sync.service.ts
+++ b/pipeline-service/src/modules/sync/sync.service.ts
@@ -165,14 +165,12 @@ async function syncDeployRuns(owner: string, repo: string): Promise<number> {
 // ─── main sync ────────────────────────────────────────────────────────────────
 
 export async function runSync(): Promise<{ prs: number; deploys: number }> {
-  const ownerRepo = config.APP_GITHUB_REPOS.split(',').map(s => s.trim()).find(Boolean);
+  const repos = config.APP_GITHUB_REPOS.split(',').map(s => s.trim()).filter(Boolean);
+  const invalid = repos.find(r => !/^[^/\s]+\/[^/\s]+$/.test(r));
+  if (invalid) throw new Error(`Invalid APP_GITHUB_REPOS entry: "${invalid}". Expected owner/repo`);
+  const ownerRepo = repos[0];
   if (!ownerRepo) throw new Error('APP_GITHUB_REPOS is empty');
-
-  const parts = ownerRepo.split('/').map(s => s.trim());
-  if (parts.length !== 2 || !parts[0] || !parts[1]) {
-    throw new Error(`Invalid APP_GITHUB_REPOS format: ${ownerRepo}. Expected owner/repo`);
-  }
-  const [owner, repo] = parts;
+  const [owner, repo] = ownerRepo.split('/');
 
   const [prs, deploys] = await Promise.all([
     syncPRs(owner, repo),

--- a/pipeline-service/src/server.ts
+++ b/pipeline-service/src/server.ts
@@ -8,7 +8,12 @@ app.listen(config.PORT, () => {
   console.log(`Pipeline Service running on port ${config.PORT} [${config.NODE_ENV}]`);
 
   // Start GitHub polling loop
-  if (config.APP_GITHUB_REPOS) {
+  const hasValidRepo = config.APP_GITHUB_REPOS
+    .split(',')
+    .map(r => r.trim())
+    .some(r => /^[^/\s]+\/[^/\s]+$/.test(r));
+
+  if (hasValidRepo) {
     const intervalMs = config.SYNC_INTERVAL_SEC * 1000;
     console.log(`GitHub polling every ${config.SYNC_INTERVAL_SEC}s for: ${config.APP_GITHUB_REPOS}`);
 

--- a/scripts/doc-reminder.sh
+++ b/scripts/doc-reminder.sh
@@ -10,7 +10,7 @@ FILE="$1"
 FILE="${FILE#./}"
 
 # Always resolve MAIN REPO (works from worktrees too)
-MAIN_REPO=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree/{print $2; exit}')
+MAIN_REPO=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree/{sub(/^worktree /, ""); print; exit}')
 [ -z "$MAIN_REPO" ] && MAIN_REPO=$(git rev-parse --show-toplevel 2>/dev/null)
 [ -z "$MAIN_REPO" ] && exit 0
 
@@ -43,16 +43,14 @@ remind() {
 if echo "$FILE" | grep -qE '\.(ts|tsx|js|jsx|prisma|yml|yaml|sh)$' && \
    ! echo "$FILE" | grep -qE '(node_modules|\.gen\.|\.d\.ts|dist/|build/)'; then
 
-  CHANGELOG="$MAIN_REPO/docs/CHANGELOG-CLAUDE-2026-03.md"
-  if [ -f "$CHANGELOG" ]; then
-    # Find or create today's entry
-    TODAY=$(date '+%Y-%m-%d')
-    if ! grep -q "^## $TODAY" "$CHANGELOG" 2>/dev/null; then
-      echo "" >> "$CHANGELOG"
-      echo "## $TODAY" >> "$CHANGELOG"
-    fi
-    echo "- \`$FILE\`" >> "$CHANGELOG"
+  CHANGELOG="$MAIN_REPO/docs/CHANGELOG-CLAUDE-$(date '+%Y-%m').md"
+  mkdir -p "$(dirname "$CHANGELOG")"
+  TODAY=$(date '+%Y-%m-%d')
+  if ! grep -q "^## $TODAY" "$CHANGELOG" 2>/dev/null; then
+    echo "" >> "$CHANGELOG"
+    echo "## $TODAY" >> "$CHANGELOG"
   fi
+  echo "- \`$FILE\`" >> "$CHANGELOG"
 fi
 
 # ── AUTO: generate-docs for API/schema/routing files ─────────────────────────

--- a/scripts/doc-reminder.sh
+++ b/scripts/doc-reminder.sh
@@ -1,47 +1,147 @@
 #!/usr/bin/env bash
-# doc-reminder.sh — Called by Claude Code PostToolUse hook
-# Only reminds about docs that CANNOT be auto-generated.
-# API reference, data model, modules, frontend routes → auto via CI.
+# doc-reminder.sh — Called by Claude Code PostToolUse hook (Edit|Write)
+#
+# Two-tier doc maintenance:
+#   AUTO:      CHANGELOG append, pending-updates queue, generate-docs for API/schema
+#   REMINDER:  stdout messages for docs that need human/Claude context to update
 
 FILE="$1"
 [ -z "$FILE" ] && exit 0
 FILE="${FILE#./}"
 
-# User manual — UI page changes → human must describe what changed
+# Always resolve MAIN REPO (works from worktrees too)
+MAIN_REPO=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree/{print $2; exit}')
+[ -z "$MAIN_REPO" ] && MAIN_REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+[ -z "$MAIN_REPO" ] && exit 0
+
+# Strip absolute path prefix so FILE is always repo-relative
+FILE="${FILE#$MAIN_REPO/}"
+
+QUEUE_FILE="$MAIN_REPO/.claude/pending-doc-updates.md"
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M')
+REMINDED=0
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+queue_append() {
+  local doc="$1"
+  local reason="$2"
+  mkdir -p "$(dirname "$QUEUE_FILE")"
+  echo "- \`$TIMESTAMP\` — \`$FILE\` → **$doc** ($reason)" >> "$QUEUE_FILE"
+}
+
+remind() {
+  local header="$1"; shift
+  echo ""
+  echo "📋 $header"
+  for msg in "$@"; do echo "   → $msg"; done
+  REMINDED=1
+}
+
+# ── AUTO: CHANGELOG append for any source file change ────────────────────────
+
+if echo "$FILE" | grep -qE '\.(ts|tsx|js|jsx|prisma|yml|yaml|sh)$' && \
+   ! echo "$FILE" | grep -qE '(node_modules|\.gen\.|\.d\.ts|dist/|build/)'; then
+
+  CHANGELOG="$MAIN_REPO/docs/CHANGELOG-CLAUDE-2026-03.md"
+  if [ -f "$CHANGELOG" ]; then
+    # Find or create today's entry
+    TODAY=$(date '+%Y-%m-%d')
+    if ! grep -q "^## $TODAY" "$CHANGELOG" 2>/dev/null; then
+      echo "" >> "$CHANGELOG"
+      echo "## $TODAY" >> "$CHANGELOG"
+    fi
+    echo "- \`$FILE\`" >> "$CHANGELOG"
+  fi
+fi
+
+# ── AUTO: generate-docs for API/schema/routing files ─────────────────────────
+
+if echo "$FILE" | grep -qE 'backend/src/modules/.*\.router\.ts$'; then
+  echo ""
+  echo "✅ Авто: маршруты изменились → запускаю generate-docs --routes"
+  (cd "$MAIN_REPO" && node scripts/generate-docs.js --routes 2>/dev/null) && \
+    echo "   docs/api/reference.md обновлён" || \
+    echo "   ⚠️  generate-docs --routes не смог выполниться"
+fi
+
+if echo "$FILE" | grep -qE 'prisma/schema\.prisma$'; then
+  echo ""
+  echo "✅ Авто: schema.prisma изменилась → запускаю generate-docs --schema"
+  (cd "$MAIN_REPO" && node scripts/generate-docs.js --schema 2>/dev/null) && \
+    echo "   docs/architecture/data-model.md обновлён" || \
+    echo "   ⚠️  generate-docs --schema не смог выполниться"
+fi
+
+if echo "$FILE" | grep -qE 'backend/src/app\.ts$'; then
+  echo ""
+  echo "✅ Авто: app.ts изменился → запускаю generate-docs --modules"
+  (cd "$MAIN_REPO" && node scripts/generate-docs.js --modules 2>/dev/null) && \
+    echo "   docs/architecture/backend-modules.md обновлён" || \
+    echo "   ⚠️  generate-docs --modules не смог выполниться"
+fi
+
+if echo "$FILE" | grep -qE 'frontend/src/App\.tsx$'; then
+  echo ""
+  echo "✅ Авто: App.tsx изменился → запускаю generate-docs --frontend"
+  (cd "$MAIN_REPO" && node scripts/generate-docs.js --frontend 2>/dev/null) && \
+    echo "   docs/architecture/frontend-architecture.md обновлён" || \
+    echo "   ⚠️  generate-docs --frontend не смог выполниться"
+fi
+
+# ── REMINDERS: docs that need Claude/human context ───────────────────────────
+
+# CLAUDE.md — sprint progress, module status, CI/CD state
+if echo "$FILE" | grep -qE 'backend/src/modules/(auth|users|projects|issues|comments|boards|sprints|time|teams|admin|releases)/'; then
+  MODULE=$(echo "$FILE" | sed 's|backend/src/modules/\([^/]*\)/.*|\1|')
+  remind "Изменён модуль \`$MODULE\`" \
+    "Обнови раздел «Текущее состояние» в CLAUDE.md если изменился контракт/поведение" \
+    "Обнови docs/ENG/API.md / docs/RU/API.md если изменились endpoint'ы"
+  queue_append "CLAUDE.md + API.md" "модуль $MODULE"
+fi
+
+# CLAUDE.md — Prisma schema (data model section)
+if echo "$FILE" | grep -qE 'prisma/schema\.prisma$'; then
+  remind "Изменена Prisma-схема" \
+    "Обнови раздел «Иерархия задач» в CLAUDE.md если изменились модели Issue/Sprint" \
+    "docs/RU/architecture/MVP_DOMAIN_MODEL.md может устареть"
+  queue_append "CLAUDE.md + MVP_DOMAIN_MODEL.md" "schema.prisma"
+fi
+
+# UI pages → user manual
 if echo "$FILE" | grep -qE 'frontend/src/pages/'; then
-  echo ""
-  echo "📋 Ремайндер: Изменена UI-страница."
-  echo "   → Обнови docs/user-manual/features/ если изменилось поведение для пользователя"
-  echo "   (API reference и роуты обновятся автоматически после мёрджа)"
+  remind "Изменена UI-страница" \
+    "Обнови docs/user-manual/ если изменилось поведение для пользователя"
+  queue_append "docs/user-manual/" "UI страница"
 fi
 
-# Design system — new public components
+# UI components/ui → design system
 if echo "$FILE" | grep -qE 'frontend/src/components/ui/'; then
-  echo ""
-  echo "📋 Ремайндер: Изменён UI-компонент из /ui/."
-  echo "   → Обнови docs/design-system/overview.md если компонент стал публичным"
+  remind "Изменён компонент из /ui/" \
+    "Обнови docs/design-system/overview.md если компонент стал публичным или изменился API"
+  queue_append "docs/design-system/" "UI компонент"
 fi
 
-# Integration code
-if echo "$FILE" | grep -qE 'backend/src/modules/(integrations|webhooks)/'; then
-  echo ""
-  echo "📋 Ремайндер: Изменён код интеграции."
-  echo "   → Обнови docs/integrations/ (gitlab.md / telegram.md)"
+# Integrations
+if echo "$FILE" | grep -qE 'backend/src/modules/(integrations|webhooks|telegram|gitlab)/'; then
+  remind "Изменён код интеграции" \
+    "Обнови docs/integrations/GITLAB_WEBHOOK.md или docs/integrations/telegram.md"
+  queue_append "docs/integrations/" "интеграция"
 fi
 
-# Deployment config
-if echo "$FILE" | grep -qE '(deploy/|\.github/workflows/)' && ! echo "$FILE" | grep -q 'update-docs'; then
-  echo ""
-  echo "📋 Ремайндер: Изменена конфигурация деплоя/CI."
-  echo "   → Обнови docs/guides/deployment.md"
+# Deploy / CI — но не сам doc-reminder и generate-docs
+if echo "$FILE" | grep -qE '(deploy/|\.github/workflows/)' && \
+   ! echo "$FILE" | grep -qE '(doc-reminder|generate-docs)'; then
+  remind "Изменена конфигурация деплоя/CI" \
+    "Обнови docs/DEPLOY.md и раздел CI/CD в CLAUDE.md"
+  queue_append "CLAUDE.md + docs/DEPLOY.md" "deploy/CI"
 fi
 
-# Auto-generated — just inform
-if echo "$FILE" | grep -qE 'backend/src/modules/.*\.router\.ts|backend/src/prisma/schema\.prisma|backend/src/app\.ts|frontend/src/App\.tsx'; then
-  echo ""
-  echo "✅ Авто-документация обновится сама после мёрджа в main:"
-  echo "   docs/api/reference.md • docs/architecture/data-model.md"
-  echo "   docs/architecture/backend-modules.md • docs/architecture/frontend-architecture.md"
+# Auth middleware / RBAC
+if echo "$FILE" | grep -qE '(middleware|rbac|auth).*\.(ts|js)$'; then
+  remind "Изменена авторизация/middleware" \
+    "Проверь раздел «Роли RBAC» в CLAUDE.md"
+  queue_append "CLAUDE.md (RBAC)" "auth/middleware"
 fi
 
 exit 0


### PR DESCRIPTION
## Что делает

Реализует batch-gated deploy flow для Pipeline Service: PRs копятся в батче → PM нажимает «Deploy Staging» → GitHub Actions деплоит → callback обновляет state machine → после QA деплой в прод.

## Изменения

### Pipeline Service
- `POST /api/batches/:id/deploy-staging` — запускает `workflow_dispatch` на `deploy-staging.yml`, создаёт `DeployEvent`, переводит батч в `DEPLOYING`
- `POST /api/batches/:id/deploy-production` — атомарная duplicate-защита через `$transaction`, запускает прод деплой
- `POST /api/batches/:id/deploy-callback` — принимает результат от GitHub Actions, автоматически переводит state machine (`DEPLOYING→TESTING`, `TESTING→RELEASED` и т.д.)
- `getOrCreateCollectingBatchId` — обёрнут в `$transaction` (фикс race condition при параллельных sync)
- `triggerWorkflowDispatch` — `AbortController` таймаут 10s, GITHUB_TOKEN guard, 403 hint

### GitHub Actions
- `deploy-staging.yml` — `workflow_dispatch` с `image_tag`/`batch_id`, concurrency guard, callback с `target: "STAGING"`
- `deploy-production.yml` — аналогично, callback с `target: "PRODUCTION"`

### Frontend
- `pipelineApi.deployStagingBatch()` / `deployProductionBatch()` — новые методы
- `DEV_KEY` защищён `import.meta.env.DEV`
- `PipelineDashboardPage` — раздельные флаги `stagingDeploying`/`prodDeploying`, polling учитывает production dispatch, DEPLOYING показывает статус вместо ручных кнопок

### Bug fix
- Merged PR без `stagingBatchId` теперь корректно привязывается к collecting батчу (conditional `updateMany`)
- Явный 422 при multiple repos в `APP_GITHUB_REPOS`

## State machine

```
COLLECTING → DEPLOYING → TESTING → PASSED → RELEASED
                ↓                     ↓
              FAILED               FAILED (staging only)
```

## Test plan

- [ ] `POST /api/github/sync` → PR попадает в COLLECTING батч
- [ ] `POST /api/batches/:id/deploy-staging` → батч переходит в DEPLOYING, `DeployEvent` создан
- [ ] `POST /api/batches/:id/deploy-callback` `{ status: "SUCCESS", target: "STAGING" }` → батч в TESTING
- [ ] `POST /api/batches/:id/deploy-callback` `{ status: "FAILURE", target: "STAGING" }` → батч в FAILED
- [ ] `POST /api/batches/:id/deploy-production` из PASSED → PASSED, production `DeployEvent` создан
- [ ] Дублирующий deploy-production → 409 Conflict
- [ ] `deploy-callback` `{ status: "FAILURE", target: "PRODUCTION" }` → батч остаётся в PASSED (retry возможен)
- [ ] Frontend: кнопки staging/production блокируются независимо