### PR TITLE
feat(pipeline): cancel stuck deploys

### DIFF
--- a/frontend/src/api/pipeline.ts
+++ b/frontend/src/api/pipeline.ts
@@ -192,4 +192,11 @@ export const pipelineApi = {
     });
     return mapBatch(unwrap(raw));
   },
+
+  cancelDeploy: async (batchId: string): Promise<StagingBatch> => {
+    const raw = await pipelineFetch<unknown>(`/api/batches/${batchId}/cancel-deploy`, {
+      method: 'POST',
+    });
+    return mapBatch(unwrap(raw));
+  },
 };

--- a/frontend/src/pages/PipelineDashboardPage.tsx
+++ b/frontend/src/pages/PipelineDashboardPage.tsx
@@ -178,6 +178,7 @@ export default function PipelineDashboardPage() {
 
   const [stagingDeploying, setStagingDeploying] = useState<string | null>(null);
   const [prodDeploying, setProdDeploying] = useState<string | null>(null);
+  const [cancelling, setCancelling] = useState<string | null>(null);
 
   const handleTransition = async (batchId: string, state: BatchState) => {
     try {
@@ -202,12 +203,16 @@ export default function PipelineDashboardPage() {
   };
 
   const handleCancelDeploy = async (batchId: string) => {
+    if (cancelling === batchId) return;
+    setCancelling(batchId);
     setError(null);
     try {
       await pipelineApi.cancelDeploy(batchId);
       await load();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Ошибка отмены деплоя');
+    } finally {
+      setCancelling(null);
     }
   };
 

--- a/frontend/src/pages/PipelineDashboardPage.tsx
+++ b/frontend/src/pages/PipelineDashboardPage.tsx
@@ -201,6 +201,16 @@ export default function PipelineDashboardPage() {
     }
   };
 
+  const handleCancelDeploy = async (batchId: string) => {
+    setError(null);
+    try {
+      await pipelineApi.cancelDeploy(batchId);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Ошибка отмены деплоя');
+    }
+  };
+
   const handleDeployProd = async (batchId: string) => {
     setProdDeploying(batchId);
     setError(null);
@@ -409,7 +419,10 @@ export default function PipelineDashboardPage() {
                     <ActionBtn label={stagingDeploying === selected.id ? 'Запуск...' : '→ Deploy Staging'} color={C.acc} onClick={() => handleDeployStaging(selected.id)} disabled={stagingDeploying !== null} />
                   )}
                   {selected.state === 'DEPLOYING' && (
-                    <span style={{ fontSize: 12, color: C.warn, fontStyle: 'italic' }}>⟳ Деплой в процессе...</span>
+                    <>
+                      <span style={{ fontSize: 12, color: C.warn, fontStyle: 'italic' }}>⟳ Деплой в процессе...</span>
+                      <ActionBtn label="✗ Отменить" color={C.error} onClick={() => handleCancelDeploy(selected.id)} />
+                    </>
                   )}
                   {selected.state === 'TESTING' && (
                     <>

--- a/pipeline-service/src/modules/batches/batches.router.ts
+++ b/pipeline-service/src/modules/batches/batches.router.ts
@@ -368,6 +368,58 @@ router.post('/:id/deploy-production', async (req, res, next) => {
   }
 });
 
+// ─── POST /api/batches/:id/cancel-deploy ─────────────────────────────────────
+
+router.post('/:id/cancel-deploy', async (req, res, next) => {
+  try {
+    const batchId = req.params.id as string;
+    const batch = await prisma.stagingBatch.findUnique({
+      where: { id: batchId },
+      include: { deployEvents: { where: { status: 'RUNNING' }, orderBy: { startedAt: 'desc' }, take: 1 } },
+    });
+    if (!batch) { res.status(404).json({ error: 'Batch not found' }); return; }
+    if (batch.state !== 'DEPLOYING') {
+      res.status(422).json({ error: `Batch must be DEPLOYING to cancel (current: ${batch.state})` });
+      return;
+    }
+
+    const runningEvent = batch.deployEvents[0];
+    const finishedAt = new Date();
+
+    const updates = runningEvent
+      ? [
+          prisma.deployEvent.update({
+            where: { id: runningEvent.id },
+            data: {
+              status: 'FAILURE',
+              finishedAt,
+              durationMs: runningEvent.startedAt ? finishedAt.getTime() - runningEvent.startedAt.getTime() : null,
+              errorMessage: 'Cancelled manually',
+            },
+          }),
+          prisma.stagingBatch.update({
+            where: { id: batchId },
+            data: { state: 'FAILED' },
+            include: { pullRequests: { select: { id: true, externalId: true, title: true, ciStatus: true } }, deployEvents: { orderBy: { startedAt: 'desc' }, take: 5 } },
+          }),
+        ]
+      : [
+          prisma.stagingBatch.update({
+            where: { id: batchId },
+            data: { state: 'FAILED' },
+            include: { pullRequests: { select: { id: true, externalId: true, title: true, ciStatus: true } }, deployEvents: { orderBy: { startedAt: 'desc' }, take: 5 } },
+          }),
+        ];
+
+    const results = await prisma.$transaction(updates);
+    const updatedBatch = results[results.length - 1];
+
+    res.json({ data: updatedBatch });
+  } catch (err) {
+    next(err);
+  }
+});
+
 // ─── POST /api/batches/:id/deploy-callback ────────────────────────────────────
 
 const callbackBody = z.object({

--- a/pipeline-service/src/modules/batches/batches.router.ts
+++ b/pipeline-service/src/modules/batches/batches.router.ts
@@ -441,6 +441,12 @@ router.post('/:id/deploy-callback', validate(callbackBody), async (req, res, nex
     });
     if (!batch) { res.status(404).json({ error: 'Batch not found' }); return; }
 
+    // If the batch was already manually cancelled, ignore late callbacks silently
+    if (batch.state === 'FAILED' && !batch.deployEvents[0]) {
+      res.json({ data: batch, deployEvent: null });
+      return;
+    }
+
     const runningEvent = batch.deployEvents[0];
     const finishedAt = new Date();
 


### PR DESCRIPTION
## Summary
- New backend endpoint `POST /api/batches/:id/cancel-deploy` — atomically transitions a stuck `DEPLOYING` batch to `FAILED` and closes the running `DeployEvent`
- Frontend `cancelDeploy()` API method + red "✗ Отменить" button in Pipeline Dashboard when batch is in `DEPLOYING` state
- Fixes the case where GitHub Actions callback never arrives and batches stay stuck indefinitely

## Test plan
- [ ] Open Pipeline Dashboard, select a batch in DEPLOYING state
- [ ] Verify "✗ Отменить" button appears next to "⟳ Деплой в процессе..."
- [ ] Click cancel → batch transitions to FAILED → "↩ Restart" button appears
- [ ] Verify non-DEPLOYING batches don't show the cancel button

🤖 Generated with [Claude Code](https://claude.com/claude-code)