### PR TITLE
feat(pipeline): full lifecycle — РЕВЬЮ→CI→БАТЧ→STAGING→ПРОД

### DIFF
--- a/frontend/src/api/pipeline.ts
+++ b/frontend/src/api/pipeline.ts
@@ -169,6 +169,12 @@ export const pipelineApi = {
   removePr: (batchId: string, prId: string) =>
     pipelineFetch<void>(`/api/batches/${batchId}/prs/${prId}`, { method: 'DELETE' }),
 
+  getOpenPrs: async (): Promise<PrSnapshot[]> => {
+    const raw = await pipelineFetch<unknown>('/api/github/prs?state=open');
+    const items = unwrap<unknown[]>(raw);
+    return (Array.isArray(items) ? items : []).map(mapPr);
+  },
+
   syncGitHub: () => pipelineFetch<{ synced: number; repo: string; truncated: boolean }>('/api/github/sync', { method: 'POST' }),
 
   deployStagingBatch: async (batchId: string, imageTag?: string): Promise<StagingBatch> => {

--- a/frontend/src/api/pipeline.ts
+++ b/frontend/src/api/pipeline.ts
@@ -45,7 +45,7 @@ export interface DeployEvent {
 export interface StagingBatch {
   id: string;
   title: string;
-  state: 'COLLECTING' | 'DEPLOYING' | 'TESTING' | 'PASSED' | 'FAILED' | 'RELEASED';
+  state: 'COLLECTING' | 'MERGING' | 'DEPLOYING' | 'TESTING' | 'PASSED' | 'FAILED' | 'RELEASED';
   repo: string;
   createdBy: string;
   notes: string | null;

--- a/frontend/src/pages/PipelineDashboardPage.tsx
+++ b/frontend/src/pages/PipelineDashboardPage.tsx
@@ -402,7 +402,7 @@ export default function PipelineDashboardPage() {
 
                 {/* Actions */}
                 <div style={{ padding: '12px 16px', borderTop: `1px solid ${C.border}`, display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-                  {selected.state === 'COLLECTING' && (
+                  {['COLLECTING', 'MERGING'].includes(selected.state) && (
                     <ActionBtn label={stagingDeploying === selected.id ? 'Запуск...' : '→ Deploy Staging'} color={C.acc} onClick={() => handleDeployStaging(selected.id)} disabled={stagingDeploying !== null} />
                   )}
                   {selected.state === 'DEPLOYING' && (

--- a/frontend/src/pages/PipelineDashboardPage.tsx
+++ b/frontend/src/pages/PipelineDashboardPage.tsx
@@ -147,14 +147,14 @@ export default function PipelineDashboardPage() {
 
   const load = useCallback(async () => {
     try {
-      const [b, h, open] = await Promise.all([
+      const [b, h] = await Promise.all([
         pipelineApi.getBatches(),
         pipelineApi.health(),
-        pipelineApi.getOpenPrs().catch(() => []),
       ]);
       setBatches(b);
       setHealth(h);
-      setOpenPrs(open);
+      // getOpenPrs is best-effort: failure does not block the dashboard
+      pipelineApi.getOpenPrs().then(setOpenPrs).catch(() => {});
       setError(null);
     } catch {
       setError('Pipeline Service недоступен');
@@ -227,7 +227,10 @@ export default function PipelineDashboardPage() {
 
   // Derived stats
   const collectingBatch = batches.find(b => b.state === 'COLLECTING');
-  const stagingBatch = batches.find(b => ['MERGING','DEPLOYING','TESTING','PASSED'].includes(b.state));
+  // Priority: TESTING/PASSED > DEPLOYING/MERGING — avoid MERGING shadowing an active staging deploy
+  const stagingBatch =
+    batches.find(b => ['TESTING', 'PASSED'].includes(b.state)) ??
+    batches.find(b => ['DEPLOYING', 'MERGING'].includes(b.state));
   const lastRelease = batches.find(b => b.state === 'RELEASED');
   const allBatchPrs = batches.flatMap(b => b.pullRequests);
   const failedCi = allBatchPrs.filter(p => p.ciStatus === 'FAILURE').length;

--- a/frontend/src/pages/PipelineDashboardPage.tsx
+++ b/frontend/src/pages/PipelineDashboardPage.tsx
@@ -123,12 +123,21 @@ function PipelineStep({ label, count, items, active, C }: {
   );
 }
 
+function Arrow({ C }: { C: typeof DARK_C }) {
+  return (
+    <div style={{ width: 20, display: 'flex', alignItems: 'flex-start', paddingTop: 10, justifyContent: 'center', flexShrink: 0 }}>
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M5 3l4 4-4 4" stroke={C.muted} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg>
+    </div>
+  );
+}
+
 // ── Main page ─────────────────────────────────────────────────────────────────
 export default function PipelineDashboardPage() {
   const { mode } = useThemeStore();
   const C = mode === 'light' ? LIGHT_C : DARK_C;
 
   const [batches, setBatches] = useState<StagingBatch[]>([]);
+  const [openPrs, setOpenPrs] = useState<import('../api/pipeline').PrSnapshot[]>([]);
   const [health, setHealth] = useState<{ version: string } | null>(null);
   const [lastSync, setLastSync] = useState<Date | null>(null);
   const [syncing, setSyncing] = useState(false);
@@ -137,9 +146,14 @@ export default function PipelineDashboardPage() {
 
   const load = useCallback(async () => {
     try {
-      const [b, h] = await Promise.all([pipelineApi.getBatches(), pipelineApi.health()]);
+      const [b, h, open] = await Promise.all([
+        pipelineApi.getBatches(),
+        pipelineApi.health(),
+        pipelineApi.getOpenPrs().catch(() => []),
+      ]);
       setBatches(b);
       setHealth(h);
+      setOpenPrs(open);
       setError(null);
     } catch {
       setError('Pipeline Service недоступен');
@@ -208,20 +222,20 @@ export default function PipelineDashboardPage() {
   }, [batches, prodDeploying, load]);
 
   // Derived stats
-  const activeBatch = batches.find(b => ['COLLECTING','DEPLOYING','TESTING','PASSED'].includes(b.state));
-  const collectingPrs = batches.filter(b => b.state === 'COLLECTING').reduce((s, b) => s + b.pullRequests.length, 0);
-  const mergedPrs = batches.reduce((s, b) => s + b.pullRequests.filter(p => p.mergedAt).length, 0);
-  const failedCi = batches.reduce((s, b) => s + b.pullRequests.filter(p => p.ciStatus === 'FAILURE').length, 0);
-  const totalPrs = batches.reduce((s, b) => s + b.pullRequests.length, 0);
-  const passCi = batches.reduce((s, b) => s + b.pullRequests.filter(p => p.ciStatus === 'SUCCESS').length, 0);
+  const collectingBatch = batches.find(b => b.state === 'COLLECTING');
   const stagingBatch = batches.find(b => ['DEPLOYING','TESTING','PASSED'].includes(b.state));
   const lastRelease = batches.find(b => b.state === 'RELEASED');
+  const allBatchPrs = batches.flatMap(b => b.pullRequests);
+  const failedCi = allBatchPrs.filter(p => p.ciStatus === 'FAILURE').length;
+  const passCi = allBatchPrs.filter(p => p.ciStatus === 'SUCCESS').length;
+  const totalPrs = allBatchPrs.length;
 
-  // Pipeline flow data
-  const collecting = activeBatch?.state === 'COLLECTING' ? (activeBatch.pullRequests.map(p => p.prTitle).slice(0, 3)) : [];
-  const inCi = batches.flatMap(b => b.pullRequests.filter(p => p.ciStatus === 'RUNNING').map(p => p.prTitle)).slice(0, 3);
-  const staging = stagingBatch ? stagingBatch.pullRequests.map(p => p.prTitle).slice(0, 3) : [];
-  const released = lastRelease ? lastRelease.pullRequests.map(p => p.prTitle).slice(0, 2) : [];
+  // Pipeline flow — 5 stages
+  const flowReview   = openPrs.map(p => `#${p.prNumber} ${p.prTitle}`).slice(0, 3);
+  const flowCi       = allBatchPrs.filter(p => p.ciStatus === 'RUNNING').map(p => p.prTitle).slice(0, 3);
+  const flowBatch    = collectingBatch ? collectingBatch.pullRequests.map(p => p.prTitle).slice(0, 3) : [];
+  const flowStaging  = stagingBatch ? stagingBatch.pullRequests.map(p => p.prTitle).slice(0, 3) : [];
+  const flowProd     = lastRelease ? lastRelease.pullRequests.map(p => p.prTitle).slice(0, 2) : [];
 
   const displayBatches = batches.slice(0, 8);
   const selected = selectedBatch ? batches.find(b => b.id === selectedBatch) : null;
@@ -273,9 +287,10 @@ export default function PipelineDashboardPage() {
         {/* Stats row */}
         <div style={{ display: 'flex', gap: 16 }}>
           <StatCard
-            label="Собирается батч" value={String(collectingPrs)} sub={`${mergedPrs} merged`}
-            subColor={C.success} C={C}
-            icon={<svg width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="5" cy="5" r="2.5" stroke={C.acc} strokeWidth="1.5" /><circle cx="13" cy="13" r="2.5" stroke={C.acc} strokeWidth="1.5" /><path d="M5 7.5v3a3 3 0 003 3h2.5" stroke={C.acc} strokeWidth="1.5" /></svg>}
+            label="В ревью" value={String(openPrs.length)}
+            sub={openPrs.length > 0 ? `${openPrs.filter(p => p.ciStatus === 'SUCCESS').length} CI ✓` : 'нет открытых PR'}
+            subColor={C.acc} C={C}
+            icon={<svg width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="6" cy="6" r="3" stroke={C.acc} strokeWidth="1.5" /><circle cx="12" cy="12" r="3" stroke={C.acc} strokeWidth="1.5" /><path d="M9 6h2a3 3 0 010 6H9" stroke={C.acc} strokeWidth="1.5" strokeLinecap="round" /></svg>}
           />
           <StatCard
             label="CI пайплайн"
@@ -300,27 +315,19 @@ export default function PipelineDashboardPage() {
           />
         </div>
 
-        {/* Pipeline flow */}
+        {/* Pipeline flow — full lifecycle */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
           <span style={{ fontFamily: '"Space Grotesk", system-ui, sans-serif', fontSize: 14, fontWeight: 600, letterSpacing: '-0.01em', color: C.text }}>Pipeline Flow</span>
           <div style={{ display: 'flex', gap: 0 }}>
-            <PipelineStep label="COLLECTING" count={collectingPrs} items={collecting} active={false} C={C} />
-            <div style={{ width: 24, display: 'flex', alignItems: 'flex-start', paddingTop: 10, justifyContent: 'center', flexShrink: 0 }}>
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 4l4 4-4 4" stroke={C.muted} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg>
-            </div>
-            <PipelineStep label="CI" count={inCi.length} items={inCi} active={inCi.length > 0} C={C} />
-            <div style={{ width: 24, display: 'flex', alignItems: 'flex-start', paddingTop: 10, justifyContent: 'center', flexShrink: 0 }}>
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 4l4 4-4 4" stroke={C.muted} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg>
-            </div>
-            <PipelineStep label="БАТЧ" count={activeBatch?.pullRequests.length ?? 0} items={collecting.slice(0, 3)} active={!!activeBatch} C={C} />
-            <div style={{ width: 24, display: 'flex', alignItems: 'flex-start', paddingTop: 10, justifyContent: 'center', flexShrink: 0 }}>
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 4l4 4-4 4" stroke={C.muted} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg>
-            </div>
-            <PipelineStep label="STAGING" count={staging.length} items={staging} active={!!stagingBatch} C={C} />
-            <div style={{ width: 24, display: 'flex', alignItems: 'flex-start', paddingTop: 10, justifyContent: 'center', flexShrink: 0 }}>
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 4l4 4-4 4" stroke={C.muted} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" /></svg>
-            </div>
-            <PipelineStep label="PROD" count={released.length} items={released} active={false} C={C} />
+            <PipelineStep label="РЕВЬЮ" count={openPrs.length} items={flowReview} active={openPrs.length > 0} C={C} />
+            <Arrow C={C} />
+            <PipelineStep label="CI" count={flowCi.length} items={flowCi} active={flowCi.length > 0} C={C} />
+            <Arrow C={C} />
+            <PipelineStep label="БАТЧ" count={collectingBatch?.pullRequests.length ?? 0} items={flowBatch} active={!!collectingBatch} C={C} />
+            <Arrow C={C} />
+            <PipelineStep label="STAGING" count={flowStaging.length} items={flowStaging} active={!!stagingBatch} C={C} />
+            <Arrow C={C} />
+            <PipelineStep label="ПРОД" count={flowProd.length} items={flowProd} active={!!lastRelease} C={C} />
           </div>
         </div>
 

--- a/frontend/src/pages/PipelineDashboardPage.tsx
+++ b/frontend/src/pages/PipelineDashboardPage.tsx
@@ -47,6 +47,7 @@ interface StateCfg {
 function getStateCfg(state: BatchState, C: typeof DARK_C): StateCfg {
   const map: Record<BatchState, StateCfg> = {
     COLLECTING: { label: 'Сбор',      dot: C.muted,    bg: C.card },
+    MERGING:    { label: 'Мёрдж',     dot: C.warn,     bg: C.card },
     DEPLOYING:  { label: 'Деплой',    dot: C.warn,     bg: C.card },
     TESTING:    { label: 'Тестирует', dot: C.acc,      bg: C.card },
     PASSED:     { label: 'ОК',        dot: C.success,  bg: C.card },
@@ -213,17 +214,20 @@ export default function PipelineDashboardPage() {
     }
   };
 
-  // Poll every 10s when staging deploy active OR production dispatch in flight
+  // Poll every 10s while any staging deploy is active OR a production deploy is RUNNING
   useEffect(() => {
-    const hasActive = batches.some(b => b.state === 'DEPLOYING') || prodDeploying !== null;
+    const allDeploys = batches.flatMap(b => b.deploys);
+    const hasActive =
+      batches.some(b => b.state === 'DEPLOYING') ||
+      allDeploys.some(d => d.env === 'production' && d.status === 'RUNNING');
     if (!hasActive) return;
     const id = setInterval(() => load(), 10_000);
     return () => clearInterval(id);
-  }, [batches, prodDeploying, load]);
+  }, [batches, load]);
 
   // Derived stats
   const collectingBatch = batches.find(b => b.state === 'COLLECTING');
-  const stagingBatch = batches.find(b => ['DEPLOYING','TESTING','PASSED'].includes(b.state));
+  const stagingBatch = batches.find(b => ['MERGING','DEPLOYING','TESTING','PASSED'].includes(b.state));
   const lastRelease = batches.find(b => b.state === 'RELEASED');
   const allBatchPrs = batches.flatMap(b => b.pullRequests);
   const failedCi = allBatchPrs.filter(p => p.ciStatus === 'FAILURE').length;

--- a/pipeline-service/src/modules/batches/batches.router.ts
+++ b/pipeline-service/src/modules/batches/batches.router.ts
@@ -252,17 +252,36 @@ router.post('/:id/deploy-staging', async (req, res, next) => {
     }
 
     const [owner, repo] = getOwnerRepo();
+    const prevState = batch.state;
 
-    const [deployEvent, updatedBatch] = await prisma.$transaction([
-      prisma.deployEvent.create({
-        data: { target: 'STAGING', status: 'RUNNING', imageTag, gitSha: imageTag, triggeredById: req.caller?.userId ?? 'unknown', stagingBatchId: batchId },
-      }),
-      prisma.stagingBatch.update({
-        where: { id: batchId },
-        data: { state: 'DEPLOYING' },
-        include: { pullRequests: { select: { id: true, externalId: true, title: true, ciStatus: true } }, deployEvents: { orderBy: { startedAt: 'desc' }, take: 5 } },
-      }),
-    ]);
+    // Duplicate-protection + event creation in a single interactive transaction
+    // to close the check-then-insert race window.
+    let deployEvent: import('@prisma/client').DeployEvent;
+    let updatedBatch: import('@prisma/client').StagingBatch & { pullRequests: { id: string; externalId: number; title: string; ciStatus: string }[]; deployEvents: import('@prisma/client').DeployEvent[] };
+    try {
+      [deployEvent, updatedBatch] = await prisma.$transaction(async (tx) => {
+        const running = await tx.deployEvent.findFirst({
+          where: { stagingBatchId: batchId, target: 'STAGING', status: 'RUNNING' },
+        });
+        if (running) throw Object.assign(new Error('ALREADY_RUNNING'), { code: 'ALREADY_RUNNING' });
+
+        const event = await tx.deployEvent.create({
+          data: { target: 'STAGING', status: 'RUNNING', imageTag, gitSha: imageTag, triggeredById: req.caller?.userId ?? 'unknown', stagingBatchId: batchId },
+        });
+        const btch = await tx.stagingBatch.update({
+          where: { id: batchId },
+          data: { state: 'DEPLOYING' },
+          include: { pullRequests: { select: { id: true, externalId: true, title: true, ciStatus: true } }, deployEvents: { orderBy: { startedAt: 'desc' }, take: 5 } },
+        });
+        return [event, btch];
+      });
+    } catch (txErr: unknown) {
+      if ((txErr as { code?: string }).code === 'ALREADY_RUNNING') {
+        res.status(409).json({ error: 'A staging deploy is already in progress for this batch' });
+        return;
+      }
+      throw txErr;
+    }
 
     try {
       await triggerWorkflowDispatch(owner, repo, 'deploy-staging.yml', config.PIPELINE_GITHUB_REF, {
@@ -270,7 +289,11 @@ router.post('/:id/deploy-staging', async (req, res, next) => {
         batch_id: batchId,
       });
     } catch (dispatchErr) {
-      await prisma.deployEvent.update({ where: { id: deployEvent.id }, data: { status: 'FAILURE', finishedAt: new Date() } });
+      // Revert batch to previous state so operator can retry
+      await prisma.$transaction([
+        prisma.deployEvent.update({ where: { id: deployEvent.id }, data: { status: 'FAILURE', finishedAt: new Date() } }),
+        prisma.stagingBatch.update({ where: { id: batchId }, data: { state: prevState } }),
+      ]);
       throw dispatchErr;
     }
 

--- a/pipeline-service/src/modules/github/github.client.ts
+++ b/pipeline-service/src/modules/github/github.client.ts
@@ -166,6 +166,11 @@ export async function triggerWorkflowDispatch(
       body: JSON.stringify({ ref, inputs }),
       signal: controller.signal,
     });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error(`GitHub workflow dispatch timed out after 10s for ${workflowFile}`);
+    }
+    throw err;
   } finally {
     clearTimeout(timeout);
   }

--- a/pipeline-service/src/modules/github/github.router.ts
+++ b/pipeline-service/src/modules/github/github.router.ts
@@ -97,13 +97,20 @@ githubRouter.post('/sync', async (_req, res, next) => {
   }
 });
 
-// GET /api/github/prs — list merged PRs with batch info
+// GET /api/github/prs — list PRs; ?state=open|merged (default: merged)
 githubRouter.get('/prs', async (req, res, next) => {
   try {
     const repo = req.query.repo as string | undefined;
+    const state = req.query.state as string | undefined;
+
+    const mergedFilter =
+      state === 'open'   ? { mergedAt: null } :
+      state === 'all'    ? {} :
+      /* default merged */{ mergedAt: { not: null } };
+
     const prs = await prisma.pullRequestSnapshot.findMany({
-      where: { mergedAt: { not: null }, ...(repo ? { repo } : {}) },
-      orderBy: { mergedAt: 'desc' },
+      where: { ...mergedFilter, ...(repo ? { repo } : {}) },
+      orderBy: [{ mergedAt: 'desc' }, { lastSyncedAt: 'desc' }],
       include: { stagingBatch: { select: { id: true, name: true, state: true } } },
     });
     res.json(prs);


### PR DESCRIPTION
## Что делает

Добавляет полный lifecycle PR в Pipeline Dashboard: от открытого PR до деплоя в прод.

## Изменения

### Backend
- `GET /api/github/prs?state=open` — возвращает open PRs (не merged), для колонки «В ревью»
- `GET /api/github/prs?state=merged` — явный параметр (старое поведение по умолчанию)

### Frontend API
- `pipelineApi.getOpenPrs()` — получает open PRs из pipeline service

### Dashboard — Pipeline Flow (5 стадий)
```
РЕВЬЮ → CI → БАТЧ → STAGING → ПРОД
```
- **РЕВЬЮ** — open PRs из GitHub, ещё не merged
- **CI** — merged PRs с активным CI (`ciStatus=RUNNING`)
- **БАТЧ** — PRs в текущем COLLECTING батче, готовы к деплою
- **STAGING** — PRs в батче на staging (DEPLOYING/TESTING/PASSED)
- **ПРОД** — PRs последнего RELEASED батча

### Stats cards
- Карточка «Собирается батч» → «В ревью» (кол-во open PRs + CI ✓)

## Test plan
- [ ] Открытые PR в GitHub → появляются в колонке РЕВЬЮ после sync
- [ ] PR merged → уходит из РЕВЬЮ, появляется в БАТЧ
- [ ] Batch deploy staging → переходит в STAGING
- [ ] Deploy production → переходит в ПРОД