### PR TITLE
fix(ci): передавать GIT_SHA и BUILD_TIME в Docker-образ бэкенда

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -44,6 +44,7 @@ jobs:
           fi
 
           echo "primary_tag=${PRIMARY_TAG}" >> "$GITHUB_OUTPUT"
+          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
           {
             echo "backend_tags<<EOF"
@@ -71,6 +72,9 @@ jobs:
           file: backend/Dockerfile
           push: true
           tags: ${{ steps.vars.outputs.backend_tags }}
+          build-args: |
+            GIT_SHA=${{ env.SOURCE_SHA }}
+            BUILD_TIME=${{ steps.vars.outputs.build_time }}
           cache-from: type=gha,scope=backend
           cache-to: type=gha,mode=max,scope=backend
 


### PR DESCRIPTION
## Summary
- В `build-and-publish.yml` добавлен `build_time` output в шаг `vars`
- Backend `docker/build-push-action` теперь получает `build-args: GIT_SHA` и `BUILD_TIME`
- Закрывает: `/api/health` возвращал `version: "unknown"` — `ARG` в Dockerfile не получал значений при сборке

**Задача:** TTMP-154

## Test plan
- [ ] CI зелёный
- [ ] Build & Publish отработал — образ пересобрался с `build-args`
- [ ] Deploy staging прошёл
- [ ] `curl http://5.129.242.171:3000/api/health` → `version` = реальный git SHA, `buildTime` = ISO timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)