### PR TITLE
fix(lint): remove unused parameter in register_ai_session

### DIFF
--- a/backend/src/mcp/tools/time.ts
+++ b/backend/src/mcp/tools/time.ts
@@ -111,7 +111,7 @@ export function registerTimeTools(server: McpServer) {
           await prisma.timeLog.createMany({ data: logsData });
         }
 
-        const splitLines = issues.map((s, i) => {
+        const splitLines = issues.map((s) => {
           const h = Math.round((totalHours * (s.ratio / safeTotalRatio)) * 100) / 100;
           return `  ${s.key} (${Math.round(s.ratio * 100)}% = ${h}h)`;
         });


### PR DESCRIPTION
Removes unused `i` parameter in `issues.map((s, i) =>` in `mcp/tools/time.ts`. One-liner missed in the previous PR merge.