### PR TITLE
feat(mcp): HTTP transport + write ops via backend API (workflow engine)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -10,21 +10,17 @@
       }
     },
     "flow-universe-staging": {
-      "command": "npm",
-      "args": ["run", "mcp"],
-      "cwd": "backend",
-      "env": {
-        "MCP_ENV": "staging",
-        "AI_HOURLY_RATE": "50"
+      "type": "streamable-http",
+      "url": "http://5.129.242.171:3002/mcp",
+      "headers": {
+        "Authorization": "Bearer REPLACE_WITH_MCP_SERVICE_TOKEN"
       }
     },
     "flow-universe-prod": {
-      "command": "npm",
-      "args": ["run", "mcp"],
-      "cwd": "backend",
-      "env": {
-        "MCP_ENV": "production",
-        "AI_HOURLY_RATE": "50"
+      "type": "streamable-http",
+      "url": "http://72.56.7.218:3002/mcp",
+      "headers": {
+        "Authorization": "Bearer REPLACE_WITH_MCP_SERVICE_TOKEN"
       }
     }
   }

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,5 +26,9 @@ FEATURES_TELEGRAM=false
 AI_PROVIDER=heuristic
 # Anthropic API key (required when AI_PROVIDER=anthropic)
 # ANTHROPIC_API_KEY=sk-ant-...
-# MCP service token (long-lived JWT for openapi-to-mcp proxy)
+# MCP service token (Bearer token for HTTP MCP endpoint)
 # MCP_SERVICE_TOKEN=
+# MCP agent service account password (set AGENT_MCP_PASSWORD before running seed)
+# Used by api-client.ts to authenticate write operations via the backend API.
+# Generate: openssl rand -base64 24
+# AGENT_MCP_PASSWORD=

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,12 +1,28 @@
 # MCP — Production environment
 # Copy to .env.production and fill real credentials (never commit .env.production)
 #
-# ВАЖНО: использовать техническую УЗ flowuniverse_mcp, не tasktime (admin)
+# ВАЖНО: использовать техническую УЗ flowuniverse_mcp для БД, не tasktime (admin)
 # Создать пользователя: psql -U postgres -d tasktime -f scripts/mcp-db-user.sql
 #
-# Доступ через SSH-туннель:
-#   ssh -L 5435:localhost:5432 root@72.56.7.218 -N
+# Режим запуска:
+#   HTTP transport (Docker на сервере):
+#     MCP_SERVICE_TOKEN=<token> MCP_AGENT_PASSWORD=<pwd> docker compose --profile mcp up -d mcp-flow-universe
+#
+#   Stdio (локальная разработка, SSH-туннель на БД):
+#     ssh -L 5435:localhost:5432 root@72.56.7.218 -N &
+#     ssh -L 3001:localhost:3000 root@72.56.7.218 -N &
+#     MCP_ENV=production npm run mcp
 DATABASE_URL="postgresql://flowuniverse_mcp:CHANGE_ME@localhost:5435/tasktime?schema=public"
 REDIS_URL="redis://localhost:6381"
 AI_HOURLY_RATE=50
 MCP_ENV=production
+
+# Write operations route through the backend API (workflow engine + RBAC).
+# In Docker: use http://host.docker.internal:3000 (backend on host) or http://backend:3000 (same network)
+# In stdio mode: tunnel the API port: ssh -L 3001:localhost:3000 root@72.56.7.218 -N
+# Write operations route through the backend API.
+# AGENT_MCP_PASSWORD must match what was used when running db:seed (sets agent user password).
+BACKEND_INTERNAL_URL=http://localhost:3000
+MCP_AGENT_EMAIL=agent@flow-universe.internal
+MCP_AGENT_PASSWORD=CHANGE_ME
+AGENT_MCP_PASSWORD=CHANGE_ME

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -1,12 +1,28 @@
 # MCP — Staging environment
 # Copy to .env.staging and fill real credentials (never commit .env.staging)
 #
-# ВАЖНО: использовать техническую УЗ flowuniverse_mcp, не tasktime (admin)
+# ВАЖНО: использовать техническую УЗ flowuniverse_mcp для БД, не tasktime (admin)
 # Создать пользователя: psql -U postgres -d tasktime -f scripts/mcp-db-user.sql
 #
-# Доступ через SSH-туннель:
-#   ssh -L 5434:localhost:5432 root@5.129.242.171 -N
+# Режим запуска:
+#   HTTP transport (Docker на сервере):
+#     MCP_SERVICE_TOKEN=<token> MCP_AGENT_PASSWORD=<pwd> docker compose --profile mcp up -d mcp-flow-universe
+#
+#   Stdio (локальная разработка, SSH-туннель на БД):
+#     ssh -L 5434:localhost:5432 root@5.129.242.171 -N &
+#     ssh -L 3001:localhost:3000 root@5.129.242.171 -N &
+#     MCP_ENV=staging npm run mcp
 DATABASE_URL="postgresql://flowuniverse_mcp:CHANGE_ME@localhost:5434/tasktime?schema=public"
 REDIS_URL="redis://localhost:6380"
 AI_HOURLY_RATE=50
 MCP_ENV=staging
+
+# Write operations route through the backend API (workflow engine + RBAC).
+# In Docker: use http://host.docker.internal:3000 (backend on host) or http://backend:3000 (same network)
+# In stdio mode: tunnel the API port: ssh -L 3001:localhost:3000 root@5.129.242.171 -N
+# Write operations route through the backend API.
+# AGENT_MCP_PASSWORD must match what was used when running db:seed (sets agent user password).
+BACKEND_INTERNAL_URL=http://localhost:3000
+MCP_AGENT_EMAIL=agent@flow-universe.internal
+MCP_AGENT_PASSWORD=CHANGE_ME
+AGENT_MCP_PASSWORD=CHANGE_ME

--- a/backend/src/mcp/api-client.ts
+++ b/backend/src/mcp/api-client.ts
@@ -1,0 +1,90 @@
+/**
+ * Internal HTTP client for MCP → Backend API calls.
+ *
+ * Write operations (status transitions, comments) go through the API so that
+ * the workflow engine, RBAC middleware, and post-functions execute normally.
+ * Read operations and agent-metadata fields (aiExecutionStatus, aiAssigneeType)
+ * still use Prisma directly since they carry no workflow logic.
+ *
+ * Required env vars:
+ *   BACKEND_INTERNAL_URL — URL of the running backend, e.g. http://localhost:3000
+ *                          or http://backend:3000 inside Docker. Defaults to
+ *                          http://localhost:3000 when not set.
+ *   MCP_AGENT_EMAIL      — login email for the agent service account
+ *                          (default: agent@flow-universe.internal)
+ *   MCP_AGENT_PASSWORD   — password for the agent service account (required)
+ */
+
+const BACKEND_URL = (process.env.BACKEND_INTERNAL_URL ?? 'http://localhost:3000').replace(/\/$/, '');
+const AGENT_EMAIL = process.env.MCP_AGENT_EMAIL ?? 'agent@flow-universe.internal';
+const AGENT_PASSWORD = process.env.MCP_AGENT_PASSWORD ?? '';
+
+let _accessToken: string | null = null;
+
+async function login(): Promise<void> {
+  if (!AGENT_PASSWORD) {
+    throw new Error(
+      'MCP_AGENT_PASSWORD is not configured. ' +
+        'Set it in your environment to allow MCP write operations via the backend API.',
+    );
+  }
+
+  const res = await fetch(`${BACKEND_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: AGENT_EMAIL, password: AGENT_PASSWORD }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Agent login failed (${res.status}): ${body}`);
+  }
+
+  const data = (await res.json()) as { accessToken: string };
+  _accessToken = data.accessToken;
+}
+
+async function token(): Promise<string> {
+  if (!_accessToken) await login();
+  return _accessToken!;
+}
+
+async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const send = async (tok: string): Promise<Response> =>
+    fetch(`${BACKEND_URL}${path}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${tok}`,
+      },
+      ...(body !== undefined && { body: JSON.stringify(body) }),
+    });
+
+  let res = await send(await token());
+
+  // Token expired — re-login once and retry
+  if (res.status === 401) {
+    _accessToken = null;
+    res = await send(await token());
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    let message: string;
+    try {
+      const json = JSON.parse(text) as { message?: string; error?: string };
+      message = json.message ?? json.error ?? text;
+    } catch {
+      message = text;
+    }
+    throw new Error(`${method} ${path} → HTTP ${res.status}: ${message}`);
+  }
+
+  const text = await res.text();
+  return (text ? JSON.parse(text) : {}) as T;
+}
+
+export const api = {
+  post: <T = unknown>(path: string, body: unknown) => request<T>('POST', path, body),
+  patch: <T = unknown>(path: string, body: unknown) => request<T>('PATCH', path, body),
+};

