### PR TITLE
feat(mcp): HTTP transport + write ops via backend API (workflow engine)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "flow-universe": {
+      "command": "npm",
+      "args": ["run", "mcp"],
+      "cwd": "/Users/pavelnovak/tasktime-mvp/.claude/worktrees/dazzling-blackwell/backend",
+      "env": {
+        "AI_HOURLY_RATE": "50"
+      }
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,8 +3,27 @@
     "flow-universe": {
       "command": "npm",
       "args": ["run", "mcp"],
-      "cwd": "/Users/pavelnovak/tasktime-mvp/.claude/worktrees/dazzling-blackwell/backend",
+      "cwd": "backend",
       "env": {
+        "MCP_ENV": "development",
+        "AI_HOURLY_RATE": "50"
+      }
+    },
+    "flow-universe-staging": {
+      "command": "npm",
+      "args": ["run", "mcp"],
+      "cwd": "backend",
+      "env": {
+        "MCP_ENV": "staging",
+        "AI_HOURLY_RATE": "50"
+      }
+    },
+    "flow-universe-prod": {
+      "command": "npm",
+      "args": ["run", "mcp"],
+      "cwd": "backend",
+      "env": {
+        "MCP_ENV": "production",
         "AI_HOURLY_RATE": "50"
       }
     }

--- a/.mcp.json
+++ b/.mcp.json
@@ -10,21 +10,17 @@
       }
     },
     "flow-universe-staging": {
-      "command": "npm",
-      "args": ["run", "mcp"],
-      "cwd": "backend",
-      "env": {
-        "MCP_ENV": "staging",
-        "AI_HOURLY_RATE": "50"
+      "type": "streamable-http",
+      "url": "http://5.129.242.171:3002/mcp",
+      "headers": {
+        "Authorization": "Bearer REPLACE_WITH_MCP_SERVICE_TOKEN"
       }
     },
     "flow-universe-prod": {
-      "command": "npm",
-      "args": ["run", "mcp"],
-      "cwd": "backend",
-      "env": {
-        "MCP_ENV": "production",
-        "AI_HOURLY_RATE": "50"
+      "type": "streamable-http",
+      "url": "http://72.56.7.218:3002/mcp",
+      "headers": {
+        "Authorization": "Bearer REPLACE_WITH_MCP_SERVICE_TOKEN"
       }
     }
   }

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,5 +26,9 @@ FEATURES_TELEGRAM=false
 AI_PROVIDER=heuristic
 # Anthropic API key (required when AI_PROVIDER=anthropic)
 # ANTHROPIC_API_KEY=sk-ant-...
-# MCP service token (long-lived JWT for openapi-to-mcp proxy)
+# MCP service token (Bearer token for HTTP MCP endpoint)
 # MCP_SERVICE_TOKEN=
+# MCP agent service account password (set AGENT_MCP_PASSWORD before running seed)
+# Used by api-client.ts to authenticate write operations via the backend API.
+# Generate: openssl rand -base64 24
+# AGENT_MCP_PASSWORD=

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,0 +1,6 @@
+# MCP — Production environment
+# Copy to .env.production and fill real credentials (never commit .env.production)
+DATABASE_URL="postgresql://tasktime:CHANGE_ME@72.56.7.218:5432/tasktime?schema=public"
+REDIS_URL="redis://72.56.7.218:6379"
+AI_HOURLY_RATE=50
+MCP_ENV=production

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -20,6 +20,9 @@ MCP_ENV=production
 # Write operations route through the backend API (workflow engine + RBAC).
 # In Docker: use http://host.docker.internal:3000 (backend on host) or http://backend:3000 (same network)
 # In stdio mode: tunnel the API port: ssh -L 3001:localhost:3000 root@72.56.7.218 -N
+# Write operations route through the backend API.
+# AGENT_MCP_PASSWORD must match what was used when running db:seed (sets agent user password).
 BACKEND_INTERNAL_URL=http://localhost:3000
 MCP_AGENT_EMAIL=agent@flow-universe.internal
 MCP_AGENT_PASSWORD=CHANGE_ME
+AGENT_MCP_PASSWORD=CHANGE_ME

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,12 +1,25 @@
 # MCP — Production environment
 # Copy to .env.production and fill real credentials (never commit .env.production)
 #
-# ВАЖНО: использовать техническую УЗ flowuniverse_mcp, не tasktime (admin)
+# ВАЖНО: использовать техническую УЗ flowuniverse_mcp для БД, не tasktime (admin)
 # Создать пользователя: psql -U postgres -d tasktime -f scripts/mcp-db-user.sql
 #
-# Доступ через SSH-туннель:
-#   ssh -L 5435:localhost:5432 root@72.56.7.218 -N
+# Режим запуска:
+#   HTTP transport (Docker на сервере):
+#     MCP_SERVICE_TOKEN=<token> MCP_AGENT_PASSWORD=<pwd> docker compose --profile mcp up -d mcp-flow-universe
+#
+#   Stdio (локальная разработка, SSH-туннель на БД):
+#     ssh -L 5435:localhost:5432 root@72.56.7.218 -N &
+#     ssh -L 3001:localhost:3000 root@72.56.7.218 -N &
+#     MCP_ENV=production npm run mcp
 DATABASE_URL="postgresql://flowuniverse_mcp:CHANGE_ME@localhost:5435/tasktime?schema=public"
 REDIS_URL="redis://localhost:6381"
 AI_HOURLY_RATE=50
 MCP_ENV=production
+
+# Write operations route through the backend API (workflow engine + RBAC).
+# In Docker: use http://host.docker.internal:3000 (backend on host) or http://backend:3000 (same network)
+# In stdio mode: tunnel the API port: ssh -L 3001:localhost:3000 root@72.56.7.218 -N
+BACKEND_INTERNAL_URL=http://localhost:3000
+MCP_AGENT_EMAIL=agent@flow-universe.internal
+MCP_AGENT_PASSWORD=CHANGE_ME

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,6 +1,12 @@
 # MCP — Production environment
 # Copy to .env.production and fill real credentials (never commit .env.production)
-DATABASE_URL="postgresql://tasktime:CHANGE_ME@72.56.7.218:5432/tasktime?schema=public"
-REDIS_URL="redis://72.56.7.218:6379"
+#
+# ВАЖНО: использовать техническую УЗ flowuniverse_mcp, не tasktime (admin)
+# Создать пользователя: psql -U postgres -d tasktime -f scripts/mcp-db-user.sql
+#
+# Доступ через SSH-туннель:
+#   ssh -L 5435:localhost:5432 root@72.56.7.218 -N
+DATABASE_URL="postgresql://flowuniverse_mcp:CHANGE_ME@localhost:5435/tasktime?schema=public"
+REDIS_URL="redis://localhost:6381"
 AI_HOURLY_RATE=50
 MCP_ENV=production

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -1,6 +1,12 @@
 # MCP — Staging environment
 # Copy to .env.staging and fill real credentials (never commit .env.staging)
-DATABASE_URL="postgresql://tasktime:CHANGE_ME@5.129.242.171:5432/tasktime?schema=public"
-REDIS_URL="redis://5.129.242.171:6379"
+#
+# ВАЖНО: использовать техническую УЗ flowuniverse_mcp, не tasktime (admin)
+# Создать пользователя: psql -U postgres -d tasktime -f scripts/mcp-db-user.sql
+#
+# Доступ через SSH-туннель:
+#   ssh -L 5434:localhost:5432 root@5.129.242.171 -N
+DATABASE_URL="postgresql://flowuniverse_mcp:CHANGE_ME@localhost:5434/tasktime?schema=public"
+REDIS_URL="redis://localhost:6380"
 AI_HOURLY_RATE=50
 MCP_ENV=staging

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -1,0 +1,6 @@
+# MCP — Staging environment
+# Copy to .env.staging and fill real credentials (never commit .env.staging)
+DATABASE_URL="postgresql://tasktime:CHANGE_ME@5.129.242.171:5432/tasktime?schema=public"
+REDIS_URL="redis://5.129.242.171:6379"
+AI_HOURLY_RATE=50
+MCP_ENV=staging

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -20,6 +20,9 @@ MCP_ENV=staging
 # Write operations route through the backend API (workflow engine + RBAC).
 # In Docker: use http://host.docker.internal:3000 (backend on host) or http://backend:3000 (same network)
 # In stdio mode: tunnel the API port: ssh -L 3001:localhost:3000 root@5.129.242.171 -N
+# Write operations route through the backend API.
+# AGENT_MCP_PASSWORD must match what was used when running db:seed (sets agent user password).
 BACKEND_INTERNAL_URL=http://localhost:3000
 MCP_AGENT_EMAIL=agent@flow-universe.internal
 MCP_AGENT_PASSWORD=CHANGE_ME
+AGENT_MCP_PASSWORD=CHANGE_ME

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -1,12 +1,25 @@
 # MCP — Staging environment
 # Copy to .env.staging and fill real credentials (never commit .env.staging)
 #
-# ВАЖНО: использовать техническую УЗ flowuniverse_mcp, не tasktime (admin)
+# ВАЖНО: использовать техническую УЗ flowuniverse_mcp для БД, не tasktime (admin)
 # Создать пользователя: psql -U postgres -d tasktime -f scripts/mcp-db-user.sql
 #
-# Доступ через SSH-туннель:
-#   ssh -L 5434:localhost:5432 root@5.129.242.171 -N
+# Режим запуска:
+#   HTTP transport (Docker на сервере):
+#     MCP_SERVICE_TOKEN=<token> MCP_AGENT_PASSWORD=<pwd> docker compose --profile mcp up -d mcp-flow-universe
+#
+#   Stdio (локальная разработка, SSH-туннель на БД):
+#     ssh -L 5434:localhost:5432 root@5.129.242.171 -N &
+#     ssh -L 3001:localhost:3000 root@5.129.242.171 -N &
+#     MCP_ENV=staging npm run mcp
 DATABASE_URL="postgresql://flowuniverse_mcp:CHANGE_ME@localhost:5434/tasktime?schema=public"
 REDIS_URL="redis://localhost:6380"
 AI_HOURLY_RATE=50
 MCP_ENV=staging
+
+# Write operations route through the backend API (workflow engine + RBAC).
+# In Docker: use http://host.docker.internal:3000 (backend on host) or http://backend:3000 (same network)
+# In stdio mode: tunnel the API port: ssh -L 3001:localhost:3000 root@5.129.242.171 -N
+BACKEND_INTERNAL_URL=http://localhost:3000
+MCP_AGENT_EMAIL=agent@flow-universe.internal
+MCP_AGENT_PASSWORD=CHANGE_ME

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@prisma/client": "^6.5.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
@@ -769,6 +770,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -827,6 +840,368 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
@@ -2140,6 +2515,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2740,7 +3154,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3788,6 +4201,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3844,6 +4278,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -3878,7 +4330,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3901,6 +4352,22 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4382,6 +4849,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -4479,6 +4955,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -4727,6 +5212,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4883,7 +5374,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jiti": {
@@ -4894,6 +5384,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -4929,6 +5428,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5441,7 +5946,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5551,7 +6055,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5612,6 +6115,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -5878,6 +6390,15 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -5962,6 +6483,55 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-array-concat": {
@@ -6161,7 +6731,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6174,7 +6743,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7097,7 +7665,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7229,7 +7796,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
@@ -7252,6 +7818,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,8 @@
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src/ --ext .ts",
     "format": "prettier --write 'src/**/*.ts'",
-    "mcp": "tsx src/mcp/server.ts"
+    "mcp": "tsx src/mcp/server.ts",
+    "mcp:http": "MCP_TRANSPORT=http tsx src/mcp/server.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,10 +26,12 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src/ --ext .ts",
-    "format": "prettier --write 'src/**/*.ts'"
+    "format": "prettier --write 'src/**/*.ts'",
+    "mcp": "tsx src/mcp/server.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@prisma/client": "^6.5.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",

--- a/backend/scripts/mcp-db-user.sql
+++ b/backend/scripts/mcp-db-user.sql
@@ -1,0 +1,110 @@
+-- =============================================================================
+-- FlowUniverse MCP — техническая учётная запись PostgreSQL
+-- =============================================================================
+-- Запуск: psql -U postgres -d tasktime -f mcp-db-user.sql
+--
+-- Принцип: минимальные привилегии для работы 14 MCP-инструментов.
+-- Агент может читать всё, писать только в рабочие таблицы,
+-- удалять и менять структуру — запрещено.
+-- =============================================================================
+
+-- 1. Создать пользователя (заменить пароль перед запуском)
+CREATE USER "flowuniverse_mcp" WITH
+  PASSWORD 'CHANGE_ME_STRONG_PASSWORD'
+  NOSUPERUSER
+  NOCREATEDB
+  NOCREATEROLE
+  NOINHERIT
+  LOGIN
+  CONNECTION LIMIT 5;
+
+COMMENT ON ROLE "flowuniverse_mcp" IS 'FlowUniverse MCP — техническая УЗ для AI-агента. Только рабочие операции, без DDL и DELETE.';
+
+-- 2. Подключение к базе
+GRANT CONNECT ON DATABASE tasktime TO "flowuniverse_mcp";
+GRANT USAGE ON SCHEMA public TO "flowuniverse_mcp";
+
+-- =============================================================================
+-- 3. SELECT — читать всё (агенту нужен полный контекст)
+-- =============================================================================
+GRANT SELECT ON
+  users,
+  projects,
+  issues,
+  sprints,
+  releases,
+  comments,
+  time_logs,
+  ai_sessions,
+  audit_logs,
+  issue_type_configs,
+  issue_type_schemes,
+  issue_type_scheme_items,
+  issue_type_scheme_projects,
+  issue_links,
+  issue_link_types,
+  issue_custom_field_values,
+  custom_fields,
+  field_schemas,
+  field_schema_items,
+  field_schema_bindings,
+  teams,
+  team_members,
+  user_project_roles,
+  project_categories,
+  workflow_statuses,
+  workflows,
+  workflow_steps,
+  workflow_transitions,
+  workflow_schemes,
+  workflow_scheme_items,
+  workflow_scheme_projects,
+  transition_screens,
+  transition_screen_items,
+  system_settings
+TO "flowuniverse_mcp";
+
+-- =============================================================================
+-- 4. INSERT — создавать новые записи
+--    (подзадачи, комментарии, логи времени, AI-сессии, audit)
+-- =============================================================================
+GRANT INSERT ON
+  issues,        -- create_subtask
+  comments,      -- add_comment, complete_issue, fail_issue
+  time_logs,     -- log_time, register_ai_session
+  ai_sessions,   -- register_ai_session
+  audit_logs     -- claim_issue, complete_issue, fail_issue, update_status
+TO "flowuniverse_mcp";
+
+-- =============================================================================
+-- 5. UPDATE — только поля задач (статус, AI-флаги)
+--    НЕ users, НЕ projects, НЕ system_settings
+-- =============================================================================
+GRANT UPDATE ON
+  issues         -- update_status, claim_issue, complete_issue, fail_issue
+TO "flowuniverse_mcp";
+
+-- =============================================================================
+-- 6. Sequences — нужны для INSERT с auto-increment
+-- =============================================================================
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO "flowuniverse_mcp";
+
+-- =============================================================================
+-- 7. Явно запрещаем опасные операции (defence-in-depth)
+--    DELETE и DDL не выдавались — но явный REVOKE защищает от случайного
+--    наследования через роли.
+-- =============================================================================
+REVOKE DELETE ON ALL TABLES IN SCHEMA public FROM "flowuniverse_mcp";
+REVOKE TRUNCATE ON ALL TABLES IN SCHEMA public FROM "flowuniverse_mcp";
+
+-- Запрет на изменение структуры БД (DDL) — superuser-только, но для ясности:
+-- ALTER, DROP, CREATE — не выдавались и не будут.
+
+-- =============================================================================
+-- 8. Проверка (запустить после создания пользователя)
+-- =============================================================================
+-- \c tasktime flowuniverse_mcp
+-- SELECT id, email FROM users LIMIT 1;           -- должно работать
+-- UPDATE users SET name='x' WHERE false;         -- должно упасть с ошибкой прав
+-- DELETE FROM issues WHERE false;                -- должно упасть с ошибкой прав
+-- DROP TABLE issues;                             -- должно упасть с ошибкой прав

--- a/backend/src/mcp/api-client.ts
+++ b/backend/src/mcp/api-client.ts
@@ -1,0 +1,90 @@
+/**
+ * Internal HTTP client for MCP → Backend API calls.
+ *
+ * Write operations (status transitions, comments) go through the API so that
+ * the workflow engine, RBAC middleware, and post-functions execute normally.
+ * Read operations and agent-metadata fields (aiExecutionStatus, aiAssigneeType)
+ * still use Prisma directly since they carry no workflow logic.
+ *
+ * Required env vars:
+ *   BACKEND_INTERNAL_URL — URL of the running backend, e.g. http://localhost:3000
+ *                          or http://backend:3000 inside Docker. Defaults to
+ *                          http://localhost:3000 when not set.
+ *   MCP_AGENT_EMAIL      — login email for the agent service account
+ *                          (default: agent@flow-universe.internal)
+ *   MCP_AGENT_PASSWORD   — password for the agent service account (required)
+ */
+
+const BACKEND_URL = (process.env.BACKEND_INTERNAL_URL ?? 'http://localhost:3000').replace(/\/$/, '');
+const AGENT_EMAIL = process.env.MCP_AGENT_EMAIL ?? 'agent@flow-universe.internal';
+const AGENT_PASSWORD = process.env.MCP_AGENT_PASSWORD ?? '';
+
+let _accessToken: string | null = null;
+
+async function login(): Promise<void> {
+  if (!AGENT_PASSWORD) {
+    throw new Error(
+      'MCP_AGENT_PASSWORD is not configured. ' +
+        'Set it in your environment to allow MCP write operations via the backend API.',
+    );
+  }
+
+  const res = await fetch(`${BACKEND_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: AGENT_EMAIL, password: AGENT_PASSWORD }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Agent login failed (${res.status}): ${body}`);
+  }
+
+  const data = (await res.json()) as { accessToken: string };
+  _accessToken = data.accessToken;
+}
+
+async function token(): Promise<string> {
+  if (!_accessToken) await login();
+  return _accessToken!;
+}
+
+async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const send = async (tok: string): Promise<Response> =>
+    fetch(`${BACKEND_URL}${path}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${tok}`,
+      },
+      ...(body !== undefined && { body: JSON.stringify(body) }),
+    });
+
+  let res = await send(await token());
+
+  // Token expired — re-login once and retry
+  if (res.status === 401) {
+    _accessToken = null;
+    res = await send(await token());
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    let message: string;
+    try {
+      const json = JSON.parse(text) as { message?: string; error?: string };
+      message = json.message ?? json.error ?? text;
+    } catch {
+      message = text;
+    }
+    throw new Error(`${method} ${path} → HTTP ${res.status}: ${message}`);
+  }
+
+  const text = await res.text();
+  return (text ? JSON.parse(text) : {}) as T;
+}
+
+export const api = {
+  post: <T = unknown>(path: string, body: unknown) => request<T>('POST', path, body),
+  patch: <T = unknown>(path: string, body: unknown) => request<T>('PATCH', path, body),
+};

