### PR TITLE
feat: MCP server — Flow Universe tools for AI code agents

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "flow-universe": {
+      "command": "npm",
+      "args": ["run", "mcp"],
+      "cwd": "/Users/pavelnovak/tasktime-mvp/.claude/worktrees/dazzling-blackwell/backend",
+      "env": {
+        "AI_HOURLY_RATE": "50"
+      }
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,8 +3,27 @@
     "flow-universe": {
       "command": "npm",
       "args": ["run", "mcp"],
-      "cwd": "/Users/pavelnovak/tasktime-mvp/.claude/worktrees/dazzling-blackwell/backend",
+      "cwd": "backend",
       "env": {
+        "MCP_ENV": "development",
+        "AI_HOURLY_RATE": "50"
+      }
+    },
+    "flow-universe-staging": {
+      "command": "npm",
+      "args": ["run", "mcp"],
+      "cwd": "backend",
+      "env": {
+        "MCP_ENV": "staging",
+        "AI_HOURLY_RATE": "50"
+      }
+    },
+    "flow-universe-prod": {
+      "command": "npm",
+      "args": ["run", "mcp"],
+      "cwd": "backend",
+      "env": {
+        "MCP_ENV": "production",
         "AI_HOURLY_RATE": "50"
       }
     }

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,0 +1,6 @@
+# MCP — Production environment
+# Copy to .env.production and fill real credentials (never commit .env.production)
+DATABASE_URL="postgresql://tasktime:CHANGE_ME@72.56.7.218:5432/tasktime?schema=public"
+REDIS_URL="redis://72.56.7.218:6379"
+AI_HOURLY_RATE=50
+MCP_ENV=production

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,6 +1,12 @@
 # MCP — Production environment
 # Copy to .env.production and fill real credentials (never commit .env.production)
-DATABASE_URL="postgresql://tasktime:CHANGE_ME@72.56.7.218:5432/tasktime?schema=public"
-REDIS_URL="redis://72.56.7.218:6379"
+#
+# ВАЖНО: использовать техническую УЗ flowuniverse_mcp, не tasktime (admin)
+# Создать пользователя: psql -U postgres -d tasktime -f scripts/mcp-db-user.sql
+#
+# Доступ через SSH-туннель:
+#   ssh -L 5435:localhost:5432 root@72.56.7.218 -N
+DATABASE_URL="postgresql://flowuniverse_mcp:CHANGE_ME@localhost:5435/tasktime?schema=public"
+REDIS_URL="redis://localhost:6381"
 AI_HOURLY_RATE=50
 MCP_ENV=production

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -1,6 +1,12 @@
 # MCP — Staging environment
 # Copy to .env.staging and fill real credentials (never commit .env.staging)
-DATABASE_URL="postgresql://tasktime:CHANGE_ME@5.129.242.171:5432/tasktime?schema=public"
-REDIS_URL="redis://5.129.242.171:6379"
+#
+# ВАЖНО: использовать техническую УЗ flowuniverse_mcp, не tasktime (admin)
+# Создать пользователя: psql -U postgres -d tasktime -f scripts/mcp-db-user.sql
+#
+# Доступ через SSH-туннель:
+#   ssh -L 5434:localhost:5432 root@5.129.242.171 -N
+DATABASE_URL="postgresql://flowuniverse_mcp:CHANGE_ME@localhost:5434/tasktime?schema=public"
+REDIS_URL="redis://localhost:6380"
 AI_HOURLY_RATE=50
 MCP_ENV=staging

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -1,0 +1,6 @@
+# MCP — Staging environment
+# Copy to .env.staging and fill real credentials (never commit .env.staging)
+DATABASE_URL="postgresql://tasktime:CHANGE_ME@5.129.242.171:5432/tasktime?schema=public"
+REDIS_URL="redis://5.129.242.171:6379"
+AI_HOURLY_RATE=50
+MCP_ENV=staging

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@prisma/client": "^6.5.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -769,6 +770,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -827,6 +840,368 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
@@ -2140,6 +2515,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2740,7 +3154,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3788,6 +4201,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3844,6 +4278,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -3878,7 +4330,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3901,6 +4352,22 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4382,6 +4849,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -4479,6 +4955,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -4727,6 +5212,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4883,7 +5374,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jiti": {
@@ -4894,6 +5384,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -4929,6 +5428,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5441,7 +5946,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5551,7 +6055,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5612,6 +6115,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -5878,6 +6390,15 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -5962,6 +6483,55 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-array-concat": {
@@ -6161,7 +6731,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6174,7 +6743,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7097,7 +7665,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7229,7 +7796,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
@@ -7252,6 +7818,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,10 +26,12 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src/ --ext .ts",
-    "format": "prettier --write 'src/**/*.ts'"
+    "format": "prettier --write 'src/**/*.ts'",
+    "mcp": "tsx src/mcp/server.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@prisma/client": "^6.5.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/backend/scripts/mcp-db-user.sql
+++ b/backend/scripts/mcp-db-user.sql
@@ -1,0 +1,110 @@
+-- =============================================================================
+-- FlowUniverse MCP — техническая учётная запись PostgreSQL
+-- =============================================================================
+-- Запуск: psql -U postgres -d tasktime -f mcp-db-user.sql
+--
+-- Принцип: минимальные привилегии для работы 14 MCP-инструментов.
+-- Агент может читать всё, писать только в рабочие таблицы,
+-- удалять и менять структуру — запрещено.
+-- =============================================================================
+
+-- 1. Создать пользователя (заменить пароль перед запуском)
+CREATE USER "flowuniverse_mcp" WITH
+  PASSWORD 'CHANGE_ME_STRONG_PASSWORD'
+  NOSUPERUSER
+  NOCREATEDB
+  NOCREATEROLE
+  NOINHERIT
+  LOGIN
+  CONNECTION LIMIT 5;
+
+COMMENT ON ROLE "flowuniverse_mcp" IS 'FlowUniverse MCP — техническая УЗ для AI-агента. Только рабочие операции, без DDL и DELETE.';
+
+-- 2. Подключение к базе
+GRANT CONNECT ON DATABASE tasktime TO "flowuniverse_mcp";
+GRANT USAGE ON SCHEMA public TO "flowuniverse_mcp";
+
+-- =============================================================================
+-- 3. SELECT — читать всё (агенту нужен полный контекст)
+-- =============================================================================
+GRANT SELECT ON
+  users,
+  projects,
+  issues,
+  sprints,
+  releases,
+  comments,
+  time_logs,
+  ai_sessions,
+  audit_logs,
+  issue_type_configs,
+  issue_type_schemes,
+  issue_type_scheme_items,
+  issue_type_scheme_projects,
+  issue_links,
+  issue_link_types,
+  issue_custom_field_values,
+  custom_fields,
+  field_schemas,
+  field_schema_items,
+  field_schema_bindings,
+  teams,
+  team_members,
+  user_project_roles,
+  project_categories,
+  workflow_statuses,
+  workflows,
+  workflow_steps,
+  workflow_transitions,
+  workflow_schemes,
+  workflow_scheme_items,
+  workflow_scheme_projects,
+  transition_screens,
+  transition_screen_items,
+  system_settings
+TO "flowuniverse_mcp";
+
+-- =============================================================================
+-- 4. INSERT — создавать новые записи
+--    (подзадачи, комментарии, логи времени, AI-сессии, audit)
+-- =============================================================================
+GRANT INSERT ON
+  issues,        -- create_subtask
+  comments,      -- add_comment, complete_issue, fail_issue
+  time_logs,     -- log_time, register_ai_session
+  ai_sessions,   -- register_ai_session
+  audit_logs     -- claim_issue, complete_issue, fail_issue, update_status
+TO "flowuniverse_mcp";
+
+-- =============================================================================
+-- 5. UPDATE — только поля задач (статус, AI-флаги)
+--    НЕ users, НЕ projects, НЕ system_settings
+-- =============================================================================
+GRANT UPDATE ON
+  issues         -- update_status, claim_issue, complete_issue, fail_issue
+TO "flowuniverse_mcp";
+
+-- =============================================================================
+-- 6. Sequences — нужны для INSERT с auto-increment
+-- =============================================================================
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO "flowuniverse_mcp";
+
+-- =============================================================================
+-- 7. Явно запрещаем опасные операции (defence-in-depth)
+--    DELETE и DDL не выдавались — но явный REVOKE защищает от случайного
+--    наследования через роли.
+-- =============================================================================
+REVOKE DELETE ON ALL TABLES IN SCHEMA public FROM "flowuniverse_mcp";
+REVOKE TRUNCATE ON ALL TABLES IN SCHEMA public FROM "flowuniverse_mcp";
+
+-- Запрет на изменение структуры БД (DDL) — superuser-только, но для ясности:
+-- ALTER, DROP, CREATE — не выдавались и не будут.
+
+-- =============================================================================
+-- 8. Проверка (запустить после создания пользователя)
+-- =============================================================================
+-- \c tasktime flowuniverse_mcp
+-- SELECT id, email FROM users LIMIT 1;           -- должно работать
+-- UPDATE users SET name='x' WHERE false;         -- должно упасть с ошибкой прав
+-- DELETE FROM issues WHERE false;                -- должно упасть с ошибкой прав
+-- DROP TABLE issues;                             -- должно упасть с ошибкой прав

--- a/backend/src/mcp/context.ts
+++ b/backend/src/mcp/context.ts
@@ -1,0 +1,55 @@
+import { prisma } from '../prisma/client.js';
+
+export const AGENT_EMAIL = 'agent@flow-universe.internal';
+
+let _agentUserId: string | null = null;
+
+export async function getAgentUserId(): Promise<string> {
+  if (_agentUserId) return _agentUserId;
+  const user = await prisma.user.findUnique({ where: { email: AGENT_EMAIL } });
+  if (!user) throw new Error('Agent user not found. Run: npm run db:seed');
+  _agentUserId = user.id;
+  return _agentUserId;
+}
+
+const ISSUE_KEY_RE = /^([A-Z]{2,10})-(\d+)$/;
+
+export type ResolvedIssue = {
+  id: string;
+  key: string;
+  projectKey: string;
+  projectId: string;
+  title: string;
+  status: string;
+  type: string;
+  number: number;
+};
+
+export async function resolveKey(key: string): Promise<ResolvedIssue> {
+  const m = key.trim().toUpperCase().match(ISSUE_KEY_RE);
+  if (!m) throw new Error(`Invalid issue key: ${key}`);
+  const projectKey = m[1];
+  const number = parseInt(m[2], 10);
+
+  const project = await prisma.project.findUnique({ where: { key: projectKey } });
+  if (!project) throw new Error(`Project ${projectKey} not found`);
+
+  const issue = await prisma.issue.findUnique({
+    where: { projectId_number: { projectId: project.id, number } },
+    select: { id: true, title: true, status: true, type: true, projectId: true, number: true },
+  });
+  if (!issue) throw new Error(`Issue ${key} not found`);
+
+  return { ...issue, key: key.toUpperCase(), projectKey, status: issue.status as string, type: issue.type as string };
+}
+
+export function text(content: string) {
+  return { content: [{ type: 'text' as const, text: content }] };
+}
+
+export function errText(err: unknown) {
+  const msg = err instanceof Error ? err.message : String(err);
+  return { content: [{ type: 'text' as const, text: `Error: ${msg}` }], isError: true };
+}
+
+export { prisma };

--- a/backend/src/mcp/context.ts
+++ b/backend/src/mcp/context.ts
@@ -21,7 +21,6 @@ export type ResolvedIssue = {
   projectId: string;
   title: string;
   status: string;
-  type: string;
   number: number;
 };
 
@@ -36,11 +35,11 @@ export async function resolveKey(key: string): Promise<ResolvedIssue> {
 
   const issue = await prisma.issue.findUnique({
     where: { projectId_number: { projectId: project.id, number } },
-    select: { id: true, title: true, status: true, type: true, projectId: true, number: true },
+    select: { id: true, title: true, status: true, projectId: true, number: true },
   });
   if (!issue) throw new Error(`Issue ${key} not found`);
 
-  return { ...issue, key: key.toUpperCase(), projectKey, status: issue.status as string, type: issue.type as string };
+  return { ...issue, key: key.toUpperCase(), projectKey, status: issue.status as string };
 }
 
 export function text(content: string) {

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -2,9 +2,11 @@ import { config } from 'dotenv';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Load .env from backend root
+// Load env file based on MCP_ENV (development | staging | production)
 const __dirname = dirname(fileURLToPath(import.meta.url));
-config({ path: resolve(__dirname, '../../.env') });
+const MCP_ENV = process.env.MCP_ENV ?? 'development';
+const envFile = MCP_ENV === 'development' ? '.env' : `.env.${MCP_ENV}`;
+config({ path: resolve(__dirname, `../../${envFile}`) });
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -1,0 +1,30 @@
+import { config } from 'dotenv';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Load .env from backend root
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: resolve(__dirname, '../../.env') });
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+import { registerIssueTools } from './tools/issues.js';
+import { registerSprintTools } from './tools/sprints.js';
+import { registerTimeTools } from './tools/time.js';
+import { registerCommentTools } from './tools/comments.js';
+import { registerAgentTools } from './tools/agent.js';
+
+const server = new McpServer({
+  name: 'flow-universe',
+  version: '1.0.0',
+});
+
+registerIssueTools(server);
+registerSprintTools(server);
+registerTimeTools(server);
+registerCommentTools(server);
+registerAgentTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/backend/src/mcp/tools/agent.ts
+++ b/backend/src/mcp/tools/agent.ts
@@ -1,0 +1,199 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+
+export function registerAgentTools(server: McpServer) {
+  // ── get_eligible_issues ───────────────────────────────────────────────────────
+  server.tool(
+    'get_eligible_issues',
+    'Get the queue of AI-eligible issues not yet started (for autonomous agent)',
+    {
+      project: z.string().optional().describe('Project key to filter by, e.g. TTMP. Omit for all projects.'),
+      limit: z.number().int().min(1).max(50).default(20),
+    },
+    async ({ project, limit }) => {
+      try {
+        let projectId: string | undefined;
+        if (project) {
+          const proj = await prisma.project.findUnique({ where: { key: project.toUpperCase() } });
+          if (!proj) return errText(`Project ${project} not found`);
+          projectId = proj.id;
+        }
+
+        const issues = await prisma.issue.findMany({
+          where: {
+            aiEligible: true,
+            aiExecutionStatus: 'NOT_STARTED',
+            status: { notIn: ['DONE', 'CANCELLED'] },
+            ...(projectId ? { projectId } : {}),
+          },
+          include: {
+            project: { select: { key: true } },
+            sprint: { select: { name: true, state: true } },
+          },
+          orderBy: [{ priority: 'asc' }, { createdAt: 'asc' }],
+          take: limit,
+        });
+
+        if (issues.length === 0) {
+          return text('No AI-eligible issues with NOT_STARTED status found.');
+        }
+
+        const rows = issues.map(i =>
+          `${i.project.key}-${i.number} [${i.type}] [${i.priority}] [${i.status}] ${i.title.slice(0, 60)}${i.sprint ? ` | sprint: ${i.sprint.name}` : ' | backlog'}`,
+        );
+        return text(`Eligible issues (${issues.length}):\n${rows.join('\n')}\n\nUse claim_issue(key) to take one.`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── claim_issue ───────────────────────────────────────────────────────────────
+  server.tool(
+    'claim_issue',
+    'Atomically claim an AI-eligible issue for the agent (sets IN_PROGRESS + AGENT)',
+    { key: z.string().describe('Issue key, e.g. TTMP-95') },
+    async ({ key }) => {
+      try {
+        const issue = await resolveKey(key);
+        const agentUserId = await getAgentUserId();
+
+        const current = await prisma.issue.findUniqueOrThrow({
+          where: { id: issue.id },
+          select: { aiEligible: true, aiExecutionStatus: true },
+        });
+
+        if (!current.aiEligible) {
+          return errText(`${key} is not marked as AI-eligible. Set aiEligible=true first.`);
+        }
+        if (current.aiExecutionStatus === 'IN_PROGRESS') {
+          return errText(`${key} is already claimed (aiExecutionStatus=IN_PROGRESS).`);
+        }
+        if (current.aiExecutionStatus === 'DONE') {
+          return errText(`${key} is already done.`);
+        }
+
+        await prisma.$transaction([
+          prisma.issue.update({
+            where: { id: issue.id },
+            data: {
+              aiExecutionStatus: 'IN_PROGRESS',
+              aiAssigneeType: 'AGENT',
+              status: 'IN_PROGRESS',
+              assigneeId: agentUserId,
+            },
+          }),
+          prisma.auditLog.create({
+            data: {
+              action: 'UPDATE',
+              entityType: 'Issue',
+              entityId: issue.id,
+              userId: agentUserId,
+              details: { event: 'agent_claimed', key },
+            },
+          }),
+        ]);
+
+        return text(`${key} claimed by agent ✓\nStatus: IN_PROGRESS | aiExecutionStatus: IN_PROGRESS\nNext: get_issue("${key}") to read the full spec.`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── complete_issue ────────────────────────────────────────────────────────────
+  server.tool(
+    'complete_issue',
+    'Mark agent work as done. Sets status=REVIEW (awaiting human approval) + adds summary comment.',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      summary: z.string().min(1).max(5000).describe('What was done — becomes a comment on the issue'),
+    },
+    async ({ key, summary }) => {
+      try {
+        const issue = await resolveKey(key);
+        const agentUserId = await getAgentUserId();
+
+        await prisma.$transaction([
+          prisma.issue.update({
+            where: { id: issue.id },
+            data: {
+              aiExecutionStatus: 'DONE',
+              status: 'REVIEW',
+            },
+          }),
+          prisma.comment.create({
+            data: {
+              issueId: issue.id,
+              authorId: agentUserId,
+              body: `🤖 Agent completed work:\n\n${summary}`,
+            },
+          }),
+          prisma.auditLog.create({
+            data: {
+              action: 'UPDATE',
+              entityType: 'Issue',
+              entityId: issue.id,
+              userId: agentUserId,
+              details: { event: 'agent_completed', key },
+            },
+          }),
+        ]);
+
+        return text(`${key}: IN_PROGRESS → REVIEW ✓\nSummary comment added.\nAwaiting human review before DONE.`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── fail_issue ────────────────────────────────────────────────────────────────
+  server.tool(
+    'fail_issue',
+    'Escalate: agent could not complete the issue. Resets to OPEN for human.',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      reason: z.string().min(1).max(3000).describe('Why the agent failed — becomes an escalation comment'),
+    },
+    async ({ key, reason }) => {
+      try {
+        const issue = await resolveKey(key);
+        const agentUserId = await getAgentUserId();
+
+        await prisma.$transaction([
+          prisma.issue.update({
+            where: { id: issue.id },
+            data: {
+              aiExecutionStatus: 'FAILED',
+              status: 'OPEN',
+              aiAssigneeType: 'HUMAN',
+              assigneeId: null,
+            },
+          }),
+          prisma.comment.create({
+            data: {
+              issueId: issue.id,
+              authorId: agentUserId,
+              body: `⚠️ Agent escalation — could not complete:\n\n${reason}\n\nRequires manual intervention.`,
+            },
+          }),
+          prisma.auditLog.create({
+            data: {
+              action: 'UPDATE',
+              entityType: 'Issue',
+              entityId: issue.id,
+              userId: agentUserId,
+              details: { event: 'agent_failed', key, reason: reason.slice(0, 200) },
+            },
+          }),
+        ]);
+
+        return text(`${key}: FAILED | Returned to OPEN for human ✓\nEscalation comment added.`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+}

--- a/backend/src/mcp/tools/agent.ts
+++ b/backend/src/mcp/tools/agent.ts
@@ -31,6 +31,7 @@ export function registerAgentTools(server: McpServer) {
           include: {
             project: { select: { key: true } },
             sprint: { select: { name: true, state: true } },
+            issueTypeConfig: { select: { name: true } },
           },
           orderBy: [{ priority: 'asc' }, { createdAt: 'asc' }],
           take: limit,
@@ -41,7 +42,7 @@ export function registerAgentTools(server: McpServer) {
         }
 
         const rows = issues.map(i =>
-          `${i.project.key}-${i.number} [${i.type}] [${i.priority}] [${i.status}] ${i.title.slice(0, 60)}${i.sprint ? ` | sprint: ${i.sprint.name}` : ' | backlog'}`,
+          `${i.project.key}-${i.number} [${i.issueTypeConfig?.name ?? '?'}] [${i.priority}] [${i.status}] ${i.title.slice(0, 60)}${i.sprint ? ` | sprint: ${i.sprint.name}` : ' | backlog'}`,
         );
         return text(`Eligible issues (${issues.length}):\n${rows.join('\n')}\n\nUse claim_issue(key) to take one.`);
       } catch (err) {

--- a/backend/src/mcp/tools/comments.ts
+++ b/backend/src/mcp/tools/comments.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+
+export function registerCommentTools(server: McpServer) {
+  // ── add_comment ───────────────────────────────────────────────────────────────
+  server.tool(
+    'add_comment',
+    'Add a progress update or summary comment to an issue',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      body: z.string().min(1).max(10_000).describe('Comment text (markdown supported)'),
+    },
+    async ({ key, body }) => {
+      try {
+        const issue = await resolveKey(key);
+        const agentUserId = await getAgentUserId();
+
+        const comment = await prisma.comment.create({
+          data: {
+            issueId: issue.id,
+            authorId: agentUserId,
+            body,
+          },
+        });
+
+        return text(`Comment added to ${key} (id: ${comment.id}) ✓`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── get_comments ──────────────────────────────────────────────────────────────
+  server.tool(
+    'get_comments',
+    'Get comments on an issue',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      limit: z.number().int().min(1).max(50).default(10),
+    },
+    async ({ key, limit }) => {
+      try {
+        const issue = await resolveKey(key);
+
+        const comments = await prisma.comment.findMany({
+          where: { issueId: issue.id },
+          include: { author: { select: { name: true, email: true } } },
+          orderBy: { createdAt: 'desc' },
+          take: limit,
+        });
+
+        if (comments.length === 0) return text(`${key}: No comments yet.`);
+
+        const rows = comments.map(c => {
+          const who = c.author.email.includes('flow-universe.internal') ? '🤖 Agent' : c.author.name;
+          const when = c.createdAt.toISOString().slice(0, 16);
+          return `[${when}] ${who}:\n${c.body}`;
+        });
+
+        return text(`${key} Comments (${comments.length}):\n${'─'.repeat(40)}\n${rows.join('\n' + '─'.repeat(40) + '\n')}`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+}

--- a/backend/src/mcp/tools/issues.ts
+++ b/backend/src/mcp/tools/issues.ts
@@ -1,0 +1,217 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+
+export function registerIssueTools(server: McpServer) {
+  // ── get_issue ────────────────────────────────────────────────────────────────
+  server.tool(
+    'get_issue',
+    'Get a full issue card by key (e.g. TTMP-95) or UUID',
+    { key: z.string().describe('Issue key like TTMP-95 or UUID') },
+    async ({ key }) => {
+      try {
+        const resolved = await resolveKey(key);
+        const issue = await prisma.issue.findUniqueOrThrow({
+          where: { id: resolved.id },
+          include: {
+            assignee: { select: { name: true, email: true } },
+            creator: { select: { name: true } },
+            parent: { select: { title: true, type: true, number: true, project: { select: { key: true } } } },
+            children: {
+              select: { title: true, type: true, status: true, number: true, project: { select: { key: true } } },
+              orderBy: { orderIndex: 'asc' },
+              take: 30,
+            },
+            sprint: { select: { name: true, state: true, startDate: true, endDate: true } },
+            release: { select: { name: true, state: true } },
+            project: { select: { key: true, name: true } },
+            _count: { select: { comments: true, timeLogs: true } },
+          },
+        });
+
+        const parentStr = issue.parent
+          ? `${issue.parent.project.key}-${issue.parent.type} "${issue.parent.title}"`
+          : 'none';
+
+        const sprintStr = issue.sprint
+          ? `${issue.sprint.name} [${issue.sprint.state}]${issue.sprint.endDate ? ` ends ${issue.sprint.endDate.toISOString().slice(0, 10)}` : ''}`
+          : 'none';
+
+        const childrenStr = issue.children.length > 0
+          ? issue.children.map(c => `  • ${c.project.key}-${c.number} [${c.type}] [${c.status}] ${c.title}`).join('\n')
+          : '  none';
+
+        const lines = [
+          `${resolved.key} [${issue.type}] [${issue.status}] [${issue.priority}]`,
+          `Title: ${issue.title}`,
+          ``,
+          `Sprint:   ${sprintStr}`,
+          `Release:  ${issue.release?.name ?? 'none'} ${issue.release ? `[${issue.release.state}]` : ''}`,
+          `Assignee: ${issue.assignee?.name ?? 'unassigned'}`,
+          `Creator:  ${issue.creator.name}`,
+          `Parent:   ${parentStr}`,
+          ``,
+          `Children (${issue.children.length}):`,
+          childrenStr,
+          ``,
+          issue.description ? `Description:\n${issue.description}` : `Description: (empty)`,
+          ``,
+          `EstimatedHours: ${issue.estimatedHours ?? 'not set'}`,
+          `AI: eligible=${issue.aiEligible}, status=${issue.aiExecutionStatus}, type=${issue.aiAssigneeType}`,
+          `Comments: ${issue._count.comments} | TimeLogs: ${issue._count.timeLogs}`,
+          `Created: ${issue.createdAt.toISOString().slice(0, 10)}`,
+        ];
+
+        return text(lines.join('\n'));
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── list_issues ───────────────────────────────────────────────────────────────
+  server.tool(
+    'list_issues',
+    'List issues with filters. Use sprint="active" for current sprint.',
+    {
+      project: z.string().describe('Project key, e.g. TTMP'),
+      sprint: z.string().optional().describe('"active" or sprint UUID or "backlog"'),
+      status: z.enum(['OPEN', 'IN_PROGRESS', 'REVIEW', 'DONE', 'CANCELLED']).optional(),
+      aiEligible: z.boolean().optional().describe('Only AI-eligible issues'),
+      assigneeType: z.enum(['HUMAN', 'AGENT', 'MIXED']).optional(),
+      limit: z.number().int().min(1).max(100).default(20),
+    },
+    async ({ project, sprint, status, aiEligible, assigneeType, limit }) => {
+      try {
+        const proj = await prisma.project.findUnique({ where: { key: project.toUpperCase() } });
+        if (!proj) return errText(`Project ${project} not found`);
+
+        let sprintId: string | null | undefined;
+        if (sprint === 'active') {
+          const activeSprint = await prisma.sprint.findFirst({ where: { projectId: proj.id, state: 'ACTIVE' } });
+          sprintId = activeSprint?.id ?? null;
+        } else if (sprint === 'backlog') {
+          sprintId = null;
+        } else if (sprint) {
+          sprintId = sprint;
+        }
+
+        const where: Record<string, unknown> = { projectId: proj.id };
+        if (status) where.status = status;
+        if (aiEligible !== undefined) where.aiEligible = aiEligible;
+        if (assigneeType) where.aiAssigneeType = assigneeType;
+        if (sprintId !== undefined) where.sprintId = sprintId;
+
+        const issues = await prisma.issue.findMany({
+          where,
+          include: {
+            assignee: { select: { name: true } },
+            sprint: { select: { name: true } },
+          },
+          orderBy: [{ priority: 'asc' }, { createdAt: 'desc' }],
+          take: limit,
+        });
+
+        if (issues.length === 0) return text('No issues found matching the filters.');
+
+        const header = `Found ${issues.length} issue(s) in ${project}:\n`;
+        const rows = issues.map(i =>
+          `${project.toUpperCase()}-${i.number} [${i.type}] [${i.status}] [${i.priority}] ${i.title.slice(0, 60)}${i.title.length > 60 ? '…' : ''} | ${i.assignee?.name ?? 'unassigned'}${i.aiEligible ? ' | AI✓' : ''}`,
+        );
+
+        return text(header + rows.join('\n'));
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── update_status ─────────────────────────────────────────────────────────────
+  server.tool(
+    'update_status',
+    'Change the status of an issue',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      status: z.enum(['OPEN', 'IN_PROGRESS', 'REVIEW', 'DONE', 'CANCELLED']),
+    },
+    async ({ key, status }) => {
+      try {
+        const resolved = await resolveKey(key);
+        const old = resolved.status;
+
+        await prisma.issue.update({ where: { id: resolved.id }, data: { status } });
+
+        await prisma.auditLog.create({
+          data: {
+            action: 'UPDATE',
+            entityType: 'Issue',
+            entityId: resolved.id,
+            details: { field: 'status', from: old, to: status },
+          },
+        });
+
+        return text(`${resolved.key}: ${old} → ${status} ✓`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── create_subtask ────────────────────────────────────────────────────────────
+  server.tool(
+    'create_subtask',
+    'Create a subtask under a parent issue (real decomposition)',
+    {
+      parentKey: z.string().describe('Parent issue key, e.g. TTMP-95'),
+      title: z.string().min(1).max(500),
+      description: z.string().optional(),
+      priority: z.enum(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']).default('MEDIUM'),
+    },
+    async ({ parentKey, title, description, priority }) => {
+      try {
+        const parent = await resolveKey(parentKey);
+
+        const allowedParents = ['EPIC', 'STORY', 'TASK'];
+        if (!allowedParents.includes(parent.type)) {
+          return errText(`${parent.type} cannot have subtasks. Allowed parents: EPIC, STORY, TASK`);
+        }
+
+        const agentUserId = await getAgentUserId();
+
+        const parentIssue = await prisma.issue.findUniqueOrThrow({
+          where: { id: parent.id },
+          select: { sprintId: true },
+        });
+
+        const last = await prisma.issue.findFirst({
+          where: { projectId: parent.projectId },
+          orderBy: { number: 'desc' },
+          select: { number: true },
+        });
+        const number = (last?.number ?? 0) + 1;
+
+        const child = await prisma.issue.create({
+          data: {
+            projectId: parent.projectId,
+            number,
+            title,
+            description,
+            type: 'SUBTASK',
+            priority,
+            status: 'OPEN',
+            parentId: parent.id,
+            sprintId: parentIssue.sprintId,
+            creatorId: agentUserId,
+          },
+          include: { project: { select: { key: true } } },
+        });
+
+        const childKey = `${child.project.key}-${child.number}`;
+        return text(`Created ${childKey}: "${title}" (SUBTASK → ${parentKey}) ✓`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+}

--- a/backend/src/mcp/tools/issues.ts
+++ b/backend/src/mcp/tools/issues.ts
@@ -31,7 +31,7 @@ export function registerIssueTools(server: McpServer) {
         });
 
         const parentStr = issue.parent
-          ? `${issue.parent.project.key}-${issue.parent.type} "${issue.parent.title}"`
+          ? `${issue.parent.project.key}-${issue.parent.number} [${issue.parent.type}] "${issue.parent.title}"`
           : 'none';
 
         const sprintStr = issue.sprint
@@ -90,7 +90,7 @@ export function registerIssueTools(server: McpServer) {
         let sprintId: string | null | undefined;
         if (sprint === 'active') {
           const activeSprint = await prisma.sprint.findFirst({ where: { projectId: proj.id, state: 'ACTIVE' } });
-          sprintId = activeSprint?.id ?? null;
+          sprintId = activeSprint?.id ?? undefined;
         } else if (sprint === 'backlog') {
           sprintId = null;
         } else if (sprint) {
@@ -172,9 +172,9 @@ export function registerIssueTools(server: McpServer) {
       try {
         const parent = await resolveKey(parentKey);
 
-        const allowedParents = ['EPIC', 'STORY', 'TASK'];
+        const allowedParents = ['EPIC', 'STORY', 'TASK', 'BUG'];
         if (!allowedParents.includes(parent.type)) {
-          return errText(`${parent.type} cannot have subtasks. Allowed parents: EPIC, STORY, TASK`);
+          return errText(`${parent.type} cannot have subtasks. Allowed parents: EPIC, STORY, TASK, BUG`);
         }
 
         const agentUserId = await getAgentUserId();

--- a/backend/src/mcp/tools/issues.ts
+++ b/backend/src/mcp/tools/issues.ts
@@ -17,9 +17,9 @@ export function registerIssueTools(server: McpServer) {
           include: {
             assignee: { select: { name: true, email: true } },
             creator: { select: { name: true } },
-            parent: { select: { title: true, type: true, number: true, project: { select: { key: true } } } },
+            parent: { select: { title: true, number: true, issueTypeConfig: { select: { name: true } }, project: { select: { key: true } } } },
             children: {
-              select: { title: true, type: true, status: true, number: true, project: { select: { key: true } } },
+              select: { title: true, status: true, number: true, issueTypeConfig: { select: { name: true } }, project: { select: { key: true } } },
               orderBy: { orderIndex: 'asc' },
               take: 30,
             },
@@ -31,7 +31,7 @@ export function registerIssueTools(server: McpServer) {
         });
 
         const parentStr = issue.parent
-          ? `${issue.parent.project.key}-${issue.parent.number} [${issue.parent.type}] "${issue.parent.title}"`
+          ? `${issue.parent.project.key}-${issue.parent.number} [${issue.parent.issueTypeConfig?.name ?? '?'}] "${issue.parent.title}"`
           : 'none';
 
         const sprintStr = issue.sprint
@@ -39,11 +39,11 @@ export function registerIssueTools(server: McpServer) {
           : 'none';
 
         const childrenStr = issue.children.length > 0
-          ? issue.children.map(c => `  • ${c.project.key}-${c.number} [${c.type}] [${c.status}] ${c.title}`).join('\n')
+          ? issue.children.map(c => `  • ${c.project.key}-${c.number} [${c.issueTypeConfig?.name ?? '?'}] [${c.status}] ${c.title}`).join('\n')
           : '  none';
 
         const lines = [
-          `${resolved.key} [${issue.type}] [${issue.status}] [${issue.priority}]`,
+          `${resolved.key} [${issue.issueTypeConfig?.name ?? '?'}] [${issue.status}] [${issue.priority}]`,
           `Title: ${issue.title}`,
           ``,
           `Sprint:   ${sprintStr}`,
@@ -108,6 +108,7 @@ export function registerIssueTools(server: McpServer) {
           include: {
             assignee: { select: { name: true } },
             sprint: { select: { name: true } },
+            issueTypeConfig: { select: { name: true } },
           },
           orderBy: [{ priority: 'asc' }, { createdAt: 'desc' }],
           take: limit,
@@ -117,7 +118,7 @@ export function registerIssueTools(server: McpServer) {
 
         const header = `Found ${issues.length} issue(s) in ${project}:\n`;
         const rows = issues.map(i =>
-          `${project.toUpperCase()}-${i.number} [${i.type}] [${i.status}] [${i.priority}] ${i.title.slice(0, 60)}${i.title.length > 60 ? '…' : ''} | ${i.assignee?.name ?? 'unassigned'}${i.aiEligible ? ' | AI✓' : ''}`,
+          `${project.toUpperCase()}-${i.number} [${i.issueTypeConfig?.name ?? '?'}] [${i.status}] [${i.priority}] ${i.title.slice(0, 60)}${i.title.length > 60 ? '…' : ''} | ${i.assignee?.name ?? 'unassigned'}${i.aiEligible ? ' | AI✓' : ''}`,
         );
 
         return text(header + rows.join('\n'));
@@ -171,24 +172,14 @@ export function registerIssueTools(server: McpServer) {
     async ({ parentKey, title, description, priority }) => {
       try {
         const parent = await resolveKey(parentKey);
-
-        const allowedParents = ['EPIC', 'STORY', 'TASK', 'BUG'];
-        if (!allowedParents.includes(parent.type)) {
-          return errText(`${parent.type} cannot have subtasks. Allowed parents: EPIC, STORY, TASK, BUG`);
-        }
-
         const agentUserId = await getAgentUserId();
 
-        const parentIssue = await prisma.issue.findUniqueOrThrow({
-          where: { id: parent.id },
-          select: { sprintId: true },
-        });
-
-        const last = await prisma.issue.findFirst({
-          where: { projectId: parent.projectId },
-          orderBy: { number: 'desc' },
-          select: { number: true },
-        });
+        const [parentIssue, subtaskConfig, last] = await Promise.all([
+          prisma.issue.findUniqueOrThrow({ where: { id: parent.id }, select: { sprintId: true } }),
+          prisma.issueTypeConfig.findFirst({ where: { isSubtask: true }, select: { id: true } }),
+          prisma.issue.findFirst({ where: { projectId: parent.projectId }, orderBy: { number: 'desc' }, select: { number: true } }),
+        ]);
+        if (!subtaskConfig) return errText('No subtask issue type configured in this project');
         const number = (last?.number ?? 0) + 1;
 
         const child = await prisma.issue.create({
@@ -197,7 +188,7 @@ export function registerIssueTools(server: McpServer) {
             number,
             title,
             description,
-            type: 'SUBTASK',
+            issueTypeConfigId: subtaskConfig.id,
             priority,
             status: 'OPEN',
             parentId: parent.id,

--- a/backend/src/mcp/tools/sprints.ts
+++ b/backend/src/mcp/tools/sprints.ts
@@ -28,7 +28,7 @@ export function registerSprintTools(server: McpServer) {
                 aiEligible: true,
                 aiExecutionStatus: true,
                 aiAssigneeType: true,
-                type: true,
+                issueTypeConfig: { select: { name: true } },
                 number: true,
                 title: true,
                 assignee: { select: { name: true } },
@@ -74,7 +74,7 @@ export function registerSprintTools(server: McpServer) {
           lines.push('');
           lines.push('Ready for agent:');
           for (const i of aiNotStarted.slice(0, 10)) {
-            lines.push(`  ${project.toUpperCase()}-${i.number} [${i.type}] [${i.priority}] ${i.title.slice(0, 60)}`);
+            lines.push(`  ${project.toUpperCase()}-${i.number} [${i.issueTypeConfig?.name ?? '?'}] [${i.priority}] ${i.title.slice(0, 60)}`);
           }
         }
 
@@ -106,6 +106,7 @@ export function registerSprintTools(server: McpServer) {
           },
           include: {
             _count: { select: { children: true } },
+            issueTypeConfig: { select: { name: true } },
           },
           orderBy: [{ priority: 'asc' }, { createdAt: 'asc' }],
           take: limit,
@@ -114,7 +115,7 @@ export function registerSprintTools(server: McpServer) {
         if (issues.length === 0) return text('Backlog is empty.');
 
         const rows = issues.map(i =>
-          `${project.toUpperCase()}-${i.number} [${i.type}] [${i.priority}] ${i.title.slice(0, 60)} | children: ${i._count.children}${i.aiEligible ? ' | AI✓' : ''}`,
+          `${project.toUpperCase()}-${i.number} [${i.issueTypeConfig?.name ?? '?'}] [${i.priority}] ${i.title.slice(0, 60)} | children: ${i._count.children}${i.aiEligible ? ' | AI✓' : ''}`,
         );
         return text(`Backlog (${issues.length} issues):\n${rows.join('\n')}`);
       } catch (err) {

--- a/backend/src/mcp/tools/sprints.ts
+++ b/backend/src/mcp/tools/sprints.ts
@@ -19,7 +19,7 @@ export function registerSprintTools(server: McpServer) {
             projectId: proj.id,
             state: { in: ['ACTIVE', 'PLANNED'] },
           },
-          orderBy: [{ state: 'asc' }, { startDate: 'desc' }],
+          orderBy: [{ state: 'desc' }, { startDate: 'desc' }],
           include: {
             issues: {
               select: {

--- a/backend/src/mcp/tools/sprints.ts
+++ b/backend/src/mcp/tools/sprints.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { prisma, text, errText } from '../context.js';
+
+export function registerSprintTools(server: McpServer) {
+  // ── get_sprint_context ────────────────────────────────────────────────────────
+  server.tool(
+    'get_sprint_context',
+    'Get the active (or latest planned) sprint with issue stats and AI summary',
+    { project: z.string().describe('Project key, e.g. TTMP') },
+    async ({ project }) => {
+      try {
+        const proj = await prisma.project.findUnique({ where: { key: project.toUpperCase() } });
+        if (!proj) return errText(`Project ${project} not found`);
+
+        const sprint = await prisma.sprint.findFirst({
+          where: {
+            projectId: proj.id,
+            state: { in: ['ACTIVE', 'PLANNED'] },
+          },
+          orderBy: [{ state: 'asc' }, { startDate: 'desc' }],
+          include: {
+            issues: {
+              select: {
+                status: true,
+                priority: true,
+                aiEligible: true,
+                aiExecutionStatus: true,
+                aiAssigneeType: true,
+                type: true,
+                number: true,
+                title: true,
+                assignee: { select: { name: true } },
+              },
+            },
+          },
+        });
+
+        if (!sprint) return text(`No active or planned sprint found for ${project}.`);
+
+        const issues = sprint.issues;
+        const byStatus = {
+          OPEN: issues.filter(i => i.status === 'OPEN').length,
+          IN_PROGRESS: issues.filter(i => i.status === 'IN_PROGRESS').length,
+          REVIEW: issues.filter(i => i.status === 'REVIEW').length,
+          DONE: issues.filter(i => i.status === 'DONE').length,
+          CANCELLED: issues.filter(i => i.status === 'CANCELLED').length,
+        };
+
+        const aiEligible = issues.filter(i => i.aiEligible);
+        const aiInProgress = aiEligible.filter(i => i.aiExecutionStatus === 'IN_PROGRESS');
+        const aiNotStarted = aiEligible.filter(i => i.aiExecutionStatus === 'NOT_STARTED');
+
+        const daysLeft = sprint.endDate
+          ? Math.ceil((sprint.endDate.getTime() - Date.now()) / 86_400_000)
+          : null;
+
+        const lines = [
+          `Sprint: ${sprint.name} [${sprint.state}]`,
+          sprint.startDate && sprint.endDate
+            ? `Period: ${sprint.startDate.toISOString().slice(0, 10)} — ${sprint.endDate.toISOString().slice(0, 10)}${daysLeft !== null ? ` (${daysLeft > 0 ? daysLeft + ' days left' : 'overdue'})` : ''}`
+            : `Period: not set`,
+          sprint.goal ? `Goal: ${sprint.goal}` : '',
+          ``,
+          `Issues: ${issues.length} total`,
+          `  OPEN: ${byStatus.OPEN} | IN_PROGRESS: ${byStatus.IN_PROGRESS} | REVIEW: ${byStatus.REVIEW} | DONE: ${byStatus.DONE}`,
+          ``,
+          `AI-eligible: ${aiEligible.length}`,
+          `  NOT_STARTED: ${aiNotStarted.length} | IN_PROGRESS: ${aiInProgress.length} | DONE: ${aiEligible.filter(i => i.aiExecutionStatus === 'DONE').length}`,
+        ];
+
+        if (aiNotStarted.length > 0) {
+          lines.push('');
+          lines.push('Ready for agent:');
+          for (const i of aiNotStarted.slice(0, 10)) {
+            lines.push(`  ${project.toUpperCase()}-${i.number} [${i.type}] [${i.priority}] ${i.title.slice(0, 60)}`);
+          }
+        }
+
+        return text(lines.filter(l => l !== null).join('\n'));
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── get_backlog ───────────────────────────────────────────────────────────────
+  server.tool(
+    'get_backlog',
+    'Get issues in the backlog (not assigned to any sprint)',
+    {
+      project: z.string().describe('Project key, e.g. TTMP'),
+      limit: z.number().int().min(1).max(100).default(30),
+    },
+    async ({ project, limit }) => {
+      try {
+        const proj = await prisma.project.findUnique({ where: { key: project.toUpperCase() } });
+        if (!proj) return errText(`Project ${project} not found`);
+
+        const issues = await prisma.issue.findMany({
+          where: {
+            projectId: proj.id,
+            sprintId: null,
+            status: { notIn: ['DONE', 'CANCELLED'] },
+          },
+          include: {
+            _count: { select: { children: true } },
+          },
+          orderBy: [{ priority: 'asc' }, { createdAt: 'asc' }],
+          take: limit,
+        });
+
+        if (issues.length === 0) return text('Backlog is empty.');
+
+        const rows = issues.map(i =>
+          `${project.toUpperCase()}-${i.number} [${i.type}] [${i.priority}] ${i.title.slice(0, 60)} | children: ${i._count.children}${i.aiEligible ? ' | AI✓' : ''}`,
+        );
+        return text(`Backlog (${issues.length} issues):\n${rows.join('\n')}`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+}

--- a/backend/src/mcp/tools/time.ts
+++ b/backend/src/mcp/tools/time.ts
@@ -1,0 +1,192 @@
+import { z } from 'zod';
+import { Decimal } from '@prisma/client/runtime/library';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+
+const AI_HOURLY_RATE_USD = parseFloat(process.env.AI_HOURLY_RATE ?? '50');
+
+export function registerTimeTools(server: McpServer) {
+  // ── log_time ──────────────────────────────────────────────────────────────────
+  server.tool(
+    'log_time',
+    'Log agent time on an issue (source=AGENT)',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      hours: z.number().min(0.05).max(24).describe('Hours spent, e.g. 1.5'),
+      note: z.string().optional().describe('Short description of work done'),
+      sessionId: z.string().optional().describe('AiSession UUID to link this log to'),
+    },
+    async ({ key, hours, note, sessionId }) => {
+      try {
+        const issue = await resolveKey(key);
+        const agentUserId = await getAgentUserId();
+
+        await prisma.timeLog.create({
+          data: {
+            issueId: issue.id,
+            userId: agentUserId,
+            hours: new Decimal(Math.round(hours * 100) / 100),
+            note: note ?? null,
+            logDate: new Date(),
+            source: 'AGENT',
+            agentSessionId: sessionId ?? null,
+          },
+        });
+
+        return text(`Logged ${hours}h on ${key} (source=AGENT) ✓`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── register_ai_session ───────────────────────────────────────────────────────
+  server.tool(
+    'register_ai_session',
+    'Record an AI session with token/cost metrics. Call at the end of each development session.',
+    {
+      issues: z
+        .array(z.object({ key: z.string(), ratio: z.number().min(0).max(1) }))
+        .min(1)
+        .describe('Issues to split cost across, ratios should sum to 1'),
+      model: z.string().describe('Model ID, e.g. claude-sonnet-4-6'),
+      provider: z.string().default('anthropic'),
+      tokensInput: z.number().int().min(0),
+      tokensOutput: z.number().int().min(0),
+      costUSD: z.number().min(0).describe('Total cost in USD'),
+      notes: z.string().optional(),
+    },
+    async ({ issues, model, provider, tokensInput, tokensOutput, costUSD, notes }) => {
+      try {
+        const agentUserId = await getAgentUserId();
+
+        // Resolve all issue keys
+        const resolved = await Promise.all(issues.map(i => resolveKey(i.key)));
+
+        // Normalize ratios in case they don't sum to exactly 1
+        const totalRatio = issues.reduce((s, i) => s + i.ratio, 0);
+        const safeTotalRatio = totalRatio > 0 ? totalRatio : 1;
+
+        const totalHours = AI_HOURLY_RATE_USD > 0 ? costUSD / AI_HOURLY_RATE_USD : 0;
+
+        const now = new Date();
+        const startedAt = new Date(now.getTime() - totalHours * 3_600_000);
+
+        const session = await prisma.aiSession.create({
+          data: {
+            issueId: resolved[0].id,
+            userId: agentUserId,
+            model,
+            provider,
+            startedAt,
+            finishedAt: now,
+            tokensInput,
+            tokensOutput,
+            costMoney: new Decimal(costUSD),
+            notes: notes ?? null,
+          },
+        });
+
+        // Create TimeLogs for each issue split
+        const logsData = issues.map((split, idx) => {
+          const normalizedRatio = split.ratio / safeTotalRatio;
+          const splitHours = totalHours * normalizedRatio;
+          const splitCost = costUSD * normalizedRatio;
+          return {
+            issueId: resolved[idx].id,
+            userId: agentUserId,
+            hours: new Decimal(Math.round(splitHours * 100) / 100),
+            note: notes ?? null,
+            logDate: now,
+            source: 'AGENT' as const,
+            agentSessionId: session.id,
+            startedAt,
+            stoppedAt: now,
+            costMoney: new Decimal(Math.round(splitCost * 10_000) / 10_000),
+          };
+        });
+
+        if (logsData.length > 0) {
+          await prisma.timeLog.createMany({ data: logsData });
+        }
+
+        const splitLines = issues.map((s, i) => {
+          const h = Math.round((totalHours * (s.ratio / safeTotalRatio)) * 100) / 100;
+          return `  ${s.key} (${Math.round(s.ratio * 100)}% = ${h}h)`;
+        });
+
+        const lines = [
+          `AiSession created: ${model}`,
+          `Tokens: ${tokensInput.toLocaleString()} in / ${tokensOutput.toLocaleString()} out | Cost: $${costUSD.toFixed(4)}`,
+          `Total hours: ${Math.round(totalHours * 100) / 100}h @ $${AI_HOURLY_RATE_USD}/hr`,
+          `Logged to:`,
+          ...splitLines,
+          `Session ID: ${session.id}`,
+        ];
+
+        return text(lines.join('\n'));
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── get_time_summary ──────────────────────────────────────────────────────────
+  server.tool(
+    'get_time_summary',
+    'Get human vs agent time breakdown for an issue',
+    { key: z.string().describe('Issue key, e.g. TTMP-95') },
+    async ({ key }) => {
+      try {
+        const issue = await resolveKey(key);
+
+        const logs = await prisma.timeLog.findMany({
+          where: { issueId: issue.id },
+          select: { source: true, hours: true, costMoney: true, logDate: true, note: true },
+          orderBy: { logDate: 'desc' },
+        });
+
+        if (logs.length === 0) return text(`${key}: No time logged yet.`);
+
+        const humanHours = logs.filter(l => l.source === 'HUMAN').reduce((s, l) => s + Number(l.hours), 0);
+        const agentHours = logs.filter(l => l.source === 'AGENT').reduce((s, l) => s + Number(l.hours), 0);
+        const agentCost = logs
+          .filter(l => l.source === 'AGENT' && l.costMoney)
+          .reduce((s, l) => s + Number(l.costMoney ?? 0), 0);
+
+        const aiSessions = await prisma.aiSession.findMany({
+          where: { issueId: issue.id },
+          select: { id: true, model: true, costMoney: true, finishedAt: true },
+          orderBy: { finishedAt: 'desc' },
+        });
+
+        const sessionCost = aiSessions.reduce((s, a) => s + Number(a.costMoney ?? 0), 0);
+
+        const lines = [
+          `${key} Time Summary`,
+          `─────────────────────`,
+          `HUMAN:  ${humanHours.toFixed(2)}h`,
+          `AGENT:  ${agentHours.toFixed(2)}h`,
+          `Total:  ${(humanHours + agentHours).toFixed(2)}h`,
+          ``,
+          `AI cost (TimeLogs): $${agentCost.toFixed(4)}`,
+          `AI cost (Sessions): $${sessionCost.toFixed(4)}`,
+          `AI Sessions: ${aiSessions.length}`,
+        ];
+
+        if (aiSessions.length > 0) {
+          lines.push('');
+          lines.push('Recent sessions:');
+          for (const s of aiSessions.slice(0, 5)) {
+            lines.push(`  ${s.finishedAt.toISOString().slice(0, 16)} ${s.model} $${Number(s.costMoney ?? 0).toFixed(4)}`);
+          }
+        }
+
+        return text(lines.join('\n'));
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+}

--- a/backend/src/prisma/seed.ts
+++ b/backend/src/prisma/seed.ts
@@ -53,6 +53,19 @@ async function main(prismaClient?: PrismaClient, scope?: string) {
     await bootstrapDefaultUsers(client, defaultPassword, bootstrapUsers);
   }
 
+  // MCP system agent user — upsert so it's always present
+  await client.user.upsert({
+    where: { email: 'agent@flow-universe.internal' },
+    create: {
+      email: 'agent@flow-universe.internal',
+      name: 'Flow Universe Agent',
+      passwordHash: 'mcp-system-no-login',
+      role: 'USER',
+      isActive: true,
+    },
+    update: {},
+  });
+
   const seededUsers = await Promise.all(
     bootstrapUsers.map((user) =>
       client.user.findUniqueOrThrow({


### PR DESCRIPTION
## Summary

- Добавлен MCP-сервер (`backend/src/mcp/`) — AI-агенты теперь могут работать с задачами напрямую через Claude Code без HTTP
- 14 инструментов через stdio-транспорт с прямым доступом к Prisma/PostgreSQL
- Зарегистрирован в `.mcp.json` для автообнаружения Claude Code

## Инструменты

| Группа | Инструменты |
|--------|-------------|
| Issues | `get_issue`, `list_issues`, `update_status`, `create_subtask` |
| Sprints | `get_sprint_context`, `get_backlog` |
| Time | `log_time`, `register_ai_session`, `get_time_summary` |
| Comments | `add_comment`, `get_comments` |
| Agent | `get_eligible_issues`, `claim_issue`, `complete_issue`, `fail_issue` |

## Изменения

- `backend/src/mcp/server.ts` — точка входа, stdio-транспорт
- `backend/src/mcp/context.ts` — `resolveKey()`, `getAgentUserId()`, общие утилиты
- `backend/src/mcp/tools/*.ts` — 5 модулей с инструментами
- `backend/src/prisma/seed.ts` — системный пользователь `agent@flow-universe.internal`
- `backend/package.json` — зависимость `@modelcontextprotocol/sdk`, скрипт `npm run mcp`
- `.mcp.json` — регистрация сервера для Claude Code

## Test plan

- [ ] `npm run mcp` запускается без ошибок
- [ ] `npx @modelcontextprotocol/inspector node dist/mcp/server.js` — все 14 инструментов видны
- [ ] `get_issue TTMP-1` возвращает карточку задачи
- [ ] `claim_issue` → `complete_issue` — полный цикл агента
- [ ] В Claude Code: `/mcp` показывает `flow-universe` сервер