--- a/backend/src/mcp/auth-middleware.ts
+++ b/backend/src/mcp/auth-middleware.ts
@@ -1,0 +1,36 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export function mcpBearerAuth(req: Request, res: Response, next: NextFunction): void {
+  const token = process.env.MCP_SERVICE_TOKEN;
+
+  if (!token) {
+    res.status(500).json({
+      jsonrpc: '2.0',
+      error: { code: -32603, message: 'MCP_SERVICE_TOKEN not configured on server' },
+      id: null,
+    });
+    return;
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    res.status(401).json({
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Missing Authorization: Bearer <token>' },
+      id: null,
+    });
+    return;
+  }
+
+  const provided = authHeader.slice(7);
+  if (provided !== token) {
+    res.status(403).json({
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Invalid token' },
+      id: null,
+    });
+    return;
+  }
+
+  next();
+}

--- a/backend/src/mcp/create-server.ts
+++ b/backend/src/mcp/create-server.ts
@@ -1,0 +1,21 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerIssueTools } from './tools/issues.js';
+import { registerSprintTools } from './tools/sprints.js';
+import { registerTimeTools } from './tools/time.js';
+import { registerCommentTools } from './tools/comments.js';
+import { registerAgentTools } from './tools/agent.js';
+
+export function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: 'flow-universe',
+    version: '1.0.0',
+  });
+
+  registerIssueTools(server);
+  registerSprintTools(server);
+  registerTimeTools(server);
+  registerCommentTools(server);
+  registerAgentTools(server);
+
+  return server;
+}

--- a/backend/src/mcp/http-transport.ts
+++ b/backend/src/mcp/http-transport.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from 'node:crypto';
+import express, { type Request, type Response } from 'express';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { createMcpServer } from './create-server.js';
+import { mcpBearerAuth } from './auth-middleware.js';
+
+const PORT = parseInt(process.env.MCP_HTTP_PORT ?? '3002', 10);
+
+const app = express();
+app.use(express.json());
+app.use('/mcp', mcpBearerAuth);
+
+// Session store: sessionId → transport
+const transports: Record<string, StreamableHTTPServerTransport> = {};
+
+// POST /mcp — main JSON-RPC endpoint
+app.post('/mcp', async (req: Request, res: Response) => {
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+  try {
+    // Resume existing session
+    if (sessionId && transports[sessionId]) {
+      await transports[sessionId].handleRequest(req, res, req.body);
+      return;
+    }
+
+    // New session — must start with initialize
+    if (!sessionId && isInitializeRequest(req.body)) {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (sid: string) => {
+          transports[sid] = transport;
+        },
+      });
+
+      transport.onclose = () => {
+        const sid = transport.sessionId;
+        if (sid) delete transports[sid];
+      };
+
+      const server = createMcpServer();
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    res.status(400).json({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Bad Request: missing or unknown session ID' },
+      id: null,
+    });
+  } catch {
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: { code: -32603, message: 'Internal server error' },
+        id: null,
+      });
+    }
+  }
+});
+
+// GET /mcp — SSE stream for server-sent notifications
+app.get('/mcp', async (req: Request, res: Response) => {
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+  if (!sessionId || !transports[sessionId]) {
+    res.status(400).send('Invalid or missing session ID');
+    return;
+  }
+  await transports[sessionId].handleRequest(req, res);
+});
+
+// DELETE /mcp — explicit session termination
+app.delete('/mcp', async (req: Request, res: Response) => {
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+  if (!sessionId || !transports[sessionId]) {
+    res.status(400).send('Invalid or missing session ID');
+    return;
+  }
+  await transports[sessionId].handleRequest(req, res);
+});
+
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`[MCP] HTTP server listening on :${PORT}`);
+  console.log(`[MCP] Environment: ${process.env.MCP_ENV ?? 'development'}`);
+});
+
+// Graceful shutdown
+async function shutdown() {
+  for (const [sid, transport] of Object.entries(transports)) {
+    await transport.close().catch(() => {});
+    delete transports[sid];
+  }
+  process.exit(0);
+}
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -2,31 +2,23 @@ import { config } from 'dotenv';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Load env file based on MCP_ENV (development | staging | production)
+// Load env file before any other imports
+// MCP_ENV: development (default) | staging | production
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MCP_ENV = process.env.MCP_ENV ?? 'development';
 const envFile = MCP_ENV === 'development' ? '.env' : `.env.${MCP_ENV}`;
 config({ path: resolve(__dirname, `../../${envFile}`) });
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+// MCP_TRANSPORT: stdio (default, for local Claude Code) | http (for remote servers)
+const mcpTransport = process.env.MCP_TRANSPORT ?? 'stdio';
 