--- a/backend/src/mcp/auth-middleware.ts
+++ b/backend/src/mcp/auth-middleware.ts
@@ -1,0 +1,36 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export function mcpBearerAuth(req: Request, res: Response, next: NextFunction): void {
+  const token = process.env.MCP_SERVICE_TOKEN;
+
+  if (!token) {
+    res.status(500).json({
+      jsonrpc: '2.0',
+      error: { code: -32603, message: 'MCP_SERVICE_TOKEN not configured on server' },
+      id: null,
+    });
+    return;
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    res.status(401).json({
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Missing Authorization: Bearer <token>' },
+      id: null,
+    });
+    return;
+  }
+
+  const provided = authHeader.slice(7);
+  if (provided !== token) {
+    res.status(403).json({
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Invalid token' },
+      id: null,
+    });
+    return;
+  }
+
+  next();
+}

--- a/backend/src/mcp/context.ts
+++ b/backend/src/mcp/context.ts
@@ -1,0 +1,55 @@
+import { prisma } from '../prisma/client.js';
+
+export const AGENT_EMAIL = 'agent@flow-universe.internal';
+
+let _agentUserId: string | null = null;
+
+export async function getAgentUserId(): Promise<string> {
+  if (_agentUserId) return _agentUserId;
+  const user = await prisma.user.findUnique({ where: { email: AGENT_EMAIL } });
+  if (!user) throw new Error('Agent user not found. Run: npm run db:seed');
+  _agentUserId = user.id;
+  return _agentUserId;
+}
+
+const ISSUE_KEY_RE = /^([A-Z]{2,10})-(\d+)$/;
+
+export type ResolvedIssue = {
+  id: string;
+  key: string;
+  projectKey: string;
+  projectId: string;
+  title: string;
+  status: string;
+  type: string;
+  number: number;
+};
+
+export async function resolveKey(key: string): Promise<ResolvedIssue> {
+  const m = key.trim().toUpperCase().match(ISSUE_KEY_RE);
+  if (!m) throw new Error(`Invalid issue key: ${key}`);
+  const projectKey = m[1];
+  const number = parseInt(m[2], 10);
+
+  const project = await prisma.project.findUnique({ where: { key: projectKey } });
+  if (!project) throw new Error(`Project ${projectKey} not found`);
+
+  const issue = await prisma.issue.findUnique({
+    where: { projectId_number: { projectId: project.id, number } },
+    select: { id: true, title: true, status: true, type: true, projectId: true, number: true },
+  });
+  if (!issue) throw new Error(`Issue ${key} not found`);
+
+  return { ...issue, key: key.toUpperCase(), projectKey, status: issue.status as string, type: issue.type as string };
+}
+
+export function text(content: string) {
+  return { content: [{ type: 'text' as const, text: content }] };
+}
+
+export function errText(err: unknown) {
+  const msg = err instanceof Error ? err.message : String(err);
+  return { content: [{ type: 'text' as const, text: `Error: ${msg}` }], isError: true };
+}
+
+export { prisma };

--- a/backend/src/mcp/context.ts
+++ b/backend/src/mcp/context.ts
@@ -21,7 +21,6 @@ export type ResolvedIssue = {
   projectId: string;
   title: string;
   status: string;
-  type: string;
   number: number;
 };
 
@@ -36,11 +35,11 @@ export async function resolveKey(key: string): Promise<ResolvedIssue> {
 
   const issue = await prisma.issue.findUnique({
     where: { projectId_number: { projectId: project.id, number } },
-    select: { id: true, title: true, status: true, type: true, projectId: true, number: true },
+    select: { id: true, title: true, status: true, projectId: true, number: true },
   });
   if (!issue) throw new Error(`Issue ${key} not found`);
 
-  return { ...issue, key: key.toUpperCase(), projectKey, status: issue.status as string, type: issue.type as string };
+  return { ...issue, key: key.toUpperCase(), projectKey, status: issue.status as string };
 }
 
 export function text(content: string) {

--- a/backend/src/mcp/create-server.ts
+++ b/backend/src/mcp/create-server.ts
@@ -1,0 +1,21 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerIssueTools } from './tools/issues.js';
+import { registerSprintTools } from './tools/sprints.js';
+import { registerTimeTools } from './tools/time.js';
+import { registerCommentTools } from './tools/comments.js';
+import { registerAgentTools } from './tools/agent.js';
+
+export function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: 'flow-universe',
+    version: '1.0.0',
+  });
+
+  registerIssueTools(server);
+  registerSprintTools(server);
+  registerTimeTools(server);
+  registerCommentTools(server);
+  registerAgentTools(server);
+
+  return server;
+}

--- a/backend/src/mcp/http-transport.ts
+++ b/backend/src/mcp/http-transport.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from 'node:crypto';
+import express, { type Request, type Response } from 'express';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { createMcpServer } from './create-server.js';
+import { mcpBearerAuth } from './auth-middleware.js';
+
+const PORT = parseInt(process.env.MCP_HTTP_PORT ?? '3002', 10);
+
+const app = express();
+app.use(express.json());
+app.use('/mcp', mcpBearerAuth);
+
+// Session store: sessionId → transport
+const transports: Record<string, StreamableHTTPServerTransport> = {};
+
+// POST /mcp — main JSON-RPC endpoint
+app.post('/mcp', async (req: Request, res: Response) => {
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+  try {
+    // Resume existing session
+    if (sessionId && transports[sessionId]) {
+      await transports[sessionId].handleRequest(req, res, req.body);
+      return;
+    }
+
+    // New session — must start with initialize
+    if (!sessionId && isInitializeRequest(req.body)) {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (sid: string) => {
+          transports[sid] = transport;
+        },
+      });
+
+      transport.onclose = () => {
+        const sid = transport.sessionId;
+        if (sid) delete transports[sid];
+      };
+
+      const server = createMcpServer();
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    res.status(400).json({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Bad Request: missing or unknown session ID' },
+      id: null,
+    });
+  } catch {
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: { code: -32603, message: 'Internal server error' },
+        id: null,
+      });
+    }
+  }
+});
+
+// GET /mcp — SSE stream for server-sent notifications
+app.get('/mcp', async (req: Request, res: Response) => {
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+  if (!sessionId || !transports[sessionId]) {
+    res.status(400).send('Invalid or missing session ID');
+    return;
+  }
+  await transports[sessionId].handleRequest(req, res);
+});
+
+// DELETE /mcp — explicit session termination
+app.delete('/mcp', async (req: Request, res: Response) => {
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+  if (!sessionId || !transports[sessionId]) {
+    res.status(400).send('Invalid or missing session ID');
+    return;
+  }
+  await transports[sessionId].handleRequest(req, res);
+});
+
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`[MCP] HTTP server listening on :${PORT}`);
+  console.log(`[MCP] Environment: ${process.env.MCP_ENV ?? 'development'}`);
+});
+
+// Graceful shutdown
+async function shutdown() {
+  for (const [sid, transport] of Object.entries(transports)) {
+    await transport.close().catch(() => {});
+    delete transports[sid];
+  }
+  process.exit(0);
+}
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -2,9 +2,11 @@ import { config } from 'dotenv';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Load .env from backend root
+// Load env file based on MCP_ENV (development | staging | production)
 const __dirname = dirname(fileURLToPath(import.meta.url));
-config({ path: resolve(__dirname, '../../.env') });
+const MCP_ENV = process.env.MCP_ENV ?? 'development';
+const envFile = MCP_ENV === 'development' ? '.env' : `.env.${MCP_ENV}`;
+config({ path: resolve(__dirname, `../../${envFile}`) });
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -2,31 +2,23 @@ import { config } from 'dotenv';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Load env file based on MCP_ENV (development | staging | production)
+// Load env file before any other imports
+// MCP_ENV: development (default) | staging | production
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MCP_ENV = process.env.MCP_ENV ?? 'development';
 const envFile = MCP_ENV === 'development' ? '.env' : `.env.${MCP_ENV}`;
 config({ path: resolve(__dirname, `../../${envFile}`) });
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+// MCP_TRANSPORT: stdio (default, for local Claude Code) | http (for remote servers)
+const mcpTransport = process.env.MCP_TRANSPORT ?? 'stdio';
 
