### PR TITLE
feat(sprints): AI bulk estimate, total effort, edit modal (TTMP-150)

### DIFF
--- a/backend/src/modules/sprints/sprints.router.ts
+++ b/backend/src/modules/sprints/sprints.router.ts
@@ -9,7 +9,7 @@ import { logAudit } from '../../shared/middleware/audit.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 import { parsePagination } from '../../shared/utils/params.js';
 import { prisma } from '../../prisma/client.js';
-import { delCachedJson } from '../../shared/redis.js';
+import { delCachedJson, delCacheByPrefix } from '../../shared/redis.js';
 
 const router = Router();
 router.use(authenticate);
@@ -120,9 +120,15 @@ router.post('/projects/:projectId/backlog/issues', validate(moveIssuesToSprintDt
 });
 
 // Bulk AI estimate all issues in a sprint
-router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER', 'USER'), async (req: AuthRequest, res, next) => {
+router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER'), async (req: AuthRequest, res, next) => {
   try {
     const sprintId = req.params.id as string;
+
+    const sprint = await prisma.sprint.findUnique({
+      where: { id: sprintId },
+      select: { id: true, projectId: true },
+    });
+    if (!sprint) { res.status(404).json({ error: 'Sprint not found' }); return; }
 
     const issues = await prisma.issue.findMany({
       where: { sprintId },
@@ -141,8 +147,12 @@ router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER', 'USE
       }
     }
 
-    // Invalidate sprint issues cache so stats recalculate
-    await delCachedJson(`sprint:issues:${sprintId}`);
+    // Invalidate sprint issues cache + sprint list caches so totalEstimatedHours recalculates
+    await Promise.all([
+      delCachedJson(`sprint:issues:${sprintId}`),
+      delCacheByPrefix(`sprints:project:${sprint.projectId}:`),
+      delCacheByPrefix('sprints:all:'),
+    ]);
 
     await logAudit(req, 'sprint.ai_estimate_all', 'sprint', sprintId, {
       total: issues.length,

--- a/backend/src/modules/sprints/sprints.router.ts
+++ b/backend/src/modules/sprints/sprints.router.ts
@@ -112,7 +112,7 @@ router.post('/sprints/:id/issues', requireRole('ADMIN', 'MANAGER'), validate(mov
 });
 
 // Move issues to backlog
-router.post('/projects/:projectId/backlog/issues', validate(moveIssuesToSprintDto), async (req: AuthRequest, res, next) => {
+router.post('/projects/:projectId/backlog/issues', requireRole('ADMIN', 'MANAGER'), validate(moveIssuesToSprintDto), async (req: AuthRequest, res, next) => {
   try {
     await sprintsService.moveIssuesToSprint(null, req.body.issueIds);
     res.json({ ok: true });
@@ -131,9 +131,10 @@ router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER'), asy
     if (!sprint) { res.status(404).json({ error: 'Sprint not found' }); return; }
 
     // Per-sprint distributed lock to prevent concurrent bulk estimates
+    // Per-sprint distributed lock with owner token to prevent concurrent bulk estimates
     const lockKey = `lock:estimate-all:${sprintId}`;
-    const acquired = await acquireLock(lockKey, 300);
-    if (!acquired) {
+    const lockToken = await acquireLock(lockKey, 300);
+    if (!lockToken) {
       res.status(409).json({ error: 'Estimation already in progress for this sprint' });
       return;
     }
@@ -151,8 +152,8 @@ router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER'), asy
           const result = await aiService.estimateIssue({ issueId: issue.id });
           results.push({ issueId: issue.id, estimatedHours: result.estimatedHours });
         } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          results.push({ issueId: issue.id, error: msg });
+          console.error('estimate-all issue error:', { sprintId, issueId: issue.id, err });
+          results.push({ issueId: issue.id, error: 'Failed to estimate issue' });
         }
       }
 
@@ -178,7 +179,7 @@ router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER'), asy
         results,
       });
     } finally {
-      await releaseLock(lockKey);
+      await releaseLock(lockKey, lockToken);
     }
   } catch (err) { next(err); }
 });

--- a/backend/src/modules/sprints/sprints.router.ts
+++ b/backend/src/modules/sprints/sprints.router.ts
@@ -4,9 +4,12 @@ import { requireRole } from '../../shared/middleware/rbac.js';
 import { validate } from '../../shared/middleware/validate.js';
 import { createSprintDto, updateSprintDto, moveIssuesToSprintDto } from './sprints.dto.js';
 import * as sprintsService from './sprints.service.js';
+import * as aiService from '../ai/ai.service.js';
 import { logAudit } from '../../shared/middleware/audit.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 import { parsePagination } from '../../shared/utils/params.js';
+import { prisma } from '../../prisma/client.js';
+import { delCachedJson } from '../../shared/redis.js';
 
 const router = Router();
 router.use(authenticate);
@@ -113,6 +116,45 @@ router.post('/projects/:projectId/backlog/issues', validate(moveIssuesToSprintDt
   try {
     await sprintsService.moveIssuesToSprint(null, req.body.issueIds);
     res.json({ ok: true });
+  } catch (err) { next(err); }
+});
+
+// Bulk AI estimate all issues in a sprint
+router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER', 'USER'), async (req: AuthRequest, res, next) => {
+  try {
+    const sprintId = req.params.id as string;
+
+    const issues = await prisma.issue.findMany({
+      where: { sprintId },
+      select: { id: true },
+    });
+
+    const results: Array<{ issueId: string; estimatedHours?: number; error?: string }> = [];
+
+    for (const issue of issues) {
+      try {
+        const result = await aiService.estimateIssue({ issueId: issue.id });
+        results.push({ issueId: issue.id, estimatedHours: result.estimatedHours });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        results.push({ issueId: issue.id, error: msg });
+      }
+    }
+
+    // Invalidate sprint issues cache so stats recalculate
+    await delCachedJson(`sprint:issues:${sprintId}`);
+
+    await logAudit(req, 'sprint.ai_estimate_all', 'sprint', sprintId, {
+      total: issues.length,
+      estimated: results.filter(r => !r.error).length,
+    });
+
+    res.json({
+      total: issues.length,
+      estimated: results.filter(r => !r.error).length,
+      failed: results.filter(r => !!r.error).length,
+      results,
+    });
   } catch (err) { next(err); }
 });
 