-import { registerIssueTools } from './tools/issues.js';
-import { registerSprintTools } from './tools/sprints.js';
-import { registerTimeTools } from './tools/time.js';
-import { registerCommentTools } from './tools/comments.js';
-import { registerAgentTools } from './tools/agent.js';
+if (mcpTransport === 'http') {
+  await import('./http-transport.js');
+} else {
+  const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
+  const { createMcpServer } = await import('./create-server.js');
 
-const server = new McpServer({
-  name: 'flow-universe',
-  version: '1.0.0',
-});
-
-registerIssueTools(server);
-registerSprintTools(server);
-registerTimeTools(server);
-registerCommentTools(server);
-registerAgentTools(server);
-
-const transport = new StdioServerTransport();
-await server.connect(transport);
+  const server = createMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/backend/src/mcp/tools/agent.ts
+++ b/backend/src/mcp/tools/agent.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+import { api } from '../api-client.js';
 
 export function registerAgentTools(server: McpServer) {
   // ── get_eligible_issues ───────────────────────────────────────────────────────
@@ -76,26 +77,16 @@ export function registerAgentTools(server: McpServer) {
           return errText(`${key} is already done.`);
         }
 
-        await prisma.$transaction([
-          prisma.issue.update({
-            where: { id: issue.id },
-            data: {
-              aiExecutionStatus: 'IN_PROGRESS',
-              aiAssigneeType: 'AGENT',
-              status: 'IN_PROGRESS',
-              assigneeId: agentUserId,
-            },
-          }),
-          prisma.auditLog.create({
-            data: {
-              action: 'UPDATE',
-              entityType: 'Issue',
-              entityId: issue.id,
-              userId: agentUserId,
-              details: { event: 'agent_claimed', key },
-            },
-          }),
-        ]);
+        // Status transition goes through the workflow engine via API.
+        // Assignee update uses the general PATCH endpoint (USER role is sufficient).
+        // AI-specific metadata (execution status, assignee type) are set directly —
+        // they have no workflow logic and the /ai-status endpoint requires MANAGER.
+        await api.patch(`/api/issues/${issue.id}/status`, { status: 'IN_PROGRESS' });
+        await api.patch(`/api/issues/${issue.id}`, { assigneeId: agentUserId });
+        await prisma.issue.update({
+          where: { id: issue.id },
+          data: { aiExecutionStatus: 'IN_PROGRESS', aiAssigneeType: 'AGENT' },
+        });
 
         return text(`${key} claimed by agent ✓\nStatus: IN_PROGRESS | aiExecutionStatus: IN_PROGRESS\nNext: get_issue("${key}") to read the full spec.`);
       } catch (err) {
@@ -115,33 +106,16 @@ export function registerAgentTools(server: McpServer) {
     async ({ key, summary }) => {
       try {
         const issue = await resolveKey(key);
-        const agentUserId = await getAgentUserId();
 
-        await prisma.$transaction([
-          prisma.issue.update({
-            where: { id: issue.id },
-            data: {
-              aiExecutionStatus: 'DONE',
-              status: 'REVIEW',
-            },
-          }),
-          prisma.comment.create({
-            data: {
-              issueId: issue.id,
-              authorId: agentUserId,
-              body: `🤖 Agent completed work:\n\n${summary}`,
-            },
-          }),
-          prisma.auditLog.create({
-            data: {
-              action: 'UPDATE',
-              entityType: 'Issue',
-              entityId: issue.id,
-              userId: agentUserId,
-              details: { event: 'agent_completed', key },
-            },
-          }),
-        ]);
+        await api.patch(`/api/issues/${issue.id}/status`, { status: 'REVIEW' });
+        await api.post(`/api/issues/${issue.id}/comments`, {
+          body: `🤖 Agent completed work:\n\n${summary}`,
+        });
+        // AI execution status is metadata only — no workflow logic, set directly.
+        await prisma.issue.update({
+          where: { id: issue.id },
+          data: { aiExecutionStatus: 'DONE' },
+        });
 
         return text(`${key}: IN_PROGRESS → REVIEW ✓\nSummary comment added.\nAwaiting human review before DONE.`);
       } catch (err) {
@@ -161,35 +135,17 @@ export function registerAgentTools(server: McpServer) {
     async ({ key, reason }) => {
       try {
         const issue = await resolveKey(key);
-        const agentUserId = await getAgentUserId();
 
-        await prisma.$transaction([
-          prisma.issue.update({
-            where: { id: issue.id },
-            data: {
-              aiExecutionStatus: 'FAILED',
-              status: 'OPEN',
-              aiAssigneeType: 'HUMAN',
-              assigneeId: null,
-            },
-          }),
-          prisma.comment.create({
-            data: {
-              issueId: issue.id,
-              authorId: agentUserId,
-              body: `⚠️ Agent escalation — could not complete:\n\n${reason}\n\nRequires manual intervention.`,
-            },
-          }),
-          prisma.auditLog.create({
-            data: {
-              action: 'UPDATE',
-              entityType: 'Issue',
-              entityId: issue.id,
-              userId: agentUserId,
-              details: { event: 'agent_failed', key, reason: reason.slice(0, 200) },
-            },
-          }),
-        ]);
+        await api.patch(`/api/issues/${issue.id}/status`, { status: 'OPEN' });
+        await api.patch(`/api/issues/${issue.id}`, { assigneeId: null });
+        await api.post(`/api/issues/${issue.id}/comments`, {
+          body: `⚠️ Agent escalation — could not complete:\n\n${reason}\n\nRequires manual intervention.`,
+        });
+        // AI metadata — no workflow logic, set directly.
+        await prisma.issue.update({
+          where: { id: issue.id },
+          data: { aiExecutionStatus: 'FAILED', aiAssigneeType: 'HUMAN' },
+        });
 
         return text(`${key}: FAILED | Returned to OPEN for human ✓\nEscalation comment added.`);
       } catch (err) {

--- a/backend/src/mcp/tools/comments.ts
+++ b/backend/src/mcp/tools/comments.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+import { prisma, resolveKey, text, errText } from '../context.js';
+import { api } from '../api-client.js';
 
 export function registerCommentTools(server: McpServer) {
   // ── add_comment ───────────────────────────────────────────────────────────────
@@ -15,15 +16,8 @@ export function registerCommentTools(server: McpServer) {
     async ({ key, body }) => {
       try {
         const issue = await resolveKey(key);
-        const agentUserId = await getAgentUserId();
 
-        const comment = await prisma.comment.create({
-          data: {
-            issueId: issue.id,
-            authorId: agentUserId,
-            body,
-          },
-        });
+        const comment = await api.post<{ id: string }>(`/api/issues/${issue.id}/comments`, { body });
 
         return text(`Comment added to ${key} (id: ${comment.id}) ✓`);
       } catch (err) {

--- a/backend/src/mcp/tools/issues.ts
+++ b/backend/src/mcp/tools/issues.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import { prisma, resolveKey, getAgentUserId, text, errText } from '../context.js';
+import { prisma, resolveKey, text, errText } from '../context.js';
+import { api } from '../api-client.js';
 
 export function registerIssueTools(server: McpServer) {
   // ── get_issue ────────────────────────────────────────────────────────────────
@@ -17,6 +18,7 @@ export function registerIssueTools(server: McpServer) {
           include: {
             assignee: { select: { name: true, email: true } },
             creator: { select: { name: true } },
+            issueTypeConfig: { select: { name: true } },
             parent: { select: { title: true, number: true, issueTypeConfig: { select: { name: true } }, project: { select: { key: true } } } },
             children: {
               select: { title: true, status: true, number: true, issueTypeConfig: { select: { name: true } }, project: { select: { key: true } } },
@@ -131,7 +133,7 @@ export function registerIssueTools(server: McpServer) {
   // ── update_status ─────────────────────────────────────────────────────────────
   server.tool(
     'update_status',
-    'Change the status of an issue',
+    'Change the status of an issue (routes through the workflow engine)',
     {
       key: z.string().describe('Issue key, e.g. TTMP-95'),
       status: z.enum(['OPEN', 'IN_PROGRESS', 'REVIEW', 'DONE', 'CANCELLED']),
@@ -141,16 +143,9 @@ export function registerIssueTools(server: McpServer) {
         const resolved = await resolveKey(key);
         const old = resolved.status;
 
-        await prisma.issue.update({ where: { id: resolved.id }, data: { status } });
-
-        await prisma.auditLog.create({
-          data: {
-            action: 'UPDATE',
-            entityType: 'Issue',
-            entityId: resolved.id,
-            details: { field: 'status', from: old, to: status },
-          },
-        });
+        // Route through backend API so the workflow engine, validators,
+        // and post-functions execute (e.g. required fields check before DONE).
+        await api.patch(`/api/issues/${resolved.id}/status`, { status });
 
         return text(`${resolved.key}: ${old} → ${status} ✓`);
       } catch (err) {
@@ -172,31 +167,19 @@ export function registerIssueTools(server: McpServer) {
     async ({ parentKey, title, description, priority }) => {
       try {
         const parent = await resolveKey(parentKey);
-        const agentUserId = await getAgentUserId();
 
-        const [parentIssue, subtaskConfig, last] = await Promise.all([
-          prisma.issue.findUniqueOrThrow({ where: { id: parent.id }, select: { sprintId: true } }),
-          prisma.issueTypeConfig.findFirst({ where: { isSubtask: true }, select: { id: true } }),
-          prisma.issue.findFirst({ where: { projectId: parent.projectId }, orderBy: { number: 'desc' }, select: { number: true } }),
-        ]);
-        if (!subtaskConfig) return errText('No subtask issue type configured in this project');
-        const number = (last?.number ?? 0) + 1;
-
-        const child = await prisma.issue.create({
-          data: {
-            projectId: parent.projectId,
-            number,
+        // Route through API so RBAC, hierarchy validation, and numbering
+        // are handled by the service layer.
+        const child = await api.post<{ number: number; project: { key: string } }>(
+          `/api/projects/${parent.projectId}/issues`,
+          {
             title,
             description,
-            issueTypeConfigId: subtaskConfig.id,
+            type: 'SUBTASK',
             priority,
-            status: 'OPEN',
             parentId: parent.id,
-            sprintId: parentIssue.sprintId,
-            creatorId: agentUserId,
           },
-          include: { project: { select: { key: true } } },
-        });
+        );
 
         const childKey = `${child.project.key}-${child.number}`;
         return text(`Created ${childKey}: "${title}" (SUBTASK → ${parentKey}) ✓`);

--- a/backend/src/prisma/seed.ts
+++ b/backend/src/prisma/seed.ts
@@ -3,6 +3,7 @@ import { pathToFileURL } from 'node:url';
 import { PrismaClient, Prisma, type User } from '@prisma/client';
 
 import { bootstrapDefaultUsers, getBootstrapUsers } from './bootstrap.js';
+import { hashPassword } from '../shared/utils/password.js';
 
 const prisma = new PrismaClient();
 
@@ -53,17 +54,21 @@ async function main(prismaClient?: PrismaClient, scope?: string) {
     await bootstrapDefaultUsers(client, defaultPassword, bootstrapUsers);
   }
 
-  // MCP system agent user — upsert so it's always present
+  // MCP system agent user — upsert so it's always present.
+  // Password is set from AGENT_MCP_PASSWORD env var (required for API write ops).
+  // Falls back to a random string so login is impossible if the var is not set.
+  const agentRawPassword = process.env.AGENT_MCP_PASSWORD ?? Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+  const agentPasswordHash = await hashPassword(agentRawPassword);
   await client.user.upsert({
     where: { email: 'agent@flow-universe.internal' },
     create: {
       email: 'agent@flow-universe.internal',
       name: 'Flow Universe Agent',
-      passwordHash: 'mcp-system-no-login',
-      role: 'USER',
+      passwordHash: agentPasswordHash,
+      role: 'MANAGER',
       isActive: true,
     },
-    update: {},
+    update: { passwordHash: agentPasswordHash, role: 'MANAGER' },
   });
 
   const seededUsers = await Promise.all(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,20 +44,37 @@ services:
       timeout: 3s
       retries: 5
 
-  # MCP-прокси для TaskTime API (openapi-to-mcp)
-  # Запуск: docker compose --profile mcp up mcp-tasktime
-  # Claude Desktop config: { "mcpServers": { "tasktime": { "url": "http://localhost:3002/mcp", "transport": "http" } } }
-  mcp-tasktime:
-    image: evilfreelancer/openapi-to-mcp:latest
+  # MCP HTTP-сервер Flow Universe (нативный, прямой доступ к БД)
+  # Запуск: MCP_SERVICE_TOKEN=<token> MCP_AGENT_PASSWORD=<pwd> docker compose --profile mcp up -d mcp-flow-universe
+  # .mcp.json коллеги: { "type": "streamable-http", "url": "http://<host>:3002/mcp",
+  #                      "headers": { "Authorization": "Bearer <token>" } }
+  mcp-flow-universe:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
     profiles: ["mcp"]
+    command: ["node", "dist/mcp/server.js"]
     environment:
-      OPENAPI_URL: http://backend:3000/api/docs/json
-      BACKEND_URL: http://backend:3000
-      BEARER_TOKEN: ${MCP_SERVICE_TOKEN:-}
+      MCP_TRANSPORT: http
+      MCP_HTTP_PORT: "3002"
+      MCP_ENV: ${MCP_ENV:-production}
+      DATABASE_URL: postgresql://tasktime:${POSTGRES_PASSWORD:-tasktime}@postgres:5432/tasktime?schema=public
+      MCP_SERVICE_TOKEN: ${MCP_SERVICE_TOKEN:?MCP_SERVICE_TOKEN is required}
+      # Write operations route through the backend API (workflow engine + RBAC).
+      # BACKEND_INTERNAL_URL must point to the running backend:
+      #   - on the same host: http://localhost:3000 (default)
+      #   - in a Docker network with a backend service: http://backend:3000
+      BACKEND_INTERNAL_URL: ${BACKEND_INTERNAL_URL:-http://localhost:3000}
+      MCP_AGENT_EMAIL: ${MCP_AGENT_EMAIL:-agent@flow-universe.internal}
+      MCP_AGENT_PASSWORD: ${MCP_AGENT_PASSWORD:?MCP_AGENT_PASSWORD is required for write operations}
     ports:
-      - "3002:3000"
+      - "3002:3002"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
-      - backend
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
 
 volumes:
   pgdata:

--- a/docs/mcp-onboarding.html
+++ b/docs/mcp-onboarding.html
@@ -1,0 +1,796 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Flow Universe MCP — Онбординг</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg:        #03050F;
+    --surface:   #0F1320;
+    --surface2:  #151929;
+    --border:    rgba(79,110,247,0.18);
+    --accent:    #4F6EF7;
+    --accent2:   #7B8FF9;
+    --green:     #34D399;
+    --yellow:    #FBBF24;
+    --red:       #F87171;
+    --text:      #E2E8F8;
+    --muted:     #7B8BB2;
+    --code-bg:   #0A0D1A;
+  }
+
+  html { scroll-behavior: smooth; }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Inter', sans-serif;
+    font-size: 15px;
+    line-height: 1.65;
+    min-height: 100vh;
+  }
+
+  /* ── Layout ─────────────────────────────────── */
+  .page { max-width: 860px; margin: 0 auto; padding: 0 24px 80px; }
+
+  /* ── Nav ─────────────────────────────────────── */
+  nav {
+    position: sticky; top: 0; z-index: 100;
+    background: rgba(3,5,15,0.85);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--border);
+    padding: 0 24px;
+  }
+  .nav-inner {
+    max-width: 860px; margin: 0 auto;
+    display: flex; align-items: center; gap: 8px;
+    height: 52px;
+  }
+  .nav-logo {
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700; font-size: 15px;
+    color: var(--text);
+    display: flex; align-items: center; gap: 8px;
+    text-decoration: none; margin-right: auto;
+  }
+  .nav-logo .dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 8px var(--accent);
+  }
+  .nav-link {
+    font-size: 13px; color: var(--muted);
+    text-decoration: none; padding: 4px 8px;
+    border-radius: 6px; transition: color .15s;
+  }
+  .nav-link:hover { color: var(--text); }
+
+  /* ── Hero ────────────────────────────────────── */
+  .hero {
+    padding: 72px 0 56px;
+    position: relative;
+  }
+  .hero-badge {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: rgba(79,110,247,0.12);
+    border: 1px solid rgba(79,110,247,0.3);
+    border-radius: 100px;
+    padding: 4px 12px; font-size: 12px;
+    color: var(--accent2); font-weight: 500;
+    margin-bottom: 24px;
+  }
+  .hero-badge::before {
+    content: ''; width: 6px; height: 6px; border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 6px var(--accent);
+    animation: pulse 2s infinite;
+  }
+  @keyframes pulse {
+    0%,100% { opacity: 1; } 50% { opacity: .4; }
+  }
+  h1 {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: clamp(28px, 5vw, 44px);
+    font-weight: 700; line-height: 1.15;
+    letter-spacing: -0.5px;
+    margin-bottom: 16px;
+  }
+  h1 span { color: var(--accent); }
+  .hero-sub {
+    font-size: 17px; color: var(--muted);
+    max-width: 560px; line-height: 1.6;
+    margin-bottom: 32px;
+  }
+  .hero-meta {
+    display: flex; gap: 24px; flex-wrap: wrap;
+  }
+  .meta-item {
+    display: flex; align-items: center; gap: 6px;
+    font-size: 13px; color: var(--muted);
+  }
+  .meta-item strong { color: var(--text); }
+
+  /* ── Section ─────────────────────────────────── */
+  section { margin-top: 64px; }
+  .section-label {
+    font-size: 11px; font-weight: 600; letter-spacing: 1.2px;
+    text-transform: uppercase; color: var(--accent);
+    margin-bottom: 12px;
+  }
+  h2 {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: clamp(20px, 3vw, 26px);
+    font-weight: 700; letter-spacing: -0.3px;
+    margin-bottom: 24px;
+  }
+  h3 {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 16px; font-weight: 600;
+    margin-bottom: 8px;
+  }
+  p { color: var(--muted); margin-bottom: 12px; }
+  p strong { color: var(--text); }
+
+  /* ── Cards ───────────────────────────────────── */
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 20px 24px;
+  }
+  .card + .card { margin-top: 12px; }
+
+  .card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 12px;
+  }
+
+  /* ── What appeared ───────────────────────────── */
+  .what-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 12px;
+    margin-bottom: 24px;
+  }
+  .what-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 20px;
+  }
+  .what-icon {
+    font-size: 24px; margin-bottom: 10px; display: block;
+  }
+  .what-card h3 { font-size: 14px; margin-bottom: 4px; }
+  .what-card p { font-size: 13px; margin: 0; }
+
+  /* ── Architecture diagram ────────────────────── */
+  .arch {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 28px 32px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+    line-height: 2;
+    color: var(--muted);
+    overflow-x: auto;
+  }
+  .arch .hl { color: var(--accent2); }
+  .arch .gr { color: var(--green); }
+  .arch .ye { color: var(--yellow); }
+  .arch .re { color: var(--red); }
+
+  /* ── Steps ───────────────────────────────────── */
+  .steps { counter-reset: step; display: flex; flex-direction: column; gap: 0; }
+  .step {
+    display: grid;
+    grid-template-columns: 40px 1fr;
+    gap: 0 20px;
+    position: relative;
+  }
+  .step:not(:last-child)::before {
+    content: '';
+    position: absolute;
+    left: 19px; top: 40px; bottom: 0;
+    width: 2px;
+    background: linear-gradient(to bottom, var(--border), transparent);
+  }
+  .step-num {
+    counter-increment: step;
+    width: 40px; height: 40px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 14px; font-weight: 700;
+    color: var(--accent);
+    flex-shrink: 0;
+    position: relative; z-index: 1;
+  }
+  .step-body { padding: 8px 0 32px; }
+  .step-body h3 { font-size: 15px; margin-bottom: 6px; }
+  .step-body p { font-size: 14px; margin-bottom: 8px; }
+
+  /* ── Code block ──────────────────────────────── */
+  .code-block {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px 16px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text);
+    overflow-x: auto;
+    position: relative;
+    margin: 8px 0;
+  }
+  .code-block .comment { color: var(--muted); }
+  .code-block .cmd { color: var(--green); }
+  .code-block .str { color: var(--yellow); }
+  .code-lang {
+    position: absolute; top: 10px; right: 12px;
+    font-size: 10px; color: var(--muted);
+    text-transform: uppercase; letter-spacing: .8px;
+  }
+
+  /* ── Tools grid ──────────────────────────────── */
+  .tool-group { margin-bottom: 28px; }
+  .tool-group-label {
+    font-size: 11px; font-weight: 600; letter-spacing: 1px;
+    text-transform: uppercase; color: var(--muted);
+    margin-bottom: 10px;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .tool-group-label::after {
+    content: ''; flex: 1; height: 1px;
+    background: var(--border);
+  }
+  .tools-list { display: flex; flex-direction: column; gap: 6px; }
+  .tool-item {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 16px;
+    display: grid;
+    grid-template-columns: 200px 1fr auto;
+    gap: 12px;
+    align-items: center;
+  }
+  .tool-name {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px; color: var(--accent2);
+    font-weight: 500;
+  }
+  .tool-desc { font-size: 13px; color: var(--muted); }
+  .tool-badge {
+    font-size: 10px; font-weight: 600; letter-spacing: .5px;
+    padding: 3px 8px; border-radius: 4px;
+    white-space: nowrap;
+  }
+  .badge-read { background: rgba(79,110,247,0.12); color: var(--accent2); }
+  .badge-write { background: rgba(52,211,153,0.1); color: var(--green); }
+  .badge-agent { background: rgba(251,191,36,0.1); color: var(--yellow); }
+
+  /* ── Example chat ────────────────────────────── */
+  .chat { display: flex; flex-direction: column; gap: 10px; }
+  .msg {
+    max-width: 80%;
+    border-radius: 12px;
+    padding: 12px 16px;
+    font-size: 14px;
+    line-height: 1.55;
+  }
+  .msg-user {
+    align-self: flex-end;
+    background: rgba(79,110,247,0.15);
+    border: 1px solid rgba(79,110,247,0.25);
+    color: var(--text);
+    border-bottom-right-radius: 4px;
+  }
+  .msg-ai {
+    align-self: flex-start;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-bottom-left-radius: 4px;
+  }
+  .msg-ai .tool-call {
+    display: inline-flex; align-items: center; gap: 5px;
+    background: rgba(79,110,247,0.08);
+    border: 1px solid rgba(79,110,247,0.2);
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px; color: var(--accent2);
+    margin: 2px;
+  }
+  .msg-ai .tool-call::before { content: '⚡'; font-size: 10px; }
+
+  /* ── Security table ──────────────────────────── */
+  .perm-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+  .perm-table th {
+    text-align: left; padding: 10px 16px;
+    font-size: 11px; font-weight: 600; letter-spacing: .8px;
+    text-transform: uppercase; color: var(--muted);
+    border-bottom: 1px solid var(--border);
+  }
+  .perm-table td {
+    padding: 10px 16px;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+    vertical-align: top;
+  }
+  .perm-table tr:last-child td { border-bottom: none; }
+  .perm-ok { color: var(--green); font-weight: 600; }
+  .perm-no { color: var(--red); font-weight: 600; }
+  .perm-table td:first-child {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px; color: var(--accent2);
+  }
+
+  /* ── Callout ─────────────────────────────────── */
+  .callout {
+    display: flex; gap: 12px;
+    background: rgba(79,110,247,0.07);
+    border: 1px solid rgba(79,110,247,0.2);
+    border-radius: 10px;
+    padding: 14px 16px;
+    font-size: 14px;
+    color: var(--muted);
+    margin: 16px 0;
+  }
+  .callout-icon { font-size: 18px; flex-shrink: 0; line-height: 1.4; }
+  .callout.warn {
+    background: rgba(251,191,36,0.06);
+    border-color: rgba(251,191,36,0.2);
+  }
+
+  /* ── Divider ─────────────────────────────────── */
+  .divider {
+    height: 1px; background: var(--border);
+    margin: 48px 0;
+  }
+
+  /* ── Footer ──────────────────────────────────── */
+  footer {
+    text-align: center; padding: 32px 0 0;
+    color: var(--muted); font-size: 13px;
+  }
+  footer a { color: var(--accent2); text-decoration: none; }
+
+  @media (max-width: 600px) {
+    .tool-item { grid-template-columns: 1fr; }
+    .hero-meta { flex-direction: column; gap: 8px; }
+    .arch { font-size: 11px; padding: 16px; }
+  }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="nav-inner">
+    <a class="nav-logo" href="#">
+      <span class="dot"></span>
+      Flow Universe MCP
+    </a>
+    <a class="nav-link" href="#what">Что появилось</a>
+    <a class="nav-link" href="#setup">Настройка</a>
+    <a class="nav-link" href="#tools">Инструменты</a>
+    <a class="nav-link" href="#examples">Примеры</a>
+  </div>
+</nav>
+
+<div class="page">
+
+  <!-- HERO -->
+  <div class="hero">
+    <div class="hero-badge">Новая возможность · Апрель 2026</div>
+    <h1>Flow Universe<br><span>MCP Server</span></h1>
+    <p class="hero-sub">
+      AI-агенты (Claude Code, Cursor) теперь могут работать с задачами напрямую — читать спринты, менять статусы, логировать время и создавать подзадачи. Без копипаста, без переключения контекста.
+    </p>
+    <div class="hero-meta">
+      <div class="meta-item">📦 <strong>14 инструментов</strong></div>
+      <div class="meta-item">🔐 <strong>Техническая УЗ с ограниченными правами</strong></div>
+      <div class="meta-item">🌍 <strong>Staging + Production</strong></div>
+      <div class="meta-item">⚡ <strong>HTTP transport, без туннелей</strong></div>
+    </div>
+  </div>
+
+  <!-- WHAT APPEARED -->
+  <section id="what">
+    <div class="section-label">Что появилось</div>
+    <h2>Четыре новых компонента</h2>
+
+    <div class="what-grid">
+      <div class="what-card">
+        <span class="what-icon">🖥️</span>
+        <h3>MCP-сервер</h3>
+        <p>backend/src/mcp/ — работает через stdio, Prisma напрямую к PostgreSQL</p>
+      </div>
+      <div class="what-card">
+        <span class="what-icon">🔑</span>
+        <h3>Техническая УЗ</h3>
+        <p>flowuniverse_mcp — Postgres-пользователь с минимальными привилегиями</p>
+      </div>
+      <div class="what-card">
+        <span class="what-icon">⚙️</span>
+        <h3>.mcp.json</h3>
+        <p>Три окружения: development, staging, production — выбираешь в инспекторе</p>
+      </div>
+      <div class="what-card">
+        <span class="what-icon">📋</span>
+        <h3>SQL-скрипт</h3>
+        <p>scripts/mcp-db-user.sql — создание техпользователя на любом сервере</p>
+      </div>
+    </div>
+
+    <div class="callout">
+      <span class="callout-icon">💡</span>
+      <div>
+        <strong style="color: var(--text)">Зачем это нужно?</strong><br>
+        Раньше нужно было открыть систему → найти задачу → скопировать описание → вставить в чат с AI → вернуться → вручную обновить статус. Теперь AI сам читает задачу из системы, работает по ней и записывает результат обратно.
+      </div>
+    </div>
+  </section>
+
+  <!-- ARCHITECTURE -->
+  <section>
+    <div class="section-label">Как это работает</div>
+    <h2>Архитектура</h2>
+
+    <div class="arch">
+<span class="hl">Claude Code / Cursor</span>  (твой ноутбук)
+    │
+    │  HTTP + Bearer token  (JSON-RPC 2.0)
+    ▼
+<span class="gr">http://72.56.7.218:3002/mcp</span>
+    │
+    │  Docker service  mcp-flow-universe
+    │  (--profile mcp, restart: unless-stopped)
+    ▼
+<span class="hl">flow-universe MCP сервер</span>  (StreamableHTTP, Express)
+    │  localhost  (внутри Docker network)
+    ▼
+<span class="ye">PostgreSQL на 72.56.7.218</span>
+    └─ пользователь: <span class="ye">flowuniverse_mcp</span>
+       ├─ <span class="gr">SELECT</span>   — все таблицы
+       ├─ <span class="gr">INSERT</span>   — issues, comments, time_logs, ai_sessions, audit_logs
+       ├─ <span class="gr">UPDATE</span>   — issues (только статус и AI-флаги)
+       └─ <span class="re">DELETE/DDL — запрещено</span>
+    </div>
+
+    <p style="margin-top: 16px">
+      MCP-сервер работает как Docker-сервис прямо на боевом сервере. Коллеге нужен только URL и токен — никаких туннелей, никакого локального бэкенда.
+    </p>
+  </section>
+
+  <!-- SETUP -->
+  <section id="setup">
+    <div class="section-label">Настройка</div>
+    <h2>Запуск за 5 шагов</h2>
+
+    <div class="steps">
+
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Запустить MCP-сервис на сервере (один раз, делает администратор)</h3>
+          <p>На сервере придумать токен и запустить Docker-сервис. Токен передать команде через 1Password / командный Vault.</p>
+          <div class="code-block">
+            <span class="code-lang">bash</span>
+            <span class="comment"># Подключиться к серверу</span><br>
+            <span class="cmd">ssh root@72.56.7.218</span><br><br>
+            <span class="comment"># Запустить MCP как Docker-сервис (токен придумать самостоятельно)</span><br>
+            <span class="cmd">cd /opt/tasktime<br>
+MCP_SERVICE_TOKEN=мой_секретный_токен \<br>
+  docker compose --profile mcp up -d mcp-flow-universe</span>
+          </div>
+          <div class="callout">
+            <span class="callout-icon">💡</span>
+            <div>Сервис стартует автоматически при перезагрузке сервера (<code style="font-family: monospace; font-size: 12px">restart: unless-stopped</code>). Повторно запускать не нужно.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>Добавить конфиг в свой .mcp.json (каждый коллега, один раз)</h3>
+          <p>Открыть <code style="font-family: monospace; color: var(--accent2); font-size: 13px">~/.claude/mcp.json</code> (или <code style="font-family: monospace; color: var(--accent2); font-size: 13px">.mcp.json</code> в корне репо) и добавить:</p>
+          <div class="code-block">
+            <span class="code-lang">json</span>
+            {<br>
+            &nbsp;&nbsp;<span class="str">"mcpServers"</span>: {<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;<span class="str">"flow-universe-prod"</span>: {<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="str">"type"</span>: <span class="str">"streamable-http"</span>,<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="str">"url"</span>: <span class="str">"http://72.56.7.218:3002/mcp"</span>,<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="str">"headers"</span>: {<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="str">"Authorization"</span>: <span class="str">"Bearer МОЙ_ТОКЕН"</span><br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;}<br>
+            &nbsp;&nbsp;}<br>
+            }
+          </div>
+          <p>Заменить <strong>МОЙ_ТОКЕН</strong> на токен полученный от администратора.</p>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Перезапустить Claude Code и проверить</h3>
+          <p>После добавления конфига — перезапустить Claude Code. Затем выполнить:</p>
+          <div class="code-block">
+            <span class="code-lang">claude</span>
+            <span class="cmd">/mcp</span>
+          </div>
+          <p>В списке должен появиться <strong>flow-universe-prod</strong> с 14 инструментами.</p>
+          <p>Проверить: попросить Claude «покажи задачу TTMP-1» — должна вернуться карточка задачи из системы.</p>
+          <div class="callout">
+            <span class="callout-icon">💡</span>
+            <div>Никакого туннеля, никакого локального бэкенда, никаких env-файлов. Только токен в конфиге.</div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- TOOLS -->
+  <section id="tools">
+    <div class="section-label">Функционал</div>
+    <h2>14 инструментов</h2>
+
+    <!-- Issues -->
+    <div class="tool-group">
+      <div class="tool-group-label">📋 Задачи</div>
+      <div class="tools-list">
+        <div class="tool-item">
+          <span class="tool-name">get_issue</span>
+          <span class="tool-desc">Полная карточка задачи по ключу (TTMP-95) или UUID</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">list_issues</span>
+          <span class="tool-desc">Список задач с фильтрами: проект, спринт, статус, AI-eligible</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">update_status</span>
+          <span class="tool-desc">Изменить статус задачи (OPEN → IN_PROGRESS → REVIEW → DONE)</span>
+          <span class="tool-badge badge-write">WRITE</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">create_subtask</span>
+          <span class="tool-desc">Создать подзадачу под родительской задачей — реальная декомпозиция</span>
+          <span class="tool-badge badge-write">WRITE</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Sprints -->
+    <div class="tool-group">
+      <div class="tool-group-label">🏃 Спринты</div>
+      <div class="tools-list">
+        <div class="tool-item">
+          <span class="tool-name">get_sprint_context</span>
+          <span class="tool-desc">Активный спринт: статистика, разбивка по AI-eligible задачам</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">get_backlog</span>
+          <span class="tool-desc">Задачи в бэклоге (не привязаны к спринту)</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Time -->
+    <div class="tool-group">
+      <div class="tool-group-label">⏱️ Время и сессии</div>
+      <div class="tools-list">
+        <div class="tool-item">
+          <span class="tool-name">log_time</span>
+          <span class="tool-desc">Залогировать часы на задачу (source=AGENT, видно в отчётах)</span>
+          <span class="tool-badge badge-write">WRITE</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">register_ai_session</span>
+          <span class="tool-desc">Записать метрики сессии: токены, стоимость, распределение по задачам</span>
+          <span class="tool-badge badge-write">WRITE</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">get_time_summary</span>
+          <span class="tool-desc">Разбивка времени на задаче: человек vs агент</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Comments -->
+    <div class="tool-group">
+      <div class="tool-group-label">💬 Комментарии</div>
+      <div class="tools-list">
+        <div class="tool-item">
+          <span class="tool-name">add_comment</span>
+          <span class="tool-desc">Добавить комментарий к задаче от имени Flow Universe Agent</span>
+          <span class="tool-badge badge-write">WRITE</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">get_comments</span>
+          <span class="tool-desc">Получить последние комментарии к задаче</span>
+          <span class="tool-badge badge-read">READ</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Agent Loop -->
+    <div class="tool-group">
+      <div class="tool-group-label">🤖 Агентский цикл</div>
+      <div class="tools-list">
+        <div class="tool-item">
+          <span class="tool-name">get_eligible_issues</span>
+          <span class="tool-desc">Очередь AI-eligible задач ещё не взятых в работу</span>
+          <span class="tool-badge badge-agent">AGENT</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">claim_issue</span>
+          <span class="tool-desc">Атомарно взять задачу: IN_PROGRESS + AGENT (без гонки состояний)</span>
+          <span class="tool-badge badge-agent">AGENT</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">complete_issue</span>
+          <span class="tool-desc">Завершить: статус → REVIEW, добавить саммари комментарий</span>
+          <span class="tool-badge badge-agent">AGENT</span>
+        </div>
+        <div class="tool-item">
+          <span class="tool-name">fail_issue</span>
+          <span class="tool-desc">Эскалация: не смог выполнить, вернуть в OPEN с причиной</span>
+          <span class="tool-badge badge-agent">AGENT</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- EXAMPLES -->
+  <section id="examples">
+    <div class="section-label">Примеры</div>
+    <h2>Как это выглядит в диалоге</h2>
+
+    <div class="card" style="margin-bottom: 20px">
+      <h3 style="margin-bottom: 16px; color: var(--muted); font-size: 13px; font-weight: 500; text-transform: uppercase; letter-spacing: .8px">Сценарий 1 — Начало рабочего дня</h3>
+      <div class="chat">
+        <div class="msg msg-user">Что у меня в активном спринте? Какие задачи можно взять в работу?</div>
+        <div class="msg msg-ai">
+          <span class="tool-call">get_sprint_context TTMP</span>
+          <span class="tool-call">list_issues project=TTMP sprint=active aiEligible=true</span>
+          <br><br>
+          Активный спринт «Sprint 12» — 18 задач, из них 5 AI-eligible:<br>
+          • TTMP-152 — GitHub webhook: Smart Commits (OPEN, MEDIUM)<br>
+          • TTMP-148 — Экспорт задач в CSV (OPEN, LOW)<br>
+          • TTMP-143 — Уведомления Telegram (OPEN, HIGH)<br>
+          ...
+        </div>
+        <div class="msg msg-user">Возьми TTMP-152</div>
+        <div class="msg msg-ai">
+          <span class="tool-call">get_issue TTMP-152</span>
+          <span class="tool-call">claim_issue TTMP-152</span>
+          <br><br>
+          Взял TTMP-152 в работу. Статус → IN_PROGRESS, задача закреплена за агентом.
+        </div>
+      </div>
+    </div>
+
+    <div class="card" style="margin-bottom: 20px">
+      <h3 style="margin-bottom: 16px; color: var(--muted); font-size: 13px; font-weight: 500; text-transform: uppercase; letter-spacing: .8px">Сценарий 2 — Декомпозиция задачи</h3>
+      <div class="chat">
+        <div class="msg msg-user">Декомпозируй TTMP-152 на подзадачи</div>
+        <div class="msg msg-ai">
+          <span class="tool-call">get_issue TTMP-152</span>
+          <br><br>
+          Создаю подзадачи по описанию...<br><br>
+          <span class="tool-call">create_subtask TTMP-152 "Парсинг issue key из commit message"</span>
+          <span class="tool-call">create_subtask TTMP-152 "HMAC-верификация X-Hub-Signature-256"</span>
+          <span class="tool-call">create_subtask TTMP-152 "Маппинг событий GitHub → статусы"</span>
+          <br><br>
+          Создал 3 подзадачи: TTMP-153, TTMP-154, TTMP-155. Можешь видеть их в системе.
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3 style="margin-bottom: 16px; color: var(--muted); font-size: 13px; font-weight: 500; text-transform: uppercase; letter-spacing: .8px">Сценарий 3 — Завершение и учёт времени</h3>
+      <div class="chat">
+        <div class="msg msg-user">Готово. Залогируй сессию: 1.5 часа, $0.80</div>
+        <div class="msg msg-ai">
+          <span class="tool-call">register_ai_session model=claude-sonnet-4-6 issues=[{TTMP-152,1.0}] costUSD=0.80</span>
+          <span class="tool-call">complete_issue TTMP-152 "Реализован GitHub webhook..."</span>
+          <br><br>
+          Залогировал: 1.5ч, $0.80. Задача TTMP-152 → REVIEW.<br>
+          Добавил комментарий с саммари. Ждёт твоего аппрува.
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- SECURITY -->
+  <section>
+    <div class="section-label">Безопасность</div>
+    <h2>Что агент может и не может</h2>
+
+    <div class="card">
+      <table class="perm-table">
+        <thead>
+          <tr>
+            <th>Операция</th>
+            <th>Разрешено</th>
+            <th>Комментарий</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>SELECT * FROM issues</td>
+            <td class="perm-ok">✓ Да</td>
+            <td style="color: var(--muted); font-size: 13px">Читать все таблицы</td>
+          </tr>
+          <tr>
+            <td>INSERT INTO issues</td>
+            <td class="perm-ok">✓ Да</td>
+            <td style="color: var(--muted); font-size: 13px">Создавать подзадачи</td>
+          </tr>
+          <tr>
+            <td>UPDATE issues SET status</td>
+            <td class="perm-ok">✓ Да</td>
+            <td style="color: var(--muted); font-size: 13px">Только поля задач</td>
+          </tr>
+          <tr>
+            <td>DELETE FROM issues</td>
+            <td class="perm-no">✗ Нет</td>
+            <td style="color: var(--muted); font-size: 13px">Явно запрещено</td>
+          </tr>
+          <tr>
+            <td>UPDATE users SET password</td>
+            <td class="perm-no">✗ Нет</td>
+            <td style="color: var(--muted); font-size: 13px">UPDATE выдан только на issues</td>
+          </tr>
+          <tr>
+            <td>DROP TABLE / ALTER TABLE</td>
+            <td class="perm-no">✗ Нет</td>
+            <td style="color: var(--muted); font-size: 13px">DDL недоступен, не owner</td>
+          </tr>
+          <tr>
+            <td>TRUNCATE</td>
+            <td class="perm-no">✗ Нет</td>
+            <td style="color: var(--muted); font-size: 13px">Явно отозвано</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="callout" style="margin-top: 16px">
+      <span class="callout-icon">🛡️</span>
+      <div>
+        <strong style="color: var(--text)">Максимум что может случиться</strong> — агент создаст лишние подзадачи или поставит неправильный статус. Это исправляется руками за минуту. Структура базы, пользователи и настройки системы неприкосновенны.
+      </div>
+    </div>
+  </section>
+
+  <div class="divider"></div>
+
+  <footer>
+    Flow Universe · MCP Server v1.0 · <a href="https://github.com/NovakPAai/tasktime-mvp/pull/10">PR #10</a> · Апрель 2026
+  </footer>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- StreamableHTTP transport — коллеги подключаются через URL, без SSH туннелей
- Write-операции роутятся через backend API — workflow engine, RBAC и post-functions работают
- `api-client.ts` — логин агента через `POST /api/auth/login`, JWT-кэш с авторе-логином
- Агент-пользователь: роль `MANAGER`, bcrypt-хэш из `AGENT_MCP_PASSWORD`
- `docker-compose.yml` — сервис `mcp-flow-universe` с `extra_hosts: host-gateway`
- `.mcp.json` — три записи: local stdio, staging HTTP, production HTTP
- `docs/mcp-onboarding.html` — онбординг-страница для коллег

## New env vars
- `AGENT_MCP_PASSWORD` — задаётся при `npm run db:seed`
- `MCP_AGENT_PASSWORD` — передаётся MCP-контейнеру
- `BACKEND_INTERNAL_URL` — URL бэкенда (default: `http://localhost:3000`)

## Test plan
- [ ] seed обновляет хэш агента
- [ ] `update_status` проходит через workflow engine
- [ ] `add_comment` создаёт комментарий через API
- [ ] Docker: `mcp-flow-universe` стартует