-import { registerIssueTools } from './tools/issues.js';
-import { registerSprintTools } from './tools/sprints.js';
-import { registerTimeTools } from './tools/time.js';
-import { registerCommentTools } from './tools/comments.js';
-import { registerAgentTools } from './tools/agent.js';
+if (mcpTransport === 'http') {
+  await import('./http-transport.js');
+} else {
+  const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
+  const { createMcpServer } = await import('./create-server.js');
 
-const server = new McpServer({
-  name: 'flow-universe',
-  version: '1.0.0',
-});
-
-registerIssueTools(server);
-registerSprintTools(server);
-registerTimeTools(server);
-registerCommentTools(server);
-registerAgentTools(server);
-
-const transport = new StdioServerTransport();
-await server.connect(transport);
+  const server = createMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -1,0 +1,30 @@
+import { config } from 'dotenv';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Load .env from backend root
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: resolve(__dirname, '../../.env') });
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+import { registerIssueTools } from './tools/issues.js';
+import { registerSprintTools } from './tools/sprints.js';
+import { registerTimeTools } from './tools/time.js';
+import { registerCommentTools } from './tools/comments.js';
+import { registerAgentTools } from './tools/agent.js';
+
+const server = new McpServer({
+  name: 'flow-universe',
+  version: '1.0.0',
+});
+
+registerIssueTools(server);
+registerSprintTools(server);
+registerTimeTools(server);
+registerCommentTools(server);
+registerAgentTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/backend/src/mcp/tools/agent.ts
+++ b/backend/src/mcp/tools/agent.ts
@@ -1,0 +1,199 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+
+export function registerAgentTools(server: McpServer) {
+  // ── get_eligible_issues ───────────────────────────────────────────────────────
+  server.tool(
+    'get_eligible_issues',
+    'Get the queue of AI-eligible issues not yet started (for autonomous agent)',
+    {
+      project: z.string().optional().describe('Project key to filter by, e.g. TTMP. Omit for all projects.'),
+      limit: z.number().int().min(1).max(50).default(20),
+    },
+    async ({ project, limit }) => {
+      try {
+        let projectId: string | undefined;
+        if (project) {
+          const proj = await prisma.project.findUnique({ where: { key: project.toUpperCase() } });
+          if (!proj) return errText(`Project ${project} not found`);
+          projectId = proj.id;
+        }
+
+        const issues = await prisma.issue.findMany({
+          where: {
+            aiEligible: true,
+            aiExecutionStatus: 'NOT_STARTED',
+            status: { notIn: ['DONE', 'CANCELLED'] },
+            ...(projectId ? { projectId } : {}),
+          },
+          include: {
+            project: { select: { key: true } },
+            sprint: { select: { name: true, state: true } },
+          },
+          orderBy: [{ priority: 'asc' }, { createdAt: 'asc' }],
+          take: limit,
+        });
+
+        if (issues.length === 0) {
+          return text('No AI-eligible issues with NOT_STARTED status found.');
+        }
+
+        const rows = issues.map(i =>
+          `${i.project.key}-${i.number} [${i.type}] [${i.priority}] [${i.status}] ${i.title.slice(0, 60)}${i.sprint ? ` | sprint: ${i.sprint.name}` : ' | backlog'}`,
+        );
+        return text(`Eligible issues (${issues.length}):\n${rows.join('\n')}\n\nUse claim_issue(key) to take one.`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── claim_issue ───────────────────────────────────────────────────────────────
+  server.tool(
+    'claim_issue',
+    'Atomically claim an AI-eligible issue for the agent (sets IN_PROGRESS + AGENT)',
+    { key: z.string().describe('Issue key, e.g. TTMP-95') },
+    async ({ key }) => {
+      try {
+        const issue = await resolveKey(key);
+        const agentUserId = await getAgentUserId();
+
+        const current = await prisma.issue.findUniqueOrThrow({
+          where: { id: issue.id },
+          select: { aiEligible: true, aiExecutionStatus: true },
+        });
+
+        if (!current.aiEligible) {
+          return errText(`${key} is not marked as AI-eligible. Set aiEligible=true first.`);
+        }
+        if (current.aiExecutionStatus === 'IN_PROGRESS') {
+          return errText(`${key} is already claimed (aiExecutionStatus=IN_PROGRESS).`);
+        }
+        if (current.aiExecutionStatus === 'DONE') {
+          return errText(`${key} is already done.`);
+        }
+
+        await prisma.$transaction([
+          prisma.issue.update({
+            where: { id: issue.id },
+            data: {
+              aiExecutionStatus: 'IN_PROGRESS',
+              aiAssigneeType: 'AGENT',
+              status: 'IN_PROGRESS',
+              assigneeId: agentUserId,
+            },
+          }),
+          prisma.auditLog.create({
+            data: {
+              action: 'UPDATE',
+              entityType: 'Issue',
+              entityId: issue.id,
+              userId: agentUserId,
+              details: { event: 'agent_claimed', key },
+            },
+          }),
+        ]);
+
+        return text(`${key} claimed by agent ✓\nStatus: IN_PROGRESS | aiExecutionStatus: IN_PROGRESS\nNext: get_issue("${key}") to read the full spec.`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── complete_issue ────────────────────────────────────────────────────────────
+  server.tool(
+    'complete_issue',
+    'Mark agent work as done. Sets status=REVIEW (awaiting human approval) + adds summary comment.',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      summary: z.string().min(1).max(5000).describe('What was done — becomes a comment on the issue'),
+    },
+    async ({ key, summary }) => {
+      try {
+        const issue = await resolveKey(key);
+        const agentUserId = await getAgentUserId();
+
+        await prisma.$transaction([
+          prisma.issue.update({
+            where: { id: issue.id },
+            data: {
+              aiExecutionStatus: 'DONE',
+              status: 'REVIEW',
+            },
+          }),
+          prisma.comment.create({
+            data: {
+              issueId: issue.id,
+              authorId: agentUserId,
+              body: `🤖 Agent completed work:\n\n${summary}`,
+            },
+          }),
+          prisma.auditLog.create({
+            data: {
+              action: 'UPDATE',
+              entityType: 'Issue',
+              entityId: issue.id,
+              userId: agentUserId,
+              details: { event: 'agent_completed', key },
+            },
+          }),
+        ]);
+
+        return text(`${key}: IN_PROGRESS → REVIEW ✓\nSummary comment added.\nAwaiting human review before DONE.`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── fail_issue ────────────────────────────────────────────────────────────────
+  server.tool(
+    'fail_issue',
+    'Escalate: agent could not complete the issue. Resets to OPEN for human.',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      reason: z.string().min(1).max(3000).describe('Why the agent failed — becomes an escalation comment'),
+    },
+    async ({ key, reason }) => {
+      try {
+        const issue = await resolveKey(key);
+        const agentUserId = await getAgentUserId();
+
+        await prisma.$transaction([
+          prisma.issue.update({
+            where: { id: issue.id },
+            data: {
+              aiExecutionStatus: 'FAILED',
+              status: 'OPEN',
+              aiAssigneeType: 'HUMAN',
+              assigneeId: null,
+            },
+          }),
+          prisma.comment.create({
+            data: {
+              issueId: issue.id,
+              authorId: agentUserId,
+              body: `⚠️ Agent escalation — could not complete:\n\n${reason}\n\nRequires manual intervention.`,
+            },
+          }),
+          prisma.auditLog.create({
+            data: {
+              action: 'UPDATE',
+              entityType: 'Issue',
+              entityId: issue.id,
+              userId: agentUserId,
+              details: { event: 'agent_failed', key, reason: reason.slice(0, 200) },
+            },
+          }),
+        ]);
+
+        return text(`${key}: FAILED | Returned to OPEN for human ✓\nEscalation comment added.`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+}

--- a/backend/src/mcp/tools/agent.ts
+++ b/backend/src/mcp/tools/agent.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+import { api } from '../api-client.js';
 
 export function registerAgentTools(server: McpServer) {
   // ── get_eligible_issues ───────────────────────────────────────────────────────
@@ -76,26 +77,16 @@ export function registerAgentTools(server: McpServer) {
           return errText(`${key} is already done.`);
         }
 
-        await prisma.$transaction([
-          prisma.issue.update({
-            where: { id: issue.id },
-            data: {
-              aiExecutionStatus: 'IN_PROGRESS',
-              aiAssigneeType: 'AGENT',
-              status: 'IN_PROGRESS',
-              assigneeId: agentUserId,
-            },
-          }),
-          prisma.auditLog.create({
-            data: {
-              action: 'UPDATE',
-              entityType: 'Issue',
-              entityId: issue.id,
-              userId: agentUserId,
-              details: { event: 'agent_claimed', key },
-            },
-          }),
-        ]);
+        // Status transition goes through the workflow engine via API.
+        // Assignee update uses the general PATCH endpoint (USER role is sufficient).
+        // AI-specific metadata (execution status, assignee type) are set directly —
+        // they have no workflow logic and the /ai-status endpoint requires MANAGER.
+        await api.patch(`/api/issues/${issue.id}/status`, { status: 'IN_PROGRESS' });
+        await api.patch(`/api/issues/${issue.id}`, { assigneeId: agentUserId });
+        await prisma.issue.update({
+          where: { id: issue.id },
+          data: { aiExecutionStatus: 'IN_PROGRESS', aiAssigneeType: 'AGENT' },
+        });
 
         return text(`${key} claimed by agent ✓\nStatus: IN_PROGRESS | aiExecutionStatus: IN_PROGRESS\nNext: get_issue("${key}") to read the full spec.`);
       } catch (err) {
@@ -115,33 +106,16 @@ export function registerAgentTools(server: McpServer) {
     async ({ key, summary }) => {
       try {
         const issue = await resolveKey(key);
-        const agentUserId = await getAgentUserId();
 
-        await prisma.$transaction([
-          prisma.issue.update({
-            where: { id: issue.id },
-            data: {
-              aiExecutionStatus: 'DONE',
-              status: 'REVIEW',
-            },
-          }),
-          prisma.comment.create({
-            data: {
-              issueId: issue.id,
-              authorId: agentUserId,
-              body: `🤖 Agent completed work:\n\n${summary}`,
-            },
-          }),
-          prisma.auditLog.create({
-            data: {
-              action: 'UPDATE',
-              entityType: 'Issue',
-              entityId: issue.id,
-              userId: agentUserId,
-              details: { event: 'agent_completed', key },
-            },
-          }),
-        ]);
+        await api.patch(`/api/issues/${issue.id}/status`, { status: 'REVIEW' });
+        await api.post(`/api/issues/${issue.id}/comments`, {
+          body: `🤖 Agent completed work:\n\n${summary}`,
+        });
+        // AI execution status is metadata only — no workflow logic, set directly.
+        await prisma.issue.update({
+          where: { id: issue.id },
+          data: { aiExecutionStatus: 'DONE' },
+        });
 
         return text(`${key}: IN_PROGRESS → REVIEW ✓\nSummary comment added.\nAwaiting human review before DONE.`);
       } catch (err) {
@@ -161,35 +135,17 @@ export function registerAgentTools(server: McpServer) {
     async ({ key, reason }) => {
       try {
         const issue = await resolveKey(key);
-        const agentUserId = await getAgentUserId();
 
-        await prisma.$transaction([
-          prisma.issue.update({
-            where: { id: issue.id },
-            data: {
-              aiExecutionStatus: 'FAILED',
-              status: 'OPEN',
-              aiAssigneeType: 'HUMAN',
-              assigneeId: null,
-            },
-          }),
-          prisma.comment.create({
-            data: {
-              issueId: issue.id,
-              authorId: agentUserId,
-              body: `⚠️ Agent escalation — could not complete:\n\n${reason}\n\nRequires manual intervention.`,
-            },
-          }),
-          prisma.auditLog.create({
-            data: {
-              action: 'UPDATE',
-              entityType: 'Issue',
-              entityId: issue.id,
-              userId: agentUserId,
-              details: { event: 'agent_failed', key, reason: reason.slice(0, 200) },
-            },
-          }),
-        ]);
+        await api.patch(`/api/issues/${issue.id}/status`, { status: 'OPEN' });
+        await api.patch(`/api/issues/${issue.id}`, { assigneeId: null });
+        await api.post(`/api/issues/${issue.id}/comments`, {
+          body: `⚠️ Agent escalation — could not complete:\n\n${reason}\n\nRequires manual intervention.`,
+        });
+        // AI metadata — no workflow logic, set directly.
+        await prisma.issue.update({
+          where: { id: issue.id },
+          data: { aiExecutionStatus: 'FAILED', aiAssigneeType: 'HUMAN' },
+        });
 
         return text(`${key}: FAILED | Returned to OPEN for human ✓\nEscalation comment added.`);
       } catch (err) {

--- a/backend/src/mcp/tools/agent.ts
+++ b/backend/src/mcp/tools/agent.ts
@@ -31,6 +31,7 @@ export function registerAgentTools(server: McpServer) {
           include: {
             project: { select: { key: true } },
             sprint: { select: { name: true, state: true } },
+            issueTypeConfig: { select: { name: true } },
           },
           orderBy: [{ priority: 'asc' }, { createdAt: 'asc' }],
           take: limit,
@@ -41,7 +42,7 @@ export function registerAgentTools(server: McpServer) {
         }
 
         const rows = issues.map(i =>
-          `${i.project.key}-${i.number} [${i.type}] [${i.priority}] [${i.status}] ${i.title.slice(0, 60)}${i.sprint ? ` | sprint: ${i.sprint.name}` : ' | backlog'}`,
+          `${i.project.key}-${i.number} [${i.issueTypeConfig?.name ?? '?'}] [${i.priority}] [${i.status}] ${i.title.slice(0, 60)}${i.sprint ? ` | sprint: ${i.sprint.name}` : ' | backlog'}`,
         );
         return text(`Eligible issues (${issues.length}):\n${rows.join('\n')}\n\nUse claim_issue(key) to take one.`);
       } catch (err) {

--- a/backend/src/mcp/tools/comments.ts
+++ b/backend/src/mcp/tools/comments.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+
+export function registerCommentTools(server: McpServer) {
+  // ── add_comment ───────────────────────────────────────────────────────────────
+  server.tool(
+    'add_comment',
+    'Add a progress update or summary comment to an issue',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      body: z.string().min(1).max(10_000).describe('Comment text (markdown supported)'),
+    },
+    async ({ key, body }) => {
+      try {
+        const issue = await resolveKey(key);
+        const agentUserId = await getAgentUserId();
+
+        const comment = await prisma.comment.create({
+          data: {
+            issueId: issue.id,
+            authorId: agentUserId,
+            body,
+          },
+        });
+
+        return text(`Comment added to ${key} (id: ${comment.id}) ✓`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── get_comments ──────────────────────────────────────────────────────────────
+  server.tool(
+    'get_comments',
+    'Get comments on an issue',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      limit: z.number().int().min(1).max(50).default(10),
+    },
+    async ({ key, limit }) => {
+      try {
+        const issue = await resolveKey(key);
+
+        const comments = await prisma.comment.findMany({
+          where: { issueId: issue.id },
+          include: { author: { select: { name: true, email: true } } },
+          orderBy: { createdAt: 'desc' },
+          take: limit,
+        });
+
+        if (comments.length === 0) return text(`${key}: No comments yet.`);
+
+        const rows = comments.map(c => {
+          const who = c.author.email.includes('flow-universe.internal') ? '🤖 Agent' : c.author.name;
+          const when = c.createdAt.toISOString().slice(0, 16);
+          return `[${when}] ${who}:\n${c.body}`;
+        });
+
+        return text(`${key} Comments (${comments.length}):\n${'─'.repeat(40)}\n${rows.join('\n' + '─'.repeat(40) + '\n')}`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+}

--- a/backend/src/mcp/tools/comments.ts
+++ b/backend/src/mcp/tools/comments.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+import { prisma, resolveKey, text, errText } from '../context.js';
+import { api } from '../api-client.js';
 
 export function registerCommentTools(server: McpServer) {
   // ── add_comment ───────────────────────────────────────────────────────────────
@@ -15,15 +16,8 @@ export function registerCommentTools(server: McpServer) {
     async ({ key, body }) => {
       try {
         const issue = await resolveKey(key);
-        const agentUserId = await getAgentUserId();
 
-        const comment = await prisma.comment.create({
-          data: {
-            issueId: issue.id,
-            authorId: agentUserId,
-            body,
-          },
-        });
+        const comment = await api.post<{ id: string }>(`/api/issues/${issue.id}/comments`, { body });
 
         return text(`Comment added to ${key} (id: ${comment.id}) ✓`);
       } catch (err) {

--- a/backend/src/mcp/tools/issues.ts
+++ b/backend/src/mcp/tools/issues.ts
@@ -1,0 +1,217 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+
+export function registerIssueTools(server: McpServer) {
+  // ── get_issue ────────────────────────────────────────────────────────────────
+  server.tool(
+    'get_issue',
+    'Get a full issue card by key (e.g. TTMP-95) or UUID',
+    { key: z.string().describe('Issue key like TTMP-95 or UUID') },
+    async ({ key }) => {
+      try {
+        const resolved = await resolveKey(key);
+        const issue = await prisma.issue.findUniqueOrThrow({
+          where: { id: resolved.id },
+          include: {
+            assignee: { select: { name: true, email: true } },
+            creator: { select: { name: true } },
+            parent: { select: { title: true, type: true, number: true, project: { select: { key: true } } } },
+            children: {
+              select: { title: true, type: true, status: true, number: true, project: { select: { key: true } } },
+              orderBy: { orderIndex: 'asc' },
+              take: 30,
+            },
+            sprint: { select: { name: true, state: true, startDate: true, endDate: true } },
+            release: { select: { name: true, state: true } },
+            project: { select: { key: true, name: true } },
+            _count: { select: { comments: true, timeLogs: true } },
+          },
+        });
+
+        const parentStr = issue.parent
+          ? `${issue.parent.project.key}-${issue.parent.type} "${issue.parent.title}"`
+          : 'none';
+
+        const sprintStr = issue.sprint
+          ? `${issue.sprint.name} [${issue.sprint.state}]${issue.sprint.endDate ? ` ends ${issue.sprint.endDate.toISOString().slice(0, 10)}` : ''}`
+          : 'none';
+
+        const childrenStr = issue.children.length > 0
+          ? issue.children.map(c => `  • ${c.project.key}-${c.number} [${c.type}] [${c.status}] ${c.title}`).join('\n')
+          : '  none';
+
+        const lines = [
+          `${resolved.key} [${issue.type}] [${issue.status}] [${issue.priority}]`,
+          `Title: ${issue.title}`,
+          ``,
+          `Sprint:   ${sprintStr}`,
+          `Release:  ${issue.release?.name ?? 'none'} ${issue.release ? `[${issue.release.state}]` : ''}`,
+          `Assignee: ${issue.assignee?.name ?? 'unassigned'}`,
+          `Creator:  ${issue.creator.name}`,
+          `Parent:   ${parentStr}`,
+          ``,
+          `Children (${issue.children.length}):`,
+          childrenStr,
+          ``,
+          issue.description ? `Description:\n${issue.description}` : `Description: (empty)`,
+          ``,
+          `EstimatedHours: ${issue.estimatedHours ?? 'not set'}`,
+          `AI: eligible=${issue.aiEligible}, status=${issue.aiExecutionStatus}, type=${issue.aiAssigneeType}`,
+          `Comments: ${issue._count.comments} | TimeLogs: ${issue._count.timeLogs}`,
+          `Created: ${issue.createdAt.toISOString().slice(0, 10)}`,
+        ];
+
+        return text(lines.join('\n'));
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── list_issues ───────────────────────────────────────────────────────────────
+  server.tool(
+    'list_issues',
+    'List issues with filters. Use sprint="active" for current sprint.',
+    {
+      project: z.string().describe('Project key, e.g. TTMP'),
+      sprint: z.string().optional().describe('"active" or sprint UUID or "backlog"'),
+      status: z.enum(['OPEN', 'IN_PROGRESS', 'REVIEW', 'DONE', 'CANCELLED']).optional(),
+      aiEligible: z.boolean().optional().describe('Only AI-eligible issues'),
+      assigneeType: z.enum(['HUMAN', 'AGENT', 'MIXED']).optional(),
+      limit: z.number().int().min(1).max(100).default(20),
+    },
+    async ({ project, sprint, status, aiEligible, assigneeType, limit }) => {
+      try {
+        const proj = await prisma.project.findUnique({ where: { key: project.toUpperCase() } });
+        if (!proj) return errText(`Project ${project} not found`);
+
+        let sprintId: string | null | undefined;
+        if (sprint === 'active') {
+          const activeSprint = await prisma.sprint.findFirst({ where: { projectId: proj.id, state: 'ACTIVE' } });
+          sprintId = activeSprint?.id ?? null;
+        } else if (sprint === 'backlog') {
+          sprintId = null;
+        } else if (sprint) {
+          sprintId = sprint;
+        }
+
+        const where: Record<string, unknown> = { projectId: proj.id };
+        if (status) where.status = status;
+        if (aiEligible !== undefined) where.aiEligible = aiEligible;
+        if (assigneeType) where.aiAssigneeType = assigneeType;
+        if (sprintId !== undefined) where.sprintId = sprintId;
+
+        const issues = await prisma.issue.findMany({
+          where,
+          include: {
+            assignee: { select: { name: true } },
+            sprint: { select: { name: true } },
+          },
+          orderBy: [{ priority: 'asc' }, { createdAt: 'desc' }],
+          take: limit,
+        });
+
+        if (issues.length === 0) return text('No issues found matching the filters.');
+
+        const header = `Found ${issues.length} issue(s) in ${project}:\n`;
+        const rows = issues.map(i =>
+          `${project.toUpperCase()}-${i.number} [${i.type}] [${i.status}] [${i.priority}] ${i.title.slice(0, 60)}${i.title.length > 60 ? '…' : ''} | ${i.assignee?.name ?? 'unassigned'}${i.aiEligible ? ' | AI✓' : ''}`,
+        );
+
+        return text(header + rows.join('\n'));
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── update_status ─────────────────────────────────────────────────────────────
+  server.tool(
+    'update_status',
+    'Change the status of an issue',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      status: z.enum(['OPEN', 'IN_PROGRESS', 'REVIEW', 'DONE', 'CANCELLED']),
+    },
+    async ({ key, status }) => {
+      try {
+        const resolved = await resolveKey(key);
+        const old = resolved.status;
+
+        await prisma.issue.update({ where: { id: resolved.id }, data: { status } });
+
+        await prisma.auditLog.create({
+          data: {
+            action: 'UPDATE',
+            entityType: 'Issue',
+            entityId: resolved.id,
+            details: { field: 'status', from: old, to: status },
+          },
+        });
+
+        return text(`${resolved.key}: ${old} → ${status} ✓`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── create_subtask ────────────────────────────────────────────────────────────
+  server.tool(
+    'create_subtask',
+    'Create a subtask under a parent issue (real decomposition)',
+    {
+      parentKey: z.string().describe('Parent issue key, e.g. TTMP-95'),
+      title: z.string().min(1).max(500),
+      description: z.string().optional(),
+      priority: z.enum(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']).default('MEDIUM'),
+    },
+    async ({ parentKey, title, description, priority }) => {
+      try {
+        const parent = await resolveKey(parentKey);
+
+        const allowedParents = ['EPIC', 'STORY', 'TASK'];
+        if (!allowedParents.includes(parent.type)) {
+          return errText(`${parent.type} cannot have subtasks. Allowed parents: EPIC, STORY, TASK`);
+        }
+
+        const agentUserId = await getAgentUserId();
+
+        const parentIssue = await prisma.issue.findUniqueOrThrow({
+          where: { id: parent.id },
+          select: { sprintId: true },
+        });
+
+        const last = await prisma.issue.findFirst({
+          where: { projectId: parent.projectId },
+          orderBy: { number: 'desc' },
+          select: { number: true },
+        });
+        const number = (last?.number ?? 0) + 1;
+
+        const child = await prisma.issue.create({
+          data: {
+            projectId: parent.projectId,
+            number,
+            title,
+            description,
+            type: 'SUBTASK',
+            priority,
+            status: 'OPEN',
+            parentId: parent.id,
+            sprintId: parentIssue.sprintId,
+            creatorId: agentUserId,
+          },
+          include: { project: { select: { key: true } } },
+        });
+
+        const childKey = `${child.project.key}-${child.number}`;
+        return text(`Created ${childKey}: "${title}" (SUBTASK → ${parentKey}) ✓`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+}

--- a/backend/src/mcp/tools/issues.ts
+++ b/backend/src/mcp/tools/issues.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+import { prisma, resolveKey, text, errText } from '../context.js';
+import { api } from '../api-client.js';
 
 export function registerIssueTools(server: McpServer) {
   // ── get_issue ────────────────────────────────────────────────────────────────
@@ -132,7 +133,7 @@ export function registerIssueTools(server: McpServer) {
   // ── update_status ─────────────────────────────────────────────────────────────
   server.tool(
     'update_status',
-    'Change the status of an issue',
+    'Change the status of an issue (routes through the workflow engine)',
     {
       key: z.string().describe('Issue key, e.g. TTMP-95'),
       status: z.enum(['OPEN', 'IN_PROGRESS', 'REVIEW', 'DONE', 'CANCELLED']),
@@ -142,16 +143,9 @@ export function registerIssueTools(server: McpServer) {
         const resolved = await resolveKey(key);
         const old = resolved.status;
 
-        await prisma.issue.update({ where: { id: resolved.id }, data: { status } });
-
-        await prisma.auditLog.create({
-          data: {
-            action: 'UPDATE',
-            entityType: 'Issue',
-            entityId: resolved.id,
-            details: { field: 'status', from: old, to: status },
-          },
-        });
+        // Route through backend API so the workflow engine, validators,
+        // and post-functions execute (e.g. required fields check before DONE).
+        await api.patch(`/api/issues/${resolved.id}/status`, { status });
 
         return text(`${resolved.key}: ${old} → ${status} ✓`);
       } catch (err) {
@@ -173,31 +167,19 @@ export function registerIssueTools(server: McpServer) {
     async ({ parentKey, title, description, priority }) => {
       try {
         const parent = await resolveKey(parentKey);
-        const agentUserId = await getAgentUserId();
 
-        const [parentIssue, subtaskConfig, last] = await Promise.all([
-          prisma.issue.findUniqueOrThrow({ where: { id: parent.id }, select: { sprintId: true } }),
-          prisma.issueTypeConfig.findFirst({ where: { isSubtask: true }, select: { id: true } }),
-          prisma.issue.findFirst({ where: { projectId: parent.projectId }, orderBy: { number: 'desc' }, select: { number: true } }),
-        ]);
-        if (!subtaskConfig) return errText('No subtask issue type configured in this project');
-        const number = (last?.number ?? 0) + 1;
-
-        const child = await prisma.issue.create({
-          data: {
-            projectId: parent.projectId,
-            number,
+        // Route through API so RBAC, hierarchy validation, and numbering
+        // are handled by the service layer.
+        const child = await api.post<{ number: number; project: { key: string } }>(
+          `/api/projects/${parent.projectId}/issues`,
+          {
             title,
             description,
-            issueTypeConfigId: subtaskConfig.id,
+            type: 'SUBTASK',
             priority,
-            status: 'OPEN',
             parentId: parent.id,
-            sprintId: parentIssue.sprintId,
-            creatorId: agentUserId,
           },
-          include: { project: { select: { key: true } } },
-        });
+        );
 
         const childKey = `${child.project.key}-${child.number}`;
         return text(`Created ${childKey}: "${title}" (SUBTASK → ${parentKey}) ✓`);

--- a/backend/src/mcp/tools/issues.ts
+++ b/backend/src/mcp/tools/issues.ts
@@ -31,7 +31,7 @@ export function registerIssueTools(server: McpServer) {
         });
 
         const parentStr = issue.parent
-          ? `${issue.parent.project.key}-${issue.parent.type} "${issue.parent.title}"`
+          ? `${issue.parent.project.key}-${issue.parent.number} [${issue.parent.type}] "${issue.parent.title}"`
           : 'none';
 
         const sprintStr = issue.sprint
@@ -90,7 +90,7 @@ export function registerIssueTools(server: McpServer) {
         let sprintId: string | null | undefined;
         if (sprint === 'active') {
           const activeSprint = await prisma.sprint.findFirst({ where: { projectId: proj.id, state: 'ACTIVE' } });
-          sprintId = activeSprint?.id ?? null;
+          sprintId = activeSprint?.id ?? undefined;
         } else if (sprint === 'backlog') {
           sprintId = null;
         } else if (sprint) {
@@ -172,9 +172,9 @@ export function registerIssueTools(server: McpServer) {
       try {
         const parent = await resolveKey(parentKey);
 
-        const allowedParents = ['EPIC', 'STORY', 'TASK'];
+        const allowedParents = ['EPIC', 'STORY', 'TASK', 'BUG'];
         if (!allowedParents.includes(parent.type)) {
-          return errText(`${parent.type} cannot have subtasks. Allowed parents: EPIC, STORY, TASK`);
+          return errText(`${parent.type} cannot have subtasks. Allowed parents: EPIC, STORY, TASK, BUG`);
         }
 
         const agentUserId = await getAgentUserId();

--- a/backend/src/mcp/tools/issues.ts
+++ b/backend/src/mcp/tools/issues.ts
@@ -17,6 +17,7 @@ export function registerIssueTools(server: McpServer) {
           include: {
             assignee: { select: { name: true, email: true } },
             creator: { select: { name: true } },
+            issueTypeConfig: { select: { name: true } },
             parent: { select: { title: true, number: true, issueTypeConfig: { select: { name: true } }, project: { select: { key: true } } } },
             children: {
               select: { title: true, status: true, number: true, issueTypeConfig: { select: { name: true } }, project: { select: { key: true } } },

--- a/backend/src/mcp/tools/issues.ts
+++ b/backend/src/mcp/tools/issues.ts
@@ -17,9 +17,9 @@ export function registerIssueTools(server: McpServer) {
           include: {
             assignee: { select: { name: true, email: true } },
             creator: { select: { name: true } },
-            parent: { select: { title: true, type: true, number: true, project: { select: { key: true } } } },
+            parent: { select: { title: true, number: true, issueTypeConfig: { select: { name: true } }, project: { select: { key: true } } } },
             children: {
-              select: { title: true, type: true, status: true, number: true, project: { select: { key: true } } },
+              select: { title: true, status: true, number: true, issueTypeConfig: { select: { name: true } }, project: { select: { key: true } } },
               orderBy: { orderIndex: 'asc' },
               take: 30,
             },
@@ -31,7 +31,7 @@ export function registerIssueTools(server: McpServer) {
         });
 
         const parentStr = issue.parent
-          ? `${issue.parent.project.key}-${issue.parent.number} [${issue.parent.type}] "${issue.parent.title}"`
+          ? `${issue.parent.project.key}-${issue.parent.number} [${issue.parent.issueTypeConfig?.name ?? '?'}] "${issue.parent.title}"`
           : 'none';
 
         const sprintStr = issue.sprint
@@ -39,11 +39,11 @@ export function registerIssueTools(server: McpServer) {
           : 'none';
 
         const childrenStr = issue.children.length > 0
-          ? issue.children.map(c => `  • ${c.project.key}-${c.number} [${c.type}] [${c.status}] ${c.title}`).join('\n')
+          ? issue.children.map(c => `  • ${c.project.key}-${c.number} [${c.issueTypeConfig?.name ?? '?'}] [${c.status}] ${c.title}`).join('\n')
           : '  none';
 
         const lines = [
-          `${resolved.key} [${issue.type}] [${issue.status}] [${issue.priority}]`,
+          `${resolved.key} [${issue.issueTypeConfig?.name ?? '?'}] [${issue.status}] [${issue.priority}]`,
           `Title: ${issue.title}`,
           ``,
           `Sprint:   ${sprintStr}`,
@@ -108,6 +108,7 @@ export function registerIssueTools(server: McpServer) {
           include: {
             assignee: { select: { name: true } },
             sprint: { select: { name: true } },
+            issueTypeConfig: { select: { name: true } },
           },
           orderBy: [{ priority: 'asc' }, { createdAt: 'desc' }],
           take: limit,
@@ -117,7 +118,7 @@ export function registerIssueTools(server: McpServer) {
 
         const header = `Found ${issues.length} issue(s) in ${project}:\n`;
         const rows = issues.map(i =>
-          `${project.toUpperCase()}-${i.number} [${i.type}] [${i.status}] [${i.priority}] ${i.title.slice(0, 60)}${i.title.length > 60 ? '…' : ''} | ${i.assignee?.name ?? 'unassigned'}${i.aiEligible ? ' | AI✓' : ''}`,
+          `${project.toUpperCase()}-${i.number} [${i.issueTypeConfig?.name ?? '?'}] [${i.status}] [${i.priority}] ${i.title.slice(0, 60)}${i.title.length > 60 ? '…' : ''} | ${i.assignee?.name ?? 'unassigned'}${i.aiEligible ? ' | AI✓' : ''}`,
         );
 
         return text(header + rows.join('\n'));
@@ -171,24 +172,14 @@ export function registerIssueTools(server: McpServer) {
     async ({ parentKey, title, description, priority }) => {
       try {
         const parent = await resolveKey(parentKey);
-
-        const allowedParents = ['EPIC', 'STORY', 'TASK', 'BUG'];
-        if (!allowedParents.includes(parent.type)) {
-          return errText(`${parent.type} cannot have subtasks. Allowed parents: EPIC, STORY, TASK, BUG`);
-        }
-
         const agentUserId = await getAgentUserId();
 
-        const parentIssue = await prisma.issue.findUniqueOrThrow({
-          where: { id: parent.id },
-          select: { sprintId: true },
-        });
-
-        const last = await prisma.issue.findFirst({
-          where: { projectId: parent.projectId },
-          orderBy: { number: 'desc' },
-          select: { number: true },
-        });
+        const [parentIssue, subtaskConfig, last] = await Promise.all([
+          prisma.issue.findUniqueOrThrow({ where: { id: parent.id }, select: { sprintId: true } }),
+          prisma.issueTypeConfig.findFirst({ where: { isSubtask: true }, select: { id: true } }),
+          prisma.issue.findFirst({ where: { projectId: parent.projectId }, orderBy: { number: 'desc' }, select: { number: true } }),
+        ]);
+        if (!subtaskConfig) return errText('No subtask issue type configured in this project');
         const number = (last?.number ?? 0) + 1;
 
         const child = await prisma.issue.create({
@@ -197,7 +188,7 @@ export function registerIssueTools(server: McpServer) {
             number,
             title,
             description,
-            type: 'SUBTASK',
+            issueTypeConfigId: subtaskConfig.id,
             priority,
             status: 'OPEN',
             parentId: parent.id,

--- a/backend/src/mcp/tools/sprints.ts
+++ b/backend/src/mcp/tools/sprints.ts
@@ -28,7 +28,7 @@ export function registerSprintTools(server: McpServer) {
                 aiEligible: true,
                 aiExecutionStatus: true,
                 aiAssigneeType: true,
-                type: true,
+                issueTypeConfig: { select: { name: true } },
                 number: true,
                 title: true,
                 assignee: { select: { name: true } },
@@ -74,7 +74,7 @@ export function registerSprintTools(server: McpServer) {
           lines.push('');
           lines.push('Ready for agent:');
           for (const i of aiNotStarted.slice(0, 10)) {
-            lines.push(`  ${project.toUpperCase()}-${i.number} [${i.type}] [${i.priority}] ${i.title.slice(0, 60)}`);
+            lines.push(`  ${project.toUpperCase()}-${i.number} [${i.issueTypeConfig?.name ?? '?'}] [${i.priority}] ${i.title.slice(0, 60)}`);
           }
         }
 
@@ -106,6 +106,7 @@ export function registerSprintTools(server: McpServer) {
           },
           include: {
             _count: { select: { children: true } },
+            issueTypeConfig: { select: { name: true } },
           },
           orderBy: [{ priority: 'asc' }, { createdAt: 'asc' }],
           take: limit,
@@ -114,7 +115,7 @@ export function registerSprintTools(server: McpServer) {
         if (issues.length === 0) return text('Backlog is empty.');
 
         const rows = issues.map(i =>
-          `${project.toUpperCase()}-${i.number} [${i.type}] [${i.priority}] ${i.title.slice(0, 60)} | children: ${i._count.children}${i.aiEligible ? ' | AI✓' : ''}`,
+          `${project.toUpperCase()}-${i.number} [${i.issueTypeConfig?.name ?? '?'}] [${i.priority}] ${i.title.slice(0, 60)} | children: ${i._count.children}${i.aiEligible ? ' | AI✓' : ''}`,
         );
         return text(`Backlog (${issues.length} issues):\n${rows.join('\n')}`);
       } catch (err) {

--- a/backend/src/mcp/tools/sprints.ts
+++ b/backend/src/mcp/tools/sprints.ts
@@ -19,7 +19,7 @@ export function registerSprintTools(server: McpServer) {
             projectId: proj.id,
             state: { in: ['ACTIVE', 'PLANNED'] },
           },
-          orderBy: [{ state: 'asc' }, { startDate: 'desc' }],
+          orderBy: [{ state: 'desc' }, { startDate: 'desc' }],
           include: {
             issues: {
               select: {

--- a/backend/src/mcp/tools/sprints.ts
+++ b/backend/src/mcp/tools/sprints.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { prisma, text, errText } from '../context.js';
+
+export function registerSprintTools(server: McpServer) {
+  // ── get_sprint_context ────────────────────────────────────────────────────────
+  server.tool(
+    'get_sprint_context',
+    'Get the active (or latest planned) sprint with issue stats and AI summary',
+    { project: z.string().describe('Project key, e.g. TTMP') },
+    async ({ project }) => {
+      try {
+        const proj = await prisma.project.findUnique({ where: { key: project.toUpperCase() } });
+        if (!proj) return errText(`Project ${project} not found`);
+
+        const sprint = await prisma.sprint.findFirst({
+          where: {
+            projectId: proj.id,
+            state: { in: ['ACTIVE', 'PLANNED'] },
+          },
+          orderBy: [{ state: 'asc' }, { startDate: 'desc' }],
+          include: {
+            issues: {
+              select: {
+                status: true,
+                priority: true,
+                aiEligible: true,
+                aiExecutionStatus: true,
+                aiAssigneeType: true,
+                type: true,
+                number: true,
+                title: true,
+                assignee: { select: { name: true } },
+              },
+            },
+          },
+        });
+
+        if (!sprint) return text(`No active or planned sprint found for ${project}.`);
+
+        const issues = sprint.issues;
+        const byStatus = {
+          OPEN: issues.filter(i => i.status === 'OPEN').length,
+          IN_PROGRESS: issues.filter(i => i.status === 'IN_PROGRESS').length,
+          REVIEW: issues.filter(i => i.status === 'REVIEW').length,
+          DONE: issues.filter(i => i.status === 'DONE').length,
+          CANCELLED: issues.filter(i => i.status === 'CANCELLED').length,
+        };
+
+        const aiEligible = issues.filter(i => i.aiEligible);
+        const aiInProgress = aiEligible.filter(i => i.aiExecutionStatus === 'IN_PROGRESS');
+        const aiNotStarted = aiEligible.filter(i => i.aiExecutionStatus === 'NOT_STARTED');
+
+        const daysLeft = sprint.endDate
+          ? Math.ceil((sprint.endDate.getTime() - Date.now()) / 86_400_000)
+          : null;
+
+        const lines = [
+          `Sprint: ${sprint.name} [${sprint.state}]`,
+          sprint.startDate && sprint.endDate
+            ? `Period: ${sprint.startDate.toISOString().slice(0, 10)} — ${sprint.endDate.toISOString().slice(0, 10)}${daysLeft !== null ? ` (${daysLeft > 0 ? daysLeft + ' days left' : 'overdue'})` : ''}`
+            : `Period: not set`,
+          sprint.goal ? `Goal: ${sprint.goal}` : '',
+          ``,
+          `Issues: ${issues.length} total`,
+          `  OPEN: ${byStatus.OPEN} | IN_PROGRESS: ${byStatus.IN_PROGRESS} | REVIEW: ${byStatus.REVIEW} | DONE: ${byStatus.DONE}`,
+          ``,
+          `AI-eligible: ${aiEligible.length}`,
+          `  NOT_STARTED: ${aiNotStarted.length} | IN_PROGRESS: ${aiInProgress.length} | DONE: ${aiEligible.filter(i => i.aiExecutionStatus === 'DONE').length}`,
+        ];
+
+        if (aiNotStarted.length > 0) {
+          lines.push('');
+          lines.push('Ready for agent:');
+          for (const i of aiNotStarted.slice(0, 10)) {
+            lines.push(`  ${project.toUpperCase()}-${i.number} [${i.type}] [${i.priority}] ${i.title.slice(0, 60)}`);
+          }
+        }
+
+        return text(lines.filter(l => l !== null).join('\n'));
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── get_backlog ───────────────────────────────────────────────────────────────
+  server.tool(
+    'get_backlog',
+    'Get issues in the backlog (not assigned to any sprint)',
+    {
+      project: z.string().describe('Project key, e.g. TTMP'),
+      limit: z.number().int().min(1).max(100).default(30),
+    },
+    async ({ project, limit }) => {
+      try {
+        const proj = await prisma.project.findUnique({ where: { key: project.toUpperCase() } });
+        if (!proj) return errText(`Project ${project} not found`);
+
+        const issues = await prisma.issue.findMany({
+          where: {
+            projectId: proj.id,
+            sprintId: null,
+            status: { notIn: ['DONE', 'CANCELLED'] },
+          },
+          include: {
+            _count: { select: { children: true } },
+          },
+          orderBy: [{ priority: 'asc' }, { createdAt: 'asc' }],
+          take: limit,
+        });
+
+        if (issues.length === 0) return text('Backlog is empty.');
+
+        const rows = issues.map(i =>
+          `${project.toUpperCase()}-${i.number} [${i.type}] [${i.priority}] ${i.title.slice(0, 60)} | children: ${i._count.children}${i.aiEligible ? ' | AI✓' : ''}`,
+        );
+        return text(`Backlog (${issues.length} issues):\n${rows.join('\n')}`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+}

--- a/backend/src/mcp/tools/time.ts
+++ b/backend/src/mcp/tools/time.ts
@@ -1,0 +1,192 @@
+import { z } from 'zod';
+import { Decimal } from '@prisma/client/runtime/library';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+
+const AI_HOURLY_RATE_USD = parseFloat(process.env.AI_HOURLY_RATE ?? '50');
+
+export function registerTimeTools(server: McpServer) {
+  // ── log_time ──────────────────────────────────────────────────────────────────
+  server.tool(
+    'log_time',
+    'Log agent time on an issue (source=AGENT)',
+    {
+      key: z.string().describe('Issue key, e.g. TTMP-95'),
+      hours: z.number().min(0.05).max(24).describe('Hours spent, e.g. 1.5'),
+      note: z.string().optional().describe('Short description of work done'),
+      sessionId: z.string().optional().describe('AiSession UUID to link this log to'),
+    },
+    async ({ key, hours, note, sessionId }) => {
+      try {
+        const issue = await resolveKey(key);
+        const agentUserId = await getAgentUserId();
+
+        await prisma.timeLog.create({
+          data: {
+            issueId: issue.id,
+            userId: agentUserId,
+            hours: new Decimal(Math.round(hours * 100) / 100),
+            note: note ?? null,
+            logDate: new Date(),
+            source: 'AGENT',
+            agentSessionId: sessionId ?? null,
+          },
+        });
+
+        return text(`Logged ${hours}h on ${key} (source=AGENT) ✓`);
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── register_ai_session ───────────────────────────────────────────────────────
+  server.tool(
+    'register_ai_session',
+    'Record an AI session with token/cost metrics. Call at the end of each development session.',
+    {
+      issues: z
+        .array(z.object({ key: z.string(), ratio: z.number().min(0).max(1) }))
+        .min(1)
+        .describe('Issues to split cost across, ratios should sum to 1'),
+      model: z.string().describe('Model ID, e.g. claude-sonnet-4-6'),
+      provider: z.string().default('anthropic'),
+      tokensInput: z.number().int().min(0),
+      tokensOutput: z.number().int().min(0),
+      costUSD: z.number().min(0).describe('Total cost in USD'),
+      notes: z.string().optional(),
+    },
+    async ({ issues, model, provider, tokensInput, tokensOutput, costUSD, notes }) => {
+      try {
+        const agentUserId = await getAgentUserId();
+
+        // Resolve all issue keys
+        const resolved = await Promise.all(issues.map(i => resolveKey(i.key)));
+
+        // Normalize ratios in case they don't sum to exactly 1
+        const totalRatio = issues.reduce((s, i) => s + i.ratio, 0);
+        const safeTotalRatio = totalRatio > 0 ? totalRatio : 1;
+
+        const totalHours = AI_HOURLY_RATE_USD > 0 ? costUSD / AI_HOURLY_RATE_USD : 0;
+
+        const now = new Date();
+        const startedAt = new Date(now.getTime() - totalHours * 3_600_000);
+
+        const session = await prisma.aiSession.create({
+          data: {
+            issueId: resolved[0].id,
+            userId: agentUserId,
+            model,
+            provider,
+            startedAt,
+            finishedAt: now,
+            tokensInput,
+            tokensOutput,
+            costMoney: new Decimal(costUSD),
+            notes: notes ?? null,
+          },
+        });
+
+        // Create TimeLogs for each issue split
+        const logsData = issues.map((split, idx) => {
+          const normalizedRatio = split.ratio / safeTotalRatio;
+          const splitHours = totalHours * normalizedRatio;
+          const splitCost = costUSD * normalizedRatio;
+          return {
+            issueId: resolved[idx].id,
+            userId: agentUserId,
+            hours: new Decimal(Math.round(splitHours * 100) / 100),
+            note: notes ?? null,
+            logDate: now,
+            source: 'AGENT' as const,
+            agentSessionId: session.id,
+            startedAt,
+            stoppedAt: now,
+            costMoney: new Decimal(Math.round(splitCost * 10_000) / 10_000),
+          };
+        });
+
+        if (logsData.length > 0) {
+          await prisma.timeLog.createMany({ data: logsData });
+        }
+
+        const splitLines = issues.map((s, i) => {
+          const h = Math.round((totalHours * (s.ratio / safeTotalRatio)) * 100) / 100;
+          return `  ${s.key} (${Math.round(s.ratio * 100)}% = ${h}h)`;
+        });
+
+        const lines = [
+          `AiSession created: ${model}`,
+          `Tokens: ${tokensInput.toLocaleString()} in / ${tokensOutput.toLocaleString()} out | Cost: $${costUSD.toFixed(4)}`,
+          `Total hours: ${Math.round(totalHours * 100) / 100}h @ $${AI_HOURLY_RATE_USD}/hr`,
+          `Logged to:`,
+          ...splitLines,
+          `Session ID: ${session.id}`,
+        ];
+
+        return text(lines.join('\n'));
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+
+  // ── get_time_summary ──────────────────────────────────────────────────────────
+  server.tool(
+    'get_time_summary',
+    'Get human vs agent time breakdown for an issue',
+    { key: z.string().describe('Issue key, e.g. TTMP-95') },
+    async ({ key }) => {
+      try {
+        const issue = await resolveKey(key);
+
+        const logs = await prisma.timeLog.findMany({
+          where: { issueId: issue.id },
+          select: { source: true, hours: true, costMoney: true, logDate: true, note: true },
+          orderBy: { logDate: 'desc' },
+        });
+
+        if (logs.length === 0) return text(`${key}: No time logged yet.`);
+
+        const humanHours = logs.filter(l => l.source === 'HUMAN').reduce((s, l) => s + Number(l.hours), 0);
+        const agentHours = logs.filter(l => l.source === 'AGENT').reduce((s, l) => s + Number(l.hours), 0);
+        const agentCost = logs
+          .filter(l => l.source === 'AGENT' && l.costMoney)
+          .reduce((s, l) => s + Number(l.costMoney ?? 0), 0);
+
+        const aiSessions = await prisma.aiSession.findMany({
+          where: { issueId: issue.id },
+          select: { id: true, model: true, costMoney: true, finishedAt: true },
+          orderBy: { finishedAt: 'desc' },
+        });
+
+        const sessionCost = aiSessions.reduce((s, a) => s + Number(a.costMoney ?? 0), 0);
+
+        const lines = [
+          `${key} Time Summary`,
+          `─────────────────────`,
+          `HUMAN:  ${humanHours.toFixed(2)}h`,
+          `AGENT:  ${agentHours.toFixed(2)}h`,
+          `Total:  ${(humanHours + agentHours).toFixed(2)}h`,
+          ``,
+          `AI cost (TimeLogs): $${agentCost.toFixed(4)}`,
+          `AI cost (Sessions): $${sessionCost.toFixed(4)}`,
+          `AI Sessions: ${aiSessions.length}`,
+        ];
+
+        if (aiSessions.length > 0) {
+          lines.push('');
+          lines.push('Recent sessions:');
+          for (const s of aiSessions.slice(0, 5)) {
+            lines.push(`  ${s.finishedAt.toISOString().slice(0, 16)} ${s.model} $${Number(s.costMoney ?? 0).toFixed(4)}`);
+          }
+        }
+
+        return text(lines.join('\n'));
+      } catch (err) {
+        return errText(err);
+      }
+    },
+  );
+}

--- a/backend/src/prisma/seed.ts
+++ b/backend/src/prisma/seed.ts
@@ -68,7 +68,7 @@ async function main(prismaClient?: PrismaClient, scope?: string) {
       role: 'MANAGER',
       isActive: true,
     },
-    update: { passwordHash: agentPasswordHash },
+    update: { passwordHash: agentPasswordHash, role: 'MANAGER' },
   });
 
   const seededUsers = await Promise.all(

--- a/backend/src/prisma/seed.ts
+++ b/backend/src/prisma/seed.ts
@@ -53,6 +53,19 @@ async function main(prismaClient?: PrismaClient, scope?: string) {
     await bootstrapDefaultUsers(client, defaultPassword, bootstrapUsers);
   }
 
+  // MCP system agent user — upsert so it's always present
+  await client.user.upsert({
+    where: { email: 'agent@flow-universe.internal' },
+    create: {
+      email: 'agent@flow-universe.internal',
+      name: 'Flow Universe Agent',
+      passwordHash: 'mcp-system-no-login',
+      role: 'USER',
+      isActive: true,
+    },
+    update: {},
+  });
+
   const seededUsers = await Promise.all(
     bootstrapUsers.map((user) =>
       client.user.findUniqueOrThrow({

--- a/backend/src/prisma/seed.ts
+++ b/backend/src/prisma/seed.ts
@@ -65,7 +65,7 @@ async function main(prismaClient?: PrismaClient, scope?: string) {
       email: 'agent@flow-universe.internal',
       name: 'Flow Universe Agent',
       passwordHash: agentPasswordHash,
-      role: 'USER',
+      role: 'MANAGER',
       isActive: true,
     },
     update: { passwordHash: agentPasswordHash },

--- a/backend/src/prisma/seed.ts
+++ b/backend/src/prisma/seed.ts
@@ -3,6 +3,7 @@ import { pathToFileURL } from 'node:url';
 import { PrismaClient, Prisma, type User } from '@prisma/client';
 
 import { bootstrapDefaultUsers, getBootstrapUsers } from './bootstrap.js';
+import { hashPassword } from '../shared/utils/password.js';
 
 const prisma = new PrismaClient();
 
@@ -53,17 +54,21 @@ async function main(prismaClient?: PrismaClient, scope?: string) {
     await bootstrapDefaultUsers(client, defaultPassword, bootstrapUsers);
   }
 
-  // MCP system agent user — upsert so it's always present
+  // MCP system agent user — upsert so it's always present.
+  // Password is set from AGENT_MCP_PASSWORD env var (required for API write ops).
+  // Falls back to a random string so login is impossible if the var is not set.
+  const agentRawPassword = process.env.AGENT_MCP_PASSWORD ?? Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+  const agentPasswordHash = await hashPassword(agentRawPassword);
   await client.user.upsert({
     where: { email: 'agent@flow-universe.internal' },
     create: {
       email: 'agent@flow-universe.internal',
       name: 'Flow Universe Agent',
-      passwordHash: 'mcp-system-no-login',
+      passwordHash: agentPasswordHash,
       role: 'USER',
       isActive: true,
     },
-    update: {},
+    update: { passwordHash: agentPasswordHash },
   });
 
   const seededUsers = await Promise.all(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,20 +44,28 @@ services:
       timeout: 3s
       retries: 5
 
-  # MCP-прокси для TaskTime API (openapi-to-mcp)
-  # Запуск: docker compose --profile mcp up mcp-tasktime
-  # Claude Desktop config: { "mcpServers": { "tasktime": { "url": "http://localhost:3002/mcp", "transport": "http" } } }
-  mcp-tasktime:
-    image: evilfreelancer/openapi-to-mcp:latest
+  # MCP HTTP-сервер Flow Universe (нативный, прямой доступ к БД)
+  # Запуск: MCP_SERVICE_TOKEN=<token> docker compose --profile mcp up -d mcp-flow-universe
+  # .mcp.json коллеги: { "type": "streamable-http", "url": "http://<host>:3002/mcp",
+  #                      "headers": { "Authorization": "Bearer <token>" } }
+  mcp-flow-universe:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
     profiles: ["mcp"]
+    command: ["node", "dist/mcp/server.js"]
     environment:
-      OPENAPI_URL: http://backend:3000/api/docs/json
-      BACKEND_URL: http://backend:3000
-      BEARER_TOKEN: ${MCP_SERVICE_TOKEN:-}
+      MCP_TRANSPORT: http
+      MCP_HTTP_PORT: "3002"
+      MCP_ENV: ${MCP_ENV:-production}
+      DATABASE_URL: postgresql://tasktime:${POSTGRES_PASSWORD:-tasktime}@postgres:5432/tasktime?schema=public
+      MCP_SERVICE_TOKEN: ${MCP_SERVICE_TOKEN:?MCP_SERVICE_TOKEN is required}
     ports:
-      - "3002:3000"
+      - "3002:3002"
     depends_on:
-      - backend
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       retries: 5
 
   # MCP HTTP-сервер Flow Universe (нативный, прямой доступ к БД)
-  # Запуск: MCP_SERVICE_TOKEN=<token> docker compose --profile mcp up -d mcp-flow-universe
+  # Запуск: MCP_SERVICE_TOKEN=<token> MCP_AGENT_PASSWORD=<pwd> docker compose --profile mcp up -d mcp-flow-universe
   # .mcp.json коллеги: { "type": "streamable-http", "url": "http://<host>:3002/mcp",
   #                      "headers": { "Authorization": "Bearer <token>" } }
   mcp-flow-universe:
@@ -60,8 +60,17 @@ services:
       MCP_ENV: ${MCP_ENV:-production}
       DATABASE_URL: postgresql://tasktime:${POSTGRES_PASSWORD:-tasktime}@postgres:5432/tasktime?schema=public
       MCP_SERVICE_TOKEN: ${MCP_SERVICE_TOKEN:?MCP_SERVICE_TOKEN is required}
+      # Write operations route through the backend API (workflow engine + RBAC).
+      # BACKEND_INTERNAL_URL must point to the running backend:
+      #   - on the same host: http://localhost:3000 (default)
+      #   - in a Docker network with a backend service: http://backend:3000
+      BACKEND_INTERNAL_URL: ${BACKEND_INTERNAL_URL:-http://localhost:3000}
+      MCP_AGENT_EMAIL: ${MCP_AGENT_EMAIL:-agent@flow-universe.internal}
+      MCP_AGENT_PASSWORD: ${MCP_AGENT_PASSWORD:?MCP_AGENT_PASSWORD is required for write operations}
     ports:
       - "3002:3002"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/mcp-onboarding.html
+++ b/docs/mcp-onboarding.html
@@ -1,0 +1,828 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Flow Universe MCP — Онбординг</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg:        #03050F;
+    --surface:   #0F1320;
+    --surface2:  #151929;
+    --border:    rgba(79,110,247,0.18);
+    --accent:    #4F6EF7;
+    --accent2:   #7B8FF9;
+    --green:     #34D399;
+    --yellow:    #FBBF24;
+    --red:       #F87171;
+    --text:      #E2E8F8;
+    --muted:     #7B8BB2;
+    --code-bg:   #0A0D1A;
+  }
+
+  html { scroll-behavior: smooth; }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Inter', sans-serif;
+    font-size: 15px;
+    line-height: 1.65;
+    min-height: 100vh;
+  }
+
+  /* ── Layout ─────────────────────────────────── */
+  .page { max-width: 860px; margin: 0 auto; padding: 0 24px 80px; }
+
+  /* ── Nav ─────────────────────────────────────── */
+  nav {
+    position: sticky; top: 0; z-index: 100;
+    background: rgba(3,5,15,0.85);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--border);
+    padding: 0 24px;
+  }
+  .nav-inner {
+    max-width: 860px; margin: 0 auto;
+    display: flex; align-items: center; gap: 8px;
+    height: 52px;
+  }
+  .nav-logo {
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700; font-size: 15px;
+    color: var(--text);
+    display: flex; align-items: center; gap: 8px;
+    text-decoration: none; margin-right: auto;
+  }
+  .nav-logo .dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 8px var(--accent);
+  }
+  .nav-link {
+    font-size: 13px; color: var(--muted);
+    text-decoration: none; padding: 4px 8px;
+    border-radius: 6px; transition: color .15s;
+  }
+  .nav-link:hover { color: var(--text); }
+
+  /* ── Hero ────────────────────────────────────── */
+  .hero {
+    padding: 72px 0 56px;
+    position: relative;
+  }
+  .hero-badge {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: rgba(79,110,247,0.12);
+    border: 1px solid rgba(79,110,247,0.3);
+    border-radius: 100px;
+    padding: 4px 12px; font-size: 12px;
+    color: var(--accent2); font-weight: 500;
+    margin-bottom: 24px;
+  }
+  .hero-badge::before {
+    content: ''; width: 6px; height: 6px; border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 6px var(--accent);
+    animation: pulse 2s infinite;
+  }
+  @keyframes pulse {
+    0%,100% { opacity: 1; } 50% { opacity: .4; }
+  }
+  h1 {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: clamp(28px, 5vw, 44px);
+    font-weight: 700; line-height: 1.15;
+    letter-spacing: -0.5px;
+    margin-bottom: 16px;
+  }
+  h1 span { color: var(--accent); }
+  .hero-sub {
+    font-size: 17px; color: var(--muted);
+    max-width: 560px; line-height: 1.6;
+    margin-bottom: 32px;
+  }
+  .hero-meta {
+    display: flex; gap: 24px; flex-wrap: wrap;
+  }
+  .meta-item {
+    display: flex; align-items: center; gap: 6px;
+    font-size: 13px; color: var(--muted);
+  }
+  .meta-item strong { color: var(--text); }
+
+  /* ── Section ─────────────────────────────────── */
+  section { margin-top: 64px; }
+  .section-label {
+    font-size: 11px; font-weight: 600; letter-spacing: 1.2px;
+    text-transform: uppercase; color: var(--accent);
+    margin-bottom: 12px;
+  }
+  h2 {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: clamp(20px, 3vw, 26px);
+    font-weight: 700; letter-spacing: -0.3px;
+    margin-bottom: 24px;
+  }
+  h3 {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 16px; font-weight: 600;
+    margin-bottom: 8px;
+  }
+  p { color: var(--muted); margin-bottom: 12px; }
+  p strong { color: var(--text); }
+
+  /* ── Cards ───────────────────────────────────── */
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 20px 24px;
+  }
+  .card + .card { margin-top: 12px; }
+
+  .card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 12px;
+  }
+
+  /* ── What appeared ───────────────────────────── */
+  .what-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 12px;
+    margin-bottom: 24px;
+  }
+  .what-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 20px;
+  }
+  .what-icon {
+    font-size: 24px; margin-bottom: 10px; display: block;
+  }
+  .what-card h3 { font-size: 14px; margin-bottom: 4px; }
+  .what-card p { font-size: 13px; margin: 0; }
+
+  /* ── Architecture diagram ────────────────────── */
+  .arch {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 28px 32px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+    line-height: 2;
+    color: var(--muted);
+    overflow-x: auto;
+  }
+  .arch .hl { color: var(--accent2); }
+  .arch .gr { color: var(--green); }
+  .arch .ye { color: var(--yellow); }
+  .arch .re { color: var(--red); }
+
+  /* ── Steps ───────────────────────────────────── */
+  .steps { counter-reset: step; display: flex; flex-direction: column; gap: 0; }
+  .step {
+    display: grid;
+    grid-template-columns: 40px 1fr;
+    gap: 0 20px;
+    position: relative;
+  }
+  .step:not(:last-child)::before {
+    content: '';
+    position: absolute;
+    left: 19px; top: 40px; bottom: 0;
+    width: 2px;
+    background: linear-gradient(to bottom, var(--border), transparent);
+  }
+  .step-num {
+    counter-increment: step;
+    width: 40px; height: 40px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 14px; font-weight: 700;
+    color: var(--accent);
+    flex-shrink: 0;
+    position: relative; z-index: 1;
+  }
+  .step-body { padding: 8px 0 32px; }
+  .step-body h3 { font-size: 15px; margin-bottom: 6px; }
+  .step-body p { font-size: 14px; margin-bottom: 8px; }
+
+  /* ── Code block ──────────────────────────────── */
+  .code-block {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px 16px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text);
+    overflow-x: auto;
+    position: relative;
+    margin: 8px 0;
+  }
+  .code-block .comment { color: var(--muted); }
+  .code-block .cmd { color: var(--green); }
+  .code-block .str { color: var(--yellow); }
+  .code-lang {
+    position: absolute; top: 10px; right: 12px;
+    font-size: 10px; color: var(--muted);
+    text-transform: uppercase; letter-spacing: .8px;
+  }
+
+  /* ── Tools grid ──────────────────────────────── */
+  .tool-group { margin-bottom: 28px; }
+  .tool-group-label {
+    font-size: 11px; font-weight: 600; letter-spacing: 1px;
+    text-transform: uppercase; color: var(--muted);
+    margin-bottom: 10px;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .tool-group-label::after {
+    content: ''; flex: 1; height: 1px;
+    background: var(--border);
+  }
+  .tools-list { display: flex; flex-direction: column; gap: 6px; }
+  .tool-item {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 16px;
+    display: grid;
+    grid-template-columns: 200px 1fr auto;
+    gap: 12px;
+    align-items: center;
+  }
+  .tool-name {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px; color: var(--accent2);
+    font-weight: 500;
+  }
+  .tool-desc { font-size: 13px; color: var(--muted); }
+  .tool-badge {
+    font-size: 10px; font-weight: 600; letter-spacing: .5px;
+    padding: 3px 8px; border-radius: 4px;
+    white-space: nowrap;
+  }
+  .badge-read { background: rgba(79,110,247,0.12); color: var(--accent2); }
+  .badge-write { background: rgba(52,211,153,0.1); color: var(--green); }
+  .badge-agent { background: rgba(251,191,36,0.1); color: var(--yellow); }
+
+  /* ── Example chat ────────────────────────────── */
+  .chat { display: flex; flex-direction: column; gap: 10px; }
+  .msg {
+    max-width: 80%;
+    border-radius: 12px;
+    padding: 12px 16px;
+    font-size: 14px;
+    line-height: 1.55;
+  }
+  .msg-user {
+    align-self: flex-end;
+    background: rgba(79,110,247,0.15);
+    border: 1px solid rgba(79,110,247,0.25);
+    color: var(--text);
+    border-bottom-right-radius: 4px;
+  }
+  .msg-ai {
+    align-self: flex-start;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-bottom-left-radius: 4px;
+  }
+  .msg-ai .tool-call {
+    display: inline-flex; align-items: center; gap: 5px;
+    background: rgba(79,110,247,0.08);
+    border: 1px solid rgba(79,110,247,0.2);
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px; color: var(--accent2);
+    margin: 2px;
+  }
+  .msg-ai .tool-call::before { content: '⚡'; font-size: 10px; }
+
+  /* ── Security table ──────────────────────────── */
+  .perm-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+  .perm-table th {
+    text-align: left; padding: 10px 16px;
+    font-size: 11px; font-weight: 600; letter-spacing: .8px;
+    text-transform: uppercase; color: var(--muted);
+    border-bottom: 1px solid var(--border);
+  }
+  .perm-table td {
+    padding: 10px 16px;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+    vertical-align: top;
+  }
+  .perm-table tr:last-child td { border-bottom: none; }
+  .perm-ok { color: var(--green); font-weight: 600; }
+  .perm-no { color: var(--red); font-weight: 600; }
+  .perm-table td:first-child {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px; color: var(--accent2);
+  }
+
+  /* ── Callout ─────────────────────────────────── */
+  .callout {
+    display: flex; gap: 12px;
+    background: rgba(79,110,247,0.07);
+    border: 1px solid rgba(79,110,247,0.2);
+    border-radius: 10px;
+    padding: 14px 16px;
+    font-size: 14px;
+    color: var(--muted);
+    margin: 16px 0;
+  }
+  .callout-icon { font-size: 18px; flex-shrink: 0; line-height: 1.4; }
+  .callout.warn {
+    background: rgba(251,191,36,0.06);
+    border-color: rgba(251,191,36,0.2);
+  }
+
+  /* ── Divider ─────────────────────────────────── */
+  .divider {
+    height: 1px; background: var(--border);
+    margin: 48px 0;
+  }
+
+  /* ── Footer ──────────────────────────────────── */
+  footer {
+    text-align: center; padding: 32px 0 0;
+    color: var(--muted); font-size: 13px;
+  }
+  footer a { color: var(--accent2); text-decoration: none; }
+
+  @media (max-width: 600px) {
+    .tool-item { grid-template-columns: 1fr; }
+    .hero-meta { flex-direction: column; gap: 8px; }
+    .arch { font-size: 11px; padding: 16px; }
+  }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="nav-inner">
+    <a class="nav-logo" href="#">
+      <span class="dot"></span>
+      Flow Universe MCP
+    </a>
+    <a class="nav-link" href="#what">Что появилось</a>
+    <a class="nav-link" href="#setup">Настройка</a>
+    <a class="nav-link" href="#tools">Инструменты</a>
+    <a class="nav-link" href="#examples">Примеры</a>
+  </div>
+</nav>
+
+<div class="page">
+
+  <!-- HERO -->
+  <div class="hero">
+    <div class="hero-badge">Новая возможность · Апрель 2026</div>
+    <h1>Flow Universe<br><span>MCP Server</span></h1>
+    <p class="hero-sub">
+      AI-агенты (Claude Code, Cursor) теперь могут работать с задачами напрямую — читать спринты, менять статусы, логировать время и создавать подзадачи. Без копипаста, без переключения контекста.
+    </p>
+    <div class="hero-meta">
+      <div class="meta-item">📦 <strong>14 инструментов</strong></div>
+      <div class="meta-item">🔐 <strong>Техническая УЗ с ограниченными правами</strong></div>
+      <div class="meta-item">🌍 <strong>Staging + Production</strong></div>
+      <div class="meta-item">⚡ <strong>Прямой доступ к БД через SSH-туннель</strong></div>
+    </div>
+  </div>
+
+  <!-- WHAT APPEARED -->
+  <section id="what">
+    <div class="section-label">Что появилось</div>
+    <h2>Четыре новых компонента</h2>
+
+    <div class="what-grid">
+      <div class="what-card">
+        <span class="what-icon">🖥️</span>
+        <h3>MCP-сервер</h3>
+        <p>backend/src/mcp/ — работает через stdio, Prisma напрямую к PostgreSQL</p>
+      </div>
+      <div class="what-card">
+        <span class="what-icon">🔑</span>
+        <h3>Техническая УЗ</h3>
+        <p>flowuniverse_mcp — Postgres-пользователь с минимальными привилегиями</p>
+      </div>
+      <div class="what-card">
+        <span class="what-icon">⚙️</span>
+        <h3>.mcp.json</h3>
+        <p>Три окружения: development, staging, production — выбираешь в инспекторе</p>
+      </div>
+      <div class="what-card">
+        <span class="what-icon">📋</span>
+        <h3>SQL-скрипт</h3>
+        <p>scripts/mcp-db-user.sql — создание техпользователя на любом сервере</p>
+      </div>
+    </div>
+
+    <div class="callout">
+      <span class="callout-icon">💡</span>
+      <div>
+        <strong style="color: var(--text)">Зачем это нужно?</strong><br>
+        Раньше нужно было открыть систему → найти задачу → скопировать описание → вставить в чат с AI → вернуться → вручную обновить статус. Теперь AI сам читает задачу из системы, работает по ней и записывает результат обратно.
+      </div>
+    </div>
+  </section>
+
+  <!-- ARCHITECTURE -->
+  <section>
+    <div class="section-label">Как это работает</div>
+    <h2>Архитектура</h2>
+
+    <div class="arch">
+<span class="hl">Claude Code / Cursor</span>  (твой ноутбук)
+    │
+    │  stdio  (JSON-RPC 2.0, защищённый канал)
+    ▼
+<span class="hl">flow-universe MCP сервер</span>  (tsx process, локально)
+    │  DATABASE_URL из .env.production
+    │
+    │  TCP через SSH-туннель
+    ▼
+<span class="gr">localhost:5435</span>  ←─── <span class="gr">ssh -L 5435:localhost:5432 root@72.56.7.218 -N</span>
+    │
+    ▼
+<span class="ye">PostgreSQL на 72.56.7.218</span>
+    └─ пользователь: <span class="ye">flowuniverse_mcp</span>
+       ├─ <span class="gr">SELECT</span>   — все таблицы
+       ├─ <span class="gr">INSERT</span>   — issues, comments, time_logs, ai_sessions, audit_logs
+       ├─ <span class="gr">UPDATE</span>   — issues (только статус и AI-флаги)
+       └─ <span class="re">DELETE/DDL — запрещено</span>
+    </div>
+
+    <p style="margin-top: 16px">
+      Туннель нужен потому что Postgres на сервере слушает только <code style="font-family: monospace; color: var(--accent2); font-size: 13px">localhost</code> — снаружи недоступен. SSH-туннель пробрасывает его к тебе на ноутбук безопасно, внутри зашифрованного канала.
+    </p>
+  </section>
+
+  <!-- SETUP -->
+  <section id="setup">
+    <div class="section-label">Настройка</div>
+    <h2>Запуск за 5 шагов</h2>
+
+    <div class="steps">
+
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Создать техпользователя в PostgreSQL (один раз)</h3>
+          <p>На каждом сервере (staging и production) выполнить SQL-скрипт. Сначала придумать пароль для flowuniverse_mcp и вставить вместо CHANGE_ME.</p>
+          <div class="code-block">
+            <span class="code-lang">bash</span>
+            <span class="comment"># Подключиться к серверу</span><br>
+            <span class="cmd">ssh root@72.56.7.218</span><br><br>
+            <span class="comment"># Создать пользователя (заменить CHANGE_ME на реальный пароль)</span><br>
+            <span class="cmd">sed 's/CHANGE_ME_STRONG_PASSWORD/МОЙ_ПАРОЛЬ/' \<br>
+  &nbsp;&nbsp;/opt/tasktime/backend/scripts/mcp-db-user.sql \<br>
+  &nbsp;&nbsp;| docker exec -i tasktime-postgres-1 psql -U postgres -d tasktime</span>
+          </div>
+          <div class="callout warn">
+            <span class="callout-icon">⚠️</span>
+            <div>Пароль сохранить в надёжном месте (1Password / командный Vault). В репо не коммитить.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>Создать локальные env-файлы</h3>
+          <p>Скопировать примеры и вставить реальный пароль от flowuniverse_mcp.</p>
+          <div class="code-block">
+            <span class="code-lang">bash</span>
+            <span class="cmd">cd /путь/к/tasktime-mvp/backend</span><br><br>
+            <span class="comment"># Для staging</span><br>
+            <span class="cmd">cp .env.staging.example .env.staging</span><br>
+            <span class="comment"># Открыть .env.staging, вписать пароль в DATABASE_URL</span><br><br>
+            <span class="comment"># Для production</span><br>
+            <span class="cmd">cp .env.production.example .env.production</span><br>
+            <span class="comment"># Открыть .env.production, вписать пароль в DATABASE_URL</span>
+          </div>
+          <p>Строка которую нужно заменить:</p>
+          <div class="code-block">
+            <span class="str">DATABASE_URL="postgresql://flowuniverse_mcp:<strong>CHANGE_ME</strong>@localhost:5435/tasktime?schema=public"</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Установить зависимости backend</h3>
+          <div class="code-block">
+            <span class="code-lang">bash</span>
+            <span class="cmd">cd backend && npm install</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <h3>Открыть SSH-туннель (держать терминал открытым)</h3>
+          <div class="code-block">
+            <span class="code-lang">bash</span>
+            <span class="comment"># Staging (пробросит localhost:5434 → 5.129.242.171:5432)</span><br>
+            <span class="cmd">ssh -L 5434:localhost:5432 root@5.129.242.171 -N</span><br><br>
+            <span class="comment"># Production (пробросит localhost:5435 → 72.56.7.218:5432)</span><br>
+            <span class="cmd">ssh -L 5435:localhost:5432 root@72.56.7.218 -N</span>
+          </div>
+          <p>Флаг <code style="font-family: monospace; color: var(--accent2); font-size: 13px">-N</code> означает «только туннель, без команды». Терминал будет висеть — это нормально.</p>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">5</div>
+        <div class="step-body">
+          <h3>Запустить MCP Inspector и проверить</h3>
+          <div class="code-block">
+            <span class="code-lang">bash</span>
+            <span class="cmd">cd backend && npx @modelcontextprotocol/inspector npm run mcp</span>
+          </div>
+          <p>Откроется <strong>http://localhost:6274</strong>. В поле:</p>
+          <ul style="color: var(--muted); font-size: 14px; padding-left: 20px; margin-bottom: 8px">
+            <li><strong style="color: var(--text)">Command:</strong> npm</li>
+            <li><strong style="color: var(--text)">Arguments:</strong> run mcp</li>
+          </ul>
+          <p>Нажать Connect → List Tools → должны появиться 14 инструментов.</p>
+          <p>Проверить: <code style="font-family: monospace; color: var(--accent2); font-size: 13px">get_issue { "key": "TTMP-1" }</code> → задача из системы.</p>
+          <div class="callout">
+            <span class="callout-icon">💡</span>
+            <div>
+              Для production нужно передать переменную окружения:<br>
+              <code style="font-family: monospace; color: var(--accent2); font-size: 12px">MCP_ENV=production npm run mcp</code>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- TOOLS -->
+  <section id="tools">
+    <div class="section-label">Функционал</div>
+    <h2>14 инструментов</h2>
+
+    <!-- Issues -->
+    <div class="tool-group">
+      <div class="tool-group-label">📋 Задачи</div>
+      <div class="tools-list">
+        <div class="tool-item">
+          <span class="tool-name">get_issue</span>
+          <span class="tool-desc">Полная карточка задачи по ключу (TTMP-95) или UUID</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">list_issues</span>
+          <span class="tool-desc">Список задач с фильтрами: проект, спринт, статус, AI-eligible</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">update_status</span>
+          <span class="tool-desc">Изменить статус задачи (OPEN → IN_PROGRESS → REVIEW → DONE)</span>
+          <span class="tool-badge badge-write">WRITE</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">create_subtask</span>
+          <span class="tool-desc">Создать подзадачу под родительской задачей — реальная декомпозиция</span>
+          <span class="tool-badge badge-write">WRITE</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Sprints -->
+    <div class="tool-group">
+      <div class="tool-group-label">🏃 Спринты</div>
+      <div class="tools-list">
+        <div class="tool-item">
+          <span class="tool-name">get_sprint_context</span>
+          <span class="tool-desc">Активный спринт: статистика, разбивка по AI-eligible задачам</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">get_backlog</span>
+          <span class="tool-desc">Задачи в бэклоге (не привязаны к спринту)</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Time -->
+    <div class="tool-group">
+      <div class="tool-group-label">⏱️ Время и сессии</div>
+      <div class="tools-list">
+        <div class="tool-item">
+          <span class="tool-name">log_time</span>
+          <span class="tool-desc">Залогировать часы на задачу (source=AGENT, видно в отчётах)</span>
+          <span class="tool-badge badge-write">WRITE</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">register_ai_session</span>
+          <span class="tool-desc">Записать метрики сессии: токены, стоимость, распределение по задачам</span>
+          <span class="tool-badge badge-write">WRITE</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">get_time_summary</span>
+          <span class="tool-desc">Разбивка времени на задаче: человек vs агент</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Comments -->
+    <div class="tool-group">
+      <div class="tool-group-label">💬 Комментарии</div>
+      <div class="tools-list">
+        <div class="tool-item">
+          <span class="tool-name">add_comment</span>
+          <span class="tool-desc">Добавить комментарий к задаче от имени Flow Universe Agent</span>
+          <span class="tool-badge badge-write">WRITE</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">get_comments</span>
+          <span class="tool-desc">Получить последние комментарии к задаче</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Agent Loop -->
+    <div class="tool-group">
+      <div class="tool-group-label">🤖 Агентский цикл</div>
+      <div class="tools-list">
+        <div class="tool-item">
+          <span class="tool-name">get_eligible_issues</span>
+          <span class="tool-desc">Очередь AI-eligible задач ещё не взятых в работу</span>
+          <span class="tool-badge badge-agent">AGENT</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">claim_issue</span>
+          <span class="tool-desc">Атомарно взять задачу: IN_PROGRESS + AGENT (без гонки состояний)</span>
+          <span class="tool-badge badge-agent">AGENT</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">complete_issue</span>
+          <span class="tool-desc">Завершить: статус → REVIEW, добавить саммари комментарий</span>
+          <span class="tool-badge badge-agent">AGENT</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">fail_issue</span>
+          <span class="tool-desc">Эскалация: не смог выполнить, вернуть в OPEN с причиной</span>
+          <span class="tool-badge badge-agent">AGENT</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- EXAMPLES -->
+  <section id="examples">
+    <div class="section-label">Примеры</div>
+    <h2>Как это выглядит в диалоге</h2>
+
+    <div class="card" style="margin-bottom: 20px">
+      <h3 style="margin-bottom: 16px; color: var(--muted); font-size: 13px; font-weight: 500; text-transform: uppercase; letter-spacing: .8px">Сценарий 1 — Начало рабочего дня</h3>
+      <div class="chat">
+        <div class="msg msg-user">Что у меня в активном спринте? Какие задачи можно взять в работу?</div>
+        <div class="msg msg-ai">
+          <span class="tool-call">get_sprint_context TTMP</span>
+          <span class="tool-call">list_issues project=TTMP sprint=active aiEligible=true</span>
+          <br><br>
+          Активный спринт «Sprint 12» — 18 задач, из них 5 AI-eligible:<br>
+          • TTMP-152 — GitHub webhook: Smart Commits (OPEN, MEDIUM)<br>
+          • TTMP-148 — Экспорт задач в CSV (OPEN, LOW)<br>
+          • TTMP-143 — Уведомления Telegram (OPEN, HIGH)<br>
+          ...
+        </div>
+        <div class="msg msg-user">Возьми TTMP-152</div>
+        <div class="msg msg-ai">
+          <span class="tool-call">get_issue TTMP-152</span>
+          <span class="tool-call">claim_issue TTMP-152</span>
+          <br><br>
+          Взял TTMP-152 в работу. Статус → IN_PROGRESS, задача закреплена за агентом.
+        </div>
+      </div>
+    </div>
+
+    <div class="card" style="margin-bottom: 20px">
+      <h3 style="margin-bottom: 16px; color: var(--muted); font-size: 13px; font-weight: 500; text-transform: uppercase; letter-spacing: .8px">Сценарий 2 — Декомпозиция задачи</h3>
+      <div class="chat">
+        <div class="msg msg-user">Декомпозируй TTMP-152 на подзадачи</div>
+        <div class="msg msg-ai">
+          <span class="tool-call">get_issue TTMP-152</span>
+          <br><br>
+          Создаю подзадачи по описанию...<br><br>
+          <span class="tool-call">create_subtask TTMP-152 "Парсинг issue key из commit message"</span>
+          <span class="tool-call">create_subtask TTMP-152 "HMAC-верификация X-Hub-Signature-256"</span>
+          <span class="tool-call">create_subtask TTMP-152 "Маппинг событий GitHub → статусы"</span>
+          <br><br>
+          Создал 3 подзадачи: TTMP-153, TTMP-154, TTMP-155. Можешь видеть их в системе.
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3 style="margin-bottom: 16px; color: var(--muted); font-size: 13px; font-weight: 500; text-transform: uppercase; letter-spacing: .8px">Сценарий 3 — Завершение и учёт времени</h3>
+      <div class="chat">
+        <div class="msg msg-user">Готово. Залогируй сессию: 1.5 часа, $0.80</div>
+        <div class="msg msg-ai">
+          <span class="tool-call">register_ai_session model=claude-sonnet-4-6 issues=[{TTMP-152,1.0}] costUSD=0.80</span>
+          <span class="tool-call">complete_issue TTMP-152 "Реализован GitHub webhook..."</span>
+          <br><br>
+          Залогировал: 1.5ч, $0.80. Задача TTMP-152 → REVIEW.<br>
+          Добавил комментарий с саммари. Ждёт твоего аппрува.
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- SECURITY -->
+  <section>
+    <div class="section-label">Безопасность</div>
+    <h2>Что агент может и не может</h2>
+
+    <div class="card">
+      <table class="perm-table">
+        <thead>
+          <tr>
+            <th>Операция</th>
+            <th>Разрешено</th>
+            <th>Комментарий</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>SELECT * FROM issues</td>
+            <td class="perm-ok">✓ Да</td>
+            <td style="color: var(--muted); font-size: 13px">Читать все таблицы</td>
+          </tr>
+          <tr>
+            <td>INSERT INTO issues</td>
+            <td class="perm-ok">✓ Да</td>
+            <td style="color: var(--muted); font-size: 13px">Создавать подзадачи</td>
+          </tr>
+          <tr>
+            <td>UPDATE issues SET status</td>
+            <td class="perm-ok">✓ Да</td>
+            <td style="color: var(--muted); font-size: 13px">Только поля задач</td>
+          </tr>
+          <tr>
+            <td>DELETE FROM issues</td>
+            <td class="perm-no">✗ Нет</td>
+            <td style="color: var(--muted); font-size: 13px">Явно запрещено</td>
+          </tr>
+          <tr>
+            <td>UPDATE users SET password</td>
+            <td class="perm-no">✗ Нет</td>
+            <td style="color: var(--muted); font-size: 13px">UPDATE выдан только на issues</td>
+          </tr>
+          <tr>
+            <td>DROP TABLE / ALTER TABLE</td>
+            <td class="perm-no">✗ Нет</td>
+            <td style="color: var(--muted); font-size: 13px">DDL недоступен, не owner</td>
+          </tr>
+          <tr>
+            <td>TRUNCATE</td>
+            <td class="perm-no">✗ Нет</td>
+            <td style="color: var(--muted); font-size: 13px">Явно отозвано</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="callout" style="margin-top: 16px">
+      <span class="callout-icon">🛡️</span>
+      <div>
+        <strong style="color: var(--text)">Максимум что может случиться</strong> — агент создаст лишние подзадачи или поставит неправильный статус. Это исправляется руками за минуту. Структура базы, пользователи и настройки системы неприкосновенны.
+      </div>
+    </div>
+  </section>
+
+  <div class="divider"></div>
+
+  <footer>
+    Flow Universe · MCP Server v1.0 · <a href="https://github.com/NovakPAai/tasktime-mvp/pull/10">PR #10</a> · Апрель 2026
+  </footer>
+
+</div>
+
+</body>
+</html>

--- a/docs/mcp-onboarding.html
+++ b/docs/mcp-onboarding.html
@@ -401,7 +401,7 @@
       <div class="meta-item">📦 <strong>14 инструментов</strong></div>
       <div class="meta-item">🔐 <strong>Техническая УЗ с ограниченными правами</strong></div>
       <div class="meta-item">🌍 <strong>Staging + Production</strong></div>
-      <div class="meta-item">⚡ <strong>Прямой доступ к БД через SSH-туннель</strong></div>
+      <div class="meta-item">⚡ <strong>HTTP transport, без туннелей</strong></div>
     </div>
   </div>
 
@@ -450,15 +450,15 @@
     <div class="arch">
 <span class="hl">Claude Code / Cursor</span>  (твой ноутбук)
     │
-    │  stdio  (JSON-RPC 2.0, защищённый канал)
+    │  HTTP + Bearer token  (JSON-RPC 2.0)
     ▼
-<span class="hl">flow-universe MCP сервер</span>  (tsx process, локально)
-    │  DATABASE_URL из .env.production
+<span class="gr">http://72.56.7.218:3002/mcp</span>
     │
-    │  TCP через SSH-туннель
+    │  Docker service  mcp-flow-universe
+    │  (--profile mcp, restart: unless-stopped)
     ▼
-<span class="gr">localhost:5435</span>  ←─── <span class="gr">ssh -L 5435:localhost:5432 root@72.56.7.218 -N</span>
-    │
+<span class="hl">flow-universe MCP сервер</span>  (StreamableHTTP, Express)
+    │  localhost  (внутри Docker network)
     ▼
 <span class="ye">PostgreSQL на 72.56.7.218</span>
     └─ пользователь: <span class="ye">flowuniverse_mcp</span>
@@ -469,7 +469,7 @@
     </div>
 
     <p style="margin-top: 16px">
-      Туннель нужен потому что Postgres на сервере слушает только <code style="font-family: monospace; color: var(--accent2); font-size: 13px">localhost</code> — снаружи недоступен. SSH-туннель пробрасывает его к тебе на ноутбук безопасно, внутри зашифрованного канала.
+      MCP-сервер работает как Docker-сервис прямо на боевом сервере. Коллеге нужен только URL и токен — никаких туннелей, никакого локального бэкенда.
     </p>
   </section>
 
@@ -483,20 +483,20 @@
       <div class="step">
         <div class="step-num">1</div>
         <div class="step-body">
-          <h3>Создать техпользователя в PostgreSQL (один раз)</h3>
-          <p>На каждом сервере (staging и production) выполнить SQL-скрипт. Сначала придумать пароль для flowuniverse_mcp и вставить вместо CHANGE_ME.</p>
+          <h3>Запустить MCP-сервис на сервере (один раз, делает администратор)</h3>
+          <p>На сервере придумать токен и запустить Docker-сервис. Токен передать команде через 1Password / командный Vault.</p>
           <div class="code-block">
             <span class="code-lang">bash</span>
             <span class="comment"># Подключиться к серверу</span><br>
             <span class="cmd">ssh root@72.56.7.218</span><br><br>
-            <span class="comment"># Создать пользователя (заменить CHANGE_ME на реальный пароль)</span><br>
-            <span class="cmd">sed 's/CHANGE_ME_STRONG_PASSWORD/МОЙ_ПАРОЛЬ/' \<br>
-  &nbsp;&nbsp;/opt/tasktime/backend/scripts/mcp-db-user.sql \<br>
-  &nbsp;&nbsp;| docker exec -i tasktime-postgres-1 psql -U postgres -d tasktime</span>
+            <span class="comment"># Запустить MCP как Docker-сервис (токен придумать самостоятельно)</span><br>
+            <span class="cmd">cd /opt/tasktime<br>
+MCP_SERVICE_TOKEN=мой_секретный_токен \<br>
+  docker compose --profile mcp up -d mcp-flow-universe</span>
           </div>
-          <div class="callout warn">
-            <span class="callout-icon">⚠️</span>
-            <div>Пароль сохранить в надёжном месте (1Password / командный Vault). В репо не коммитить.</div>
+          <div class="callout">
+            <span class="callout-icon">💡</span>
+            <div>Сервис стартует автоматически при перезагрузке сервера (<code style="font-family: monospace; font-size: 12px">restart: unless-stopped</code>). Повторно запускать не нужно.</div>
           </div>
         </div>
       </div>
@@ -504,72 +504,40 @@
       <div class="step">
         <div class="step-num">2</div>
         <div class="step-body">
-          <h3>Создать локальные env-файлы</h3>
-          <p>Скопировать примеры и вставить реальный пароль от flowuniverse_mcp.</p>
+          <h3>Добавить конфиг в свой .mcp.json (каждый коллега, один раз)</h3>
+          <p>Открыть <code style="font-family: monospace; color: var(--accent2); font-size: 13px">~/.claude/mcp.json</code> (или <code style="font-family: monospace; color: var(--accent2); font-size: 13px">.mcp.json</code> в корне репо) и добавить:</p>
           <div class="code-block">
-            <span class="code-lang">bash</span>
-            <span class="cmd">cd /путь/к/tasktime-mvp/backend</span><br><br>
-            <span class="comment"># Для staging</span><br>
-            <span class="cmd">cp .env.staging.example .env.staging</span><br>
-            <span class="comment"># Открыть .env.staging, вписать пароль в DATABASE_URL</span><br><br>
-            <span class="comment"># Для production</span><br>
-            <span class="cmd">cp .env.production.example .env.production</span><br>
-            <span class="comment"># Открыть .env.production, вписать пароль в DATABASE_URL</span>
+            <span class="code-lang">json</span>
+            {<br>
+            &nbsp;&nbsp;<span class="str">"mcpServers"</span>: {<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;<span class="str">"flow-universe-prod"</span>: {<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="str">"type"</span>: <span class="str">"streamable-http"</span>,<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="str">"url"</span>: <span class="str">"http://72.56.7.218:3002/mcp"</span>,<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="str">"headers"</span>: {<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="str">"Authorization"</span>: <span class="str">"Bearer МОЙ_ТОКЕН"</span><br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;}<br>
+            &nbsp;&nbsp;}<br>
+            }
           </div>
-          <p>Строка которую нужно заменить:</p>
-          <div class="code-block">
-            <span class="str">DATABASE_URL="postgresql://flowuniverse_mcp:<strong>CHANGE_ME</strong>@localhost:5435/tasktime?schema=public"</span>
-          </div>
+          <p>Заменить <strong>МОЙ_ТОКЕН</strong> на токен полученный от администратора.</p>
         </div>
       </div>
 
       <div class="step">
         <div class="step-num">3</div>
         <div class="step-body">
-          <h3>Установить зависимости backend</h3>
+          <h3>Перезапустить Claude Code и проверить</h3>
+          <p>После добавления конфига — перезапустить Claude Code. Затем выполнить:</p>
           <div class="code-block">
-            <span class="code-lang">bash</span>
-            <span class="cmd">cd backend && npm install</span>
+            <span class="code-lang">claude</span>
+            <span class="cmd">/mcp</span>
           </div>
-        </div>
-      </div>
-
-      <div class="step">
-        <div class="step-num">4</div>
-        <div class="step-body">
-          <h3>Открыть SSH-туннель (держать терминал открытым)</h3>
-          <div class="code-block">
-            <span class="code-lang">bash</span>
-            <span class="comment"># Staging (пробросит localhost:5434 → 5.129.242.171:5432)</span><br>
-            <span class="cmd">ssh -L 5434:localhost:5432 root@5.129.242.171 -N</span><br><br>
-            <span class="comment"># Production (пробросит localhost:5435 → 72.56.7.218:5432)</span><br>
-            <span class="cmd">ssh -L 5435:localhost:5432 root@72.56.7.218 -N</span>
-          </div>
-          <p>Флаг <code style="font-family: monospace; color: var(--accent2); font-size: 13px">-N</code> означает «только туннель, без команды». Терминал будет висеть — это нормально.</p>
-        </div>
-      </div>
-
-      <div class="step">
-        <div class="step-num">5</div>
-        <div class="step-body">
-          <h3>Запустить MCP Inspector и проверить</h3>
-          <div class="code-block">
-            <span class="code-lang">bash</span>
-            <span class="cmd">cd backend && npx @modelcontextprotocol/inspector npm run mcp</span>
-          </div>
-          <p>Откроется <strong>http://localhost:6274</strong>. В поле:</p>
-          <ul style="color: var(--muted); font-size: 14px; padding-left: 20px; margin-bottom: 8px">
-            <li><strong style="color: var(--text)">Command:</strong> npm</li>
-            <li><strong style="color: var(--text)">Arguments:</strong> run mcp</li>
-          </ul>
-          <p>Нажать Connect → List Tools → должны появиться 14 инструментов.</p>
-          <p>Проверить: <code style="font-family: monospace; color: var(--accent2); font-size: 13px">get_issue { "key": "TTMP-1" }</code> → задача из системы.</p>
+          <p>В списке должен появиться <strong>flow-universe-prod</strong> с 14 инструментами.</p>
+          <p>Проверить: попросить Claude «покажи задачу TTMP-1» — должна вернуться карточка задачи из системы.</p>
           <div class="callout">
             <span class="callout-icon">💡</span>
-            <div>
-              Для production нужно передать переменную окружения:<br>
-              <code style="font-family: monospace; color: var(--accent2); font-size: 12px">MCP_ENV=production npm run mcp</code>
-            </div>
+            <div>Никакого туннеля, никакого локального бэкенда, никаких env-файлов. Только токен в конфиге.</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- MCP сервер теперь поддерживает HTTP transport (`MCP_TRANSPORT=http`) — коллеги подключаются через URL без SSH туннелей
- Write-операции (`update_status`, `create_subtask`, `add_comment`, `claim_issue`, `complete_issue`, `fail_issue`) роутятся через backend API — workflow engine, RBAC и post-functions выполняются корректно
- Новый `api-client.ts` — логин как агент-сервисная УЗ, JWT-кэш с авторе-логином при 401
- Агент-пользователь получил роль `MANAGER` и настоящий bcrypt-хэш пароля из `AGENT_MCP_PASSWORD`
- `docker-compose.yml` — добавлен `mcp-flow-universe` сервис с `extra_hosts: host-gateway`
- `.mcp.json` — три записи: local stdio, staging HTTP, production HTTP

## New env vars
- `AGENT_MCP_PASSWORD` — задаётся при `npm run db:seed`, хэшируется в агент-пользователя
- `MCP_AGENT_PASSWORD` — передаётся MCP-контейнеру для логина через API
- `BACKEND_INTERNAL_URL` — URL бэкенда для write-вызовов (default: `http://localhost:3000`)

## Test plan
- [ ] `npm run db:seed` с `AGENT_MCP_PASSWORD` обновляет хэш агента
- [ ] MCP inspector: `update_status` проходит через workflow engine
- [ ] MCP inspector: `add_comment` создаёт комментарий через API
- [ ] Docker: `docker compose --profile mcp up -d mcp-flow-universe` стартует