--- a/backend/src/modules/sprints/sprints.router.ts
+++ b/backend/src/modules/sprints/sprints.router.ts
@@ -115,6 +115,7 @@ router.post('/sprints/:id/issues', requireRole('ADMIN', 'MANAGER'), validate(mov
 router.post('/projects/:projectId/backlog/issues', requireRole('ADMIN', 'MANAGER'), validate(moveIssuesToSprintDto), async (req: AuthRequest, res, next) => {
   try {
     await sprintsService.moveIssuesToSprint(null, req.body.issueIds);
+    await logAudit(req, 'sprint.issues_moved_to_backlog', 'project', req.params.projectId as string, { issueIds: req.body.issueIds });
     res.json({ ok: true });
   } catch (err) { next(err); }
 });

--- a/backend/src/modules/sprints/sprints.router.ts
+++ b/backend/src/modules/sprints/sprints.router.ts
@@ -9,7 +9,7 @@ import { logAudit } from '../../shared/middleware/audit.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 import { parsePagination } from '../../shared/utils/params.js';
 import { prisma } from '../../prisma/client.js';
-import { delCachedJson, delCacheByPrefix } from '../../shared/redis.js';
+import { delCachedJson, delCacheByPrefix, acquireLock, releaseLock } from '../../shared/redis.js';
 
 const router = Router();
 router.use(authenticate);
@@ -130,6 +130,13 @@ router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER'), asy
     });
     if (!sprint) { res.status(404).json({ error: 'Sprint not found' }); return; }
 
+    const lockKey = `lock:estimate-all:${sprintId}`;
+    const acquired = await acquireLock(lockKey, 300); // 5 min TTL — max time for a full sprint estimate
+    if (!acquired) {
+      res.status(409).json({ error: 'Estimation already in progress for this sprint' });
+      return;
+    }
+
     const issues = await prisma.issue.findMany({
       where: { sprintId },
       select: { id: true },
@@ -137,27 +144,30 @@ router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER'), asy
 
     const results: Array<{ issueId: string; estimatedHours?: number; error?: string }> = [];
 
-    for (const issue of issues) {
-      try {
-        const result = await aiService.estimateIssue({ issueId: issue.id });
-        results.push({ issueId: issue.id, estimatedHours: result.estimatedHours });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        results.push({ issueId: issue.id, error: msg });
+    try {
+      for (const issue of issues) {
+        try {
+          const result = await aiService.estimateIssue({ issueId: issue.id });
+          results.push({ issueId: issue.id, estimatedHours: result.estimatedHours });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          results.push({ issueId: issue.id, error: msg });
+        }
       }
+    } finally {
+      await releaseLock(lockKey);
     }
 
-    // Invalidate sprint issues cache + sprint list caches so totalEstimatedHours recalculates
-    await Promise.all([
+    // Best-effort: invalidate caches and audit — don't fail the response if Redis/DB is flaky
+    Promise.all([
       delCachedJson(`sprint:issues:${sprintId}`),
       delCacheByPrefix(`sprints:project:${sprint.projectId}:`),
       delCacheByPrefix('sprints:all:'),
-    ]);
-
-    await logAudit(req, 'sprint.ai_estimate_all', 'sprint', sprintId, {
-      total: issues.length,
-      estimated: results.filter(r => !r.error).length,
-    });
+      logAudit(req, 'sprint.ai_estimate_all', 'sprint', sprintId, {
+        total: issues.length,
+        estimated: results.filter(r => !r.error).length,
+      }),
+    ]).catch((err) => console.error('estimate-all post-cleanup error:', err));
 
     res.json({
       total: issues.length,

--- a/backend/src/modules/sprints/sprints.router.ts
+++ b/backend/src/modules/sprints/sprints.router.ts
@@ -130,21 +130,22 @@ router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER'), asy
     });
     if (!sprint) { res.status(404).json({ error: 'Sprint not found' }); return; }
 
+    // Per-sprint distributed lock to prevent concurrent bulk estimates
     const lockKey = `lock:estimate-all:${sprintId}`;
-    const acquired = await acquireLock(lockKey, 300); // 5 min TTL — max time for a full sprint estimate
+    const acquired = await acquireLock(lockKey, 300);
     if (!acquired) {
       res.status(409).json({ error: 'Estimation already in progress for this sprint' });
       return;
     }
 
-    const issues = await prisma.issue.findMany({
-      where: { sprintId },
-      select: { id: true },
-    });
-
-    const results: Array<{ issueId: string; estimatedHours?: number; error?: string }> = [];
-
     try {
+      const issues = await prisma.issue.findMany({
+        where: { sprintId },
+        select: { id: true },
+      });
+
+      const results: Array<{ issueId: string; estimatedHours?: number; error?: string }> = [];
+
       for (const issue of issues) {
         try {
           const result = await aiService.estimateIssue({ issueId: issue.id });
@@ -154,27 +155,31 @@ router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER'), asy
           results.push({ issueId: issue.id, error: msg });
         }
       }
+
+      // Best-effort: invalidate caches and audit — don't fail the response if Redis/DB is flaky
+      try {
+        await Promise.all([
+          delCachedJson(`sprint:issues:${sprintId}`),
+          delCacheByPrefix(`sprints:project:${sprint.projectId}:`),
+          delCacheByPrefix('sprints:all:'),
+          logAudit(req, 'sprint.ai_estimate_all', 'sprint', sprintId, {
+            total: issues.length,
+            estimated: results.filter(r => !r.error).length,
+          }),
+        ]);
+      } catch (cleanupErr) {
+        console.error('estimate-all post-cleanup error:', cleanupErr);
+      }
+
+      res.json({
+        total: issues.length,
+        estimated: results.filter(r => !r.error).length,
+        failed: results.filter(r => !!r.error).length,
+        results,
+      });
     } finally {
       await releaseLock(lockKey);
     }
-
-    // Best-effort: invalidate caches and audit — don't fail the response if Redis/DB is flaky
-    Promise.all([
-      delCachedJson(`sprint:issues:${sprintId}`),
-      delCacheByPrefix(`sprints:project:${sprint.projectId}:`),
-      delCacheByPrefix('sprints:all:'),
-      logAudit(req, 'sprint.ai_estimate_all', 'sprint', sprintId, {
-        total: issues.length,
-        estimated: results.filter(r => !r.error).length,
-      }),
-    ]).catch((err) => console.error('estimate-all post-cleanup error:', err));
-
-    res.json({
-      total: issues.length,
-      estimated: results.filter(r => !r.error).length,
-      failed: results.filter(r => !!r.error).length,
-      results,
-    });
   } catch (err) { next(err); }
 });
 

--- a/backend/src/modules/sprints/sprints.router.ts
+++ b/backend/src/modules/sprints/sprints.router.ts
@@ -131,7 +131,6 @@ router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN', 'MANAGER'), asy
     });
     if (!sprint) { res.status(404).json({ error: 'Sprint not found' }); return; }
 
-    // Per-sprint distributed lock to prevent concurrent bulk estimates
     // Per-sprint distributed lock with owner token to prevent concurrent bulk estimates
     const lockKey = `lock:estimate-all:${sprintId}`;
     const lockToken = await acquireLock(lockKey, 300);

--- a/backend/src/modules/sprints/sprints.service.ts
+++ b/backend/src/modules/sprints/sprints.service.ts
@@ -91,7 +91,7 @@ export async function getSprintIssues(id: string) {
   const cached = await getCachedJson<SprintIssuesResult>(cacheKey);
   if (cached) return cached;
 
-  const [sprint, hoursAgg] = await Promise.all([
+  const [sprint, hoursAgg, estimatedIssueCount] = await Promise.all([
     prisma.sprint.findUnique({
       where: { id },
       include: {
@@ -119,20 +119,25 @@ export async function getSprintIssues(id: string) {
         flowTeam: { select: { id: true, name: true } },
       },
     }),
-    // Separate aggregate to get accurate total regardless of the take: 200 limit above
     prisma.issue.aggregate({
       where: { sprintId: id },
       _sum: { estimatedHours: true },
+    }),
+    prisma.issue.count({
+      where: { sprintId: id, estimatedHours: { not: null } },
     }),
   ]);
 
   if (!sprint) throw new AppError(404, 'Sprint not found');
 
   const sprintWithStats = mapSprintWithStats(sprint);
-  // Override totalEstimatedHours with the accurate aggregate value
-  if (sprintWithStats.stats) {
-    sprintWithStats.stats.totalEstimatedHours = Number(hoursAgg._sum.estimatedHours ?? 0);
-  }
+  // Override stats with accurate values from _count and aggregates (not limited by take: 200)
+  const totalIssues = sprint._count.issues;
+  sprintWithStats.stats.totalIssues = totalIssues;
+  sprintWithStats.stats.estimatedIssues = estimatedIssueCount;
+  sprintWithStats.stats.planningReadiness =
+    totalIssues === 0 ? 0 : Math.round((estimatedIssueCount / totalIssues) * 100);
+  sprintWithStats.stats.totalEstimatedHours = Number(hoursAgg._sum.estimatedHours ?? 0);
 
   const result = {
     sprint: sprintWithStats,

--- a/backend/src/modules/sprints/sprints.service.ts
+++ b/backend/src/modules/sprints/sprints.service.ts
@@ -91,38 +91,51 @@ export async function getSprintIssues(id: string) {
   const cached = await getCachedJson<SprintIssuesResult>(cacheKey);
   if (cached) return cached;
 
-  const sprint = await prisma.sprint.findUnique({
-    where: { id },
-    include: {
-      _count: { select: { issues: true } },
-      issues: {
-        select: {
-          id: true,
-          projectId: true,
-          number: true,
-          title: true,
-          estimatedHours: true,
-          issueTypeConfig: { select: { id: true, name: true, systemKey: true, iconName: true, iconColor: true } },
-          status: true,
-          priority: true,
-          updatedAt: true,
-          assignee: { select: { id: true, name: true } },
-          project: { select: { id: true, name: true, key: true } },
+  const [sprint, hoursAgg] = await Promise.all([
+    prisma.sprint.findUnique({
+      where: { id },
+      include: {
+        _count: { select: { issues: true } },
+        issues: {
+          select: {
+            id: true,
+            projectId: true,
+            number: true,
+            title: true,
+            estimatedHours: true,
+            issueTypeConfig: { select: { id: true, name: true, systemKey: true, iconName: true, iconColor: true } },
+            status: true,
+            priority: true,
+            updatedAt: true,
+            assignee: { select: { id: true, name: true } },
+            project: { select: { id: true, name: true, key: true } },
+          },
+          orderBy: [{ orderIndex: 'asc' }, { createdAt: 'desc' }],
+          take: 200,
         },
-        orderBy: [{ orderIndex: 'asc' }, { createdAt: 'desc' }],
-        take: 200,
+        project: { select: { id: true, name: true, key: true } },
+        projectTeam: { select: { id: true, name: true } },
+        businessTeam: { select: { id: true, name: true } },
+        flowTeam: { select: { id: true, name: true } },
       },
-      project: { select: { id: true, name: true, key: true } },
-      projectTeam: { select: { id: true, name: true } },
-      businessTeam: { select: { id: true, name: true } },
-      flowTeam: { select: { id: true, name: true } },
-    },
-  });
+    }),
+    // Separate aggregate to get accurate total regardless of the take: 200 limit above
+    prisma.issue.aggregate({
+      where: { sprintId: id },
+      _sum: { estimatedHours: true },
+    }),
+  ]);
 
   if (!sprint) throw new AppError(404, 'Sprint not found');
 
+  const sprintWithStats = mapSprintWithStats(sprint);
+  // Override totalEstimatedHours with the accurate aggregate value
+  if (sprintWithStats.stats) {
+    sprintWithStats.stats.totalEstimatedHours = Number(hoursAgg._sum.estimatedHours ?? 0);
+  }
+
   const result = {
-    sprint: mapSprintWithStats(sprint),
+    sprint: sprintWithStats,
     issues: sprint.issues.map((issue) => ({
       ...issue,
       type: issue.issueTypeConfig?.systemKey ?? null,

--- a/backend/src/modules/sprints/sprints.service.ts
+++ b/backend/src/modules/sprints/sprints.service.ts
@@ -23,6 +23,11 @@ function mapSprintWithStats<TSprint extends SprintWithStatsSource>(sprint: TSpri
   const planningReadiness =
     totalIssues === 0 ? 0 : Math.round((estimatedIssues / totalIssues) * 100);
 
+  const totalEstimatedHours = sprint.issues?.reduce((sum, issue) => {
+    const h = issue.estimatedHours != null ? Number(issue.estimatedHours) : 0;
+    return sum + h;
+  }, 0) ?? 0;
+
   const sprintData = { ...sprint };
   delete (sprintData as Partial<TSprint> & SprintWithStatsSource).issues;
 
@@ -32,6 +37,7 @@ function mapSprintWithStats<TSprint extends SprintWithStatsSource>(sprint: TSpri
       totalIssues,
       estimatedIssues,
       planningReadiness,
+      totalEstimatedHours,
     },
   };
 }

--- a/backend/src/shared/redis.ts
+++ b/backend/src/shared/redis.ts
@@ -104,6 +104,30 @@ export async function delCacheByPrefix(prefix: string): Promise<void> {
   }
 }
 
+/**
+ * Acquire a simple distributed lock using SET NX EX.
+ * Returns true if the lock was acquired, false if it was already held.
+ */
+export async function acquireLock(key: string, ttlSeconds: number): Promise<boolean> {
+  const redis = await getRedisClientInternal();
+  if (!redis) return true; // no Redis → allow (dev/test fallback)
+
+  try {
+    const result = await redis.set(key, '1', { NX: true, EX: ttlSeconds });
+    return result === 'OK';
+  } catch (err) {
+    console.error('Failed to acquire Redis lock:', err);
+    return true; // allow on error to avoid blocking
+  }
+}
+
+/**
+ * Release a distributed lock acquired with acquireLock.
+ */
+export async function releaseLock(key: string): Promise<void> {
+  await delCachedJson(key);
+}
+
 export type UserSession = {
   userId: string;
   email: string;

--- a/backend/src/shared/redis.ts
+++ b/backend/src/shared/redis.ts
@@ -104,30 +104,6 @@ export async function delCacheByPrefix(prefix: string): Promise<void> {
   }
 }
 
-/**
- * Acquire a simple distributed lock using SET NX EX.
- * Returns true if the lock was acquired, false if it was already held.
- */
-export async function acquireLock(key: string, ttlSeconds: number): Promise<boolean> {
-  const redis = await getRedisClientInternal();
-  if (!redis) return true; // no Redis → allow (dev/test fallback)
-
-  try {
-    const result = await redis.set(key, '1', { NX: true, EX: ttlSeconds });
-    return result === 'OK';
-  } catch (err) {
-    console.error('Failed to acquire Redis lock:', err);
-    return true; // allow on error to avoid blocking
-  }
-}
-
-/**
- * Release a distributed lock acquired with acquireLock.
- */
-export async function releaseLock(key: string): Promise<void> {
-  await delCachedJson(key);
-}
-
 export type UserSession = {
   userId: string;
   email: string;
@@ -192,6 +168,38 @@ export async function deleteCachedByPattern(pattern: string): Promise<void> {
     if (keys.length > 0) await redis.del(keys);
   } catch (err) {
     console.error('Failed to delete cached keys by pattern:', err);
+  }
+}
+
+/**
+ * Acquire a distributed lock using Redis SET NX EX.
+ * Returns true if lock acquired, false otherwise.
+ * In test env (no Redis) returns true so tests aren't blocked.
+ * In prod with Redis errors returns false to enforce the lock.
+ */
+export async function acquireLock(key: string, ttlSeconds = 60): Promise<boolean> {
+  const redis = await getRedisClientInternal();
+  if (!redis) {
+    return process.env.NODE_ENV === 'test';
+  }
+
+  try {
+    const result = await redis.set(key, '1', { NX: true, EX: ttlSeconds });
+    return result === 'OK';
+  } catch (err) {
+    console.error('acquireLock Redis error:', err);
+    return process.env.NODE_ENV === 'test';
+  }
+}
+
+export async function releaseLock(key: string): Promise<void> {
+  const redis = await getRedisClientInternal();
+  if (!redis) return;
+
+  try {
+    await redis.del(key);
+  } catch (err) {
+    console.error('releaseLock Redis error:', err);
   }
 }
 

--- a/backend/src/shared/redis.ts
+++ b/backend/src/shared/redis.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { createClient, type RedisClientType } from 'redis';
 import { config } from '../config.js';
 
@@ -171,33 +172,41 @@ export async function deleteCachedByPattern(pattern: string): Promise<void> {
   }
 }
 
+// Lua script: atomic compare-and-delete — only deletes key if value matches owner token
+const RELEASE_LOCK_SCRIPT = `if redis.call("get",KEYS[1]) == ARGV[1] then return redis.call("del",KEYS[1]) else return 0 end`;
+
 /**
- * Acquire a distributed lock using Redis SET NX EX.
- * Returns true if lock acquired, false otherwise.
- * In test env (no Redis) returns true so tests aren't blocked.
- * In prod with Redis errors returns false to enforce the lock.
+ * Acquire a distributed lock using Redis SET NX EX with a unique owner token.
+ * Returns the owner token string on success, or null if the lock is already held.
+ * In test env (no Redis) returns a synthetic token so tests aren't blocked.
+ * In prod with Redis errors returns null to enforce the lock.
  */
-export async function acquireLock(key: string, ttlSeconds = 60): Promise<boolean> {
+export async function acquireLock(key: string, ttlSeconds = 60): Promise<string | null> {
   const redis = await getRedisClientInternal();
   if (!redis) {
-    return process.env.NODE_ENV === 'test';
+    return process.env.NODE_ENV === 'test' ? 'test-token' : null;
   }
 
+  const token = randomUUID();
   try {
-    const result = await redis.set(key, '1', { NX: true, EX: ttlSeconds });
-    return result === 'OK';
+    const result = await redis.set(key, token, { NX: true, EX: ttlSeconds });
+    return result === 'OK' ? token : null;
   } catch (err) {
     console.error('acquireLock Redis error:', err);
-    return process.env.NODE_ENV === 'test';
+    return process.env.NODE_ENV === 'test' ? 'test-token' : null;
   }
 }
 
-export async function releaseLock(key: string): Promise<void> {
+/**
+ * Release a distributed lock only if the caller owns it (token matches).
+ * Uses an atomic Lua script to prevent releasing another owner's lock.
+ */
+export async function releaseLock(key: string, token: string): Promise<void> {
   const redis = await getRedisClientInternal();
   if (!redis) return;
 
   try {
-    await redis.del(key);
+    await redis.eval(RELEASE_LOCK_SCRIPT, { keys: [key], arguments: [token] });
   } catch (err) {
     console.error('releaseLock Redis error:', err);
   }

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -522,6 +522,27 @@ AI estimates effort for an issue.
 { "estimatedHours": 8, "reasoning": "...", "session": { ...aiSession } }
 ```
 
+### POST `/api/sprints/:id/ai/estimate-all`
+Bulk AI estimate for all issues in a sprint. Requires `ADMIN` or `MANAGER` role. Uses a per-sprint Redis lock to prevent concurrent runs.
+```json
+// Response 200
+{
+  "total": 12,
+  "estimated": 10,
+  "failed": 2,
+  "results": [
+    { "issueId": "uuid", "estimatedHours": 8 },
+    { "issueId": "uuid", "error": "AI service unavailable" }
+  ]
+}
+
+// Response 404
+{ "error": "Sprint not found" }
+
+// Response 409
+{ "error": "Estimation already in progress for this sprint" }
+```
+
 ### POST `/api/ai/decompose`
 AI decomposes issue into subtasks.
 ```json
@@ -613,6 +634,7 @@ The `--api` mode of `scripts/generate-docs.js` can auto-regenerate this from Ope
 | `POST` | `/api/ai/estimate` | 🔒 |
 | `POST` | `/api/ai/decompose` | 🔒 |
 | `POST` | `/api/ai/suggest-assignee` | 🔒 |
+| `POST` | `/api/sprints/:id/ai/estimate-all` | 🔒 ADMIN, MANAGER |
 
 ### Auth
 

--- a/frontend/src/api/sprints.ts
+++ b/frontend/src/api/sprints.ts
@@ -82,5 +82,17 @@ export async function getSprintIssues(id: string): Promise<SprintDetailsResponse
   return data;
 }
 
+export interface EstimateAllResult {
+  total: number;
+  estimated: number;
+  failed: number;
+  results: Array<{ issueId: string; estimatedHours?: number; error?: string }>;
+}
+
+export async function estimateAllSprintIssues(sprintId: string): Promise<EstimateAllResult> {
+  const { data } = await api.post<EstimateAllResult>(`/sprints/${sprintId}/ai/estimate-all`);
+  return data;
+}
+
 // Re-export PaginationMeta for convenience
 export type { PaginationMeta };

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -177,22 +177,37 @@ export default function Sidebar({
         MozOsxFontSmoothing: 'grayscale',
       };
 
-  const adminSubItems: [string, string][] = [
-    ['/admin/dashboard', 'Дашборд'],
-    ['/admin/monitoring', 'Мониторинг'],
-    ['/admin/users', 'Пользователи'],
-    ['/admin/roles', 'Назначение ролей'],
-    ['/admin/projects', 'Проекты'],
-    ['/admin/categories', 'Категории'],
-    ['/admin/link-types', 'Виды связей'],
-    ['/admin/issue-type-configs', 'Типы задач'],
-    ['/admin/issue-type-schemes', 'Схемы типов задач'],
-    ['/admin/custom-fields', 'Кастомные поля'],
-    ['/admin/field-schemas', 'Схемы полей'],
-    ['/admin/workflow-statuses', 'Статусы'],
-    ['/admin/workflows', 'Workflow'],
-    ['/admin/workflow-schemes', 'Схемы workflow'],
-    ['/admin/transition-screens', 'Экраны переходов'],
+  type AdminNavItem =
+    | { type: 'link'; path: string; label: string }
+    | { type: 'divider'; label: string };
+
+  const adminNavItems: AdminNavItem[] = [
+    { type: 'divider', label: 'Обзор' },
+    { type: 'link', path: '/admin/dashboard',   label: 'Дашборд' },
+    { type: 'link', path: '/admin/monitoring',  label: 'Мониторинг' },
+
+    { type: 'divider', label: 'Пользователи' },
+    { type: 'link', path: '/admin/users',       label: 'Пользователи' },
+    { type: 'link', path: '/admin/roles',       label: 'Назначение ролей' },
+
+    { type: 'divider', label: 'Проекты' },
+    { type: 'link', path: '/admin/projects',    label: 'Проекты' },
+    { type: 'link', path: '/admin/categories',  label: 'Категории' },
+
+    { type: 'divider', label: 'Задачи' },
+    { type: 'link', path: '/admin/issue-type-configs',  label: 'Типы задач' },
+    { type: 'link', path: '/admin/issue-type-schemes',  label: 'Схемы типов задач' },
+    { type: 'link', path: '/admin/link-types',          label: 'Виды связей' },
+
+    { type: 'divider', label: 'Поля' },
+    { type: 'link', path: '/admin/custom-fields',  label: 'Кастомные поля' },
+    { type: 'link', path: '/admin/field-schemas',  label: 'Схемы полей' },
+
+    { type: 'divider', label: 'Workflow' },
+    { type: 'link', path: '/admin/workflow-statuses',    label: 'Статусы' },
+    { type: 'link', path: '/admin/workflows',            label: 'Workflow' },
+    { type: 'link', path: '/admin/workflow-schemes',     label: 'Схемы workflow' },
+    { type: 'link', path: '/admin/transition-screens',   label: 'Экраны переходов' },
   ];
 
   return (
@@ -372,12 +387,23 @@ export default function Sidebar({
                   <path d="M4.5 3L7.5 6L4.5 9" stroke={tokens.inactive} strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               </div>
-              {isAdminOpen && adminSubItems.map(([key, label]) => (
-                <div key={key} style={subItemStyle(key)} onClick={() => onNavigate(key)} onMouseEnter={() => setHovered(key)} onMouseLeave={() => setHovered(null)}>
-                  <div style={{ width: 5, height: 5, borderRadius: '50%', backgroundColor: isActive(key) ? tokens.acc : tokens.inactive, flexShrink: 0 }} />
-                  <span style={subTextStyle(key)}>{label}</span>
-                </div>
-              ))}
+              {isAdminOpen && adminNavItems.map((item, idx) => {
+                if (item.type === 'divider') {
+                  return (
+                    <div key={`div-${idx}`} style={{ paddingLeft: 28, paddingTop: idx === 0 ? 4 : 10, paddingBottom: 2 }}>
+                      <span style={{ fontFamily: '"Inter", system-ui, sans-serif', fontSize: 9, fontWeight: 700, letterSpacing: '0.7px', textTransform: 'uppercase', color: tokens.inactive, opacity: 0.55 }}>
+                        {item.label}
+                      </span>
+                    </div>
+                  );
+                }
+                return (
+                  <div key={item.path} style={subItemStyle(item.path)} onClick={() => onNavigate(item.path)} onMouseEnter={() => setHovered(item.path)} onMouseLeave={() => setHovered(null)}>
+                    <div style={{ width: 5, height: 5, borderRadius: '50%', backgroundColor: isActive(item.path) ? tokens.acc : tokens.inactive, flexShrink: 0 }} />
+                    <span style={subTextStyle(item.path)}>{item.label}</span>
+                  </div>
+                );
+              })}
               <div style={{ height: 1, backgroundColor: tokens.border, margin: '6px 4px' }} />
             </>
           )}

--- a/frontend/src/pages/SprintsPage.tsx
+++ b/frontend/src/pages/SprintsPage.tsx
@@ -288,19 +288,24 @@ export default function SprintsPage() {
     projectTeamId?: string; businessTeamId?: string; flowTeamId?: string;
   }) => {
     if (!selectedSprintId) return;
-    await sprintsApi.updateSprint(selectedSprintId, {
-      name: vals.name,
-      goal: vals.goal ?? null,
-      startDate: vals.startDate ? vals.startDate.toISOString() : null,
-      endDate: vals.endDate ? vals.endDate.toISOString() : null,
-      projectTeamId: vals.projectTeamId ?? null,
-      businessTeamId: vals.businessTeamId ?? null,
-      flowTeamId: vals.flowTeamId ?? null,
-    });
-    setEditOpen(false);
-    editForm.resetFields();
-    void load();
-    void message.success('Спринт обновлён');
+    try {
+      await sprintsApi.updateSprint(selectedSprintId, {
+        name: vals.name,
+        goal: vals.goal ?? null,
+        startDate: vals.startDate ? vals.startDate.toISOString() : null,
+        endDate: vals.endDate ? vals.endDate.toISOString() : null,
+        projectTeamId: vals.projectTeamId ?? null,
+        businessTeamId: vals.businessTeamId ?? null,
+        flowTeamId: vals.flowTeamId ?? null,
+      });
+      setEditOpen(false);
+      editForm.resetFields();
+      void load();
+      void message.success('Спринт обновлён');
+    } catch (e) {
+      const err = e as AxiosError<{ error?: string }>;
+      void message.error(err.response?.data?.error ?? 'Ошибка сохранения');
+    }
   };
 
   const handleEstimateAll = async () => {

--- a/frontend/src/pages/SprintsPage.tsx
+++ b/frontend/src/pages/SprintsPage.tsx
@@ -7,7 +7,8 @@
 import { useEffect, useState, useCallback } from 'react';
 import type { AxiosError } from 'axios';
 import { useParams, Link } from 'react-router-dom';
-import { Modal, Form, Input, Popconfirm, Select, Checkbox, message } from 'antd';
+import { Modal, Form, Input, Popconfirm, Select, Checkbox, DatePicker, message } from 'antd';
+import dayjs from 'dayjs';
 import * as sprintsApi from '../api/sprints';
 import * as projectsApi from '../api/projects';
 import * as teamsApi from '../api/teams';
@@ -171,7 +172,10 @@ export default function SprintsPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [backlogOpen, setBacklogOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [estimating, setEstimating] = useState(false);
   const [form] = Form.useForm();
+  const [editForm] = Form.useForm();
   const canManage = hasAnyRequiredRole(user?.role, ['ADMIN', 'MANAGER']);
 
   const load = useCallback(async () => {
@@ -261,6 +265,61 @@ export default function SprintsPage() {
     void sprintsApi.getSprintIssues(selectedSprintId)
       .then(data => setSprintIssues(data.issues))
       .catch(() => {});
+  };
+
+  const openEditModal = (sprint: typeof selectedSprint) => {
+    if (!sprint) return;
+    editForm.setFieldsValue({
+      name: sprint.name,
+      goal: sprint.goal ?? '',
+      startDate: sprint.startDate ? dayjs(sprint.startDate) : null,
+      endDate: sprint.endDate ? dayjs(sprint.endDate) : null,
+      projectTeamId: sprint.projectTeam?.id ?? undefined,
+      businessTeamId: sprint.businessTeam?.id ?? undefined,
+      flowTeamId: sprint.flowTeam?.id ?? undefined,
+    });
+    setEditOpen(true);
+  };
+
+  const handleEditSave = async (vals: {
+    name: string; goal?: string;
+    startDate?: ReturnType<typeof dayjs> | null;
+    endDate?: ReturnType<typeof dayjs> | null;
+    projectTeamId?: string; businessTeamId?: string; flowTeamId?: string;
+  }) => {
+    if (!selectedSprintId) return;
+    await sprintsApi.updateSprint(selectedSprintId, {
+      name: vals.name,
+      goal: vals.goal ?? null,
+      startDate: vals.startDate ? vals.startDate.toISOString() : null,
+      endDate: vals.endDate ? vals.endDate.toISOString() : null,
+      projectTeamId: vals.projectTeamId ?? null,
+      businessTeamId: vals.businessTeamId ?? null,
+      flowTeamId: vals.flowTeamId ?? null,
+    });
+    setEditOpen(false);
+    editForm.resetFields();
+    void load();
+    void message.success('Спринт обновлён');
+  };
+
+  const handleEstimateAll = async () => {
+    if (!selectedSprintId) return;
+    setEstimating(true);
+    try {
+      const result = await sprintsApi.estimateAllSprintIssues(selectedSprintId);
+      void message.success(`Оценено ${result.estimated} из ${result.total} задач`);
+      void load();
+      // Reload sprint issues to reflect new estimatedHours
+      void sprintsApi.getSprintIssues(selectedSprintId)
+        .then(data => setSprintIssues(data.issues))
+        .catch(() => {});
+    } catch (e) {
+      const err = e as AxiosError<{ error?: string }>;
+      void message.error(err.response?.data?.error ?? 'Ошибка оценки');
+    } finally {
+      setEstimating(false);
+    }
   };
 
   const selectedSprint = sprints.find(s => s.id === selectedSprintId) ?? null;
@@ -388,6 +447,15 @@ export default function SprintsPage() {
               </div>
 
               <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+                {canManage && (
+                  <button
+                    type="button"
+                    onClick={() => openEditModal(selectedSprint)}
+                    style={{ backgroundColor: closeBtnBg, border: `1px solid ${T.border}`, borderRadius: 8, paddingTop: 6, paddingBottom: 6, paddingLeft: 12, paddingRight: 12, cursor: 'pointer', color: T.t3, fontFamily: F.sans, fontSize: 12 }}
+                  >
+                    ✎ Редактировать
+                  </button>
+                )}
                 <div>
                   <div style={{ color: T.t4, fontFamily: F.sans, fontSize: 10, lineHeight: '12px', textAlign: 'right' }}>Дата начала</div>
                   <div style={{ color: T.t2, fontFamily: F.display, fontSize: 12, fontWeight: 600, lineHeight: '16px', textAlign: 'right' }}>
@@ -453,19 +521,31 @@ export default function SprintsPage() {
                   </span>
                 </div>
               )}
-              {/* Status dots */}
-              <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-                {[
-                  { dot: T.green,  label: `Done: ${doneCount}` },
-                  { dot: T.amber,  label: `In Progress: ${inProgressCount}` },
-                  { dot: T.violet, label: `Review: ${reviewCount}` },
-                  { dot: T.t3,     label: `Open: ${openCount}` },
-                ].map(({ dot, label }) => (
-                  <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-                    <div style={{ backgroundColor: dot, borderRadius: '50%', width: 6, height: 6, flexShrink: 0 }} />
-                    <span style={{ color: T.t3, fontFamily: F.sans, fontSize: 11, lineHeight: '14px' }}>{label}</span>
+              {/* Status dots + total estimated hours */}
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+                  {[
+                    { dot: T.green,  label: `Done: ${doneCount}` },
+                    { dot: T.amber,  label: `In Progress: ${inProgressCount}` },
+                    { dot: T.violet, label: `Review: ${reviewCount}` },
+                    { dot: T.t3,     label: `Open: ${openCount}` },
+                  ].map(({ dot, label }) => (
+                    <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                      <div style={{ backgroundColor: dot, borderRadius: '50%', width: 6, height: 6, flexShrink: 0 }} />
+                      <span style={{ color: T.t3, fontFamily: F.sans, fontSize: 11, lineHeight: '14px' }}>{label}</span>
+                    </div>
+                  ))}
+                </div>
+                {selectedSprint.stats != null && (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+                    <span style={{ color: T.t4, fontFamily: F.sans, fontSize: 11, lineHeight: '14px' }}>Общая оценка:</span>
+                    <span style={{ color: T.t1, fontFamily: F.display, fontSize: 12, fontWeight: 600, lineHeight: '14px' }}>
+                      {selectedSprint.stats.totalEstimatedHours > 0
+                        ? `${selectedSprint.stats.totalEstimatedHours.toFixed(1)} ч`
+                        : '—'}
+                    </span>
                   </div>
-                ))}
+                )}
               </div>
             </div>
           </div>
@@ -488,6 +568,16 @@ export default function SprintsPage() {
                 >
                   Детали
                 </button>
+                {canManage && sprintIssues.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => void handleEstimateAll()}
+                    disabled={estimating}
+                    style={{ backgroundColor: closeBtnBg, border: `1px solid ${T.border}`, borderRadius: 6, paddingTop: 5, paddingBottom: 5, paddingLeft: 12, paddingRight: 12, cursor: estimating ? 'not-allowed' : 'pointer', color: estimating ? T.t4 : T.acc, fontFamily: F.sans, fontSize: 11, lineHeight: '14px', opacity: estimating ? 0.6 : 1 }}
+                  >
+                    {estimating ? 'Оцениваю…' : 'Оценить трудоёмкость задач'}
+                  </button>
+                )}
                 {canManage && selectedSprint.state !== 'CLOSED' && (
                   <button
                     type="button"
@@ -730,6 +820,42 @@ export default function SprintsPage() {
           <Form.Item name="goal" label="Цель">
             <Input.TextArea rows={2} />
           </Form.Item>
+          <Form.Item name="projectTeamId" label="Проектная команда">
+            <Select allowClear options={teams.map(t => ({ value: t.id, label: t.name }))} />
+          </Form.Item>
+          <Form.Item name="businessTeamId" label="Бизнес-функциональная команда">
+            <Select allowClear options={teams.map(t => ({ value: t.id, label: t.name }))} />
+          </Form.Item>
+          <Form.Item name="flowTeamId" label="Flow-команда">
+            <Select allowClear options={teams.map(t => ({ value: t.id, label: t.name }))} />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      {/* ── Edit sprint modal ────────────────────────────────────────────────── */}
+      <Modal
+        title="Редактировать спринт"
+        open={editOpen}
+        onCancel={() => { setEditOpen(false); editForm.resetFields(); }}
+        onOk={() => editForm.submit()}
+        okText="Сохранить"
+        cancelText="Отмена"
+      >
+        <Form form={editForm} layout="vertical" onFinish={v => void handleEditSave(v)}>
+          <Form.Item name="name" label="Название" rules={[{ required: true, message: 'Введите название' }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="goal" label="Цель">
+            <Input.TextArea rows={2} />
+          </Form.Item>
+          <div style={{ display: 'flex', gap: 12 }}>
+            <Form.Item name="startDate" label="Дата начала" style={{ flex: 1 }}>
+              <DatePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+            </Form.Item>
+            <Form.Item name="endDate" label="Дата окончания" style={{ flex: 1 }}>
+              <DatePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+            </Form.Item>
+          </div>
           <Form.Item name="projectTeamId" label="Проектная команда">
             <Select allowClear options={teams.map(t => ({ value: t.id, label: t.name }))} />
           </Form.Item>

--- a/frontend/src/types/sprint.types.ts
+++ b/frontend/src/types/sprint.types.ts
@@ -18,7 +18,7 @@ export interface Sprint {
   projectTeam?: Team;
   businessTeam?: Team;
   flowTeam?: Team;
-  stats?: { totalIssues: number; estimatedIssues: number; planningReadiness: number };
+  stats?: { totalIssues: number; estimatedIssues: number; planningReadiness: number; totalEstimatedHours: number };
 }
 
 export interface SprintDetailsResponse {


### PR DESCRIPTION
## Summary

- **Кнопка «Оценить трудоёмкость задач»** — в заголовке таблицы задач спринта; последовательно вызывает AI-оценку для каждой задачи через новый endpoint `POST /sprints/:id/ai/estimate-all`; показывает прогресс и результат через message
- **Общая трудоёмкость спринта** — отображается в блоке прогресса hero-карточки (`Общая оценка: X.X ч`); считается на бэкенде в `mapSprintWithStats` как сумма `estimatedHours` всех задач спринта
- **Кнопка «✎ Редактировать»** — в top-row hero-карточки (только для ADMIN/MANAGER); открывает модалку с предзаполненными полями: название, цель, даты начала/окончания, команды; `PATCH /sprints/:id`

## Test plan

- [ ] Зайти на страницу спринтов проекта → убедиться, что у ACTIVE-спринта с задачами появились кнопки «Редактировать» и «Оценить трудоёмкость задач»
- [ ] Нажать «Редактировать» → проверить предзаполнение полей, изменить название/даты → Сохранить → имя обновилось в hero-карточке
- [ ] Нажать «Оценить трудоёмкость задач» → кнопка переходит в состояние «Оцениваю…», по завершении появляется notification с количеством оценённых задач
- [ ] После оценки «Общая оценка» в hero-карточке отображает ненулевое значение в часах
- [ ] Для viewer/user кнопки «Редактировать» и «Оценить» не видны

🤖 Generated with [Claude Code](https://claude.ai/claude-code)