### PR TITLE
feat(releases): release management data model [TTMP-174]

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "db:seed:dev": "npx tsx src/prisma/seed.ts",
     "db:seed:ttmp": "SEED_SCOPE=TTMP_ONLY node dist/prisma/seed.js",
     "db:seed:workflow": "npx tsx src/prisma/seed-workflow.ts",
+    "db:seed:release-workflow": "npx tsx src/prisma/seed-release-workflow.ts",
     "db:sync:prod-to-dev": "tsx src/prisma/prod-sync.ts",
     "db:generate": "prisma generate",
     "db:migrate:dev": "prisma migrate dev",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -36,6 +36,8 @@ import workflowsRouter from './modules/workflows/workflows.router.js';
 import workflowSchemesRouter from './modules/workflow-schemes/workflow-schemes.router.js';
 import transitionScreensRouter from './modules/transition-screens/transition-screens.router.js';
 import workflowEngineRouter from './modules/workflow-engine/workflow-engine.router.js';
+import releaseStatusesRouter from './modules/releases/release-statuses.router.js';
+import releaseWorkflowsAdminRouter from './modules/releases/release-workflows-admin.router.js';
 import { getSchemeForProject } from './modules/workflow-schemes/workflow-schemes.service.js';
 import { authenticate } from './shared/middleware/auth.js';
 import { requireRole } from './shared/middleware/rbac.js';
@@ -130,6 +132,8 @@ export function createApp() {
   app.use('/api/admin/workflows', workflowsRouter);
   app.use('/api/admin/workflow-schemes', workflowSchemesRouter);
   app.use('/api/admin/transition-screens', transitionScreensRouter);
+  app.use('/api/admin/release-statuses', releaseStatusesRouter);
+  app.use('/api/admin/release-workflows', releaseWorkflowsAdminRouter);
   app.use('/api', workflowEngineRouter);
 
   // Public: project workflow scheme

--- a/backend/src/modules/releases/release-statuses.dto.ts
+++ b/backend/src/modules/releases/release-statuses.dto.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const createReleaseStatusDto = z.object({
+  name: z.string().min(1).max(200),
+  category: z.enum(['PLANNING', 'IN_PROGRESS', 'DONE', 'CANCELLED']),
+  color: z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),
+  description: z.string().max(500).optional(),
+  orderIndex: z.number().int().nonnegative().optional(),
+});
+
+export const updateReleaseStatusDto = z.object({
+  name: z.string().min(1).max(200).optional(),
+  category: z.enum(['PLANNING', 'IN_PROGRESS', 'DONE', 'CANCELLED']).optional(),
+  color: z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),
+  description: z.string().max(500).nullish(),
+  orderIndex: z.number().int().nonnegative().optional(),
+});
+
+export type CreateReleaseStatusDto = z.infer<typeof createReleaseStatusDto>;
+export type UpdateReleaseStatusDto = z.infer<typeof updateReleaseStatusDto>;

--- a/backend/src/modules/releases/release-statuses.router.ts
+++ b/backend/src/modules/releases/release-statuses.router.ts
@@ -1,0 +1,66 @@
+import { Router } from 'express';
+import { authenticate } from '../../shared/middleware/auth.js';
+import { requireRole } from '../../shared/middleware/rbac.js';
+import { validate } from '../../shared/middleware/validate.js';
+import { logAudit } from '../../shared/middleware/audit.js';
+import { createReleaseStatusDto, updateReleaseStatusDto } from './release-statuses.dto.js';
+import * as service from './release-statuses.service.js';
+import type { AuthRequest } from '../../shared/types/index.js';
+
+const router = Router();
+
+router.use(authenticate);
+router.use(requireRole('ADMIN', 'SUPER_ADMIN'));
+
+// GET /api/admin/release-statuses
+router.get('/', async (_req, res, next) => {
+  try {
+    res.json(await service.listReleaseStatuses());
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /api/admin/release-statuses
+router.post('/', validate(createReleaseStatusDto), async (req: AuthRequest, res, next) => {
+  try {
+    const status = await service.createReleaseStatus(req.body);
+    await logAudit(req, 'release_status.created', 'release_status', status.id, req.body);
+    res.status(201).json(status);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /api/admin/release-statuses/:id
+router.get('/:id', async (req, res, next) => {
+  try {
+    res.json(await service.getReleaseStatus(req.params['id'] as string));
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PATCH /api/admin/release-statuses/:id
+router.patch('/:id', validate(updateReleaseStatusDto), async (req: AuthRequest, res, next) => {
+  try {
+    const status = await service.updateReleaseStatus(req.params['id'] as string, req.body);
+    await logAudit(req, 'release_status.updated', 'release_status', req.params['id'] as string, req.body);
+    res.json(status);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE /api/admin/release-statuses/:id
+router.delete('/:id', async (req: AuthRequest, res, next) => {
+  try {
+    await service.deleteReleaseStatus(req.params['id'] as string);
+    await logAudit(req, 'release_status.deleted', 'release_status', req.params['id'] as string);
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/modules/releases/release-statuses.service.ts
+++ b/backend/src/modules/releases/release-statuses.service.ts
@@ -70,11 +70,26 @@ export async function updateReleaseStatus(id: string, dto: UpdateReleaseStatusDt
 export async function deleteReleaseStatus(id: string) {
   const status = await prisma.releaseStatus.findUnique({
     where: { id },
-    include: { _count: { select: { releases: true, workflowSteps: true } } },
+    include: {
+      _count: {
+        select: {
+          releases: true,
+          workflowSteps: true,
+          transitionsFrom: true,
+          transitionsTo: true,
+        },
+      },
+    },
   });
   if (!status) throw new AppError(404, 'Release status not found');
-  if (status._count.releases > 0) throw new AppError(400, 'RELEASE_STATUS_IN_USE');
-  if (status._count.workflowSteps > 0) throw new AppError(400, 'RELEASE_STATUS_IN_USE');
+  if (
+    status._count.releases > 0 ||
+    status._count.workflowSteps > 0 ||
+    status._count.transitionsFrom > 0 ||
+    status._count.transitionsTo > 0
+  ) {
+    throw new AppError(400, 'RELEASE_STATUS_IN_USE');
+  }
 
   await prisma.releaseStatus.delete({ where: { id } });
   await invalidateStatusCache();

--- a/backend/src/modules/releases/release-statuses.service.ts
+++ b/backend/src/modules/releases/release-statuses.service.ts
@@ -1,0 +1,82 @@
+import { prisma } from '../../prisma/client.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import { getCachedJson, setCachedJson, delCachedJson } from '../../shared/redis.js';
+import type { CreateReleaseStatusDto, UpdateReleaseStatusDto } from './release-statuses.dto.js';
+
+const STATUS_CACHE_KEY = 'release-statuses:all';
+const STATUS_CACHE_TTL = 600; // 10 minutes
+
+async function invalidateStatusCache() {
+  await delCachedJson(STATUS_CACHE_KEY);
+}
+
+const statusInclude = {
+  _count: { select: { releases: true, workflowSteps: true } },
+} as const;
+
+export async function listReleaseStatuses() {
+  const cached = await getCachedJson<unknown[]>(STATUS_CACHE_KEY);
+  if (cached) return cached;
+
+  const statuses = await prisma.releaseStatus.findMany({
+    orderBy: [{ orderIndex: 'asc' }, { createdAt: 'asc' }],
+    include: statusInclude,
+  });
+
+  await setCachedJson(STATUS_CACHE_KEY, statuses, STATUS_CACHE_TTL);
+  return statuses;
+}
+
+export async function getReleaseStatus(id: string) {
+  const status = await prisma.releaseStatus.findUnique({ where: { id }, include: statusInclude });
+  if (!status) throw new AppError(404, 'Release status not found');
+  return status;
+}
+
+export async function createReleaseStatus(dto: CreateReleaseStatusDto) {
+  const status = await prisma.releaseStatus.create({
+    data: {
+      name: dto.name,
+      category: dto.category,
+      color: dto.color ?? '#888888',
+      description: dto.description,
+      orderIndex: dto.orderIndex ?? 0,
+    },
+    include: statusInclude,
+  });
+  await invalidateStatusCache();
+  return status;
+}
+
+export async function updateReleaseStatus(id: string, dto: UpdateReleaseStatusDto) {
+  const status = await prisma.releaseStatus.findUnique({ where: { id } });
+  if (!status) throw new AppError(404, 'Release status not found');
+
+  const updated = await prisma.releaseStatus.update({
+    where: { id },
+    data: {
+      ...(dto.name !== undefined && { name: dto.name }),
+      ...(dto.category !== undefined && { category: dto.category }),
+      ...(dto.color !== undefined && { color: dto.color }),
+      ...(dto.description !== undefined && { description: dto.description }),
+      ...(dto.orderIndex !== undefined && { orderIndex: dto.orderIndex }),
+    },
+    include: statusInclude,
+  });
+  await invalidateStatusCache();
+  return updated;
+}
+
+export async function deleteReleaseStatus(id: string) {
+  const status = await prisma.releaseStatus.findUnique({
+    where: { id },
+    include: { _count: { select: { releases: true, workflowSteps: true } } },
+  });
+  if (!status) throw new AppError(404, 'Release status not found');
+  if (status._count.releases > 0) throw new AppError(400, 'RELEASE_STATUS_IN_USE');
+  if (status._count.workflowSteps > 0) throw new AppError(400, 'RELEASE_STATUS_IN_USE');
+
+  await prisma.releaseStatus.delete({ where: { id } });
+  await invalidateStatusCache();
+  return { ok: true };
+}

--- a/backend/src/modules/releases/release-workflow-engine.service.ts
+++ b/backend/src/modules/releases/release-workflow-engine.service.ts
@@ -1,4 +1,4 @@
-import type { UserRole, ReleaseStatusCategory, Prisma } from '@prisma/client';
+import type { UserRole, StatusCategory, ReleaseStatusCategory, Prisma } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { getCachedJson, setCachedJson, delCachedJson } from '../../shared/redis.js';
@@ -33,7 +33,9 @@ async function loadReleaseWorkflowFull(workflowId: string) {
 
 type ReleaseConditionRule =
   | { type: 'USER_HAS_GLOBAL_ROLE'; roles: UserRole[] }
-  | { type: 'ALL_ITEMS_IN_STATUS_CATEGORY'; category: ReleaseStatusCategory }
+  // category is a StatusCategory (TODO | IN_PROGRESS | DONE) because we
+  // are checking issue workflow statuses, not release statuses.
+  | { type: 'ALL_ITEMS_IN_STATUS_CATEGORY'; category: StatusCategory }
   | { type: 'ALL_SPRINTS_CLOSED' }
   | { type: 'MIN_ITEMS_COUNT'; minCount: number };
 
@@ -48,13 +50,14 @@ async function evaluateReleaseCondition(
       return rule.roles.includes(ctx.actorRole);
 
     case 'ALL_ITEMS_IN_STATUS_CATEGORY': {
-      // All issues linked via ReleaseItem must be in the given status category
+      // All issues linked via ReleaseItem must be in the given workflow status category.
+      // rule.category is WorkflowStatusCategory (TODO | IN_PROGRESS | DONE).
       const nonMatching = await prisma.releaseItem.count({
         where: {
           releaseId: ctx.releaseId,
           issue: {
             workflowStatus: {
-              category: { not: rule.category as never },
+              category: { not: rule.category },
             },
           },
         },

--- a/backend/src/modules/releases/release-workflow-engine.service.ts
+++ b/backend/src/modules/releases/release-workflow-engine.service.ts
@@ -1,0 +1,300 @@
+import type { UserRole, ReleaseStatusCategory, Prisma } from '@prisma/client';
+import { prisma } from '../../prisma/client.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import { getCachedJson, setCachedJson, delCachedJson } from '../../shared/redis.js';
+
+// ─── Cache ────────────────────────────────────────────────────────────────────
+
+const WORKFLOW_CACHE_TTL = 300; // 5 minutes
+const rwCacheKey = (workflowId: string): string => `rw:${workflowId}`;
+
+export async function invalidateReleaseWorkflowCache(workflowId: string): Promise<void> {
+  await delCachedJson(rwCacheKey(workflowId));
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type ReleaseWorkflowFull = Awaited<ReturnType<typeof loadReleaseWorkflowFull>>;
+
+async function loadReleaseWorkflowFull(workflowId: string) {
+  return prisma.releaseWorkflow.findUniqueOrThrow({
+    where: { id: workflowId },
+    include: {
+      steps: { include: { status: true }, orderBy: { orderIndex: 'asc' } },
+      transitions: {
+        include: { fromStatus: true, toStatus: true },
+        orderBy: { id: 'asc' },
+      },
+    },
+  });
+}
+
+// ─── Release-specific condition types ────────────────────────────────────────
+
+type ReleaseConditionRule =
+  | { type: 'USER_HAS_GLOBAL_ROLE'; roles: UserRole[] }
+  | { type: 'ALL_ITEMS_IN_STATUS_CATEGORY'; category: ReleaseStatusCategory }
+  | { type: 'ALL_SPRINTS_CLOSED' }
+  | { type: 'MIN_ITEMS_COUNT'; minCount: number };
+
+// ─── Condition evaluator (async, release-specific) ────────────────────────────
+
+async function evaluateReleaseCondition(
+  rule: ReleaseConditionRule,
+  ctx: { actorRole: UserRole; releaseId: string },
+): Promise<boolean> {
+  switch (rule.type) {
+    case 'USER_HAS_GLOBAL_ROLE':
+      return rule.roles.includes(ctx.actorRole);
+
+    case 'ALL_ITEMS_IN_STATUS_CATEGORY': {
+      // All issues linked via ReleaseItem must be in the given status category
+      const nonMatching = await prisma.releaseItem.count({
+        where: {
+          releaseId: ctx.releaseId,
+          issue: {
+            workflowStatus: {
+              category: { not: rule.category as never },
+            },
+          },
+        },
+      });
+      return nonMatching === 0;
+    }
+
+    case 'ALL_SPRINTS_CLOSED': {
+      const openSprints = await prisma.sprint.count({
+        where: { releaseId: ctx.releaseId, state: { not: 'CLOSED' } },
+      });
+      return openSprints === 0;
+    }
+
+    case 'MIN_ITEMS_COUNT': {
+      const total = await prisma.releaseItem.count({
+        where: { releaseId: ctx.releaseId },
+      });
+      return total >= rule.minCount;
+    }
+
+    default:
+      return true;
+  }
+}
+
+async function evaluateReleaseConditions(
+  rules: ReleaseConditionRule[],
+  ctx: { actorRole: UserRole; releaseId: string },
+): Promise<{ allowed: boolean; failedCondition?: string }> {
+  for (const rule of rules) {
+    const passed = await evaluateReleaseCondition(rule, ctx);
+    if (!passed) {
+      return { allowed: false, failedCondition: rule.type };
+    }
+  }
+  return { allowed: true };
+}
+
+// ─── TTMP-187: resolveWorkflowForRelease ──────────────────────────────────────
+
+export async function resolveWorkflowForRelease(release: {
+  id: string;
+  workflowId: string | null;
+  type: 'ATOMIC' | 'INTEGRATION';
+}): Promise<ReleaseWorkflowFull> {
+  // If release has an explicit workflowId — use it with cache
+  if (release.workflowId) {
+    const cacheKey = rwCacheKey(release.workflowId);
+    const cached = await getCachedJson<ReleaseWorkflowFull>(cacheKey);
+    if (cached) return cached;
+
+    const workflow = await loadReleaseWorkflowFull(release.workflowId);
+    await setCachedJson(cacheKey, workflow, WORKFLOW_CACHE_TTL);
+    return workflow;
+  }
+
+  // No workflowId — find default workflow compatible with this release type
+  // Priority: type-specific default > universal default
+  let workflow = await prisma.releaseWorkflow.findFirst({
+    where: { releaseType: release.type, isDefault: true, isActive: true },
+  });
+
+  if (!workflow) {
+    workflow = await prisma.releaseWorkflow.findFirst({
+      where: { releaseType: null, isDefault: true, isActive: true },
+    });
+  }
+
+  if (!workflow) {
+    throw new AppError(409, 'NO_RELEASE_WORKFLOW_CONFIGURED');
+  }
+
+  const cacheKey = rwCacheKey(workflow.id);
+  const cached = await getCachedJson<ReleaseWorkflowFull>(cacheKey);
+  if (cached) return cached;
+
+  const full = await loadReleaseWorkflowFull(workflow.id);
+  await setCachedJson(cacheKey, full, WORKFLOW_CACHE_TTL);
+  return full;
+}
+
+// ─── TTMP-188: getAvailableTransitions ───────────────────────────────────────
+
+export interface ReleaseTransitionResponse {
+  id: string;
+  name: string;
+  toStatus: {
+    id: string;
+    name: string;
+    category: ReleaseStatusCategory;
+    color: string;
+  };
+}
+
+export interface ReleaseAvailableTransitionsResponse {
+  currentStatus: {
+    id: string;
+    name: string;
+    category: ReleaseStatusCategory;
+    color: string;
+  } | null;
+  transitions: ReleaseTransitionResponse[];
+}
+
+export async function getAvailableTransitions(
+  releaseId: string,
+  actorId: string,
+  actorRole: UserRole,
+): Promise<ReleaseAvailableTransitionsResponse> {
+  const release = await prisma.release.findUnique({
+    where: { id: releaseId },
+    include: { status: true },
+  });
+  if (!release) throw new AppError(404, 'Release not found');
+
+  const workflow = await resolveWorkflowForRelease(release);
+
+  const candidates = workflow.transitions.filter(
+    (t) => t.isGlobal || t.fromStatusId === release.statusId,
+  );
+
+  const available: ReleaseTransitionResponse[] = [];
+
+  for (const t of candidates) {
+    const conditionRules = t.conditions ? (t.conditions as unknown as ReleaseConditionRule[]) : [];
+    if (conditionRules.length > 0) {
+      try {
+        const { allowed } = await evaluateReleaseConditions(conditionRules, {
+          actorRole,
+          releaseId,
+        });
+        if (!allowed) continue;
+      } catch {
+        continue;
+      }
+    }
+
+    available.push({
+      id: t.id,
+      name: t.name,
+      toStatus: {
+        id: t.toStatus.id,
+        name: t.toStatus.name,
+        category: t.toStatus.category,
+        color: t.toStatus.color,
+      },
+    });
+  }
+
+  return {
+    currentStatus: release.status
+      ? {
+          id: release.status.id,
+          name: release.status.name,
+          category: release.status.category,
+          color: release.status.color,
+        }
+      : null,
+    transitions: available,
+  };
+}
+
+// ─── TTMP-189: executeTransition ─────────────────────────────────────────────
+
+export async function executeTransition(
+  releaseId: string,
+  transitionId: string,
+  actorId: string,
+  actorRole: UserRole,
+  comment?: string,
+): Promise<void> {
+  const release = await prisma.release.findUnique({
+    where: { id: releaseId },
+    include: { status: true },
+  });
+  if (!release) throw new AppError(404, 'Release not found');
+
+  const transition = await prisma.releaseWorkflowTransition.findUnique({
+    where: { id: transitionId },
+    include: { toStatus: true, fromStatus: true },
+  });
+  if (!transition) throw new AppError(400, 'Transition not found');
+
+  // Validate transition belongs to the workflow resolved for this release
+  const workflow = await resolveWorkflowForRelease(release);
+  if (transition.workflowId !== workflow.id) {
+    throw new AppError(409, 'INVALID_TRANSITION');
+  }
+
+  // Validate from-status
+  if (!transition.isGlobal && transition.fromStatusId !== release.statusId) {
+    throw new AppError(409, 'INVALID_TRANSITION');
+  }
+
+  // Evaluate conditions
+  const conditionRules = transition.conditions ? (transition.conditions as unknown as ReleaseConditionRule[]) : [];
+  if (conditionRules.length > 0) {
+    const { allowed, failedCondition } = await evaluateReleaseConditions(conditionRules, {
+      actorRole,
+      releaseId,
+    });
+    if (!allowed) {
+      throw new AppError(403, 'CONDITION_NOT_MET', {
+        details: { conditionType: failedCondition ?? 'UNKNOWN' },
+      });
+    }
+  }
+
+  // Build update data
+  const updateData: Prisma.ReleaseUpdateInput = {
+    status: { connect: { id: transition.toStatusId } },
+  };
+
+  // Set releaseDate when transitioning to DONE category
+  if (transition.toStatus.category === 'DONE' && !release.releaseDate) {
+    updateData.releaseDate = new Date();
+  }
+
+  await prisma.release.update({
+    where: { id: releaseId },
+    data: updateData,
+  });
+
+  // Audit log
+  await prisma.auditLog.create({
+    data: {
+      action: 'release.transitioned',
+      entityType: 'release',
+      entityId: releaseId,
+      userId: actorId,
+      details: {
+        transitionId: transition.id,
+        transitionName: transition.name,
+        fromStatusId: release.statusId,
+        fromStatusName: release.status?.name ?? null,
+        toStatusId: transition.toStatusId,
+        toStatusName: transition.toStatus.name,
+        ...(comment ? { comment } : {}),
+      } as Prisma.InputJsonValue,
+    },
+  });
+}

--- a/backend/src/modules/releases/release-workflow-engine.service.ts
+++ b/backend/src/modules/releases/release-workflow-engine.service.ts
@@ -182,15 +182,11 @@ export async function getAvailableTransitions(
   for (const t of candidates) {
     const conditionRules = t.conditions ? (t.conditions as unknown as ReleaseConditionRule[]) : [];
     if (conditionRules.length > 0) {
-      try {
-        const { allowed } = await evaluateReleaseConditions(conditionRules, {
-          actorRole,
-          releaseId,
-        });
-        if (!allowed) continue;
-      } catch {
-        continue;
-      }
+      const { allowed } = await evaluateReleaseConditions(conditionRules, {
+        actorRole,
+        releaseId,
+      });
+      if (!allowed) continue;
     }
 
     available.push({
@@ -274,27 +270,32 @@ export async function executeTransition(
     updateData.releaseDate = new Date();
   }
 
-  await prisma.release.update({
-    where: { id: releaseId },
-    data: updateData,
-  });
-
-  // Audit log
-  await prisma.auditLog.create({
-    data: {
-      action: 'release.transitioned',
-      entityType: 'release',
-      entityId: releaseId,
-      userId: actorId,
-      details: {
-        transitionId: transition.id,
-        transitionName: transition.name,
-        fromStatusId: release.statusId,
-        fromStatusName: release.status?.name ?? null,
-        toStatusId: transition.toStatusId,
-        toStatusName: transition.toStatus.name,
-        ...(comment ? { comment } : {}),
-      } as Prisma.InputJsonValue,
-    },
-  });
+  // Atomic: update release + audit in one transaction, guard on current statusId
+  await prisma.$transaction([
+    prisma.release.update({
+      where: {
+        id: releaseId,
+        // Optimistic concurrency: ensure status hasn't changed since we loaded it
+        statusId: release.statusId,
+      },
+      data: updateData,
+    }),
+    prisma.auditLog.create({
+      data: {
+        action: 'release.transitioned',
+        entityType: 'release',
+        entityId: releaseId,
+        userId: actorId,
+        details: {
+          transitionId: transition.id,
+          transitionName: transition.name,
+          fromStatusId: release.statusId,
+          fromStatusName: release.status?.name ?? null,
+          toStatusId: transition.toStatusId,
+          toStatusName: transition.toStatus.name,
+          ...(comment ? { comment } : {}),
+        } as Prisma.InputJsonValue,
+      },
+    }),
+  ]);
 }

--- a/backend/src/modules/releases/release-workflows-admin.dto.ts
+++ b/backend/src/modules/releases/release-workflows-admin.dto.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+export const createReleaseWorkflowDto = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(500).optional(),
+  releaseType: z.enum(['ATOMIC', 'INTEGRATION']).nullable().optional(),
+  isDefault: z.boolean().optional(),
+  isActive: z.boolean().optional(),
+});
+
+export const updateReleaseWorkflowDto = z.object({
+  name: z.string().min(1).max(200).optional(),
+  description: z.string().max(500).nullish(),
+  releaseType: z.enum(['ATOMIC', 'INTEGRATION']).nullable().optional(),
+  isDefault: z.boolean().optional(),
+  isActive: z.boolean().optional(),
+});
+
+export const createReleaseWorkflowStepDto = z.object({
+  statusId: z.string().uuid(),
+  isInitial: z.boolean().optional(),
+  orderIndex: z.number().int().nonnegative().optional(),
+});
+
+export const updateReleaseWorkflowStepDto = z.object({
+  isInitial: z.boolean().optional(),
+  orderIndex: z.number().int().nonnegative().optional(),
+});
+
+const conditionsField = z.array(z.record(z.unknown())).nullish();
+
+export const createReleaseWorkflowTransitionDto = z.object({
+  name: z.string().min(1).max(200),
+  fromStatusId: z.string().uuid(),
+  toStatusId: z.string().uuid(),
+  isGlobal: z.boolean().optional(),
+  conditions: conditionsField,
+});
+
+export const updateReleaseWorkflowTransitionDto = z.object({
+  name: z.string().min(1).max(200).optional(),
+  fromStatusId: z.string().uuid().optional(),
+  toStatusId: z.string().uuid().optional(),
+  isGlobal: z.boolean().optional(),
+  conditions: conditionsField,
+});
+
+export type CreateReleaseWorkflowDto = z.infer<typeof createReleaseWorkflowDto>;
+export type UpdateReleaseWorkflowDto = z.infer<typeof updateReleaseWorkflowDto>;
+export type CreateReleaseWorkflowStepDto = z.infer<typeof createReleaseWorkflowStepDto>;
+export type UpdateReleaseWorkflowStepDto = z.infer<typeof updateReleaseWorkflowStepDto>;
+export type CreateReleaseWorkflowTransitionDto = z.infer<typeof createReleaseWorkflowTransitionDto>;
+export type UpdateReleaseWorkflowTransitionDto = z.infer<typeof updateReleaseWorkflowTransitionDto>;

--- a/backend/src/modules/releases/release-workflows-admin.router.ts
+++ b/backend/src/modules/releases/release-workflows-admin.router.ts
@@ -1,0 +1,165 @@
+import { Router } from 'express';
+import { authenticate } from '../../shared/middleware/auth.js';
+import { requireRole } from '../../shared/middleware/rbac.js';
+import { validate } from '../../shared/middleware/validate.js';
+import { logAudit } from '../../shared/middleware/audit.js';
+import {
+  createReleaseWorkflowDto,
+  updateReleaseWorkflowDto,
+  createReleaseWorkflowStepDto,
+  updateReleaseWorkflowStepDto,
+  createReleaseWorkflowTransitionDto,
+  updateReleaseWorkflowTransitionDto,
+} from './release-workflows-admin.dto.js';
+import * as service from './release-workflows-admin.service.js';
+import type { AuthRequest } from '../../shared/types/index.js';
+
+const router = Router();
+
+router.use(authenticate);
+router.use(requireRole('ADMIN', 'SUPER_ADMIN'));
+
+// ─── Workflows CRUD ───────────────────────────────────────────────────────────
+
+// GET /api/admin/release-workflows
+router.get('/', async (_req, res, next) => {
+  try {
+    res.json(await service.listReleaseWorkflows());
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /api/admin/release-workflows
+router.post('/', validate(createReleaseWorkflowDto), async (req: AuthRequest, res, next) => {
+  try {
+    const wf = await service.createReleaseWorkflow(req.body);
+    await logAudit(req, 'release_workflow.created', 'release_workflow', wf.id, req.body);
+    res.status(201).json(wf);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /api/admin/release-workflows/:id
+router.get('/:id', async (req, res, next) => {
+  try {
+    res.json(await service.getReleaseWorkflow(req.params['id'] as string));
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT /api/admin/release-workflows/:id
+router.put('/:id', validate(updateReleaseWorkflowDto), async (req: AuthRequest, res, next) => {
+  try {
+    const wf = await service.updateReleaseWorkflow(req.params['id'] as string, req.body);
+    await logAudit(req, 'release_workflow.updated', 'release_workflow', req.params['id'] as string, req.body);
+    res.json(wf);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE /api/admin/release-workflows/:id
+router.delete('/:id', async (req: AuthRequest, res, next) => {
+  try {
+    await service.deleteReleaseWorkflow(req.params['id'] as string);
+    await logAudit(req, 'release_workflow.deleted', 'release_workflow', req.params['id'] as string);
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── RM-04.3: Graph validation ────────────────────────────────────────────────
+
+// GET /api/admin/release-workflows/:id/validate
+router.get('/:id/validate', async (req, res, next) => {
+  try {
+    const report = await service.validateReleaseWorkflow(req.params['id'] as string);
+    res.json(report);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── Steps ────────────────────────────────────────────────────────────────────
+
+// POST /api/admin/release-workflows/:id/steps
+router.post('/:id/steps', validate(createReleaseWorkflowStepDto), async (req: AuthRequest, res, next) => {
+  try {
+    const step = await service.addReleaseWorkflowStep(req.params['id'] as string, req.body);
+    await logAudit(req, 'release_workflow_step.created', 'release_workflow_step', step.id, { workflowId: req.params['id'] });
+    res.status(201).json(step);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PATCH /api/admin/release-workflows/:id/steps/:stepId
+router.patch('/:id/steps/:stepId', validate(updateReleaseWorkflowStepDto), async (req: AuthRequest, res, next) => {
+  try {
+    const step = await service.updateReleaseWorkflowStep(
+      req.params['id'] as string,
+      req.params['stepId'] as string,
+      req.body,
+    );
+    await logAudit(req, 'release_workflow_step.updated', 'release_workflow_step', req.params['stepId'] as string, req.body);
+    res.json(step);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE /api/admin/release-workflows/:id/steps/:stepId
+router.delete('/:id/steps/:stepId', async (req: AuthRequest, res, next) => {
+  try {
+    await service.deleteReleaseWorkflowStep(req.params['id'] as string, req.params['stepId'] as string);
+    await logAudit(req, 'release_workflow_step.deleted', 'release_workflow_step', req.params['stepId'] as string);
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── Transitions ──────────────────────────────────────────────────────────────
+
+// POST /api/admin/release-workflows/:id/transitions
+router.post('/:id/transitions', validate(createReleaseWorkflowTransitionDto), async (req: AuthRequest, res, next) => {
+  try {
+    const t = await service.createReleaseWorkflowTransition(req.params['id'] as string, req.body);
+    await logAudit(req, 'release_workflow_transition.created', 'release_workflow_transition', t.id, { workflowId: req.params['id'] });
+    res.status(201).json(t);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT /api/admin/release-workflows/:id/transitions/:tid
+router.put('/:id/transitions/:tid', validate(updateReleaseWorkflowTransitionDto), async (req: AuthRequest, res, next) => {
+  try {
+    const t = await service.updateReleaseWorkflowTransition(
+      req.params['id'] as string,
+      req.params['tid'] as string,
+      req.body,
+    );
+    await logAudit(req, 'release_workflow_transition.updated', 'release_workflow_transition', req.params['tid'] as string, req.body);
+    res.json(t);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE /api/admin/release-workflows/:id/transitions/:tid
+router.delete('/:id/transitions/:tid', async (req: AuthRequest, res, next) => {
+  try {
+    await service.deleteReleaseWorkflowTransition(req.params['id'] as string, req.params['tid'] as string);
+    await logAudit(req, 'release_workflow_transition.deleted', 'release_workflow_transition', req.params['tid'] as string);
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/modules/releases/release-workflows-admin.service.ts
+++ b/backend/src/modules/releases/release-workflows-admin.service.ts
@@ -116,20 +116,14 @@ export async function validateReleaseWorkflow(workflowId: string): Promise<Relea
   }
 
   // DEAD_END_STATUS
-  // A global transition is available from *every* status, so any status that has
-  // at least one outgoing global transition is not a dead-end regardless of its
-  // direct outgoing edges.
-  const hasGlobalOutgoing = wf.transitions.some((t) => t.isGlobal);
-
+  // outgoing already includes global transitions (available from every status),
+  // so outgoing.length === 0 is only true when there are neither direct nor global
+  // transitions — the redundant hasGlobalOutgoing guard is removed.
   for (const step of wf.steps) {
     const outgoing = wf.transitions.filter(
       (t) => t.fromStatusId === step.statusId || t.isGlobal,
     );
-    if (
-      outgoing.length === 0 &&
-      !hasGlobalOutgoing &&
-      step.status.category !== 'DONE'
-    ) {
+    if (outgoing.length === 0 && step.status.category !== 'DONE') {
       warnings.push({
         type: 'DEAD_END_STATUS',
         message: `Status "${step.status.name}" has no outgoing transitions and is not DONE category`,

--- a/backend/src/modules/releases/release-workflows-admin.service.ts
+++ b/backend/src/modules/releases/release-workflows-admin.service.ts
@@ -1,0 +1,351 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../../prisma/client.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import { invalidateReleaseWorkflowCache } from './release-workflow-engine.service.js';
+import type {
+  CreateReleaseWorkflowDto,
+  UpdateReleaseWorkflowDto,
+  CreateReleaseWorkflowStepDto,
+  UpdateReleaseWorkflowStepDto,
+  CreateReleaseWorkflowTransitionDto,
+  UpdateReleaseWorkflowTransitionDto,
+} from './release-workflows-admin.dto.js';
+
+// ─── Include helper ───────────────────────────────────────────────────────────
+
+const workflowInclude = {
+  steps: { include: { status: true }, orderBy: { orderIndex: 'asc' as const } },
+  transitions: {
+    include: { fromStatus: true, toStatus: true },
+    orderBy: { id: 'asc' as const },
+  },
+  _count: { select: { releases: true } },
+} as const;
+
+// ─── Workflows CRUD ───────────────────────────────────────────────────────────
+
+export async function listReleaseWorkflows() {
+  return prisma.releaseWorkflow.findMany({
+    orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }],
+    include: workflowInclude,
+  });
+}
+
+export async function getReleaseWorkflow(id: string) {
+  const wf = await prisma.releaseWorkflow.findUnique({ where: { id }, include: workflowInclude });
+  if (!wf) throw new AppError(404, 'Release workflow not found');
+  return wf;
+}
+
+export async function createReleaseWorkflow(dto: CreateReleaseWorkflowDto) {
+  return prisma.releaseWorkflow.create({
+    data: {
+      name: dto.name,
+      description: dto.description,
+      releaseType: dto.releaseType ?? null,
+      isDefault: dto.isDefault ?? false,
+      isActive: dto.isActive ?? true,
+    },
+    include: workflowInclude,
+  });
+}
+
+export async function updateReleaseWorkflow(id: string, dto: UpdateReleaseWorkflowDto) {
+  const wf = await prisma.releaseWorkflow.findUnique({ where: { id } });
+  if (!wf) throw new AppError(404, 'Release workflow not found');
+
+  const updated = await prisma.releaseWorkflow.update({
+    where: { id },
+    data: {
+      ...(dto.name !== undefined && { name: dto.name }),
+      ...(dto.description !== undefined && { description: dto.description }),
+      ...(dto.releaseType !== undefined && { releaseType: dto.releaseType }),
+      ...(dto.isDefault !== undefined && { isDefault: dto.isDefault }),
+      ...(dto.isActive !== undefined && { isActive: dto.isActive }),
+    },
+    include: workflowInclude,
+  });
+  await invalidateReleaseWorkflowCache(id);
+  return updated;
+}
+
+export async function deleteReleaseWorkflow(id: string) {
+  const wf = await prisma.releaseWorkflow.findUnique({
+    where: { id },
+    include: { _count: { select: { releases: true } } },
+  });
+  if (!wf) throw new AppError(404, 'Release workflow not found');
+  if (wf._count.releases > 0) throw new AppError(400, 'RELEASE_WORKFLOW_IN_USE');
+
+  await prisma.releaseWorkflow.delete({ where: { id } });
+  await invalidateReleaseWorkflowCache(id);
+  return { ok: true };
+}
+
+// ─── RM-04.3: Graph validation ────────────────────────────────────────────────
+
+export interface ReleaseWorkflowValidationReport {
+  isValid: boolean;
+  errors: Array<{ type: string; message: string }>;
+  warnings: Array<{ type: string; message: string; statusId?: string; statusName?: string }>;
+}
+
+export async function validateReleaseWorkflow(workflowId: string): Promise<ReleaseWorkflowValidationReport> {
+  const wf = await prisma.releaseWorkflow.findUnique({
+    where: { id: workflowId },
+    include: {
+      steps: { include: { status: true } },
+      transitions: true,
+    },
+  });
+  if (!wf) throw new AppError(404, 'Release workflow not found');
+
+  const errors: ReleaseWorkflowValidationReport['errors'] = [];
+  const warnings: ReleaseWorkflowValidationReport['warnings'] = [];
+
+  // NO_INITIAL_STATUS
+  const initialSteps = wf.steps.filter((s) => s.isInitial);
+  if (initialSteps.length === 0) {
+    errors.push({ type: 'NO_INITIAL_STATUS', message: 'Workflow has no initial status (isInitial = true)' });
+  }
+
+  // NO_DONE_STATUS
+  const doneSteps = wf.steps.filter((s) => s.status.category === 'DONE');
+  if (doneSteps.length === 0) {
+    errors.push({ type: 'NO_DONE_STATUS', message: 'Workflow has no status with category DONE' });
+  }
+
+  // DEAD_END_STATUS
+  const globalTransitionToStatusIds = new Set(
+    wf.transitions.filter((t) => t.isGlobal).map((t) => t.toStatusId),
+  );
+
+  for (const step of wf.steps) {
+    const outgoing = wf.transitions.filter((t) => t.fromStatusId === step.statusId);
+    if (
+      outgoing.length === 0 &&
+      !globalTransitionToStatusIds.has(step.statusId) &&
+      step.status.category !== 'DONE'
+    ) {
+      warnings.push({
+        type: 'DEAD_END_STATUS',
+        message: `Status "${step.status.name}" has no outgoing transitions and is not DONE category`,
+        statusId: step.statusId,
+        statusName: step.status.name,
+      });
+    }
+  }
+
+  // UNREACHABLE_STATUS
+  if (initialSteps.length > 0) {
+    const reachable = new Set<string>();
+    const queue = [initialSteps[0].statusId];
+    reachable.add(initialSteps[0].statusId);
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const nexts = wf.transitions
+        .filter((t) => t.fromStatusId === current || t.isGlobal)
+        .map((t) => t.toStatusId);
+      for (const next of nexts) {
+        if (!reachable.has(next)) {
+          reachable.add(next);
+          queue.push(next);
+        }
+      }
+    }
+
+    for (const step of wf.steps) {
+      if (!reachable.has(step.statusId)) {
+        warnings.push({
+          type: 'UNREACHABLE_STATUS',
+          message: `Status "${step.status.name}" is not reachable from the initial status`,
+          statusId: step.statusId,
+          statusName: step.status.name,
+        });
+      }
+    }
+  }
+
+  // UNUSED_STATUS
+  const usedStatusIds = new Set<string>();
+  for (const t of wf.transitions) {
+    usedStatusIds.add(t.fromStatusId);
+    usedStatusIds.add(t.toStatusId);
+  }
+  for (const step of wf.steps) {
+    if (!usedStatusIds.has(step.statusId)) {
+      warnings.push({
+        type: 'UNUSED_STATUS',
+        message: `Status "${step.status.name}" is not referenced in any transition`,
+        statusId: step.statusId,
+        statusName: step.status.name,
+      });
+    }
+  }
+
+  return { isValid: errors.length === 0, errors, warnings };
+}
+
+// ─── Steps ────────────────────────────────────────────────────────────────────
+
+export async function addReleaseWorkflowStep(workflowId: string, dto: CreateReleaseWorkflowStepDto) {
+  const wf = await prisma.releaseWorkflow.findUnique({ where: { id: workflowId } });
+  if (!wf) throw new AppError(404, 'Release workflow not found');
+
+  const status = await prisma.releaseStatus.findUnique({ where: { id: dto.statusId } });
+  if (!status) throw new AppError(404, 'Release status not found');
+
+  const existing = await prisma.releaseWorkflowStep.findUnique({
+    where: { workflowId_statusId: { workflowId, statusId: dto.statusId } },
+  });
+  if (existing) throw new AppError(409, 'Status already in workflow');
+
+  if (dto.isInitial) {
+    await prisma.releaseWorkflowStep.updateMany({
+      where: { workflowId, isInitial: true },
+      data: { isInitial: false },
+    });
+  }
+
+  const maxOrder = await prisma.releaseWorkflowStep.aggregate({
+    where: { workflowId },
+    _max: { orderIndex: true },
+  });
+  const orderIndex = dto.orderIndex ?? (maxOrder._max.orderIndex ?? -1) + 1;
+
+  const step = await prisma.releaseWorkflowStep.create({
+    data: { workflowId, statusId: dto.statusId, isInitial: dto.isInitial ?? false, orderIndex },
+    include: { status: true },
+  });
+  await invalidateReleaseWorkflowCache(workflowId);
+  return step;
+}
+
+export async function updateReleaseWorkflowStep(
+  workflowId: string,
+  stepId: string,
+  dto: UpdateReleaseWorkflowStepDto,
+) {
+  const wf = await prisma.releaseWorkflow.findUnique({ where: { id: workflowId } });
+  if (!wf) throw new AppError(404, 'Release workflow not found');
+
+  const step = await prisma.releaseWorkflowStep.findFirst({ where: { id: stepId, workflowId } });
+  if (!step) throw new AppError(404, 'Release workflow step not found');
+
+  if (dto.isInitial) {
+    await prisma.releaseWorkflowStep.updateMany({
+      where: { workflowId, isInitial: true },
+      data: { isInitial: false },
+    });
+  }
+
+  const updated = await prisma.releaseWorkflowStep.update({
+    where: { id: stepId },
+    data: {
+      ...(dto.isInitial !== undefined && { isInitial: dto.isInitial }),
+      ...(dto.orderIndex !== undefined && { orderIndex: dto.orderIndex }),
+    },
+    include: { status: true },
+  });
+  await invalidateReleaseWorkflowCache(workflowId);
+  return updated;
+}
+
+export async function deleteReleaseWorkflowStep(workflowId: string, stepId: string) {
+  const wf = await prisma.releaseWorkflow.findUnique({ where: { id: workflowId } });
+  if (!wf) throw new AppError(404, 'Release workflow not found');
+
+  const step = await prisma.releaseWorkflowStep.findFirst({ where: { id: stepId, workflowId } });
+  if (!step) throw new AppError(404, 'Release workflow step not found');
+
+  await prisma.releaseWorkflowStep.delete({ where: { id: stepId } });
+  await invalidateReleaseWorkflowCache(workflowId);
+  return { ok: true };
+}
+
+// ─── Transitions ──────────────────────────────────────────────────────────────
+
+async function assertStatusInReleaseWorkflow(workflowId: string, statusId: string, label: string) {
+  const step = await prisma.releaseWorkflowStep.findUnique({
+    where: { workflowId_statusId: { workflowId, statusId } },
+  });
+  if (!step) throw new AppError(400, `${label} must be a step in the workflow`);
+}
+
+export async function createReleaseWorkflowTransition(
+  workflowId: string,
+  dto: CreateReleaseWorkflowTransitionDto,
+) {
+  const wf = await prisma.releaseWorkflow.findUnique({ where: { id: workflowId } });
+  if (!wf) throw new AppError(404, 'Release workflow not found');
+
+  await assertStatusInReleaseWorkflow(workflowId, dto.fromStatusId, 'fromStatus');
+  await assertStatusInReleaseWorkflow(workflowId, dto.toStatusId, 'toStatus');
+
+  const dup = await prisma.releaseWorkflowTransition.findFirst({
+    where: { workflowId, fromStatusId: dto.fromStatusId, toStatusId: dto.toStatusId },
+  });
+  if (dup) throw new AppError(409, 'TRANSITION_ALREADY_EXISTS');
+
+  const transition = await prisma.releaseWorkflowTransition.create({
+    data: {
+      workflowId,
+      name: dto.name,
+      fromStatusId: dto.fromStatusId,
+      toStatusId: dto.toStatusId,
+      isGlobal: dto.isGlobal ?? false,
+      conditions: dto.conditions ? (dto.conditions as Prisma.InputJsonValue) : Prisma.JsonNull,
+    },
+    include: { fromStatus: true, toStatus: true },
+  });
+  await invalidateReleaseWorkflowCache(workflowId);
+  return transition;
+}
+
+export async function updateReleaseWorkflowTransition(
+  workflowId: string,
+  transitionId: string,
+  dto: UpdateReleaseWorkflowTransitionDto,
+) {
+  const wf = await prisma.releaseWorkflow.findUnique({ where: { id: workflowId } });
+  if (!wf) throw new AppError(404, 'Release workflow not found');
+
+  const transition = await prisma.releaseWorkflowTransition.findFirst({
+    where: { id: transitionId, workflowId },
+  });
+  if (!transition) throw new AppError(404, 'Release workflow transition not found');
+
+  if (dto.fromStatusId !== undefined) await assertStatusInReleaseWorkflow(workflowId, dto.fromStatusId, 'fromStatus');
+  if (dto.toStatusId !== undefined) await assertStatusInReleaseWorkflow(workflowId, dto.toStatusId, 'toStatus');
+
+  const updated = await prisma.releaseWorkflowTransition.update({
+    where: { id: transitionId },
+    data: {
+      ...(dto.name !== undefined && { name: dto.name }),
+      ...(dto.fromStatusId !== undefined && { fromStatusId: dto.fromStatusId }),
+      ...(dto.toStatusId !== undefined && { toStatusId: dto.toStatusId }),
+      ...(dto.isGlobal !== undefined && { isGlobal: dto.isGlobal }),
+      ...(dto.conditions !== undefined && {
+        conditions: dto.conditions ? (dto.conditions as Prisma.InputJsonValue) : Prisma.JsonNull,
+      }),
+    },
+    include: { fromStatus: true, toStatus: true },
+  });
+  await invalidateReleaseWorkflowCache(workflowId);
+  return updated;
+}
+
+export async function deleteReleaseWorkflowTransition(workflowId: string, transitionId: string) {
+  const wf = await prisma.releaseWorkflow.findUnique({ where: { id: workflowId } });
+  if (!wf) throw new AppError(404, 'Release workflow not found');
+
+  const transition = await prisma.releaseWorkflowTransition.findFirst({
+    where: { id: transitionId, workflowId },
+  });
+  if (!transition) throw new AppError(404, 'Release workflow transition not found');
+
+  await prisma.releaseWorkflowTransition.delete({ where: { id: transitionId } });
+  await invalidateReleaseWorkflowCache(workflowId);
+  return { ok: true };
+}

--- a/backend/src/modules/releases/release-workflows-admin.service.ts
+++ b/backend/src/modules/releases/release-workflows-admin.service.ts
@@ -116,15 +116,18 @@ export async function validateReleaseWorkflow(workflowId: string): Promise<Relea
   }
 
   // DEAD_END_STATUS
-  const globalTransitionToStatusIds = new Set(
-    wf.transitions.filter((t) => t.isGlobal).map((t) => t.toStatusId),
-  );
+  // A global transition is available from *every* status, so any status that has
+  // at least one outgoing global transition is not a dead-end regardless of its
+  // direct outgoing edges.
+  const hasGlobalOutgoing = wf.transitions.some((t) => t.isGlobal);
 
   for (const step of wf.steps) {
-    const outgoing = wf.transitions.filter((t) => t.fromStatusId === step.statusId);
+    const outgoing = wf.transitions.filter(
+      (t) => t.fromStatusId === step.statusId || t.isGlobal,
+    );
     if (
       outgoing.length === 0 &&
-      !globalTransitionToStatusIds.has(step.statusId) &&
+      !hasGlobalOutgoing &&
       step.status.category !== 'DONE'
     ) {
       warnings.push({
@@ -201,23 +204,25 @@ export async function addReleaseWorkflowStep(workflowId: string, dto: CreateRele
   });
   if (existing) throw new AppError(409, 'Status already in workflow');
 
-  if (dto.isInitial) {
-    await prisma.releaseWorkflowStep.updateMany({
-      where: { workflowId, isInitial: true },
-      data: { isInitial: false },
-    });
-  }
-
   const maxOrder = await prisma.releaseWorkflowStep.aggregate({
     where: { workflowId },
     _max: { orderIndex: true },
   });
   const orderIndex = dto.orderIndex ?? (maxOrder._max.orderIndex ?? -1) + 1;
 
-  const step = await prisma.releaseWorkflowStep.create({
-    data: { workflowId, statusId: dto.statusId, isInitial: dto.isInitial ?? false, orderIndex },
-    include: { status: true },
+  const step = await prisma.$transaction(async (tx) => {
+    if (dto.isInitial) {
+      await tx.releaseWorkflowStep.updateMany({
+        where: { workflowId, isInitial: true },
+        data: { isInitial: false },
+      });
+    }
+    return tx.releaseWorkflowStep.create({
+      data: { workflowId, statusId: dto.statusId, isInitial: dto.isInitial ?? false, orderIndex },
+      include: { status: true },
+    });
   });
+
   await invalidateReleaseWorkflowCache(workflowId);
   return step;
 }
@@ -233,21 +238,23 @@ export async function updateReleaseWorkflowStep(
   const step = await prisma.releaseWorkflowStep.findFirst({ where: { id: stepId, workflowId } });
   if (!step) throw new AppError(404, 'Release workflow step not found');
 
-  if (dto.isInitial) {
-    await prisma.releaseWorkflowStep.updateMany({
-      where: { workflowId, isInitial: true },
-      data: { isInitial: false },
+  const updated = await prisma.$transaction(async (tx) => {
+    if (dto.isInitial) {
+      await tx.releaseWorkflowStep.updateMany({
+        where: { workflowId, isInitial: true },
+        data: { isInitial: false },
+      });
+    }
+    return tx.releaseWorkflowStep.update({
+      where: { id: stepId },
+      data: {
+        ...(dto.isInitial !== undefined && { isInitial: dto.isInitial }),
+        ...(dto.orderIndex !== undefined && { orderIndex: dto.orderIndex }),
+      },
+      include: { status: true },
     });
-  }
-
-  const updated = await prisma.releaseWorkflowStep.update({
-    where: { id: stepId },
-    data: {
-      ...(dto.isInitial !== undefined && { isInitial: dto.isInitial }),
-      ...(dto.orderIndex !== undefined && { orderIndex: dto.orderIndex }),
-    },
-    include: { status: true },
   });
+
   await invalidateReleaseWorkflowCache(workflowId);
   return updated;
 }
@@ -259,7 +266,16 @@ export async function deleteReleaseWorkflowStep(workflowId: string, stepId: stri
   const step = await prisma.releaseWorkflowStep.findFirst({ where: { id: stepId, workflowId } });
   if (!step) throw new AppError(404, 'Release workflow step not found');
 
-  await prisma.releaseWorkflowStep.delete({ where: { id: stepId } });
+  // Delete step and any transitions that reference this status (from or to)
+  await prisma.$transaction([
+    prisma.releaseWorkflowTransition.deleteMany({
+      where: {
+        workflowId,
+        OR: [{ fromStatusId: step.statusId }, { toStatusId: step.statusId }],
+      },
+    }),
+    prisma.releaseWorkflowStep.delete({ where: { id: stepId } }),
+  ]);
   await invalidateReleaseWorkflowCache(workflowId);
   return { ok: true };
 }

--- a/backend/src/modules/releases/releases.dto.ts
+++ b/backend/src/modules/releases/releases.dto.ts
@@ -2,6 +2,16 @@ import { z } from 'zod';
 
 // ─── RM-03.2: Create release (new global endpoint, type-aware) ────────────────
 
+// ─── Date validation helper ───────────────────────────────────────────────────
+
+const isoDate = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/)
+  .refine((s) => {
+    const d = new Date(s);
+    return !isNaN(d.getTime()) && d.toISOString().startsWith(s);
+  }, 'Invalid calendar date');
+
 export const createReleaseDto = z.object({
   name: z.string().min(1).max(100),
   description: z.string().max(5000).optional(),
@@ -9,7 +19,7 @@ export const createReleaseDto = z.object({
   type: z.enum(['ATOMIC', 'INTEGRATION']).default('ATOMIC'),
   projectId: z.string().uuid().optional(),
   workflowId: z.string().uuid().optional(),
-  plannedDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
+  plannedDate: isoDate.nullable().optional(),
 });
 
 // ─── RM-03.3: Update release (immutable: type, projectId; no statusId) ────────
@@ -18,8 +28,8 @@ export const updateReleaseDto = z.object({
   name: z.string().min(1).max(100).optional(),
   description: z.string().max(5000).nullable().optional(),
   level: z.enum(['MINOR', 'MAJOR']).optional(),
-  plannedDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
-  releaseDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
+  plannedDate: isoDate.nullable().optional(),
+  releaseDate: isoDate.nullable().optional(),
 });
 
 // ─── RM-03.1: List query params ───────────────────────────────────────────────
@@ -29,10 +39,10 @@ export const listReleasesQueryDto = z.object({
   statusId: z.string().uuid().optional(),
   statusCategory: z.enum(['PLANNING', 'IN_PROGRESS', 'DONE', 'CANCELLED']).optional(),
   projectId: z.string().uuid().optional(),
-  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
-  to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
-  releaseDateFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
-  releaseDateTo: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  from: isoDate.optional(),
+  to: isoDate.optional(),
+  releaseDateFrom: isoDate.optional(),
+  releaseDateTo: isoDate.optional(),
   search: z.string().max(200).optional(),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),
@@ -43,11 +53,21 @@ export const listReleasesQueryDto = z.object({
 // ─── RM-03.5: ReleaseItem management ─────────────────────────────────────────
 
 export const releaseItemsAddDto = z.object({
-  issueIds: z.array(z.string().uuid()).min(1).max(100),
+  issueIds: z
+    .array(z.string().uuid())
+    .min(1)
+    .max(100)
+    .transform((ids) => [...new Set(ids)])
+    .refine((ids) => ids.length >= 1, 'issueIds must contain at least one unique id'),
 });
 
 export const releaseItemsRemoveDto = z.object({
-  issueIds: z.array(z.string().uuid()).min(1).max(100),
+  issueIds: z
+    .array(z.string().uuid())
+    .min(1)
+    .max(100)
+    .transform((ids) => [...new Set(ids)])
+    .refine((ids) => ids.length >= 1, 'issueIds must contain at least one unique id'),
 });
 
 export const listReleaseItemsQueryDto = z.object({
@@ -65,6 +85,12 @@ export const cloneReleaseDto = z.object({
   projectId: z.string().uuid().nullable().optional(),
   cloneItems: z.boolean().default(false),
   cloneSprints: z.boolean().default(false),
+});
+
+// ─── RM-03.6: Execute transition body ────────────────────────────────────────
+
+export const executeTransitionDto = z.object({
+  comment: z.string().max(2000).optional(),
 });
 
 // ─── Legacy DTOs (kept for backward compat) ──────────────────────────────────

--- a/backend/src/modules/releases/releases.dto.ts
+++ b/backend/src/modules/releases/releases.dto.ts
@@ -1,18 +1,73 @@
 import { z } from 'zod';
 
+// ─── RM-03.2: Create release (new global endpoint, type-aware) ────────────────
+
 export const createReleaseDto = z.object({
   name: z.string().min(1).max(100),
   description: z.string().max(5000).optional(),
-  level: z.enum(['MINOR', 'MAJOR']),
+  level: z.enum(['MINOR', 'MAJOR']).default('MINOR'),
+  type: z.enum(['ATOMIC', 'INTEGRATION']).default('ATOMIC'),
+  projectId: z.string().uuid().optional(),
+  workflowId: z.string().uuid().optional(),
+  plannedDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
 });
+
+// ─── RM-03.3: Update release (immutable: type, projectId; no statusId) ────────
 
 export const updateReleaseDto = z.object({
   name: z.string().min(1).max(100).optional(),
   description: z.string().max(5000).nullable().optional(),
   level: z.enum(['MINOR', 'MAJOR']).optional(),
-  state: z.enum(['DRAFT', 'READY', 'RELEASED']).optional(),
+  plannedDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
   releaseDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
 });
+
+// ─── RM-03.1: List query params ───────────────────────────────────────────────
+
+export const listReleasesQueryDto = z.object({
+  type: z.enum(['ATOMIC', 'INTEGRATION']).optional(),
+  statusId: z.string().uuid().optional(),
+  statusCategory: z.enum(['PLANNING', 'IN_PROGRESS', 'DONE', 'CANCELLED']).optional(),
+  projectId: z.string().uuid().optional(),
+  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  releaseDateFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  releaseDateTo: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  search: z.string().max(200).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  sortBy: z.enum(['name', 'createdAt', 'plannedDate', 'releaseDate']).default('createdAt'),
+  sortDir: z.enum(['asc', 'desc']).default('desc'),
+});
+
+// ─── RM-03.5: ReleaseItem management ─────────────────────────────────────────
+
+export const releaseItemsAddDto = z.object({
+  issueIds: z.array(z.string().uuid()).min(1).max(100),
+});
+
+export const releaseItemsRemoveDto = z.object({
+  issueIds: z.array(z.string().uuid()).min(1).max(100),
+});
+
+export const listReleaseItemsQueryDto = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  status: z.string().optional(),
+  projectId: z.string().uuid().optional(),
+});
+
+// ─── RM-03.8: Clone release ───────────────────────────────────────────────────
+
+export const cloneReleaseDto = z.object({
+  name: z.string().min(1).max(100).optional(),
+  type: z.enum(['ATOMIC', 'INTEGRATION']).optional(),
+  projectId: z.string().uuid().nullable().optional(),
+  cloneItems: z.boolean().default(false),
+  cloneSprints: z.boolean().default(false),
+});
+
+// ─── Legacy DTOs (kept for backward compat) ──────────────────────────────────
 
 export const moveIssuesToReleaseDto = z.object({
   issueIds: z.array(z.string().uuid()).min(1),
@@ -24,5 +79,10 @@ export const manageSprintsInReleaseDto = z.object({
 
 export type CreateReleaseDto = z.infer<typeof createReleaseDto>;
 export type UpdateReleaseDto = z.infer<typeof updateReleaseDto>;
+export type ListReleasesQueryDto = z.infer<typeof listReleasesQueryDto>;
+export type ReleaseItemsAddDto = z.infer<typeof releaseItemsAddDto>;
+export type ReleaseItemsRemoveDto = z.infer<typeof releaseItemsRemoveDto>;
+export type ListReleaseItemsQueryDto = z.infer<typeof listReleaseItemsQueryDto>;
+export type CloneReleaseDto = z.infer<typeof cloneReleaseDto>;
 export type MoveIssuesToReleaseDto = z.infer<typeof moveIssuesToReleaseDto>;
 export type ManageSprintsInReleaseDto = z.infer<typeof manageSprintsInReleaseDto>;

--- a/backend/src/modules/releases/releases.router.ts
+++ b/backend/src/modules/releases/releases.router.ts
@@ -5,7 +5,11 @@ import { validate } from '../../shared/middleware/validate.js';
 import {
   createReleaseDto,
   updateReleaseDto,
-  moveIssuesToReleaseDto,
+  listReleasesQueryDto,
+  releaseItemsAddDto,
+  releaseItemsRemoveDto,
+  listReleaseItemsQueryDto,
+  cloneReleaseDto,
   manageSprintsInReleaseDto,
 } from './releases.dto.js';
 import * as releasesService from './releases.service.js';
@@ -16,6 +20,208 @@ import type { AuthRequest } from '../../shared/types/index.js';
 const router = Router();
 router.use(authenticate);
 
+// ─── RM-03.1: GET /releases — global list with filtering ────────────────────
+
+router.get('/releases', async (req: AuthRequest, res, next) => {
+  try {
+    const query = listReleasesQueryDto.parse(req.query);
+    const result = await releasesService.listReleasesGlobal(query);
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── RM-03.2: POST /releases — create with type ATOMIC/INTEGRATION ──────────
+
+router.post(
+  '/releases',
+  requireRole('ADMIN', 'MANAGER'),
+  validate(createReleaseDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const release = await releasesService.createReleaseGlobal(req.body, req.user!.userId);
+      await logAudit(req, 'release.created', 'release', release.id, {
+        name: release.name,
+        type: release.type,
+        level: release.level,
+      });
+      res.status(201).json(release);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ─── RM-03.3: PATCH /releases/:id — update (immutable: type, projectId) ─────
+
+router.patch(
+  '/releases/:id',
+  requireRole('ADMIN', 'MANAGER'),
+  validate(updateReleaseDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const release = await releasesService.updateRelease(req.params.id as string, req.body);
+      await logAudit(req, 'release.updated', 'release', release.id, req.body);
+      res.json(release);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ─── RM-03.4: DELETE /releases/:id ───────────────────────────────────────────
+
+router.delete(
+  '/releases/:id',
+  requireRole('ADMIN', 'MANAGER'),
+  async (req: AuthRequest, res, next) => {
+    try {
+      await releasesService.deleteRelease(req.params.id as string);
+      await logAudit(req, 'release.deleted', 'release', req.params.id as string);
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ─── RM-03.5: ReleaseItem CRUD ────────────────────────────────────────────────
+
+router.get('/releases/:id/items', async (req: AuthRequest, res, next) => {
+  try {
+    const query = listReleaseItemsQueryDto.parse(req.query);
+    const result = await releasesService.listReleaseItems(req.params.id as string, query);
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post(
+  '/releases/:id/items',
+  requireRole('ADMIN', 'MANAGER'),
+  validate(releaseItemsAddDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      await releasesService.addReleaseItems(
+        req.params.id as string,
+        req.body,
+        req.user!.userId,
+      );
+      await logAudit(req, 'release.items_added', 'release', req.params.id as string, {
+        issueIds: req.body.issueIds,
+      });
+      res.json({ ok: true });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+router.post(
+  '/releases/:id/items/remove',
+  requireRole('ADMIN', 'MANAGER'),
+  validate(releaseItemsRemoveDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      await releasesService.removeReleaseItems(
+        req.params.id as string,
+        req.body.issueIds,
+      );
+      await logAudit(req, 'release.items_removed', 'release', req.params.id as string, {
+        issueIds: req.body.issueIds,
+      });
+      res.json({ ok: true });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ─── RM-03.6: Transitions (already implemented) ──────────────────────────────
+
+router.get('/releases/:id/transitions', async (req: AuthRequest, res, next) => {
+  try {
+    const result = await releaseWorkflowEngine.getAvailableTransitions(
+      req.params.id as string,
+      req.user!.userId,
+      req.user!.role,
+    );
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/releases/:id/transitions/:transitionId', async (req: AuthRequest, res, next) => {
+  try {
+    const comment = (req.body as { comment?: string }).comment;
+    await releaseWorkflowEngine.executeTransition(
+      req.params.id as string,
+      req.params.transitionId as string,
+      req.user!.userId,
+      req.user!.role,
+      comment,
+    );
+    await logAudit(req, 'release.transitioned', 'release', req.params.id as string, {
+      transitionId: req.params.transitionId,
+    });
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── RM-03.7: GET /releases/:id/readiness — extended ─────────────────────────
+
+router.get('/releases/:id/readiness', async (req, res, next) => {
+  try {
+    const readiness = await releasesService.getReleaseReadiness(req.params.id as string);
+    res.json(readiness);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── RM-03.8: POST /releases/:id/clone ───────────────────────────────────────
+
+router.post(
+  '/releases/:id/clone',
+  requireRole('ADMIN', 'MANAGER'),
+  validate(cloneReleaseDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const cloned = await releasesService.cloneRelease(
+        req.params.id as string,
+        req.body,
+        req.user!.userId,
+      );
+      res.status(201).json(cloned);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ─── RM-03.9: Deprecated endpoints → 410 Gone ────────────────────────────────
+
+router.post('/releases/:id/ready', (_req, res) => {
+  res.status(410).json({
+    error: 'Deprecated',
+    message: 'Use POST /api/releases/:id/transitions/:transitionId',
+  });
+});
+
+router.post('/releases/:id/released', (_req, res) => {
+  res.status(410).json({
+    error: 'Deprecated',
+    message: 'Use POST /api/releases/:id/transitions/:transitionId',
+  });
+});
+
+// ─── Legacy project-scoped routes ────────────────────────────────────────────
+
 router.get('/projects/:projectId/releases', async (req, res, next) => {
   try {
     const list = await releasesService.listReleases(req.params.projectId as string);
@@ -24,6 +230,27 @@ router.get('/projects/:projectId/releases', async (req, res, next) => {
     next(err);
   }
 });
+
+router.post(
+  '/projects/:projectId/releases',
+  requireRole('ADMIN', 'MANAGER'),
+  validate(createReleaseDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const release = await releasesService.createReleaseGlobal(
+        { ...req.body, projectId: req.params.projectId, type: 'ATOMIC' },
+        req.user!.userId,
+      );
+      await logAudit(req, 'release.created', 'release', release.id, {
+        name: release.name,
+        level: release.level,
+      });
+      res.status(201).json(release);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 
 router.get('/releases/:id/issues', async (req, res, next) => {
   try {
@@ -42,82 +269,6 @@ router.get('/releases/:id/sprints', async (req, res, next) => {
     next(err);
   }
 });
-
-router.get('/releases/:id/readiness', async (req, res, next) => {
-  try {
-    const readiness = await releasesService.getReleaseReadiness(req.params.id as string);
-    res.json(readiness);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.post(
-  '/projects/:projectId/releases',
-  requireRole('ADMIN', 'MANAGER'),
-  validate(createReleaseDto),
-  async (req: AuthRequest, res, next) => {
-    try {
-      const release = await releasesService.createRelease(
-        req.params.projectId as string,
-        req.body,
-      );
-      await logAudit(req, 'release.created', 'release', release.id, { name: release.name, level: release.level });
-      res.status(201).json(release);
-    } catch (err) {
-      next(err);
-    }
-  },
-);
-
-router.patch(
-  '/releases/:id',
-  requireRole('ADMIN', 'MANAGER'),
-  validate(updateReleaseDto),
-  async (req: AuthRequest, res, next) => {
-    try {
-      const release = await releasesService.updateRelease(req.params.id as string, req.body);
-      await logAudit(req, 'release.updated', 'release', release.id, req.body);
-      res.json(release);
-    } catch (err) {
-      next(err);
-    }
-  },
-);
-
-router.post(
-  '/releases/:id/issues',
-  requireRole('ADMIN', 'MANAGER'),
-  validate(moveIssuesToReleaseDto),
-  async (req: AuthRequest, res, next) => {
-    try {
-      await releasesService.addIssuesToRelease(req.params.id as string, req.body.issueIds);
-      await logAudit(req, 'release.issues_added', 'release', req.params.id as string, {
-        issueIds: req.body.issueIds,
-      });
-      res.json({ ok: true });
-    } catch (err) {
-      next(err);
-    }
-  },
-);
-
-router.post(
-  '/releases/:id/issues/remove',
-  requireRole('ADMIN', 'MANAGER'),
-  validate(moveIssuesToReleaseDto),
-  async (req: AuthRequest, res, next) => {
-    try {
-      await releasesService.removeIssuesFromRelease(req.params.id as string, req.body.issueIds);
-      await logAudit(req, 'release.issues_removed', 'release', req.params.id as string, {
-        issueIds: req.body.issueIds,
-      });
-      res.json({ ok: true });
-    } catch (err) {
-      next(err);
-    }
-  },
-);
 
 router.post(
   '/releases/:id/sprints',
@@ -147,69 +298,6 @@ router.post(
         sprintIds: req.body.sprintIds,
       });
       res.json({ ok: true });
-    } catch (err) {
-      next(err);
-    }
-  },
-);
-
-// GET /releases/:id/transitions — доступные переходы для релиза
-router.get('/releases/:id/transitions', async (req: AuthRequest, res, next) => {
-  try {
-    const result = await releaseWorkflowEngine.getAvailableTransitions(
-      req.params.id as string,
-      req.user!.userId,
-      req.user!.role,
-    );
-    res.json(result);
-  } catch (err) {
-    next(err);
-  }
-});
-
-// POST /releases/:id/transitions/:transitionId — выполнить переход
-router.post('/releases/:id/transitions/:transitionId', async (req: AuthRequest, res, next) => {
-  try {
-    const comment = (req.body as { comment?: string }).comment;
-    await releaseWorkflowEngine.executeTransition(
-      req.params.id as string,
-      req.params.transitionId as string,
-      req.user!.userId,
-      req.user!.role,
-      comment,
-    );
-    await logAudit(req, 'release.transitioned', 'release', req.params.id as string, {
-      transitionId: req.params.transitionId,
-    });
-    res.json({ ok: true });
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.post(
-  '/releases/:id/ready',
-  requireRole('ADMIN', 'MANAGER'),
-  async (req: AuthRequest, res, next) => {
-    try {
-      const release = await releasesService.markReleaseReady(req.params.id as string);
-      await logAudit(req, 'release.ready', 'release', release.id);
-      res.json(release);
-    } catch (err) {
-      next(err);
-    }
-  },
-);
-
-router.post(
-  '/releases/:id/released',
-  requireRole('ADMIN', 'MANAGER'),
-  async (req: AuthRequest, res, next) => {
-    try {
-      const releaseDate = (req.body as { releaseDate?: string }).releaseDate;
-      const release = await releasesService.markReleaseReleased(req.params.id as string, releaseDate);
-      await logAudit(req, 'release.released', 'release', release.id);
-      res.json(release);
     } catch (err) {
       next(err);
     }

--- a/backend/src/modules/releases/releases.router.ts
+++ b/backend/src/modules/releases/releases.router.ts
@@ -9,6 +9,7 @@ import {
   manageSprintsInReleaseDto,
 } from './releases.dto.js';
 import * as releasesService from './releases.service.js';
+import * as releaseWorkflowEngine from './release-workflow-engine.service.js';
 import { logAudit } from '../../shared/middleware/audit.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 
@@ -151,6 +152,40 @@ router.post(
     }
   },
 );
+
+// GET /releases/:id/transitions — доступные переходы для релиза
+router.get('/releases/:id/transitions', async (req: AuthRequest, res, next) => {
+  try {
+    const result = await releaseWorkflowEngine.getAvailableTransitions(
+      req.params.id as string,
+      req.user!.userId,
+      req.user!.role,
+    );
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /releases/:id/transitions/:transitionId — выполнить переход
+router.post('/releases/:id/transitions/:transitionId', async (req: AuthRequest, res, next) => {
+  try {
+    const comment = (req.body as { comment?: string }).comment;
+    await releaseWorkflowEngine.executeTransition(
+      req.params.id as string,
+      req.params.transitionId as string,
+      req.user!.userId,
+      req.user!.role,
+      comment,
+    );
+    await logAudit(req, 'release.transitioned', 'release', req.params.id as string, {
+      transitionId: req.params.transitionId,
+    });
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.post(
   '/releases/:id/ready',

--- a/backend/src/modules/releases/releases.router.ts
+++ b/backend/src/modules/releases/releases.router.ts
@@ -54,6 +54,28 @@ router.post(
   },
 );
 
+// ─── GET /releases/:id — single release ──────────────────────────────────────
+
+router.get('/releases/:id', async (req: AuthRequest, res, next) => {
+  try {
+    const release = await releasesService.getRelease(req.params.id as string);
+    res.json(release);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── GET /releases/:id/history — audit log ───────────────────────────────────
+
+router.get('/releases/:id/history', async (req: AuthRequest, res, next) => {
+  try {
+    const history = await releasesService.getReleaseHistory(req.params.id as string);
+    res.json(history);
+  } catch (err) {
+    next(err);
+  }
+});
+
 // ─── RM-03.3: PATCH /releases/:id — update (immutable: type, projectId) ─────
 
 router.patch(

--- a/backend/src/modules/releases/releases.router.ts
+++ b/backend/src/modules/releases/releases.router.ts
@@ -11,6 +11,7 @@ import {
   listReleaseItemsQueryDto,
   cloneReleaseDto,
   manageSprintsInReleaseDto,
+  executeTransitionDto,
 } from './releases.dto.js';
 import * as releasesService from './releases.service.js';
 import * as releaseWorkflowEngine from './release-workflow-engine.service.js';
@@ -139,39 +140,45 @@ router.post(
   },
 );
 
-// ─── RM-03.6: Transitions (already implemented) ──────────────────────────────
+// ─── RM-03.6: Transitions ────────────────────────────────────────────────────
 
-router.get('/releases/:id/transitions', async (req: AuthRequest, res, next) => {
-  try {
-    const result = await releaseWorkflowEngine.getAvailableTransitions(
-      req.params.id as string,
-      req.user!.userId,
-      req.user!.role,
-    );
-    res.json(result);
-  } catch (err) {
-    next(err);
-  }
-});
+router.get(
+  '/releases/:id/transitions',
+  requireRole('ADMIN', 'MANAGER', 'USER'),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const result = await releaseWorkflowEngine.getAvailableTransitions(
+        req.params.id as string,
+        req.user!.userId,
+        req.user!.role,
+      );
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 
-router.post('/releases/:id/transitions/:transitionId', async (req: AuthRequest, res, next) => {
-  try {
-    const comment = (req.body as { comment?: string }).comment;
-    await releaseWorkflowEngine.executeTransition(
-      req.params.id as string,
-      req.params.transitionId as string,
-      req.user!.userId,
-      req.user!.role,
-      comment,
-    );
-    await logAudit(req, 'release.transitioned', 'release', req.params.id as string, {
-      transitionId: req.params.transitionId,
-    });
-    res.json({ ok: true });
-  } catch (err) {
-    next(err);
-  }
-});
+router.post(
+  '/releases/:id/transitions/:transitionId',
+  requireRole('ADMIN', 'MANAGER', 'USER'),
+  validate(executeTransitionDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      await releaseWorkflowEngine.executeTransition(
+        req.params.id as string,
+        req.params.transitionId as string,
+        req.user!.userId,
+        req.user!.role,
+        (req.body as { comment?: string }).comment,
+      );
+      // audit is written inside executeTransition via prisma.$transaction
+      res.json({ ok: true });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 
 // ─── RM-03.7: GET /releases/:id/readiness — extended ─────────────────────────
 

--- a/backend/src/modules/releases/releases.service.ts
+++ b/backend/src/modules/releases/releases.service.ts
@@ -658,10 +658,10 @@ export async function removeIssuesFromRelease(releaseId: string, issueIds: strin
 }
 
 // Deprecated stubs — kept for legacy handlers
-export async function markReleaseReady(_id: string): Promise<never> {
+export async function markReleaseReady(): Promise<never> {
   throw new AppError(410, 'Deprecated');
 }
 
-export async function markReleaseReleased(_id: string, _releaseDate?: string): Promise<never> {
+export async function markReleaseReleased(): Promise<never> {
   throw new AppError(410, 'Deprecated');
 }

--- a/backend/src/modules/releases/releases.service.ts
+++ b/backend/src/modules/releases/releases.service.ts
@@ -93,7 +93,7 @@ export async function updateRelease(id: string, dto: UpdateReleaseDto) {
 
   if (dto.name !== undefined && dto.name !== release.name) {
     const existing = await prisma.release.findUnique({
-      where: { projectId_name: { projectId: release.projectId, name: dto.name } },
+      where: { projectId_name: { projectId: release.projectId!, name: dto.name } },
     });
     if (existing) throw new AppError(409, 'Release with this name already exists');
   }
@@ -159,7 +159,7 @@ export async function addIssuesToRelease(releaseId: string, issueIds: string[]) 
   if (release.state === 'RELEASED') throw new AppError(400, 'Cannot add issues to a released release');
 
   await prisma.issue.updateMany({
-    where: { id: { in: issueIds }, projectId: release.projectId },
+    where: { id: { in: issueIds }, ...(release.projectId ? { projectId: release.projectId } : {}) },
     data: { releaseId },
   });
 }

--- a/backend/src/modules/releases/releases.service.ts
+++ b/backend/src/modules/releases/releases.service.ts
@@ -69,6 +69,7 @@ export async function listReleasesGlobal(query: ListReleasesQueryDto) {
       include: {
         status: { select: { id: true, name: true, category: true, color: true } },
         project: { select: { id: true, name: true, key: true } },
+        createdBy: { select: { id: true, name: true } },
         _count: { select: { items: true, sprints: true } },
       },
       orderBy,
@@ -251,6 +252,35 @@ export async function deleteRelease(id: string): Promise<void> {
   await invalidateReleasesListCache();
 }
 
+// ─── GET /releases/:id — single release ──────────────────────────────────────
+
+export async function getRelease(id: string) {
+  const release = await prisma.release.findUnique({
+    where: { id },
+    include: {
+      status: { select: { id: true, name: true, category: true, color: true } },
+      project: { select: { id: true, name: true, key: true } },
+      createdBy: { select: { id: true, name: true } },
+      _count: { select: { items: true, sprints: true } },
+    },
+  });
+  if (!release) throw new AppError(404, 'Release not found');
+  return release;
+}
+
+// ─── GET /releases/:id/history — audit log ────────────────────────────────────
+
+export async function getReleaseHistory(id: string) {
+  const release = await prisma.release.findUnique({ where: { id } });
+  if (!release) throw new AppError(404, 'Release not found');
+  return prisma.auditLog.findMany({
+    where: { entityType: 'release', entityId: id },
+    include: { user: { select: { id: true, name: true } } },
+    orderBy: { createdAt: 'desc' },
+    take: 100,
+  });
+}
+
 // ─── RM-03.5: ReleaseItem CRUD ────────────────────────────────────────────────
 
 export async function addReleaseItems(releaseId: string, dto: ReleaseItemsAddDto, addedById: string) {
@@ -334,7 +364,8 @@ export async function listReleaseItems(releaseId: string, query: ListReleaseItem
             projectId: true,
             project: { select: { id: true, name: true, key: true } },
             assignee: { select: { id: true, name: true } },
-            issueTypeConfig: true,
+            issueTypeConfig: { select: { id: true, name: true, systemKey: true, iconColor: true } },
+            workflowStatus: { select: { id: true, name: true, category: true, color: true } },
           },
         },
       },

--- a/backend/src/modules/releases/releases.service.ts
+++ b/backend/src/modules/releases/releases.service.ts
@@ -1,12 +1,542 @@
+import type { Prisma } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
-import type { CreateReleaseDto, UpdateReleaseDto } from './releases.dto.js';
+import { getCachedJson, setCachedJson, delCachedJson } from '../../shared/redis.js';
+import { resolveWorkflowForRelease } from './release-workflow-engine.service.js';
+import type {
+  CreateReleaseDto,
+  UpdateReleaseDto,
+  ListReleasesQueryDto,
+  ReleaseItemsAddDto,
+  CloneReleaseDto,
+  ListReleaseItemsQueryDto,
+} from './releases.dto.js';
+
+// ─── Cache helpers ────────────────────────────────────────────────────────────
+
+const RELEASES_LIST_CACHE_TTL = 60; // 60 seconds
+const releasesListCacheKey = (suffix: string) => `releases:list:${suffix}`;
+
+export async function invalidateReleasesListCache(): Promise<void> {
+  // Pattern-based invalidation: delete known keys; for simplicity use a sentinel
+  await delCachedJson('releases:list:*');
+}
+
+// ─── RM-03.1: GET /api/releases — global list ────────────────────────────────
+
+export async function listReleasesGlobal(query: ListReleasesQueryDto) {
+  const { type, statusId, statusCategory, projectId, from, to, releaseDateFrom, releaseDateTo,
+    search, page, limit, sortBy, sortDir } = query;
+
+  const where: Prisma.ReleaseWhereInput = {};
+
+  if (type) where.type = type;
+  if (statusId) where.statusId = statusId;
+  if (statusCategory) where.status = { category: statusCategory };
+  if (projectId) where.projectId = projectId;
+  if (search) {
+    where.name = { contains: search, mode: 'insensitive' };
+  }
+  if (from || to) {
+    where.createdAt = {
+      ...(from ? { gte: new Date(from) } : {}),
+      ...(to ? { lte: new Date(to + 'T23:59:59Z') } : {}),
+    };
+  }
+  if (releaseDateFrom || releaseDateTo) {
+    where.releaseDate = {
+      ...(releaseDateFrom ? { gte: new Date(releaseDateFrom) } : {}),
+      ...(releaseDateTo ? { lte: new Date(releaseDateTo) } : {}),
+    };
+  }
+
+  const orderBy: Prisma.ReleaseOrderByWithRelationInput = { [sortBy]: sortDir };
+
+  const cacheKey = releasesListCacheKey(
+    Buffer.from(JSON.stringify({ where, orderBy, page, limit })).toString('base64').slice(0, 64),
+  );
+
+  const cached = await getCachedJson<{ data: unknown[]; total: number; page: number; limit: number }>(cacheKey);
+  if (cached) return cached;
+
+  const [releases, total] = await Promise.all([
+    prisma.release.findMany({
+      where,
+      include: {
+        status: { select: { id: true, name: true, category: true, color: true } },
+        project: { select: { id: true, name: true, key: true } },
+        _count: { select: { items: true, sprints: true } },
+      },
+      orderBy,
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.release.count({ where }),
+  ]);
+
+  // For INTEGRATION releases, attach _projects array (keys of projects from items)
+  const enriched = await Promise.all(
+    releases.map(async (r) => {
+      if (r.type !== 'INTEGRATION') return r;
+      const projectKeys = await prisma.issue.findMany({
+        where: { releaseItems: { some: { releaseId: r.id } } },
+        select: { project: { select: { key: true } } },
+        distinct: ['projectId'],
+      });
+      return {
+        ...r,
+        _projects: projectKeys.map((i) => i.project.key),
+      };
+    }),
+  );
+
+  const result = { data: enriched, total, page, limit };
+  await setCachedJson(cacheKey, result, RELEASES_LIST_CACHE_TTL);
+  return result;
+}
+
+// ─── RM-03.2: POST /api/releases — create with type + auto workflow status ────
+
+export async function createReleaseGlobal(dto: CreateReleaseDto, createdById: string) {
+  // Validate ATOMIC / INTEGRATION constraints
+  if (dto.type === 'ATOMIC' && !dto.projectId) {
+    throw new AppError(422, 'projectId is required for ATOMIC release');
+  }
+  if (dto.type === 'INTEGRATION' && dto.projectId) {
+    throw new AppError(422, 'projectId must be absent for INTEGRATION release');
+  }
+
+  if (dto.projectId) {
+    const project = await prisma.project.findUnique({ where: { id: dto.projectId } });
+    if (!project) throw new AppError(404, 'Project not found');
+  }
+
+  // Name uniqueness: ATOMIC — scoped to project; INTEGRATION — globally unique (projectId IS NULL)
+  const existingName = await prisma.release.findFirst({
+    where: {
+      name: dto.name,
+      ...(dto.type === 'ATOMIC'
+        ? { projectId: dto.projectId }
+        : { projectId: null }),
+    },
+  });
+  if (existingName) throw new AppError(409, 'Release with this name already exists');
+
+  // Resolve initial workflow status
+  let statusId: string | null = null;
+  let workflowId: string | null = dto.workflowId ?? null;
+
+  try {
+    const workflow = await resolveWorkflowForRelease({
+      id: 'new',
+      workflowId: workflowId,
+      type: dto.type ?? 'ATOMIC',
+    });
+    workflowId = workflow.id;
+
+    const initialStep = workflow.steps.find((s) => s.isInitial);
+    if (initialStep) statusId = initialStep.statusId;
+  } catch {
+    // No workflow configured — create without status
+  }
+
+  const release = await prisma.release.create({
+    data: {
+      type: dto.type ?? 'ATOMIC',
+      projectId: dto.projectId ?? null,
+      name: dto.name,
+      description: dto.description,
+      level: dto.level ?? 'MINOR',
+      statusId,
+      workflowId,
+      createdById,
+      plannedDate: dto.plannedDate ? new Date(dto.plannedDate) : null,
+    },
+    include: {
+      status: { select: { id: true, name: true, category: true, color: true } },
+      project: { select: { id: true, name: true, key: true } },
+    },
+  });
+
+  return release;
+}
+
+// ─── RM-03.3: PATCH /api/releases/:id — update (immutable: type, projectId) ──
+
+export async function updateRelease(id: string, dto: UpdateReleaseDto) {
+  const release = await prisma.release.findUnique({
+    where: { id },
+    include: { status: true },
+  });
+  if (!release) throw new AppError(404, 'Release not found');
+
+  // If status is in DONE category — only description can be changed
+  if (release.status?.category === 'DONE') {
+    const forbiddenFields = (['name', 'level', 'plannedDate', 'releaseDate'] as const).filter(
+      (f) => dto[f] !== undefined,
+    );
+    if (forbiddenFields.length > 0) {
+      throw new AppError(
+        422,
+        `Cannot update ${forbiddenFields.join(', ')} on a release in DONE status`,
+      );
+    }
+  }
+
+  // Name uniqueness check (scoped same as create)
+  if (dto.name !== undefined && dto.name !== release.name) {
+    const existing = await prisma.release.findFirst({
+      where: {
+        name: dto.name,
+        id: { not: id },
+        ...(release.projectId ? { projectId: release.projectId } : { projectId: null }),
+      },
+    });
+    if (existing) throw new AppError(409, 'Release with this name already exists');
+  }
+
+  return prisma.release.update({
+    where: { id },
+    data: {
+      ...(dto.name !== undefined && { name: dto.name }),
+      ...(dto.description !== undefined && { description: dto.description }),
+      ...(dto.level !== undefined && { level: dto.level }),
+      ...(dto.plannedDate !== undefined && {
+        plannedDate: dto.plannedDate ? new Date(dto.plannedDate) : null,
+      }),
+      ...(dto.releaseDate !== undefined && {
+        releaseDate: dto.releaseDate ? new Date(dto.releaseDate) : null,
+      }),
+    },
+    include: {
+      status: { select: { id: true, name: true, category: true, color: true } },
+      project: { select: { id: true, name: true, key: true } },
+    },
+  });
+}
+
+// ─── RM-03.4: DELETE /api/releases/:id ────────────────────────────────────────
+
+export async function deleteRelease(id: string): Promise<void> {
+  const release = await prisma.release.findUnique({
+    where: { id },
+    include: { status: true },
+  });
+  if (!release) throw new AppError(404, 'Release not found');
+
+  // Forbid delete if status category is DONE
+  if (release.status?.category === 'DONE') {
+    throw new AppError(422, 'Cannot delete a release in DONE status');
+  }
+
+  // Nullify Sprint.releaseId for sprints linked to this release
+  await prisma.sprint.updateMany({
+    where: { releaseId: id },
+    data: { releaseId: null },
+  });
+
+  // Delete the release (ReleaseItem cascade handled by Prisma onDelete: Cascade)
+  await prisma.release.delete({ where: { id } });
+}
+
+// ─── RM-03.5: ReleaseItem CRUD ────────────────────────────────────────────────
+
+export async function addReleaseItems(releaseId: string, dto: ReleaseItemsAddDto, addedById: string) {
+  const release = await prisma.release.findUnique({
+    where: { id: releaseId },
+    include: { status: true },
+  });
+  if (!release) throw new AppError(404, 'Release not found');
+
+  // Forbid for DONE / CANCELLED status categories
+  if (release.status?.category === 'DONE' || release.status?.category === 'CANCELLED') {
+    throw new AppError(422, 'Cannot add items to a release in DONE/CANCELLED status');
+  }
+
+  // Validate issues exist
+  const issues = await prisma.issue.findMany({
+    where: { id: { in: dto.issueIds } },
+    select: { id: true, projectId: true },
+  });
+  if (issues.length !== dto.issueIds.length) {
+    throw new AppError(404, 'One or more issues not found');
+  }
+
+  // ATOMIC: only issues from the same project
+  if (release.type === 'ATOMIC' && release.projectId) {
+    const wrongProject = issues.find((i) => i.projectId !== release.projectId);
+    if (wrongProject) {
+      throw new AppError(
+        422,
+        'ATOMIC release can only contain issues from its own project',
+      );
+    }
+  }
+
+  // Upsert each item (skip if already exists via createMany skipDuplicates)
+  await prisma.releaseItem.createMany({
+    data: dto.issueIds.map((issueId) => ({
+      releaseId,
+      issueId,
+      addedById,
+    })),
+    skipDuplicates: true,
+  });
+}
+
+export async function removeReleaseItems(releaseId: string, issueIds: string[]) {
+  const release = await prisma.release.findUnique({ where: { id: releaseId } });
+  if (!release) throw new AppError(404, 'Release not found');
+
+  await prisma.releaseItem.deleteMany({
+    where: { releaseId, issueId: { in: issueIds } },
+  });
+}
+
+export async function listReleaseItems(releaseId: string, query: ListReleaseItemsQueryDto) {
+  const release = await prisma.release.findUnique({ where: { id: releaseId } });
+  if (!release) throw new AppError(404, 'Release not found');
+
+  const { page, limit, projectId } = query;
+
+  const where: Prisma.ReleaseItemWhereInput = { releaseId };
+  if (projectId) where.issue = { projectId };
+
+  const [items, total] = await Promise.all([
+    prisma.releaseItem.findMany({
+      where,
+      include: {
+        issue: {
+          select: {
+            id: true,
+            number: true,
+            title: true,
+            status: true,
+            priority: true,
+            projectId: true,
+            project: { select: { id: true, name: true, key: true } },
+            assignee: { select: { id: true, name: true } },
+            issueTypeConfig: true,
+          },
+        },
+      },
+      orderBy: { addedAt: 'desc' },
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.releaseItem.count({ where }),
+  ]);
+
+  return { data: items, total, page, limit };
+}
+
+// ─── RM-03.7: GET /releases/:id/readiness — extended metrics ─────────────────
+
+export async function getReleaseReadiness(id: string) {
+  const release = await prisma.release.findUnique({ where: { id } });
+  if (!release) throw new AppError(404, 'Release not found');
+
+  const [
+    totalSprints,
+    closedSprints,
+    totalItems,
+    doneItems,
+    cancelledItems,
+    inProgressItems,
+  ] = await Promise.all([
+    prisma.sprint.count({ where: { releaseId: id } }),
+    prisma.sprint.count({ where: { releaseId: id, state: 'CLOSED' } }),
+    prisma.releaseItem.count({ where: { releaseId: id } }),
+    prisma.releaseItem.count({
+      where: {
+        releaseId: id,
+        issue: { workflowStatus: { category: 'DONE' } },
+      },
+    }),
+    // cancelledItems: issues in DONE category but not in doneItems approximation
+    // WorkflowStatus has no CANCELLED category — use status name heuristic
+    prisma.releaseItem.count({
+      where: {
+        releaseId: id,
+        issue: { workflowStatus: { name: { contains: 'cancel', mode: 'insensitive' } } },
+      },
+    }),
+    prisma.releaseItem.count({
+      where: {
+        releaseId: id,
+        issue: { workflowStatus: { category: 'IN_PROGRESS' } },
+      },
+    }),
+  ]);
+
+  const completionPercent =
+    totalItems > 0 ? Math.round(((doneItems + cancelledItems) / totalItems) * 100) : 0;
+
+  // byProject — breakdown for INTEGRATION releases
+  let byProject: Array<{ projectId: string; key: string; name: string; total: number; done: number }> = [];
+  if (release.type === 'INTEGRATION') {
+    const projectGroups = await prisma.releaseItem.groupBy({
+      by: ['releaseId'],
+      where: { releaseId: id },
+      _count: { issueId: true },
+    });
+    // Detailed breakdown via raw aggregation
+    const projectBreakdown = await prisma.$queryRaw<
+      Array<{ project_id: string; project_key: string; project_name: string; total: bigint; done: bigint }>
+    >`
+      SELECT
+        p.id as project_id,
+        p.key as project_key,
+        p.name as project_name,
+        COUNT(ri.id) as total,
+        COUNT(CASE WHEN ws.category = 'DONE' THEN 1 END) as done
+      FROM release_items ri
+      JOIN issues i ON i.id = ri.issue_id
+      JOIN projects p ON p.id = i.project_id
+      LEFT JOIN workflow_statuses ws ON ws.id = i.workflow_status_id
+      WHERE ri.release_id = ${id}
+      GROUP BY p.id, p.key, p.name
+    `;
+    byProject = projectBreakdown.map((row) => ({
+      projectId: row.project_id,
+      key: row.project_key,
+      name: row.project_name,
+      total: Number(row.total),
+      done: Number(row.done),
+    }));
+    // Suppress unused variable warning
+    void projectGroups;
+  }
+
+  return {
+    totalSprints,
+    closedSprints,
+    totalItems,
+    doneItems,
+    cancelledItems,
+    inProgressItems,
+    completionPercent,
+    byProject,
+  };
+}
+
+// ─── RM-03.8: POST /releases/:id/clone ────────────────────────────────────────
+
+export async function cloneRelease(id: string, dto: CloneReleaseDto, createdById: string) {
+  const source = await prisma.release.findUnique({
+    where: { id },
+    include: {
+      items: true,
+      sprints: { select: { id: true } },
+    },
+  });
+  if (!source) throw new AppError(404, 'Release not found');
+
+  const newType = dto.type ?? source.type;
+  const newProjectId =
+    dto.projectId !== undefined ? dto.projectId : source.projectId;
+
+  // Validate ATOMIC / INTEGRATION constraints
+  if (newType === 'ATOMIC' && !newProjectId) {
+    throw new AppError(422, 'projectId is required for ATOMIC release');
+  }
+  if (newType === 'INTEGRATION' && newProjectId) {
+    throw new AppError(422, 'projectId must be absent for INTEGRATION release');
+  }
+
+  // Auto-generate name if not provided
+  const newName = dto.name ?? `${source.name} (copy)`;
+
+  // Check name uniqueness
+  const existing = await prisma.release.findFirst({
+    where: {
+      name: newName,
+      ...(newType === 'ATOMIC' ? { projectId: newProjectId } : { projectId: null }),
+    },
+  });
+  if (existing) throw new AppError(409, `Release named "${newName}" already exists`);
+
+  // Resolve initial workflow status
+  let statusId: string | null = null;
+  let workflowId: string | null = source.workflowId;
+
+  try {
+    const workflow = await resolveWorkflowForRelease({
+      id: 'new',
+      workflowId,
+      type: newType,
+    });
+    workflowId = workflow.id;
+    const initialStep = workflow.steps.find((s) => s.isInitial);
+    if (initialStep) statusId = initialStep.statusId;
+  } catch {
+    // No workflow — continue without status
+  }
+
+  const cloned = await prisma.release.create({
+    data: {
+      type: newType,
+      projectId: newProjectId ?? null,
+      name: newName,
+      description: source.description,
+      level: source.level,
+      statusId,
+      workflowId,
+      createdById,
+    },
+    include: {
+      status: { select: { id: true, name: true, category: true, color: true } },
+      project: { select: { id: true, name: true, key: true } },
+    },
+  });
+
+  // Clone items if requested
+  if (dto.cloneItems && source.items.length > 0) {
+    await prisma.releaseItem.createMany({
+      data: source.items.map((item) => ({
+        releaseId: cloned.id,
+        issueId: item.issueId,
+        addedById: createdById,
+      })),
+      skipDuplicates: true,
+    });
+  }
+
+  // Clone sprints (re-assign) if requested
+  if (dto.cloneSprints && source.sprints.length > 0) {
+    await prisma.sprint.updateMany({
+      where: { id: { in: source.sprints.map((s) => s.id) } },
+      data: { releaseId: cloned.id },
+    });
+  }
+
+  // Audit log
+  await prisma.auditLog.create({
+    data: {
+      action: 'release.cloned',
+      entityType: 'release',
+      entityId: cloned.id,
+      userId: createdById,
+      details: {
+        sourceReleaseId: id,
+        sourceName: source.name,
+        cloneItems: dto.cloneItems,
+        cloneSprints: dto.cloneSprints,
+      } as Prisma.InputJsonValue,
+    },
+  });
+
+  return cloned;
+}
+
+// ─── Legacy helpers (kept for old project-scoped route) ───────────────────────
 
 export async function listReleases(projectId: string) {
   return prisma.release.findMany({
     where: { projectId },
     include: {
-      _count: { select: { issues: true, sprints: true } },
+      status: { select: { id: true, name: true, category: true, color: true } },
+      _count: { select: { items: true, sprints: true } },
       project: { select: { id: true, name: true, key: true } },
     },
     orderBy: [{ state: 'asc' }, { createdAt: 'desc' }],
@@ -17,21 +547,26 @@ export async function getReleaseWithIssues(id: string) {
   const release = await prisma.release.findUnique({
     where: { id },
     include: {
-      _count: { select: { issues: true, sprints: true } },
-      issues: {
-        select: {
-          id: true,
-          projectId: true,
-          number: true,
-          title: true,
-          issueTypeConfig: true,
-          status: true,
-          priority: true,
-          updatedAt: true,
-          assignee: { select: { id: true, name: true } },
-          project: { select: { id: true, name: true, key: true } },
+      status: { select: { id: true, name: true, category: true, color: true } },
+      _count: { select: { items: true, sprints: true } },
+      items: {
+        include: {
+          issue: {
+            select: {
+              id: true,
+              projectId: true,
+              number: true,
+              title: true,
+              issueTypeConfig: true,
+              status: true,
+              priority: true,
+              updatedAt: true,
+              assignee: { select: { id: true, name: true } },
+              project: { select: { id: true, name: true, key: true } },
+            },
+          },
         },
-        orderBy: [{ orderIndex: 'asc' }, { createdAt: 'desc' }],
+        orderBy: { addedAt: 'desc' },
       },
       sprints: {
         select: {
@@ -60,64 +595,16 @@ export async function getReleaseSprints(id: string) {
     where: { releaseId: id },
     include: {
       _count: { select: { issues: true } },
-      issues: {
-        select: { id: true, status: true },
-      },
+      issues: { select: { id: true, status: true } },
     },
     orderBy: { createdAt: 'asc' },
-  });
-}
-
-export async function createRelease(projectId: string, dto: CreateReleaseDto) {
-  const project = await prisma.project.findUnique({ where: { id: projectId } });
-  if (!project) throw new AppError(404, 'Project not found');
-
-  const existing = await prisma.release.findUnique({
-    where: { projectId_name: { projectId, name: dto.name } },
-  });
-  if (existing) throw new AppError(409, 'Release with this name already exists');
-
-  return prisma.release.create({
-    data: {
-      projectId,
-      name: dto.name,
-      description: dto.description,
-      level: dto.level,
-    },
-  });
-}
-
-export async function updateRelease(id: string, dto: UpdateReleaseDto) {
-  const release = await prisma.release.findUnique({ where: { id } });
-  if (!release) throw new AppError(404, 'Release not found');
-
-  if (dto.name !== undefined && dto.name !== release.name) {
-    const existing = await prisma.release.findUnique({
-      where: { projectId_name: { projectId: release.projectId!, name: dto.name } },
-    });
-    if (existing) throw new AppError(409, 'Release with this name already exists');
-  }
-
-  return prisma.release.update({
-    where: { id },
-    data: {
-      ...(dto.name !== undefined && { name: dto.name }),
-      ...(dto.description !== undefined && { description: dto.description }),
-      ...(dto.level !== undefined && { level: dto.level }),
-      ...(dto.state !== undefined && { state: dto.state }),
-      ...(dto.releaseDate !== undefined && {
-        releaseDate: dto.releaseDate ? new Date(dto.releaseDate) : null,
-      }),
-    },
   });
 }
 
 export async function addSprintsToRelease(releaseId: string, sprintIds: string[]) {
   const release = await prisma.release.findUnique({ where: { id: releaseId } });
   if (!release) throw new AppError(404, 'Release not found');
-  if (release.state === 'RELEASED') throw new AppError(400, 'Cannot modify a released release');
 
-  // Check sprints exist in same project and are not already in another release
   const sprints = await prisma.sprint.findMany({
     where: { id: { in: sprintIds } },
     select: { id: true, name: true, projectId: true, releaseId: true },
@@ -128,7 +615,7 @@ export async function addSprintsToRelease(releaseId: string, sprintIds: string[]
   }
 
   for (const sprint of sprints) {
-    if (sprint.projectId !== release.projectId) {
+    if (release.projectId && sprint.projectId !== release.projectId) {
       throw new AppError(400, `Sprint "${sprint.name}" belongs to a different project`);
     }
     if (sprint.releaseId && sprint.releaseId !== releaseId) {
@@ -145,7 +632,6 @@ export async function addSprintsToRelease(releaseId: string, sprintIds: string[]
 export async function removeSprintsFromRelease(releaseId: string, sprintIds: string[]) {
   const release = await prisma.release.findUnique({ where: { id: releaseId } });
   if (!release) throw new AppError(404, 'Release not found');
-  if (release.state === 'RELEASED') throw new AppError(400, 'Cannot modify a released release');
 
   await prisma.sprint.updateMany({
     where: { id: { in: sprintIds }, releaseId },
@@ -153,10 +639,10 @@ export async function removeSprintsFromRelease(releaseId: string, sprintIds: str
   });
 }
 
+// Legacy: kept for backward compat
 export async function addIssuesToRelease(releaseId: string, issueIds: string[]) {
   const release = await prisma.release.findUnique({ where: { id: releaseId } });
   if (!release) throw new AppError(404, 'Release not found');
-  if (release.state === 'RELEASED') throw new AppError(400, 'Cannot add issues to a released release');
 
   await prisma.issue.updateMany({
     where: { id: { in: issueIds }, ...(release.projectId ? { projectId: release.projectId } : {}) },
@@ -171,91 +657,11 @@ export async function removeIssuesFromRelease(releaseId: string, issueIds: strin
   });
 }
 
-export async function markReleaseReady(id: string) {
-  const release = await prisma.release.findUnique({ where: { id } });
-  if (!release) throw new AppError(404, 'Release not found');
-  if (release.state !== 'DRAFT') throw new AppError(400, 'Only DRAFT releases can be marked READY');
-
-  // Guard: must have at least one sprint with at least one issue
-  const sprintCount = await prisma.sprint.count({ where: { releaseId: id } });
-  if (sprintCount === 0) {
-    throw new AppError(400, 'Release must have at least one sprint before marking ready');
-  }
-
-  const issueInSprintCount = await prisma.issue.count({
-    where: { sprint: { releaseId: id } },
-  });
-  if (issueInSprintCount === 0) {
-    throw new AppError(400, 'Release sprints must contain at least one issue before marking ready');
-  }
-
-  return prisma.release.update({
-    where: { id },
-    data: { state: 'READY' },
-  });
+// Deprecated stubs — kept for legacy handlers
+export async function markReleaseReady(_id: string): Promise<never> {
+  throw new AppError(410, 'Deprecated');
 }
 
-export async function markReleaseReleased(id: string, releaseDate?: string) {
-  const release = await prisma.release.findUnique({ where: { id } });
-  if (!release) throw new AppError(404, 'Release not found');
-  if (release.state === 'RELEASED') throw new AppError(400, 'Release is already released');
-
-  // Guard: all sprints must be CLOSED
-  const openSprintCount = await prisma.sprint.count({
-    where: { releaseId: id, state: { not: 'CLOSED' } },
-  });
-  if (openSprintCount > 0) {
-    throw new AppError(
-      400,
-      `Cannot release: ${openSprintCount} sprint(s) are not closed yet`,
-    );
-  }
-
-  // Guard: all issues in release sprints must be DONE or CANCELLED
-  const openIssueCount = await prisma.issue.count({
-    where: {
-      sprint: { releaseId: id },
-      status: { notIn: ['DONE', 'CANCELLED'] },
-    },
-  });
-  if (openIssueCount > 0) {
-    throw new AppError(
-      400,
-      `Cannot release: ${openIssueCount} issue(s) in release sprints are not done`,
-    );
-  }
-
-  return prisma.release.update({
-    where: { id },
-    data: {
-      state: 'RELEASED',
-      releaseDate: releaseDate ? new Date(releaseDate) : new Date(),
-    },
-  });
-}
-
-export async function getReleaseReadiness(id: string) {
-  const release = await prisma.release.findUnique({ where: { id } });
-  if (!release) throw new AppError(404, 'Release not found');
-
-  const [totalSprints, closedSprints, totalIssues, doneIssues] = await Promise.all([
-    prisma.sprint.count({ where: { releaseId: id } }),
-    prisma.sprint.count({ where: { releaseId: id, state: 'CLOSED' } }),
-    prisma.issue.count({ where: { sprint: { releaseId: id } } }),
-    prisma.issue.count({
-      where: { sprint: { releaseId: id }, status: { in: ['DONE', 'CANCELLED'] } },
-    }),
-  ]);
-
-  const canMarkReady = totalSprints > 0 && totalIssues > 0;
-  const canRelease = totalSprints > 0 && totalSprints === closedSprints && totalIssues === doneIssues;
-
-  return {
-    totalSprints,
-    closedSprints,
-    totalIssues,
-    doneIssues,
-    canMarkReady,
-    canRelease,
-  };
+export async function markReleaseReleased(_id: string, _releaseDate?: string): Promise<never> {
+  throw new AppError(410, 'Deprecated');
 }

--- a/backend/src/modules/releases/releases.service.ts
+++ b/backend/src/modules/releases/releases.service.ts
@@ -52,9 +52,13 @@ export async function listReleasesGlobal(query: ListReleasesQueryDto) {
 
   const orderBy: Prisma.ReleaseOrderByWithRelationInput = { [sortBy]: sortDir };
 
-  const cacheKey = releasesListCacheKey(
-    Buffer.from(JSON.stringify({ where, orderBy, page, limit })).toString('base64').slice(0, 64),
-  );
+  // Use a deterministic hash to avoid prefix collisions from base64 truncation
+  const payload = JSON.stringify({ where, orderBy, page, limit });
+  let hash = 0;
+  for (let i = 0; i < payload.length; i++) {
+    hash = Math.imul(31, hash) + payload.charCodeAt(i) | 0;
+  }
+  const cacheKey = releasesListCacheKey((hash >>> 0).toString(36));
 
   const cached = await getCachedJson<{ data: unknown[]; total: number; page: number; limit: number }>(cacheKey);
   if (cached) return cached;
@@ -136,8 +140,11 @@ export async function createReleaseGlobal(dto: CreateReleaseDto, createdById: st
 
     const initialStep = workflow.steps.find((s) => s.isInitial);
     if (initialStep) statusId = initialStep.statusId;
-  } catch {
-    // No workflow configured — create without status
+  } catch (err) {
+    // Only swallow "no workflow configured" — propagate real DB / config errors
+    if (!(err instanceof AppError) || err.message !== 'NO_RELEASE_WORKFLOW_CONFIGURED') {
+      throw err;
+    }
   }
 
   const release = await prisma.release.create({
@@ -158,6 +165,7 @@ export async function createReleaseGlobal(dto: CreateReleaseDto, createdById: st
     },
   });
 
+  await invalidateReleasesListCache();
   return release;
 }
 
@@ -195,7 +203,7 @@ export async function updateRelease(id: string, dto: UpdateReleaseDto) {
     if (existing) throw new AppError(409, 'Release with this name already exists');
   }
 
-  return prisma.release.update({
+  const updated = await prisma.release.update({
     where: { id },
     data: {
       ...(dto.name !== undefined && { name: dto.name }),
@@ -213,6 +221,8 @@ export async function updateRelease(id: string, dto: UpdateReleaseDto) {
       project: { select: { id: true, name: true, key: true } },
     },
   });
+  await invalidateReleasesListCache();
+  return updated;
 }
 
 // ─── RM-03.4: DELETE /api/releases/:id ────────────────────────────────────────
@@ -229,14 +239,16 @@ export async function deleteRelease(id: string): Promise<void> {
     throw new AppError(422, 'Cannot delete a release in DONE status');
   }
 
-  // Nullify Sprint.releaseId for sprints linked to this release
-  await prisma.sprint.updateMany({
-    where: { releaseId: id },
-    data: { releaseId: null },
-  });
-
-  // Delete the release (ReleaseItem cascade handled by Prisma onDelete: Cascade)
-  await prisma.release.delete({ where: { id } });
+  // Atomic: nullify sprint refs and delete release together
+  await prisma.$transaction([
+    prisma.sprint.updateMany({
+      where: { releaseId: id },
+      data: { releaseId: null },
+    }),
+    // ReleaseItem rows cascade-deleted by onDelete: Cascade on the FK
+    prisma.release.delete({ where: { id } }),
+  ]);
+  await invalidateReleasesListCache();
 }
 
 // ─── RM-03.5: ReleaseItem CRUD ────────────────────────────────────────────────
@@ -297,10 +309,16 @@ export async function listReleaseItems(releaseId: string, query: ListReleaseItem
   const release = await prisma.release.findUnique({ where: { id: releaseId } });
   if (!release) throw new AppError(404, 'Release not found');
 
-  const { page, limit, projectId } = query;
+  const { page, limit, projectId, status } = query;
 
   const where: Prisma.ReleaseItemWhereInput = { releaseId };
-  if (projectId) where.issue = { projectId };
+  if (projectId && status) {
+    where.issue = { projectId, workflowStatus: { name: status } };
+  } else if (projectId) {
+    where.issue = { projectId };
+  } else if (status) {
+    where.issue = { workflowStatus: { name: status } };
+  }
 
   const [items, total] = await Promise.all([
     prisma.releaseItem.findMany({
@@ -469,63 +487,68 @@ export async function cloneRelease(id: string, dto: CloneReleaseDto, createdById
     workflowId = workflow.id;
     const initialStep = workflow.steps.find((s) => s.isInitial);
     if (initialStep) statusId = initialStep.statusId;
-  } catch {
-    // No workflow — continue without status
+  } catch (err) {
+    if (!(err instanceof AppError) || err.message !== 'NO_RELEASE_WORKFLOW_CONFIGURED') {
+      throw err;
+    }
   }
 
-  const cloned = await prisma.release.create({
-    data: {
-      type: newType,
-      projectId: newProjectId ?? null,
-      name: newName,
-      description: source.description,
-      level: source.level,
-      statusId,
-      workflowId,
-      createdById,
-    },
-    include: {
-      status: { select: { id: true, name: true, category: true, color: true } },
-      project: { select: { id: true, name: true, key: true } },
-    },
+  // Atomic: create clone, items, sprints reassignment and audit in one transaction
+  const [cloned] = await prisma.$transaction(async (tx) => {
+    const created = await tx.release.create({
+      data: {
+        type: newType,
+        projectId: newProjectId ?? null,
+        name: newName,
+        description: source.description,
+        level: source.level,
+        statusId,
+        workflowId,
+        createdById,
+      },
+      include: {
+        status: { select: { id: true, name: true, category: true, color: true } },
+        project: { select: { id: true, name: true, key: true } },
+      },
+    });
+
+    if (dto.cloneItems && source.items.length > 0) {
+      await tx.releaseItem.createMany({
+        data: source.items.map((item) => ({
+          releaseId: created.id,
+          issueId: item.issueId,
+          addedById: createdById,
+        })),
+        skipDuplicates: true,
+      });
+    }
+
+    if (dto.cloneSprints && source.sprints.length > 0) {
+      await tx.sprint.updateMany({
+        where: { id: { in: source.sprints.map((s) => s.id) } },
+        data: { releaseId: created.id },
+      });
+    }
+
+    await tx.auditLog.create({
+      data: {
+        action: 'release.cloned',
+        entityType: 'release',
+        entityId: created.id,
+        userId: createdById,
+        details: {
+          sourceReleaseId: id,
+          sourceName: source.name,
+          cloneItems: dto.cloneItems,
+          cloneSprints: dto.cloneSprints,
+        } as Prisma.InputJsonValue,
+      },
+    });
+
+    return [created];
   });
 
-  // Clone items if requested
-  if (dto.cloneItems && source.items.length > 0) {
-    await prisma.releaseItem.createMany({
-      data: source.items.map((item) => ({
-        releaseId: cloned.id,
-        issueId: item.issueId,
-        addedById: createdById,
-      })),
-      skipDuplicates: true,
-    });
-  }
-
-  // Clone sprints (re-assign) if requested
-  if (dto.cloneSprints && source.sprints.length > 0) {
-    await prisma.sprint.updateMany({
-      where: { id: { in: source.sprints.map((s) => s.id) } },
-      data: { releaseId: cloned.id },
-    });
-  }
-
-  // Audit log
-  await prisma.auditLog.create({
-    data: {
-      action: 'release.cloned',
-      entityType: 'release',
-      entityId: cloned.id,
-      userId: createdById,
-      details: {
-        sourceReleaseId: id,
-        sourceName: source.name,
-        cloneItems: dto.cloneItems,
-        cloneSprints: dto.cloneSprints,
-      } as Prisma.InputJsonValue,
-    },
-  });
-
+  await invalidateReleasesListCache();
   return cloned;
 }
 

--- a/backend/src/modules/releases/releases.service.ts
+++ b/backend/src/modules/releases/releases.service.ts
@@ -131,14 +131,25 @@ export async function createReleaseGlobal(dto: CreateReleaseDto, createdById: st
   let statusId: string | null = null;
   let workflowId: string | null = dto.workflowId ?? null;
 
+  const releaseType = dto.type ?? 'ATOMIC';
+
   try {
     const workflow = await resolveWorkflowForRelease({
       id: 'new',
       workflowId: workflowId,
-      type: dto.type ?? 'ATOMIC',
+      type: releaseType,
     });
-    workflowId = workflow.id;
 
+    // If the caller provided an explicit workflowId, verify it is compatible with
+    // the release type (a type-specific workflow must not be used for another type).
+    if (dto.workflowId && workflow.releaseType !== null && workflow.releaseType !== releaseType) {
+      throw new AppError(
+        422,
+        `WORKFLOW_INCOMPATIBLE_WITH_RELEASE_TYPE: workflow is restricted to ${workflow.releaseType} releases`,
+      );
+    }
+
+    workflowId = workflow.id;
     const initialStep = workflow.steps.find((s) => s.isInitial);
     if (initialStep) statusId = initialStep.statusId;
   } catch (err) {
@@ -150,7 +161,7 @@ export async function createReleaseGlobal(dto: CreateReleaseDto, createdById: st
 
   const release = await prisma.release.create({
     data: {
-      type: dto.type ?? 'ATOMIC',
+      type: releaseType,
       projectId: dto.projectId ?? null,
       name: dto.name,
       description: dto.description,
@@ -402,12 +413,19 @@ export async function getReleaseReadiness(id: string) {
         issue: { workflowStatus: { category: 'DONE' } },
       },
     }),
-    // cancelledItems: issues in DONE category but not in doneItems approximation
-    // WorkflowStatus has no CANCELLED category — use status name heuristic
+    // cancelledItems: issues whose workflow status name contains "cancel".
+    // WorkflowStatus has no CANCELLED category — use status name heuristic.
+    // Exclude items already counted as doneItems (category=DONE) to avoid
+    // double-counting statuses like "Cancelled" that may sit in DONE category.
     prisma.releaseItem.count({
       where: {
         releaseId: id,
-        issue: { workflowStatus: { name: { contains: 'cancel', mode: 'insensitive' } } },
+        issue: {
+          workflowStatus: {
+            name: { contains: 'cancel', mode: 'insensitive' },
+            category: { not: 'DONE' },
+          },
+        },
       },
     }),
     prisma.releaseItem.count({
@@ -424,12 +442,6 @@ export async function getReleaseReadiness(id: string) {
   // byProject — breakdown for INTEGRATION releases
   let byProject: Array<{ projectId: string; key: string; name: string; total: number; done: number }> = [];
   if (release.type === 'INTEGRATION') {
-    const projectGroups = await prisma.releaseItem.groupBy({
-      by: ['releaseId'],
-      where: { releaseId: id },
-      _count: { issueId: true },
-    });
-    // Detailed breakdown via raw aggregation
     const projectBreakdown = await prisma.$queryRaw<
       Array<{ project_id: string; project_key: string; project_name: string; total: bigint; done: bigint }>
     >`
@@ -453,8 +465,6 @@ export async function getReleaseReadiness(id: string) {
       total: Number(row.total),
       done: Number(row.done),
     }));
-    // Suppress unused variable warning
-    void projectGroups;
   }
 
   return {

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -45,7 +45,7 @@ export async function updateUser(id: string, dto: UpdateUserDto) {
 
 type RoleChangeActor = {
   userId: string;
-  role: 'SUPER_ADMIN' | 'ADMIN' | 'MANAGER' | 'USER' | 'VIEWER';
+  role: 'SUPER_ADMIN' | 'ADMIN' | 'MANAGER' | 'RELEASE_MANAGER' | 'USER' | 'VIEWER';
 };
 
 export async function changeRole(actor: RoleChangeActor, id: string, dto: ChangeRoleDto) {

--- a/backend/src/modules/workflow-engine/workflow-engine.router.ts
+++ b/backend/src/modules/workflow-engine/workflow-engine.router.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { authenticate } from '../../shared/middleware/auth.js';
 import { validate } from '../../shared/middleware/validate.js';
 import { ExecuteTransitionDto } from './workflow-engine.dto.js';
-import { getAvailableTransitions, executeTransition } from './workflow-engine.service.js';
+import { getAvailableTransitions, executeTransition, getBatchTransitions } from './workflow-engine.service.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 
 const router = Router();
@@ -35,6 +35,21 @@ router.post('/issues/:id/transitions', validate(ExecuteTransitionDto), async (re
       dto.screenFieldValues,
     );
     res.json(issue);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /api/issues/batch-transitions — get transitions for multiple issues at once
+router.post('/issues/batch-transitions', async (req: AuthRequest, res, next) => {
+  try {
+    const { issueIds } = req.body as { issueIds: string[] };
+    if (!Array.isArray(issueIds) || issueIds.length === 0) {
+      res.status(400).json({ error: 'issueIds must be a non-empty array' });
+      return;
+    }
+    const result = await getBatchTransitions(issueIds, req.user!.userId, req.user!.role);
+    res.json(result);
   } catch (err) {
     next(err);
   }

--- a/backend/src/modules/workflow-engine/workflow-engine.service.ts
+++ b/backend/src/modules/workflow-engine/workflow-engine.service.ts
@@ -372,3 +372,84 @@ export async function executeTransition(
 
   return updatedIssue;
 }
+
+// ─── Batch transitions ────────────────────────────────────────────────────────
+
+export interface BatchTransitionsItem {
+  issueId: string;
+  issueKey: string;
+  title: string;
+  currentStatus: { id: string; name: string; category: string; color: string } | null;
+  transitions: TransitionResponse[];
+}
+
+export async function getBatchTransitions(
+  issueIds: string[],
+  actorId: string,
+  actorRole: UserRole,
+): Promise<BatchTransitionsItem[]> {
+  const issues = await prisma.issue.findMany({
+    where: { id: { in: issueIds } },
+    include: {
+      workflowStatus: true,
+      project: { select: { key: true } },
+    },
+  });
+
+  const results: BatchTransitionsItem[] = [];
+
+  for (const issue of issues) {
+    const workflow = await resolveWorkflowForIssue(issue);
+
+    const candidates = workflow.transitions.filter(
+      (t) => t.isGlobal || t.fromStatusId === issue.workflowStatusId,
+    );
+
+    const available: TransitionResponse[] = [];
+
+    for (const t of candidates) {
+      try {
+        const conditionRules = t.conditions ? (t.conditions as unknown as ConditionRule[]) : [];
+        if (conditionRules.length > 0) {
+          const allowed = evaluateConditions(conditionRules, {
+            actorId,
+            actorRole,
+            issue: { assigneeId: issue.assigneeId, creatorId: issue.creatorId },
+          });
+          if (!allowed) continue;
+        }
+      } catch {
+        continue;
+      }
+
+      available.push({
+        id: t.id,
+        name: t.name,
+        toStatus: {
+          id: t.toStatus.id,
+          name: t.toStatus.name,
+          category: t.toStatus.category,
+          color: t.toStatus.color,
+        },
+        requiresScreen: !!t.screen,
+      });
+    }
+
+    results.push({
+      issueId: issue.id,
+      issueKey: `${issue.project.key}-${issue.number}`,
+      title: issue.title,
+      currentStatus: issue.workflowStatus
+        ? {
+            id: issue.workflowStatus.id,
+            name: issue.workflowStatus.name,
+            category: issue.workflowStatus.category,
+            color: issue.workflowStatus.color,
+          }
+        : null,
+      transitions: available,
+    });
+  }
+
+  return results;
+}

--- a/backend/src/prisma/migrations/20260411000000_release_management_models/migration.sql
+++ b/backend/src/prisma/migrations/20260411000000_release_management_models/migration.sql
@@ -1,0 +1,183 @@
+-- RM-01.1: Add new enums
+CREATE TYPE "ReleaseType" AS ENUM ('ATOMIC', 'INTEGRATION');
+CREATE TYPE "ReleaseStatusCategory" AS ENUM ('PLANNING', 'IN_PROGRESS', 'DONE', 'CANCELLED');
+
+-- RM-01.4: Add RELEASE_MANAGER to UserRole
+ALTER TYPE "UserRole" ADD VALUE IF NOT EXISTS 'RELEASE_MANAGER';
+
+-- RM-01.1: Create ReleaseStatus table
+CREATE TABLE "release_statuses" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "category" "ReleaseStatusCategory" NOT NULL,
+    "color" TEXT NOT NULL DEFAULT '#888888',
+    "description" TEXT,
+    "order_index" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "release_statuses_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "release_statuses_name_key" ON "release_statuses"("name");
+CREATE INDEX "release_statuses_category_idx" ON "release_statuses"("category");
+
+-- RM-01.1: Create ReleaseWorkflow table
+CREATE TABLE "release_workflows" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "release_type" "ReleaseType",
+    "is_default" BOOLEAN NOT NULL DEFAULT false,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "release_workflows_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "release_workflows_name_key" ON "release_workflows"("name");
+
+-- RM-01.1: Create ReleaseWorkflowStep table
+CREATE TABLE "release_workflow_steps" (
+    "id" TEXT NOT NULL,
+    "workflow_id" TEXT NOT NULL,
+    "status_id" TEXT NOT NULL,
+    "is_initial" BOOLEAN NOT NULL DEFAULT false,
+    "order_index" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "release_workflow_steps_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "release_workflow_steps_workflow_id_status_id_key" ON "release_workflow_steps"("workflow_id", "status_id");
+
+ALTER TABLE "release_workflow_steps" ADD CONSTRAINT "release_workflow_steps_workflow_id_fkey" FOREIGN KEY ("workflow_id") REFERENCES "release_workflows"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "release_workflow_steps" ADD CONSTRAINT "release_workflow_steps_status_id_fkey" FOREIGN KEY ("status_id") REFERENCES "release_statuses"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- RM-01.1: Create ReleaseWorkflowTransition table
+CREATE TABLE "release_workflow_transitions" (
+    "id" TEXT NOT NULL,
+    "workflow_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "from_status_id" TEXT NOT NULL,
+    "to_status_id" TEXT NOT NULL,
+    "conditions" JSONB,
+    "is_global" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "release_workflow_transitions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "release_workflow_transitions_workflow_id_idx" ON "release_workflow_transitions"("workflow_id");
+
+ALTER TABLE "release_workflow_transitions" ADD CONSTRAINT "release_workflow_transitions_workflow_id_fkey" FOREIGN KEY ("workflow_id") REFERENCES "release_workflows"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "release_workflow_transitions" ADD CONSTRAINT "release_workflow_transitions_from_status_id_fkey" FOREIGN KEY ("from_status_id") REFERENCES "release_statuses"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "release_workflow_transitions" ADD CONSTRAINT "release_workflow_transitions_to_status_id_fkey" FOREIGN KEY ("to_status_id") REFERENCES "release_statuses"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- RM-01.2: Create ReleaseItem table
+CREATE TABLE "release_items" (
+    "id" TEXT NOT NULL,
+    "release_id" TEXT NOT NULL,
+    "issue_id" TEXT NOT NULL,
+    "added_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "added_by_id" TEXT NOT NULL,
+
+    CONSTRAINT "release_items_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "release_items_release_id_issue_id_key" ON "release_items"("release_id", "issue_id");
+CREATE INDEX "release_items_release_id_idx" ON "release_items"("release_id");
+CREATE INDEX "release_items_issue_id_idx" ON "release_items"("issue_id");
+
+ALTER TABLE "release_items" ADD CONSTRAINT "release_items_release_id_fkey" FOREIGN KEY ("release_id") REFERENCES "releases"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "release_items" ADD CONSTRAINT "release_items_issue_id_fkey" FOREIGN KEY ("issue_id") REFERENCES "issues"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "release_items" ADD CONSTRAINT "release_items_added_by_id_fkey" FOREIGN KEY ("added_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- RM-01.3: Modify Release table
+-- Add new columns (nullable first for existing data)
+ALTER TABLE "releases" ADD COLUMN "type" "ReleaseType" NOT NULL DEFAULT 'ATOMIC';
+ALTER TABLE "releases" ADD COLUMN "status_id" TEXT;
+ALTER TABLE "releases" ADD COLUMN "workflow_id" TEXT;
+ALTER TABLE "releases" ADD COLUMN "planned_date" DATE;
+ALTER TABLE "releases" ADD COLUMN "created_by_id" TEXT;
+
+-- Make projectId nullable
+ALTER TABLE "releases" ALTER COLUMN "project_id" DROP NOT NULL;
+
+-- Add indexes
+CREATE INDEX "releases_status_id_idx" ON "releases"("status_id");
+CREATE INDEX "releases_type_idx" ON "releases"("type");
+CREATE INDEX "releases_workflow_id_idx" ON "releases"("workflow_id");
+
+-- Add foreign keys
+ALTER TABLE "releases" ADD CONSTRAINT "releases_status_id_fkey" FOREIGN KEY ("status_id") REFERENCES "release_statuses"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "releases" ADD CONSTRAINT "releases_workflow_id_fkey" FOREIGN KEY ("workflow_id") REFERENCES "release_workflows"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "releases" ADD CONSTRAINT "releases_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Drop old index on (projectId, state) since state is being deprecated
+DROP INDEX IF EXISTS "releases_project_id_state_idx";
+
+-- RM-01.5: Seed default release statuses
+INSERT INTO "release_statuses" ("id", "name", "category", "color", "description", "order_index", "updated_at") VALUES
+  ('rs-draft',    'Черновик',          'PLANNING',    '#8C8C8C', 'Начальный статус. Сбор задач в релиз.',                  0, NOW()),
+  ('rs-building', 'В сборке',          'IN_PROGRESS', '#1890FF', 'Идёт сборка и интеграция компонентов.',                  1, NOW()),
+  ('rs-testing',  'На тестировании',   'IN_PROGRESS', '#FA8C16', 'Релиз передан на QA/тестирование.',                      2, NOW()),
+  ('rs-ready',    'Готов к выпуску',    'IN_PROGRESS', '#52C41A', 'Тестирование пройдено, ожидает развёртывания.',           3, NOW()),
+  ('rs-released', 'Выпущен',           'DONE',        '#389E0D', 'Релиз развёрнут в production.',                           4, NOW()),
+  ('rs-cancelled','Отменён',           'CANCELLED',   '#FF4D4F', 'Релиз отменён.',                                         5, NOW())
+ON CONFLICT ("name") DO NOTHING;
+
+-- RM-01.5: Seed default release workflow
+INSERT INTO "release_workflows" ("id", "name", "description", "release_type", "is_default", "is_active", "updated_at") VALUES
+  ('rw-default', 'Стандартный релизный процесс', 'Дефолтный workflow: Черновик → В сборке → На тестировании → Готов к выпуску → Выпущен', NULL, true, true, NOW())
+ON CONFLICT ("name") DO NOTHING;
+
+-- RM-01.5: Seed workflow steps
+INSERT INTO "release_workflow_steps" ("id", "workflow_id", "status_id", "is_initial", "order_index") VALUES
+  ('rws-1', 'rw-default', 'rs-draft',     true,  0),
+  ('rws-2', 'rw-default', 'rs-building',  false, 1),
+  ('rws-3', 'rw-default', 'rs-testing',   false, 2),
+  ('rws-4', 'rw-default', 'rs-ready',     false, 3),
+  ('rws-5', 'rw-default', 'rs-released',  false, 4),
+  ('rws-6', 'rw-default', 'rs-cancelled', false, 5)
+ON CONFLICT ("workflow_id", "status_id") DO NOTHING;
+
+-- RM-01.5: Seed workflow transitions
+INSERT INTO "release_workflow_transitions" ("id", "workflow_id", "name", "from_status_id", "to_status_id", "conditions", "is_global") VALUES
+  ('rwt-1', 'rw-default', 'Начать сборку',                'rs-draft',    'rs-building',  NULL, false),
+  ('rwt-2', 'rw-default', 'Отправить на тестирование',    'rs-building', 'rs-testing',   NULL, false),
+  ('rwt-3', 'rw-default', 'Тесты пройдены',               'rs-testing',  'rs-ready',     NULL, false),
+  ('rwt-4', 'rw-default', 'Выпустить',                    'rs-ready',    'rs-released',  NULL, false),
+  ('rwt-5', 'rw-default', 'Экстренный выпуск',            'rs-building', 'rs-released',  NULL, false),
+  ('rwt-6', 'rw-default', 'Отменить',                     'rs-draft',    'rs-cancelled', NULL, true)
+ON CONFLICT DO NOTHING;
+
+-- RM-01.6: Migrate existing releases (state → statusId, set workflow and type)
+-- Map DRAFT → Черновик, READY → Готов к выпуску, RELEASED → Выпущен
+UPDATE "releases" SET
+  "status_id" = CASE "state"
+    WHEN 'DRAFT'    THEN 'rs-draft'
+    WHEN 'READY'    THEN 'rs-ready'
+    WHEN 'RELEASED' THEN 'rs-released'
+    ELSE 'rs-draft'
+  END,
+  "workflow_id" = 'rw-default',
+  "type" = 'ATOMIC'
+WHERE "status_id" IS NULL;
+
+-- RM-01.6: Set createdById to first admin user as fallback for existing releases
+UPDATE "releases" r SET "created_by_id" = (
+  SELECT u."id" FROM "users" u WHERE u."role" = 'ADMIN' ORDER BY u."created_at" ASC LIMIT 1
+)
+WHERE r."created_by_id" IS NULL;
+
+-- RM-01.6: Migrate Issue.releaseId → ReleaseItem
+INSERT INTO "release_items" ("id", "release_id", "issue_id", "added_at", "added_by_id")
+SELECT
+  gen_random_uuid()::text,
+  i."release_id",
+  i."id",
+  i."created_at",
+  COALESCE(i."assignee_id", i."creator_id")
+FROM "issues" i
+WHERE i."release_id" IS NOT NULL
+ON CONFLICT ("release_id", "issue_id") DO NOTHING;

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -33,6 +33,8 @@ model User {
   ownedProjects      Project[]               @relation("project_owner")
   projectRoles       UserProjectRole[]
   customFieldUpdates IssueCustomFieldValue[]
+  createdReleases    Release[]               @relation("releaseCreator")
+  addedReleaseItems  ReleaseItem[]           @relation("releaseItemAdder")
 
   @@map("users")
 }
@@ -41,6 +43,7 @@ enum UserRole {
   SUPER_ADMIN
   ADMIN
   MANAGER
+  RELEASE_MANAGER
   USER
   VIEWER
 }
@@ -233,6 +236,7 @@ model Issue {
   sourceLinks      IssueLink[]             @relation("linkSource")
   targetLinks      IssueLink[]             @relation("linkTarget")
   customFieldValues IssueCustomFieldValue[]
+  releaseItems     ReleaseItem[]
 
   @@unique([projectId, number])
   @@index([projectId, status])
@@ -320,25 +324,9 @@ enum SprintState {
 
 // ===== RELEASES =====
 
-model Release {
-  id          String       @id @default(uuid())
-  projectId   String       @map("project_id")
-  name        String       // e.g. "1.2.0", "2.0.0"
-  description String?      // optional release notes
-  level       ReleaseLevel @default(MINOR)
-  state       ReleaseState @default(DRAFT)
-  releaseDate DateTime?    @map("release_date") @db.Date
-  createdAt   DateTime     @default(now()) @map("created_at")
-  updatedAt   DateTime     @updatedAt @map("updated_at")
-
-  project Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  issues  Issue[]
-  sprints Sprint[]
-
-  @@unique([projectId, name], map: "releases_project_id_name_key")
-  @@index([projectId])
-  @@index([projectId, state])
-  @@map("releases")
+enum ReleaseType {
+  ATOMIC       // атомарный — одна система/проект
+  INTEGRATION  // интеграционный — кросс-проектный
 }
 
 enum ReleaseLevel {
@@ -346,10 +334,134 @@ enum ReleaseLevel {
   MAJOR   // новые фичи
 }
 
+// Deprecated: replaced by ReleaseStatus + ReleaseWorkflow. Kept for migration only.
 enum ReleaseState {
   DRAFT    // сбор задач
   READY    // готов к выпуску
   RELEASED // выпущен
+}
+
+enum ReleaseStatusCategory {
+  PLANNING      // сбор, планирование
+  IN_PROGRESS   // в работе (сборка, тестирование, стабилизация)
+  DONE          // выпущен, закрыт
+  CANCELLED     // отменён
+}
+
+model ReleaseStatus {
+  id          String                @id @default(uuid())
+  name        String                @unique
+  category    ReleaseStatusCategory
+  color       String                @default("#888888")
+  description String?
+  orderIndex  Int                   @default(0) @map("order_index")
+  createdAt   DateTime              @default(now()) @map("created_at")
+  updatedAt   DateTime              @updatedAt @map("updated_at")
+
+  releases        Release[]
+  workflowSteps   ReleaseWorkflowStep[]
+  transitionsFrom ReleaseWorkflowTransition[] @relation("FromReleaseStatus")
+  transitionsTo   ReleaseWorkflowTransition[] @relation("ToReleaseStatus")
+
+  @@index([category])
+  @@map("release_statuses")
+}
+
+model ReleaseWorkflow {
+  id          String       @id @default(uuid())
+  name        String       @unique
+  description String?
+  releaseType ReleaseType? @map("release_type") // null = для любого типа
+  isDefault   Boolean      @default(false) @map("is_default")
+  isActive    Boolean      @default(true) @map("is_active")
+  createdAt   DateTime     @default(now()) @map("created_at")
+  updatedAt   DateTime     @updatedAt @map("updated_at")
+
+  steps       ReleaseWorkflowStep[]
+  transitions ReleaseWorkflowTransition[]
+  releases    Release[]
+
+  @@map("release_workflows")
+}
+
+model ReleaseWorkflowStep {
+  id         String  @id @default(uuid())
+  workflowId String  @map("workflow_id")
+  statusId   String  @map("status_id")
+  isInitial  Boolean @default(false) @map("is_initial")
+  orderIndex Int     @default(0) @map("order_index")
+
+  workflow ReleaseWorkflow @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+  status   ReleaseStatus   @relation(fields: [statusId], references: [id])
+
+  @@unique([workflowId, statusId])
+  @@map("release_workflow_steps")
+}
+
+model ReleaseWorkflowTransition {
+  id           String  @id @default(uuid())
+  workflowId   String  @map("workflow_id")
+  name         String
+  fromStatusId String  @map("from_status_id")
+  toStatusId   String  @map("to_status_id")
+  conditions   Json?
+  isGlobal     Boolean @default(false) @map("is_global")
+
+  workflow   ReleaseWorkflow @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+  fromStatus ReleaseStatus   @relation("FromReleaseStatus", fields: [fromStatusId], references: [id])
+  toStatus   ReleaseStatus   @relation("ToReleaseStatus", fields: [toStatusId], references: [id])
+
+  @@index([workflowId])
+  @@map("release_workflow_transitions")
+}
+
+model ReleaseItem {
+  id        String   @id @default(uuid())
+  releaseId String   @map("release_id")
+  issueId   String   @map("issue_id")
+  addedAt   DateTime @default(now()) @map("added_at")
+  addedById String   @map("added_by_id")
+
+  release Release @relation(fields: [releaseId], references: [id], onDelete: Cascade)
+  issue   Issue   @relation(fields: [issueId], references: [id], onDelete: Cascade)
+  addedBy User    @relation("releaseItemAdder", fields: [addedById], references: [id])
+
+  @@unique([releaseId, issueId])
+  @@index([releaseId])
+  @@index([issueId])
+  @@map("release_items")
+}
+
+model Release {
+  id          String        @id @default(uuid())
+  type        ReleaseType   @default(ATOMIC)
+  projectId   String?       @map("project_id")         // nullable для INTEGRATION
+  name        String
+  description String?
+  level       ReleaseLevel  @default(MINOR)
+  state       ReleaseState  @default(DRAFT)             // deprecated, kept for migration
+  statusId    String?       @map("status_id")           // FK на ReleaseStatus
+  workflowId  String?       @map("workflow_id")         // FK на ReleaseWorkflow
+  releaseDate DateTime?     @map("release_date") @db.Date
+  plannedDate DateTime?     @map("planned_date") @db.Date
+  createdById String?       @map("created_by_id")       // автор релиза
+  createdAt   DateTime      @default(now()) @map("created_at")
+  updatedAt   DateTime      @updatedAt @map("updated_at")
+
+  project   Project?         @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  status    ReleaseStatus?   @relation(fields: [statusId], references: [id])
+  workflow  ReleaseWorkflow? @relation(fields: [workflowId], references: [id])
+  createdBy User?            @relation("releaseCreator", fields: [createdById], references: [id])
+  items     ReleaseItem[]
+  issues    Issue[]
+  sprints   Sprint[]
+
+  @@unique([projectId, name], map: "releases_project_id_name_key")
+  @@index([projectId])
+  @@index([statusId])
+  @@index([type])
+  @@index([workflowId])
+  @@map("releases")
 }
 
 // ===== COMMENTS =====

--- a/backend/src/prisma/seed-release-workflow.ts
+++ b/backend/src/prisma/seed-release-workflow.ts
@@ -1,0 +1,109 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('Seeding release workflow data...');
+
+  // 1. Release Statuses (idempotent upsert by unique name)
+  const statusDefs = [
+    { id: 'rs-draft',     name: 'Черновик',          category: 'PLANNING'    as const, color: '#8C8C8C', description: 'Начальный статус. Сбор задач в релиз.',                orderIndex: 0 },
+    { id: 'rs-building',  name: 'В сборке',          category: 'IN_PROGRESS' as const, color: '#1890FF', description: 'Идёт сборка и интеграция компонентов.',                orderIndex: 1 },
+    { id: 'rs-testing',   name: 'На тестировании',   category: 'IN_PROGRESS' as const, color: '#FA8C16', description: 'Релиз передан на QA/тестирование.',                    orderIndex: 2 },
+    { id: 'rs-ready',     name: 'Готов к выпуску',    category: 'IN_PROGRESS' as const, color: '#52C41A', description: 'Тестирование пройдено, ожидает развёртывания.',         orderIndex: 3 },
+    { id: 'rs-released',  name: 'Выпущен',           category: 'DONE'        as const, color: '#389E0D', description: 'Релиз развёрнут в production.',                         orderIndex: 4 },
+    { id: 'rs-cancelled', name: 'Отменён',           category: 'CANCELLED'   as const, color: '#FF4D4F', description: 'Релиз отменён.',                                       orderIndex: 5 },
+  ];
+
+  for (const def of statusDefs) {
+    const s = await prisma.releaseStatus.upsert({
+      where: { name: def.name },
+      update: {},
+      create: {
+        id: def.id,
+        name: def.name,
+        category: def.category,
+        color: def.color,
+        description: def.description,
+        orderIndex: def.orderIndex,
+      },
+    });
+    console.log(`  ReleaseStatus: ${def.name} (${s.id})`);
+  }
+
+  // 2. Default Release Workflow
+  const workflow = await prisma.releaseWorkflow.upsert({
+    where: { name: 'Стандартный релизный процесс' },
+    update: {},
+    create: {
+      id: 'rw-default',
+      name: 'Стандартный релизный процесс',
+      description: 'Дефолтный workflow: Черновик → В сборке → На тестировании → Готов к выпуску → Выпущен',
+      releaseType: null,
+      isDefault: true,
+      isActive: true,
+    },
+  });
+  console.log(`  ReleaseWorkflow: ${workflow.name} (${workflow.id})`);
+
+  // 3. Workflow Steps
+  const stepDefs = [
+    { statusId: 'rs-draft',     isInitial: true,  orderIndex: 0 },
+    { statusId: 'rs-building',  isInitial: false, orderIndex: 1 },
+    { statusId: 'rs-testing',   isInitial: false, orderIndex: 2 },
+    { statusId: 'rs-ready',     isInitial: false, orderIndex: 3 },
+    { statusId: 'rs-released',  isInitial: false, orderIndex: 4 },
+    { statusId: 'rs-cancelled', isInitial: false, orderIndex: 5 },
+  ];
+
+  for (const def of stepDefs) {
+    await prisma.releaseWorkflowStep.upsert({
+      where: { workflowId_statusId: { workflowId: workflow.id, statusId: def.statusId } },
+      update: {},
+      create: {
+        workflowId: workflow.id,
+        statusId: def.statusId,
+        isInitial: def.isInitial,
+        orderIndex: def.orderIndex,
+      },
+    });
+    console.log(`  Step: ${def.statusId} (initial=${def.isInitial})`);
+  }
+
+  // 4. Workflow Transitions
+  const transitionDefs = [
+    { id: 'rwt-1', name: 'Начать сборку',              fromStatusId: 'rs-draft',    toStatusId: 'rs-building',  isGlobal: false },
+    { id: 'rwt-2', name: 'Отправить на тестирование',  fromStatusId: 'rs-building', toStatusId: 'rs-testing',   isGlobal: false },
+    { id: 'rwt-3', name: 'Тесты пройдены',              fromStatusId: 'rs-testing',  toStatusId: 'rs-ready',     isGlobal: false },
+    { id: 'rwt-4', name: 'Выпустить',                  fromStatusId: 'rs-ready',    toStatusId: 'rs-released',  isGlobal: false },
+    { id: 'rwt-5', name: 'Экстренный выпуск',          fromStatusId: 'rs-building', toStatusId: 'rs-released',  isGlobal: false },
+    { id: 'rwt-6', name: 'Отменить',                   fromStatusId: 'rs-draft',    toStatusId: 'rs-cancelled', isGlobal: true  },
+  ];
+
+  for (const def of transitionDefs) {
+    await prisma.releaseWorkflowTransition.upsert({
+      where: { id: def.id },
+      update: {},
+      create: {
+        id: def.id,
+        workflowId: workflow.id,
+        name: def.name,
+        fromStatusId: def.fromStatusId,
+        toStatusId: def.toStatusId,
+        isGlobal: def.isGlobal,
+      },
+    });
+    console.log(`  Transition: ${def.name} (${def.fromStatusId} → ${def.toStatusId})`);
+  }
+
+  console.log('Release workflow seed completed.');
+}
+
+main()
+  .catch((e) => {
+    console.error('Seed failed:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/tests/releases-sprints.test.ts
+++ b/backend/tests/releases-sprints.test.ts
@@ -152,107 +152,25 @@ describe('POST /releases/:id/sprints/remove', () => {
 });
 
 // =============================================
-// markReleaseReady guards
+// Deprecated endpoints → 410 Gone
+// (markReleaseReady / markReleaseReleased replaced by workflow transitions)
 // =============================================
 
-describe('POST /releases/:id/ready — guards', () => {
-  it('400 if no sprints in release', async () => {
+describe('POST /releases/:id/ready — deprecated', () => {
+  it('returns 410 Gone', async () => {
     const res = await request.post(`/api/releases/${releaseId}/ready`)
       .set('Authorization', `Bearer ${adminToken}`);
-    expect(res.status).toBe(400);
-    expect(res.body.error).toMatch(/sprint/i);
-  });
-
-  it('400 if sprints are empty (no issues)', async () => {
-    await request.post(`/api/releases/${releaseId}/sprints`)
-      .set('Authorization', `Bearer ${adminToken}`)
-      .send({ sprintIds: [sprintId] });
-
-    const res = await request.post(`/api/releases/${releaseId}/ready`)
-      .set('Authorization', `Bearer ${adminToken}`);
-    expect(res.status).toBe(400);
-    expect(res.body.error).toMatch(/issue/i);
-  });
-
-  it('200 OK when sprint has issues', async () => {
-    // Add sprint and issue to it
-    await request.post(`/api/releases/${releaseId}/sprints`)
-      .set('Authorization', `Bearer ${adminToken}`)
-      .send({ sprintIds: [sprintId] });
-    await request.post(`/api/sprints/${sprintId}/issues`)
-      .set('Authorization', `Bearer ${adminToken}`)
-      .send({ issueIds: [issueId] });
-
-    const res = await request.post(`/api/releases/${releaseId}/ready`)
-      .set('Authorization', `Bearer ${adminToken}`);
-    expect(res.status).toBe(200);
-    expect(res.body.state).toBe('READY');
+    expect(res.status).toBe(410);
+    expect(res.body.error).toBe('Deprecated');
   });
 });
 
-// =============================================
-// markReleaseReleased guards
-// =============================================
-
-describe('POST /releases/:id/released — guards', () => {
-  it('400 if sprints are not CLOSED', async () => {
-    await request.post(`/api/releases/${releaseId}/sprints`)
-      .set('Authorization', `Bearer ${adminToken}`)
-      .send({ sprintIds: [sprintId] });
-    await request.post(`/api/sprints/${sprintId}/issues`)
-      .set('Authorization', `Bearer ${adminToken}`)
-      .send({ issueIds: [issueId] });
-    await request.post(`/api/releases/${releaseId}/ready`)
-      .set('Authorization', `Bearer ${adminToken}`);
-
-    // Sprint is PLANNED, not CLOSED
+describe('POST /releases/:id/released — deprecated', () => {
+  it('returns 410 Gone', async () => {
     const res = await request.post(`/api/releases/${releaseId}/released`)
       .set('Authorization', `Bearer ${adminToken}`);
-    expect(res.status).toBe(400);
-    expect(res.body.error).toMatch(/sprint/i);
-  });
-
-  it('400 if sprint is ACTIVE (not CLOSED)', async () => {
-    // NOTE: closeSprint moves incomplete issues to backlog, so it's impossible
-    // to have a CLOSED sprint with open issues. The guard for open issues is
-    // triggered when sprints are still ACTIVE/PLANNED.
-    await request.post(`/api/releases/${releaseId}/sprints`)
-      .set('Authorization', `Bearer ${adminToken}`)
-      .send({ sprintIds: [sprintId] });
-    await request.post(`/api/sprints/${sprintId}/issues`)
-      .set('Authorization', `Bearer ${adminToken}`)
-      .send({ issueIds: [issueId] });
-    await request.post(`/api/releases/${releaseId}/ready`)
-      .set('Authorization', `Bearer ${adminToken}`);
-    // Sprint is PLANNED (not yet CLOSED)
-    const res = await request.post(`/api/releases/${releaseId}/released`)
-      .set('Authorization', `Bearer ${adminToken}`);
-    expect(res.status).toBe(400);
-    expect(res.body.error).toMatch(/sprint/i);
-  });
-
-  it('200 OK when all sprints CLOSED and issues DONE', async () => {
-    await request.post(`/api/releases/${releaseId}/sprints`)
-      .set('Authorization', `Bearer ${adminToken}`)
-      .send({ sprintIds: [sprintId] });
-    await request.post(`/api/sprints/${sprintId}/issues`)
-      .set('Authorization', `Bearer ${adminToken}`)
-      .send({ issueIds: [issueId] });
-    await request.post(`/api/releases/${releaseId}/ready`)
-      .set('Authorization', `Bearer ${adminToken}`);
-    await request.post(`/api/sprints/${sprintId}/start`)
-      .set('Authorization', `Bearer ${adminToken}`);
-    await request.post(`/api/sprints/${sprintId}/close`)
-      .set('Authorization', `Bearer ${adminToken}`);
-    // Mark issue DONE
-    await request.patch(`/api/issues/${issueId}/status`)
-      .set('Authorization', `Bearer ${adminToken}`)
-      .send({ status: 'DONE' });
-
-    const res = await request.post(`/api/releases/${releaseId}/released`)
-      .set('Authorization', `Bearer ${adminToken}`);
-    expect(res.status).toBe(200);
-    expect(res.body.state).toBe('RELEASED');
+    expect(res.status).toBe(410);
+    expect(res.body.error).toBe('Deprecated');
   });
 });
 
@@ -268,27 +186,32 @@ describe('GET /releases/:id/readiness', () => {
     expect(res.body).toMatchObject({
       totalSprints: 0,
       closedSprints: 0,
-      totalIssues: 0,
-      doneIssues: 0,
-      canMarkReady: false,
-      canRelease: false,
+      totalItems: 0,
+      doneItems: 0,
+      completionPercent: 0,
     });
   });
 
-  it('reflects added sprint and issue', async () => {
+  it('reflects added sprint', async () => {
     await request.post(`/api/releases/${releaseId}/sprints`)
       .set('Authorization', `Bearer ${adminToken}`)
       .send({ sprintIds: [sprintId] });
-    await request.post(`/api/sprints/${sprintId}/issues`)
+
+    const res = await request.get(`/api/releases/${releaseId}/readiness`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.totalSprints).toBe(1);
+    expect(res.body.closedSprints).toBe(0);
+  });
+
+  it('reflects added release item', async () => {
+    await request.post(`/api/releases/${releaseId}/items`)
       .set('Authorization', `Bearer ${adminToken}`)
       .send({ issueIds: [issueId] });
 
     const res = await request.get(`/api/releases/${releaseId}/readiness`)
       .set('Authorization', `Bearer ${adminToken}`);
     expect(res.status).toBe(200);
-    expect(res.body.totalSprints).toBe(1);
-    expect(res.body.totalIssues).toBe(1);
-    expect(res.body.canMarkReady).toBe(true);
-    expect(res.body.canRelease).toBe(false);
+    expect(res.body.totalItems).toBe(1);
   });
 });

--- a/docs/plans/snapshot-TTMP-179.json
+++ b/docs/plans/snapshot-TTMP-179.json
@@ -1,0 +1,11 @@
+{
+  "TTMP-179": {
+    "id": "395e6780-14e5-4541-8fce-6de7d50024ba",
+    "number": 179,
+    "title": "[RM-06] Обновление ReleasesPage (frontend)",
+    "description": "## Цель\nАдаптация существующей ReleasesPage (/projects/:id/releases) под новую модель: workflow-статусы вместо DRAFT/READY/RELEASED, показ интеграционных релизов проекта.\n\n## Acceptance Criteria\n- Workflow-статусы с цветными бейджами вместо жёстких enum\n- Кнопки доступных переходов вместо markReady/markReleased\n- Показ интеграционных релизов, содержащих задачи проекта (read-only, ссылка на /releases)\n- Обратная совместимость с текущим UX\n- Dual-theme",
+    "status": "OPEN",
+    "aiExecutionStatus": "NOT_STARTED",
+    "projectKey": "TTMP"
+  }
+}

--- a/docs/plans/snapshot-TTMP-180.json
+++ b/docs/plans/snapshot-TTMP-180.json
@@ -1,0 +1,11 @@
+{
+  "TTMP-180": {
+    "id": "d64f5cec-ff93-4f4c-a1f0-2804111fb764",
+    "number": 180,
+    "title": "[RM-07] Визуальный редактор workflow релизов (frontend)",
+    "description": "## Цель\nВизуальный drag-n-drop редактор workflow релизов на @xyflow/react в админке. Узлы = статусы, рёбра = переходы. Панель свойств, валидация в реальном времени.\n\n## Acceptance Criteria\n- Интеграция @xyflow/react (React Flow)\n- Узлы = статусы (перетаскиваемые, с цветами по категории)\n- Рёбра = переходы (кликабельные, с названием)\n- Панель свойств при клике на переход (conditions, isGlobal)\n- Валидация графа в реальном времени (подсветка ошибок)\n- Привязка workflow к типу релиза (ATOMIC/INTEGRATION/универсальный)\n- Сохранение изменений через admin API\n- Dual-theme",
+    "status": "IN_PROGRESS",
+    "aiExecutionStatus": "NOT_STARTED",
+    "projectKey": "TTMP"
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ant-design/icons": "^5.6.1",
         "@hello-pangea/dnd": "^18.0.1",
+        "@xyflow/react": "^12.10.2",
         "antd": "^5.24.2",
         "axios": "^1.7.9",
         "react": "^18.3.1",
@@ -2268,6 +2269,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2918,6 +2968,66 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/acorn": {
@@ -3628,6 +3738,12 @@
         }
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -3754,6 +3870,111 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.6.1",
     "@hello-pangea/dnd": "^18.0.1",
+    "@xyflow/react": "^12.10.2",
     "antd": "^5.24.2",
     "axios": "^1.7.9",
     "react": "^18.3.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,8 @@ import AdminWorkflowSchemesPage from './pages/admin/AdminWorkflowSchemesPage';
 import AdminWorkflowSchemeEditorPage from './pages/admin/AdminWorkflowSchemeEditorPage';
 import AdminTransitionScreensPage from './pages/admin/AdminTransitionScreensPage';
 import AdminTransitionScreenEditorPage from './pages/admin/AdminTransitionScreenEditorPage';
+import AdminReleaseWorkflowsPage from './pages/admin/AdminReleaseWorkflowsPage';
+import AdminReleaseWorkflowEditorPage from './pages/admin/AdminReleaseWorkflowEditorPage';
 import AdminSystemPage from './pages/admin/AdminSystemPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 import SettingsPage from './pages/SettingsPage';
@@ -194,6 +196,8 @@ export default function App() {
             <Route path="admin/workflow-schemes/:id" element={<AdminWorkflowSchemeEditorPage />} />
             <Route path="admin/transition-screens" element={<AdminTransitionScreensPage />} />
             <Route path="admin/transition-screens/:id" element={<AdminTransitionScreenEditorPage />} />
+            <Route path="admin/release-workflows" element={<AdminReleaseWorkflowsPage />} />
+            <Route path="admin/release-workflows/:id" element={<AdminReleaseWorkflowEditorPage />} />
             <Route path="admin/system" element={<AdminSystemPage />} />
             <Route path="settings" element={<SettingsPage />} />
             <Route path="pipeline" element={<PipelineDashboardPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -197,7 +197,9 @@ export default function App() {
             <Route path="admin/system" element={<AdminSystemPage />} />
             <Route path="settings" element={<SettingsPage />} />
             <Route path="pipeline" element={<PipelineDashboardPage />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
           </Route>
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </BrowserRouter>
     </ConfigProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -203,7 +203,6 @@ export default function App() {
             <Route path="pipeline" element={<PipelineDashboardPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Route>
-          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </BrowserRouter>
     </ConfigProvider>

--- a/frontend/src/api/release-workflows-admin.ts
+++ b/frontend/src/api/release-workflows-admin.ts
@@ -1,0 +1,182 @@
+import api from './client';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ReleaseStatus {
+  id: string;
+  name: string;
+  category: 'PLANNING' | 'IN_PROGRESS' | 'DONE' | 'CANCELLED';
+  color: string;
+  description?: string | null;
+  orderIndex: number;
+}
+
+export interface ReleaseWorkflowStep {
+  id: string;
+  workflowId: string;
+  statusId: string;
+  isInitial: boolean;
+  orderIndex: number;
+  status: ReleaseStatus;
+}
+
+export interface ReleaseWorkflowTransition {
+  id: string;
+  workflowId: string;
+  name: string;
+  fromStatusId: string;
+  toStatusId: string;
+  isGlobal: boolean;
+  conditions: unknown[] | null;
+  fromStatus: ReleaseStatus;
+  toStatus: ReleaseStatus;
+}
+
+export interface ReleaseWorkflow {
+  id: string;
+  name: string;
+  description?: string | null;
+  releaseType: 'ATOMIC' | 'INTEGRATION' | null;
+  isDefault: boolean;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+  steps: ReleaseWorkflowStep[];
+  transitions: ReleaseWorkflowTransition[];
+  _count: { releases: number };
+}
+
+export interface ValidationReport {
+  isValid: boolean;
+  errors: Array<{ type: string; message: string }>;
+  warnings: Array<{ type: string; message: string; statusId?: string; statusName?: string }>;
+}
+
+// ─── Workflows CRUD ───────────────────────────────────────────────────────────
+
+export async function listReleaseWorkflows(): Promise<ReleaseWorkflow[]> {
+  const { data } = await api.get<ReleaseWorkflow[]>('/admin/release-workflows');
+  return data;
+}
+
+export async function getReleaseWorkflow(id: string): Promise<ReleaseWorkflow> {
+  const { data } = await api.get<ReleaseWorkflow>(`/admin/release-workflows/${id}`);
+  return data;
+}
+
+export async function createReleaseWorkflow(body: {
+  name: string;
+  description?: string;
+  releaseType?: 'ATOMIC' | 'INTEGRATION' | null;
+  isDefault?: boolean;
+  isActive?: boolean;
+}): Promise<ReleaseWorkflow> {
+  const { data } = await api.post<ReleaseWorkflow>('/admin/release-workflows', body);
+  return data;
+}
+
+export async function updateReleaseWorkflow(
+  id: string,
+  body: {
+    name?: string;
+    description?: string | null;
+    releaseType?: 'ATOMIC' | 'INTEGRATION' | null;
+    isDefault?: boolean;
+    isActive?: boolean;
+  },
+): Promise<ReleaseWorkflow> {
+  const { data } = await api.put<ReleaseWorkflow>(`/admin/release-workflows/${id}`, body);
+  return data;
+}
+
+export async function deleteReleaseWorkflow(id: string): Promise<void> {
+  await api.delete(`/admin/release-workflows/${id}`);
+}
+
+export async function validateReleaseWorkflow(id: string): Promise<ValidationReport> {
+  const { data } = await api.get<ValidationReport>(`/admin/release-workflows/${id}/validate`);
+  return data;
+}
+
+// ─── Steps ────────────────────────────────────────────────────────────────────
+
+export async function addReleaseWorkflowStep(
+  workflowId: string,
+  body: { statusId: string; isInitial?: boolean; orderIndex?: number },
+): Promise<ReleaseWorkflowStep> {
+  const { data } = await api.post<ReleaseWorkflowStep>(
+    `/admin/release-workflows/${workflowId}/steps`,
+    body,
+  );
+  return data;
+}
+
+export async function updateReleaseWorkflowStep(
+  workflowId: string,
+  stepId: string,
+  body: { isInitial?: boolean; orderIndex?: number },
+): Promise<ReleaseWorkflowStep> {
+  const { data } = await api.patch<ReleaseWorkflowStep>(
+    `/admin/release-workflows/${workflowId}/steps/${stepId}`,
+    body,
+  );
+  return data;
+}
+
+export async function deleteReleaseWorkflowStep(
+  workflowId: string,
+  stepId: string,
+): Promise<void> {
+  await api.delete(`/admin/release-workflows/${workflowId}/steps/${stepId}`);
+}
+
+// ─── Transitions ──────────────────────────────────────────────────────────────
+
+export async function createReleaseWorkflowTransition(
+  workflowId: string,
+  body: {
+    name: string;
+    fromStatusId: string;
+    toStatusId: string;
+    isGlobal?: boolean;
+    conditions?: unknown[] | null;
+  },
+): Promise<ReleaseWorkflowTransition> {
+  const { data } = await api.post<ReleaseWorkflowTransition>(
+    `/admin/release-workflows/${workflowId}/transitions`,
+    body,
+  );
+  return data;
+}
+
+export async function updateReleaseWorkflowTransition(
+  workflowId: string,
+  transitionId: string,
+  body: {
+    name?: string;
+    fromStatusId?: string;
+    toStatusId?: string;
+    isGlobal?: boolean;
+    conditions?: unknown[] | null;
+  },
+): Promise<ReleaseWorkflowTransition> {
+  const { data } = await api.put<ReleaseWorkflowTransition>(
+    `/admin/release-workflows/${workflowId}/transitions/${transitionId}`,
+    body,
+  );
+  return data;
+}
+
+export async function deleteReleaseWorkflowTransition(
+  workflowId: string,
+  transitionId: string,
+): Promise<void> {
+  await api.delete(`/admin/release-workflows/${workflowId}/transitions/${transitionId}`);
+}
+
+// ─── Release Statuses ─────────────────────────────────────────────────────────
+
+export async function listReleaseStatuses(): Promise<ReleaseStatus[]> {
+  const { data } = await api.get<ReleaseStatus[]>('/admin/release-statuses');
+  return data;
+}

--- a/frontend/src/api/releases.ts
+++ b/frontend/src/api/releases.ts
@@ -1,25 +1,100 @@
 import api from './client';
-import type { Release, Issue, SprintInRelease, ReleaseReadiness } from '../types';
+import type {
+  Release,
+  ReleaseItem,
+  SprintInRelease,
+  ReleaseReadiness,
+  ReleaseTransitionsResponse,
+  ReleaseAuditEntry,
+} from '../types';
+
+// ─── Global list ─────────────────────────────────────────────────────────────
+
+export interface ListReleasesQuery {
+  type?: 'ATOMIC' | 'INTEGRATION';
+  statusId?: string;
+  statusCategory?: string;
+  projectId?: string;
+  from?: string;
+  to?: string;
+  search?: string;
+  page?: number;
+  limit?: number;
+  sortBy?: string;
+  sortDir?: 'asc' | 'desc';
+}
+
+export async function listReleasesGlobal(
+  query?: ListReleasesQuery,
+): Promise<{ data: Release[]; total: number; page: number; limit: number }> {
+  const { data } = await api.get('/releases', { params: query });
+  return data;
+}
 
 export async function listReleases(projectId: string): Promise<Release[]> {
   const { data } = await api.get<Release[]>(`/projects/${projectId}/releases`);
   return data;
 }
 
-export async function getReleaseWithIssues(releaseId: string): Promise<Release & { issues: Issue[] }> {
-  const { data } = await api.get<Release & { issues: Issue[] }>(`/releases/${releaseId}/issues`);
+// ─── Single release ───────────────────────────────────────────────────────────
+
+export async function getRelease(releaseId: string): Promise<Release> {
+  const { data } = await api.get<Release>(`/releases/${releaseId}`);
   return data;
 }
+
+// ─── Release items (issues) ───────────────────────────────────────────────────
+
+export async function getReleaseItems(
+  releaseId: string,
+  params?: { page?: number; limit?: number; projectId?: string },
+): Promise<{ data: ReleaseItem[]; total: number; page: number; limit: number }> {
+  const { data } = await api.get(`/releases/${releaseId}/items`, { params });
+  return data;
+}
+
+export async function getReleaseWithIssues(releaseId: string): Promise<Release & { issues: unknown[] }> {
+  const { data } = await api.get<Release & { issues: unknown[] }>(`/releases/${releaseId}/issues`);
+  return data;
+}
+
+// ─── Sprints ──────────────────────────────────────────────────────────────────
 
 export async function getReleaseSprints(releaseId: string): Promise<SprintInRelease[]> {
   const { data } = await api.get<SprintInRelease[]>(`/releases/${releaseId}/sprints`);
   return data;
 }
 
+// ─── Readiness ────────────────────────────────────────────────────────────────
+
 export async function getReleaseReadiness(releaseId: string): Promise<ReleaseReadiness> {
   const { data } = await api.get<ReleaseReadiness>(`/releases/${releaseId}/readiness`);
   return data;
 }
+
+// ─── History ─────────────────────────────────────────────────────────────────
+
+export async function getReleaseHistory(releaseId: string): Promise<ReleaseAuditEntry[]> {
+  const { data } = await api.get<ReleaseAuditEntry[]>(`/releases/${releaseId}/history`);
+  return data;
+}
+
+// ─── Transitions ─────────────────────────────────────────────────────────────
+
+export async function getAvailableTransitions(releaseId: string): Promise<ReleaseTransitionsResponse> {
+  const { data } = await api.get<ReleaseTransitionsResponse>(`/releases/${releaseId}/transitions`);
+  return data;
+}
+
+export async function executeTransition(
+  releaseId: string,
+  transitionId: string,
+  comment?: string,
+): Promise<void> {
+  await api.post(`/releases/${releaseId}/transitions/${transitionId}`, { comment });
+}
+
+// ─── CRUD ─────────────────────────────────────────────────────────────────────
 
 export async function createRelease(
   projectId: string,
@@ -29,20 +104,53 @@ export async function createRelease(
   return data;
 }
 
+export interface CreateReleaseGlobalBody {
+  name: string;
+  description?: string;
+  level?: 'MINOR' | 'MAJOR';
+  type?: 'ATOMIC' | 'INTEGRATION';
+  projectId?: string;
+  workflowId?: string;
+  plannedDate?: string | null;
+}
+
+export async function createReleaseGlobal(body: CreateReleaseGlobalBody): Promise<Release> {
+  const { data } = await api.post<Release>('/releases', body);
+  return data;
+}
+
 export async function updateRelease(
   releaseId: string,
-  body: { name?: string; description?: string | null; level?: 'MINOR' | 'MAJOR'; state?: 'DRAFT' | 'READY' | 'RELEASED'; releaseDate?: string | null },
+  body: {
+    name?: string;
+    description?: string | null;
+    level?: 'MINOR' | 'MAJOR';
+    plannedDate?: string | null;
+    releaseDate?: string | null;
+  },
 ): Promise<Release> {
   const { data } = await api.patch<Release>(`/releases/${releaseId}`, body);
   return data;
 }
 
+// ─── Items management ─────────────────────────────────────────────────────────
+
+export async function addReleaseItems(releaseId: string, issueIds: string[]): Promise<void> {
+  await api.post(`/releases/${releaseId}/items`, { issueIds });
+}
+
+export async function removeReleaseItems(releaseId: string, issueIds: string[]): Promise<void> {
+  await api.post(`/releases/${releaseId}/items/remove`, { issueIds });
+}
+
+// ─── Legacy aliases ───────────────────────────────────────────────────────────
+
 export async function addIssuesToRelease(releaseId: string, issueIds: string[]): Promise<void> {
-  await api.post(`/releases/${releaseId}/issues`, { issueIds });
+  return addReleaseItems(releaseId, issueIds);
 }
 
 export async function removeIssuesFromRelease(releaseId: string, issueIds: string[]): Promise<void> {
-  await api.post(`/releases/${releaseId}/issues/remove`, { issueIds });
+  return removeReleaseItems(releaseId, issueIds);
 }
 
 export async function addSprintsToRelease(releaseId: string, sprintIds: string[]): Promise<void> {
@@ -52,6 +160,8 @@ export async function addSprintsToRelease(releaseId: string, sprintIds: string[]
 export async function removeSprintsFromRelease(releaseId: string, sprintIds: string[]): Promise<void> {
   await api.post(`/releases/${releaseId}/sprints/remove`, { sprintIds });
 }
+
+// ─── Deprecated (kept for backward compat) ────────────────────────────────────
 
 export async function markReleaseReady(releaseId: string): Promise<Release> {
   const { data } = await api.post<Release>(`/releases/${releaseId}/ready`);

--- a/frontend/src/api/workflow-engine.ts
+++ b/frontend/src/api/workflow-engine.ts
@@ -31,10 +31,21 @@ export interface AvailableTransitionsResponse {
   transitions: TransitionOption[];
 }
 
+export interface BatchTransitionsItem {
+  issueId: string;
+  issueKey: string;
+  title: string;
+  currentStatus: WorkflowStatus | null;
+  transitions: TransitionOption[];
+}
+
 export const workflowEngineApi = {
   getTransitions: (issueId: string) =>
     api.get<AvailableTransitionsResponse>(`/issues/${issueId}/transitions`).then(r => r.data),
 
   executeTransition: (issueId: string, data: { transitionId: string; screenFieldValues?: Record<string, unknown> }) =>
     api.post<{ id: string; status: string }>(`/issues/${issueId}/transitions`, data).then(r => r.data),
+
+  getBatchTransitions: (issueIds: string[]) =>
+    api.post<BatchTransitionsItem[]>('/issues/batch-transitions', { issueIds }).then(r => r.data),
 };

--- a/frontend/src/components/issues/BulkStatusWizardModal.tsx
+++ b/frontend/src/components/issues/BulkStatusWizardModal.tsx
@@ -1,0 +1,344 @@
+/**
+ * BulkStatusWizardModal — workflow-aware bulk status change wizard.
+ *
+ * Step 1: Fetches available transitions for all selected issues,
+ *         aggregates unique target statuses, shows how many issues
+ *         can transition to each.
+ * Step 2: Confirms the list of issues that will/won't change,
+ *         then executes transitions in parallel.
+ */
+import { useEffect, useState } from 'react';
+import { Modal, Spin, Button, Space, message } from 'antd';
+import { CheckCircleOutlined, CloseCircleOutlined } from '@ant-design/icons';
+import { workflowEngineApi, type BatchTransitionsItem, type WorkflowStatus } from '../../api/workflow-engine';
+import { useThemeStore } from '../../store/theme.store';
+
+// ─── Tokens ──────────────────────────────────────────────────────────────────
+
+const DARK_C = {
+  bg:         '#0F1320',
+  bgSection:  '#080B14',
+  border:     '#1E2640',
+  t1:         '#E2E8F8',
+  t2:         '#C9D1D9',
+  t3:         '#8B949E',
+  t4:         '#3D4D6B',
+  acc:        '#4F6EF7',
+  green:      '#4ADE80',
+  red:        '#F87171',
+  statusCard: '#131929',
+  statusCardHover: '#1A2540',
+  statusCardSelected: '#1E2F5A',
+  statusCardSelectedBorder: '#4F6EF7',
+};
+const LIGHT_C = {
+  bg:         '#FFFFFF',
+  bgSection:  '#F9FAFB',
+  border:     '#E5E7EB',
+  t1:         '#111827',
+  t2:         '#374151',
+  t3:         '#6B7280',
+  t4:         '#9CA3AF',
+  acc:        '#4F6EF7',
+  green:      '#16A34A',
+  red:        '#DC2626',
+  statusCard: '#F9FAFB',
+  statusCardHover: '#F3F4F6',
+  statusCardSelected: '#EEF2FF',
+  statusCardSelectedBorder: '#4F6EF7',
+};
+
+const F = { sans: '"Inter", system-ui, sans-serif' };
+
+// ─── Aggregated target status ─────────────────────────────────────────────────
+
+interface TargetStatus {
+  status: WorkflowStatus;
+  /** issues that CAN transition to this status and the transition id to use */
+  eligible: { item: BatchTransitionsItem; transitionId: string }[];
+  /** issues that CANNOT transition to this status from their current state */
+  ineligible: BatchTransitionsItem[];
+}
+
+function aggregateTargets(data: BatchTransitionsItem[]): TargetStatus[] {
+  const map = new Map<string, TargetStatus>();
+
+  for (const item of data) {
+    // Collect all reachable toStatuses for this issue
+    const seen = new Set<string>();
+    for (const t of item.transitions) {
+      if (seen.has(t.toStatus.id)) continue;
+      seen.add(t.toStatus.id);
+      if (!map.has(t.toStatus.id)) {
+        map.set(t.toStatus.id, { status: t.toStatus, eligible: [], ineligible: [] });
+      }
+      map.get(t.toStatus.id)!.eligible.push({ item, transitionId: t.id });
+    }
+  }
+
+  // Fill in ineligible for each target status
+  for (const [, target] of map) {
+    const eligibleIds = new Set(target.eligible.map(e => e.item.issueId));
+    for (const item of data) {
+      if (!eligibleIds.has(item.issueId)) {
+        target.ineligible.push(item);
+      }
+    }
+  }
+
+  return [...map.values()].sort((a, b) => a.status.name.localeCompare(b.status.name));
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  open: boolean;
+  issueIds: string[];
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export default function BulkStatusWizardModal({ open, issueIds, onSuccess, onCancel }: Props) {
+  const { mode } = useThemeStore();
+  const C = mode === 'light' ? LIGHT_C : DARK_C;
+
+  const [step, setStep] = useState<'pick' | 'confirm'>('pick');
+  const [loading, setLoading] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [targets, setTargets] = useState<TargetStatus[]>([]);
+  const [selected, setSelected] = useState<TargetStatus | null>(null);
+
+  // Reset when opened
+  useEffect(() => {
+    if (!open) return;
+    setStep('pick');
+    setSelected(null);
+    setTargets([]);
+    setLoading(true);
+    workflowEngineApi.getBatchTransitions(issueIds)
+      .then(items => {
+        setTargets(aggregateTargets(items));
+      })
+      .catch(() => message.error('Не удалось загрузить доступные переходы'))
+      .finally(() => setLoading(false));
+  }, [open, issueIds]);
+
+  const handlePickStatus = (target: TargetStatus) => {
+    setSelected(target);
+    setStep('confirm');
+  };
+
+  const handleApply = async () => {
+    if (!selected) return;
+    setApplying(true);
+    let successCount = 0;
+    let failCount = 0;
+    await Promise.allSettled(
+      selected.eligible.map(async ({ item, transitionId }) => {
+        try {
+          await workflowEngineApi.executeTransition(item.issueId, { transitionId });
+          successCount++;
+        } catch {
+          failCount++;
+        }
+      })
+    );
+    setApplying(false);
+    if (failCount === 0) {
+      message.success(`Статус изменён для ${successCount} задач`);
+    } else {
+      message.warning(`Изменено: ${successCount}, ошибок: ${failCount}`);
+    }
+    onSuccess();
+  };
+
+  // ─── Render helpers ─────────────────────────────────────────
+
+  const renderStatusDot = (color: string) => (
+    <span style={{ width: 8, height: 8, borderRadius: '50%', background: color, display: 'inline-block', flexShrink: 0 }} />
+  );
+
+  const renderStep1 = () => {
+    if (loading) return (
+      <div style={{ display: 'flex', justifyContent: 'center', padding: 40 }}>
+        <Spin />
+      </div>
+    );
+
+    if (targets.length === 0) return (
+      <div style={{ textAlign: 'center', padding: 32, color: C.t3, fontFamily: F.sans, fontSize: 13 }}>
+        Нет доступных переходов для выбранных задач
+      </div>
+    );
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <p style={{ fontFamily: F.sans, fontSize: 13, color: C.t3, margin: '0 0 12px' }}>
+          Выбрано задач: <strong style={{ color: C.t1 }}>{issueIds.length}</strong>.
+          Выберите целевой статус:
+        </p>
+        {targets.map(target => (
+          <button
+            key={target.status.id}
+            onClick={() => handlePickStatus(target)}
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              background: C.statusCard,
+              border: `1px solid ${C.border}`,
+              borderRadius: 8,
+              padding: '10px 14px',
+              cursor: target.eligible.length === 0 ? 'not-allowed' : 'pointer',
+              opacity: target.eligible.length === 0 ? 0.4 : 1,
+              textAlign: 'left',
+              width: '100%',
+              transition: 'background 0.15s',
+            }}
+            disabled={target.eligible.length === 0}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              {renderStatusDot(target.status.color)}
+              <span style={{ fontFamily: F.sans, fontSize: 13, fontWeight: 600, color: C.t1 }}>
+                {target.status.name}
+              </span>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+              <span style={{ fontFamily: F.sans, fontSize: 11, color: C.green }}>
+                {target.eligible.length} перейдут
+              </span>
+              {target.ineligible.length > 0 && (
+                <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t4 }}>
+                  {target.ineligible.length} пропустят
+                </span>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+    );
+  };
+
+  const renderStep2 = () => {
+    if (!selected) return null;
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+          <span style={{ fontFamily: F.sans, fontSize: 13, color: C.t3 }}>Целевой статус:</span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            {renderStatusDot(selected.status.color)}
+            <span style={{ fontFamily: F.sans, fontSize: 13, fontWeight: 600, color: C.t1 }}>
+              {selected.status.name}
+            </span>
+          </span>
+        </div>
+
+        {/* Eligible */}
+        {selected.eligible.length > 0 && (
+          <div>
+            <div style={{ fontFamily: F.sans, fontSize: 11, fontWeight: 600, color: C.green, marginBottom: 6, display: 'flex', alignItems: 'center', gap: 6 }}>
+              <CheckCircleOutlined />
+              Изменятся ({selected.eligible.length}):
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 200, overflowY: 'auto' }}>
+              {selected.eligible.map(({ item }) => (
+                <div key={item.issueId} style={{
+                  display: 'flex', alignItems: 'center', gap: 8,
+                  background: C.bgSection, borderRadius: 6, padding: '5px 10px',
+                }}>
+                  <span style={{ fontFamily: F.sans, fontSize: 11, fontWeight: 600, color: C.acc, flexShrink: 0 }}>
+                    {item.issueKey}
+                  </span>
+                  {item.currentStatus && (
+                    <>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                        {renderStatusDot(item.currentStatus.color)}
+                        <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t3 }}>{item.currentStatus.name}</span>
+                      </span>
+                      <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t4 }}>→</span>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                        {renderStatusDot(selected.status.color)}
+                        <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t1 }}>{selected.status.name}</span>
+                      </span>
+                    </>
+                  )}
+                  <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t2, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>
+                    {item.title}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Ineligible */}
+        {selected.ineligible.length > 0 && (
+          <div>
+            <div style={{ fontFamily: F.sans, fontSize: 11, fontWeight: 600, color: C.t4, marginBottom: 6, display: 'flex', alignItems: 'center', gap: 6 }}>
+              <CloseCircleOutlined />
+              Будут пропущены ({selected.ineligible.length}):
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 120, overflowY: 'auto' }}>
+              {selected.ineligible.map(item => (
+                <div key={item.issueId} style={{
+                  display: 'flex', alignItems: 'center', gap: 8, opacity: 0.5,
+                  background: C.bgSection, borderRadius: 6, padding: '5px 10px',
+                }}>
+                  <span style={{ fontFamily: F.sans, fontSize: 11, fontWeight: 600, color: C.acc, flexShrink: 0 }}>
+                    {item.issueKey}
+                  </span>
+                  {item.currentStatus && (
+                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                      {renderStatusDot(item.currentStatus.color)}
+                      <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t3 }}>{item.currentStatus.name}</span>
+                    </span>
+                  )}
+                  <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t2, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>
+                    {item.title}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // ─── Footer ──────────────────────────────────────────────────
+
+  const footer = step === 'pick' ? (
+    <Button onClick={onCancel} style={{ fontFamily: F.sans }}>Отмена</Button>
+  ) : (
+    <Space>
+      <Button onClick={() => setStep('pick')} style={{ fontFamily: F.sans }}>Назад</Button>
+      <Button onClick={onCancel} style={{ fontFamily: F.sans }}>Отмена</Button>
+      <Button
+        type="primary"
+        loading={applying}
+        disabled={!selected || selected.eligible.length === 0}
+        onClick={handleApply}
+        style={{ fontFamily: F.sans }}
+      >
+        Применить к {selected?.eligible.length ?? 0} задачам
+      </Button>
+    </Space>
+  );
+
+  return (
+    <Modal
+      open={open}
+      title={
+        <span style={{ fontFamily: F.sans, fontSize: 15, fontWeight: 600, color: C.t1 }}>
+          {step === 'pick' ? 'Изменить статус задач' : 'Подтверждение изменения статуса'}
+        </span>
+      }
+      onCancel={onCancel}
+      footer={footer}
+      width={560}
+      styles={{ body: { background: C.bg, padding: '20px 24px' }, header: { background: C.bg }, footer: { background: C.bg } }}
+    >
+      {step === 'pick' ? renderStep1() : renderStep2()}
+    </Modal>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -222,6 +222,9 @@ export default function Sidebar({
     { type: 'link', path: '/admin/workflow-schemes',     label: 'Схемы workflow' },
     { type: 'link', path: '/admin/transition-screens',   label: 'Экраны переходов' },
 
+    { type: 'divider', label: 'Релизы' },
+    { type: 'link', path: '/admin/release-workflows',    label: 'Workflow релизов' },
+
     ...(isSuperAdmin ? [
       { type: 'divider' as const, label: 'Администрирование' },
       { type: 'link' as const, path: '/admin/system', label: 'Система' },

--- a/frontend/src/pages/GlobalReleasesPage.tsx
+++ b/frontend/src/pages/GlobalReleasesPage.tsx
@@ -1,118 +1,1377 @@
-import { useEffect, useState } from 'react';
-import { Select, Tag, Typography } from 'antd';
-import { Link } from 'react-router-dom';
-import apiClient from '../api/client';
+/**
+ * GlobalReleasesPage — TTMP-178 [RM-05] GlobalReleasesPage (frontend)
+ * Artboards: 4EO-0 (Dark) + 4JG-0 (Light). Zero CSS classes, zero Ant Design layout.
+ */
+import { useEffect, useState, useCallback, useRef } from 'react';
+import type { AxiosError } from 'axios';
+import {
+  Modal,
+  Form,
+  Input,
+  Select,
+  DatePicker,
+  Radio,
+  Table,
+  Tooltip,
+  Progress,
+  message,
+  Spin,
+  Popconfirm,
+} from 'antd';
+import {
+  PlusOutlined,
+  CloseOutlined,
+  SearchOutlined,
+  ReloadOutlined,
+  DeleteOutlined,
+  CheckCircleOutlined,
+  ClockCircleOutlined,
+  MinusCircleOutlined,
+} from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import dayjs from 'dayjs';
 import * as releasesApi from '../api/releases';
-import type { Project, Release } from '../types';
+import * as projectsApi from '../api/projects';
+import * as issuesApi from '../api/issues';
+import * as sprintsApi from '../api/sprints';
+import { useAuthStore } from '../store/auth.store';
+import { useThemeStore } from '../store/theme.store';
+import type {
+  Release,
+  ReleaseItem,
+  SprintInRelease,
+  ReleaseReadiness,
+  ReleaseTransition,
+  ReleaseAuditEntry,
+} from '../types';
+import type { Project } from '../types/project.types';
+import type { Issue } from '../types/issue.types';
+import type { Sprint } from '../types/sprint.types';
 
-const STATE_LABEL: Record<string, string> = {
-  DRAFT: 'Черновик',
-  READY: 'Готов к выпуску',
-  RELEASED: 'Выпущен',
+// ─── Tokens Dark (Paper 4EO-0) ──────────────────────────────────────────────
+const DARK_C = {
+  bg:           '#080B14',
+  bgCard:       '#0F1320',
+  bgRow:        '#0F1320',
+  bgRowHover:   '#161B22',
+  border:       '#21262D',
+  borderBtn:    '#30363D',
+  t1:           '#E2E8F8',
+  t2:           '#C9D1D9',
+  t3:           '#8B949E',
+  t4:           '#484F58',
+  acc:          '#4F6EF7',
+  accHover:     '#6B83F5',
+  tabActiveBg:  '#4F6EF71A',
+  tabActiveText:'#4F6EF7',
+  tabText:      '#8B949E',
+  inputBg:      '#0D1117',
+  inputBorder:  '#30363D',
+  panelBg:      '#080B14',
+  panelBorder:  '#21262D',
 };
 
-const STATE_TONE: Record<string, string> = {
-  DRAFT: 'default',
-  READY: 'processing',
-  RELEASED: 'success',
+// ─── Tokens Light (Paper 4JG-0) ─────────────────────────────────────────────
+const LIGHT_C = {
+  bg:           '#F6F8FA',
+  bgCard:       '#FFFFFF',
+  bgRow:        '#FFFFFF',
+  bgRowHover:   '#F6F8FA',
+  border:       '#D0D7DE',
+  borderBtn:    '#D0D7DE',
+  t1:           '#1F2328',
+  t2:           '#1F2328',
+  t3:           '#656D76',
+  t4:           '#8C959F',
+  acc:          '#4F6EF7',
+  accHover:     '#3B57D4',
+  tabActiveBg:  '#4F6EF71A',
+  tabActiveText:'#4F6EF7',
+  tabText:      '#656D76',
+  inputBg:      '#FFFFFF',
+  inputBorder:  '#D0D7DE',
+  panelBg:      '#FFFFFF',
+  panelBorder:  '#D0D7DE',
 };
 
-interface ProjectRelease {
-  project: Project;
-  releases: Release[];
+const F = {
+  display: '"Space Grotesk", system-ui, sans-serif',
+  sans:    '"Inter", system-ui, sans-serif',
+};
+
+// ─── Release type / level / status helpers ───────────────────────────────────
+
+function typeBadge(type: string) {
+  const isInt = type === 'INTEGRATION';
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 4,
+      padding: '2px 8px', borderRadius: 4,
+      fontSize: 11, fontWeight: 600, fontFamily: F.display,
+      background: isInt ? '#7C3AED26' : '#1677FF1A',
+      color: isInt ? '#A78BFA' : '#4F6EF7',
+    }}>
+      {isInt ? 'INTEGRATION' : 'ATOMIC'}
+    </span>
+  );
 }
 
-export default function GlobalReleasesPage() {
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [data, setData] = useState<ProjectRelease[]>([]);
-  const [filter, setFilter] = useState<string>('ALL');
-  const [loading, setLoading] = useState(false);
+function levelBadge(level: string, isDark: boolean) {
+  const isMajor = level === 'MAJOR';
+  return (
+    <span style={{
+      display: 'inline-block', padding: '2px 7px', borderRadius: 4,
+      fontSize: 11, fontWeight: 600, fontFamily: F.display,
+      background: isMajor ? (isDark ? '#A88BFA26' : '#7C3AED1A') : (isDark ? '#8B949E26' : '#8C959F1A'),
+      color: isMajor ? (isDark ? '#A78BFA' : '#7C3AED') : (isDark ? '#8B949E' : '#57606A'),
+    }}>
+      {isMajor ? 'MAJOR' : 'MINOR'}
+    </span>
+  );
+}
 
-  useEffect(() => {
-    apiClient.get<Project[]>('/projects').then((r) => setProjects(r.data));
+function statusBadge(status: Release['status'] | null | undefined, C: typeof DARK_C) {
+  if (!status) return <span style={{ color: C.t4, fontSize: 12 }}>—</span>;
+  const cat = status.category;
+  const catColor = cat === 'DONE' ? '#4ADE80'
+    : cat === 'IN_PROGRESS' ? '#4F6EF7'
+    : cat === 'CANCELLED' ? '#F87171'
+    : '#8B949E';
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5,
+      padding: '2px 8px', borderRadius: 4,
+      fontSize: 12, fontWeight: 500, fontFamily: F.sans,
+      background: `${catColor}1F`,
+      color: catColor,
+    }}>
+      <span style={{
+        width: 6, height: 6, borderRadius: '50%',
+        background: status.color || catColor,
+        display: 'inline-block',
+      }} />
+      {status.name}
+    </span>
+  );
+}
+
+function formatDate(d?: string | null) {
+  if (!d) return '—';
+  return dayjs(d).format('DD.MM.YYYY');
+}
+
+function actionLabel(action: string): string {
+  const map: Record<string, string> = {
+    'release.created': 'Создан релиз',
+    'release.updated': 'Обновлён',
+    'release.deleted': 'Удалён',
+    'release.items_added': 'Добавлены задачи',
+    'release.items_removed': 'Удалены задачи',
+    'release.sprints_added': 'Добавлены спринты',
+    'release.sprints_removed': 'Удалены спринты',
+    'release.transition': 'Переход статуса',
+    'release.transition.executed': 'Переход статуса',
+  };
+  return map[action] || action;
+}
+
+// ─── Detail slide panel ───────────────────────────────────────────────────────
+
+type DetailTab = 'issues' | 'sprints' | 'readiness' | 'history';
+
+interface DetailPanelProps {
+  release: Release | null;
+  C: typeof DARK_C;
+  isDark: boolean;
+  canManage: boolean;
+  onClose: () => void;
+  onTransition: (releaseId: string, transitionId: string) => Promise<void>;
+  onReleasesRefresh: () => void;
+}
+
+function DetailPanel({ release, C, isDark, canManage, onClose, onTransition, onReleasesRefresh }: DetailPanelProps) {
+  const [tab, setTab] = useState<DetailTab>('issues');
+  const [items, setItems] = useState<ReleaseItem[]>([]);
+  const [itemsTotal, setItemsTotal] = useState(0);
+  const [itemsPage, setItemsPage] = useState(1);
+  const [sprints, setSprints] = useState<SprintInRelease[]>([]);
+  const [readiness, setReadiness] = useState<ReleaseReadiness | null>(null);
+  const [history, setHistory] = useState<ReleaseAuditEntry[]>([]);
+  const [transitions, setTransitions] = useState<ReleaseTransition[]>([]);
+  const [currentStatus, setCurrentStatus] = useState<Release['status'] | null>(null);
+  const [loadingItems, setLoadingItems] = useState(false);
+  const [loadingSprints, setLoadingSprints] = useState(false);
+  const [loadingReadiness, setLoadingReadiness] = useState(false);
+  const [loadingHistory, setLoadingHistory] = useState(false);
+  const [loadingTransitions, setLoadingTransitions] = useState(false);
+  const [transitioning, setTransitioning] = useState<string | null>(null);
+  const [addIssuesOpen, setAddIssuesOpen] = useState(false);
+  const [addSprintsOpen, setAddSprintsOpen] = useState(false);
+  const [allIssues, setAllIssues] = useState<Issue[]>([]);
+  const [allSprints, setAllSprints] = useState<Sprint[]>([]);
+  const [selectedIssueIds, setSelectedIssueIds] = useState<string[]>([]);
+  const [selectedSprintIds, setSelectedSprintIds] = useState<string[]>([]);
+  const [issueSearch, setIssueSearch] = useState('');
+
+  const loadItems = useCallback(async (id: string, page = 1) => {
+    setLoadingItems(true);
+    try {
+      const r = await releasesApi.getReleaseItems(id, { page, limit: 20 });
+      setItems(r.data);
+      setItemsTotal(r.total);
+      setItemsPage(page);
+    } finally {
+      setLoadingItems(false);
+    }
+  }, []);
+
+  const loadSprints = useCallback(async (id: string) => {
+    setLoadingSprints(true);
+    try {
+      setSprints(await releasesApi.getReleaseSprints(id));
+    } finally {
+      setLoadingSprints(false);
+    }
+  }, []);
+
+  const loadReadiness = useCallback(async (id: string) => {
+    setLoadingReadiness(true);
+    try {
+      setReadiness(await releasesApi.getReleaseReadiness(id));
+    } finally {
+      setLoadingReadiness(false);
+    }
+  }, []);
+
+  const loadHistory = useCallback(async (id: string) => {
+    setLoadingHistory(true);
+    try {
+      setHistory(await releasesApi.getReleaseHistory(id));
+    } finally {
+      setLoadingHistory(false);
+    }
+  }, []);
+
+  const loadTransitions = useCallback(async (id: string) => {
+    setLoadingTransitions(true);
+    try {
+      const r = await releasesApi.getAvailableTransitions(id);
+      setTransitions(r.transitions);
+      setCurrentStatus(r.currentStatus);
+    } catch {
+      setTransitions([]);
+    } finally {
+      setLoadingTransitions(false);
+    }
   }, []);
 
   useEffect(() => {
-    if (!projects.length) return;
-    setLoading(true);
-    Promise.all(
-      projects.map((p) =>
-        releasesApi.listReleases(p.id)
-          .then((releases) => ({ project: p, releases }))
-          .catch(() => ({ project: p, releases: [] as Release[] })),
-      ),
-    )
-      .then((results) => setData(results.filter((r) => r.releases.length > 0)))
-      .finally(() => setLoading(false));
-  }, [projects]);
+    if (!release) return;
+    setTab('issues');
+    setItems([]); setSprints([]); setReadiness(null); setHistory([]);
+    loadItems(release.id);
+    loadTransitions(release.id);
+  }, [release?.id]);
 
-  const filtered = data.map((pr) => ({
-    ...pr,
-    releases: filter === 'ALL' ? pr.releases : pr.releases.filter((r) => r.state === filter),
-  })).filter((pr) => pr.releases.length > 0);
+  useEffect(() => {
+    if (!release) return;
+    if (tab === 'sprints') loadSprints(release.id);
+    if (tab === 'readiness') loadReadiness(release.id);
+    if (tab === 'history') loadHistory(release.id);
+  }, [tab, release?.id]);
+
+  const handleTransition = async (transitionId: string) => {
+    if (!release) return;
+    setTransitioning(transitionId);
+    try {
+      await onTransition(release.id, transitionId);
+      await loadTransitions(release.id);
+      onReleasesRefresh();
+    } finally {
+      setTransitioning(null);
+    }
+  };
+
+  const handleAddIssues = async () => {
+    if (!release || selectedIssueIds.length === 0) return;
+    try {
+      await releasesApi.addReleaseItems(release.id, selectedIssueIds);
+      message.success('Задачи добавлены');
+      setAddIssuesOpen(false);
+      setSelectedIssueIds([]);
+      loadItems(release.id);
+    } catch (e) {
+      const err = e as AxiosError<{ error?: string }>;
+      message.error(err.response?.data?.error || 'Ошибка');
+    }
+  };
+
+  const handleRemoveIssue = async (issueId: string) => {
+    if (!release) return;
+    try {
+      await releasesApi.removeReleaseItems(release.id, [issueId]);
+      message.success('Задача удалена из релиза');
+      loadItems(release.id);
+    } catch {
+      message.error('Ошибка');
+    }
+  };
+
+  const handleAddSprints = async () => {
+    if (!release || selectedSprintIds.length === 0) return;
+    try {
+      await releasesApi.addSprintsToRelease(release.id, selectedSprintIds);
+      message.success('Спринты добавлены');
+      setAddSprintsOpen(false);
+      setSelectedSprintIds([]);
+      loadSprints(release.id);
+    } catch (e) {
+      const err = e as AxiosError<{ error?: string }>;
+      message.error(err.response?.data?.error || 'Ошибка');
+    }
+  };
+
+  const handleRemoveSprint = async (sprintId: string) => {
+    if (!release) return;
+    try {
+      await releasesApi.removeSprintsFromRelease(release.id, [sprintId]);
+      message.success('Спринт удалён из релиза');
+      loadSprints(release.id);
+    } catch {
+      message.error('Ошибка');
+    }
+  };
+
+  const openAddIssues = async () => {
+    if (!release?.projectId) return;
+    const issues = await issuesApi.listIssues(release.projectId);
+    setAllIssues(issues);
+    setAddIssuesOpen(true);
+  };
+
+  const openAddSprints = async () => {
+    if (!release?.projectId) return;
+    const res = await sprintsApi.listSprints(release.projectId);
+    setAllSprints(res.data);
+    setAddSprintsOpen(true);
+  };
+
+  const filteredIssues = issueSearch
+    ? allIssues.filter(i => i.title.toLowerCase().includes(issueSearch.toLowerCase()) || String(i.number).includes(issueSearch))
+    : allIssues;
+
+  if (!release) return null;
+
+  const TABS: { key: DetailTab; label: string }[] = [
+    { key: 'issues', label: 'Задачи' },
+    { key: 'sprints', label: 'Спринты' },
+    { key: 'readiness', label: 'Готовность' },
+    { key: 'history', label: 'История' },
+  ];
 
   return (
-    <div className="tt-page">
-      <div className="tt-page-header">
-        <div>
-          <h1 className="tt-page-title">Релизы</h1>
-          <p className="tt-page-subtitle">Все релизы по всем проектам</p>
+    <div style={{
+      position: 'fixed', right: 0, top: 0, bottom: 0, zIndex: 1000,
+      width: 720,
+      background: C.panelBg,
+      borderLeft: `1px solid ${C.panelBorder}`,
+      display: 'flex', flexDirection: 'column',
+      boxShadow: isDark ? '-8px 0 32px rgba(0,0,0,0.6)' : '-4px 0 20px rgba(0,0,0,0.12)',
+      fontFamily: F.sans,
+    }}>
+      {/* Panel header */}
+      <div style={{
+        padding: '16px 20px 0',
+        borderBottom: `1px solid ${C.border}`,
+        flexShrink: 0,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginBottom: 12 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6, flexWrap: 'wrap' }}>
+              {typeBadge(release.type)}
+              {levelBadge(release.level, isDark)}
+              {statusBadge(currentStatus ?? release.status, C)}
+            </div>
+            <h2 style={{
+              margin: 0, color: C.t1, fontSize: 17, fontWeight: 700,
+              fontFamily: F.display, lineHeight: 1.3,
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>{release.name}</h2>
+            {release.description && (
+              <p style={{ margin: '4px 0 0', color: C.t3, fontSize: 12, lineHeight: 1.5 }}>
+                {release.description}
+              </p>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              border: 'none', background: 'transparent', cursor: 'pointer',
+              color: C.t3, padding: 4, lineHeight: 1, flexShrink: 0,
+            }}
+          >
+            <CloseOutlined style={{ fontSize: 16 }} />
+          </button>
+        </div>
+
+        {/* Transition buttons */}
+        {canManage && (
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 12 }}>
+            {loadingTransitions ? (
+              <Spin size="small" />
+            ) : transitions.map(t => {
+              const tColor = t.toStatus.color || C.acc;
+              return (
+                <Popconfirm
+                  key={t.id}
+                  title={`Перейти в статус «${t.toStatus.name}»?`}
+                  onConfirm={() => handleTransition(t.id)}
+                  okText="Да"
+                  cancelText="Отмена"
+                >
+                  <button
+                    disabled={transitioning === t.id}
+                    style={{
+                      border: `1px solid ${tColor}60`,
+                      background: `${tColor}15`,
+                      color: tColor,
+                      borderRadius: 6,
+                      padding: '4px 12px',
+                      fontSize: 12,
+                      fontWeight: 600,
+                      fontFamily: F.display,
+                      cursor: 'pointer',
+                      opacity: transitioning === t.id ? 0.6 : 1,
+                    }}
+                  >
+                    → {t.toStatus.name}
+                  </button>
+                </Popconfirm>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Tabs */}
+        <div style={{ display: 'flex', gap: 0 }}>
+          {TABS.map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() => setTab(key)}
+              style={{
+                border: 'none',
+                borderBottom: tab === key ? `2px solid ${C.acc}` : '2px solid transparent',
+                background: 'transparent',
+                color: tab === key ? C.tabActiveText : C.tabText,
+                padding: '8px 16px',
+                fontSize: 13,
+                fontWeight: tab === key ? 600 : 400,
+                fontFamily: F.sans,
+                cursor: 'pointer',
+                marginBottom: -1,
+              }}
+            >
+              {label}
+            </button>
+          ))}
         </div>
       </div>
 
-      <div className="tt-filters-row" style={{ marginBottom: 16 }}>
+      {/* Panel body */}
+      <div style={{ flex: 1, overflow: 'auto', padding: 20 }}>
+
+        {/* ── Issues tab ─────────────────────────────── */}
+        {tab === 'issues' && (
+          <div>
+            {canManage && release.type === 'ATOMIC' && release.projectId && (
+              <div style={{ marginBottom: 12 }}>
+                <button
+                  onClick={openAddIssues}
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 6,
+                    border: `1px solid ${C.borderBtn}`,
+                    background: 'transparent', color: C.t2,
+                    borderRadius: 6, padding: '5px 12px',
+                    fontSize: 12, fontFamily: F.sans, cursor: 'pointer',
+                  }}
+                >
+                  <PlusOutlined /> Добавить задачи
+                </button>
+              </div>
+            )}
+            {loadingItems ? (
+              <div style={{ textAlign: 'center', padding: 40 }}><Spin /></div>
+            ) : items.length === 0 ? (
+              <div style={{ color: C.t3, fontSize: 13, textAlign: 'center', padding: 40 }}>
+                Задачи не добавлены
+              </div>
+            ) : (
+              <>
+                {/* Group by project for INTEGRATION */}
+                {release.type === 'INTEGRATION' ? (
+                  (() => {
+                    const byProject: Record<string, { key: string; name: string; items: ReleaseItem[] }> = {};
+                    for (const item of items) {
+                      const pid = item.issue.projectId;
+                      if (!byProject[pid]) byProject[pid] = { key: item.issue.project.key, name: item.issue.project.name, items: [] };
+                      byProject[pid].items.push(item);
+                    }
+                    return Object.values(byProject).map(group => (
+                      <div key={group.key} style={{ marginBottom: 16 }}>
+                        <div style={{
+                          fontSize: 11, fontWeight: 700, color: C.t3,
+                          fontFamily: F.display, marginBottom: 6, letterSpacing: '0.06em',
+                          textTransform: 'uppercase',
+                        }}>
+                          {group.key} · {group.name}
+                        </div>
+                        <IssueTable items={group.items} C={C} isDark={isDark} canManage={canManage} onRemove={handleRemoveIssue} />
+                      </div>
+                    ));
+                  })()
+                ) : (
+                  <IssueTable items={items} C={C} isDark={isDark} canManage={canManage} onRemove={handleRemoveIssue} />
+                )}
+                {itemsTotal > 20 && (
+                  <div style={{ marginTop: 12, textAlign: 'center' }}>
+                    <button
+                      onClick={() => release && loadItems(release.id, itemsPage + 1)}
+                      style={{
+                        border: `1px solid ${C.borderBtn}`, background: 'transparent',
+                        color: C.t2, borderRadius: 6, padding: '5px 16px',
+                        fontSize: 12, fontFamily: F.sans, cursor: 'pointer',
+                      }}
+                    >
+                      Загрузить ещё
+                    </button>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        )}
+
+        {/* ── Sprints tab ─────────────────────────────── */}
+        {tab === 'sprints' && (
+          <div>
+            {canManage && release.type === 'ATOMIC' && release.projectId && (
+              <div style={{ marginBottom: 12 }}>
+                <button
+                  onClick={openAddSprints}
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 6,
+                    border: `1px solid ${C.borderBtn}`,
+                    background: 'transparent', color: C.t2,
+                    borderRadius: 6, padding: '5px 12px',
+                    fontSize: 12, fontFamily: F.sans, cursor: 'pointer',
+                  }}
+                >
+                  <PlusOutlined /> Добавить спринт
+                </button>
+              </div>
+            )}
+            {loadingSprints ? (
+              <div style={{ textAlign: 'center', padding: 40 }}><Spin /></div>
+            ) : sprints.length === 0 ? (
+              <div style={{ color: C.t3, fontSize: 13, textAlign: 'center', padding: 40 }}>
+                Спринты не добавлены
+              </div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {sprints.map(s => {
+                  const issueCount = s._count?.issues ?? s.issues?.length ?? 0;
+                  const doneCount = s.issues?.filter(i => i.status === 'DONE').length ?? 0;
+                  const progress = issueCount > 0 ? Math.round((doneCount / issueCount) * 100) : 0;
+                  const stateColor = s.state === 'ACTIVE' ? '#4F6EF7' : s.state === 'CLOSED' ? '#4ADE80' : C.t3;
+                  const stateLab = s.state === 'ACTIVE' ? 'Активен' : s.state === 'CLOSED' ? 'Закрыт' : 'Запланирован';
+                  return (
+                    <div key={s.id} style={{
+                      border: `1px solid ${C.border}`, borderRadius: 8,
+                      padding: '12px 16px', background: C.bgCard,
+                    }}>
+                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+                            <span style={{ fontSize: 14, fontWeight: 600, color: C.t1, fontFamily: F.display }}>{s.name}</span>
+                            <span style={{
+                              fontSize: 11, fontWeight: 600, padding: '1px 6px', borderRadius: 4,
+                              background: `${stateColor}1F`, color: stateColor,
+                            }}>{stateLab}</span>
+                          </div>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                            <span style={{ color: C.t3, fontSize: 12 }}>{issueCount} задач</span>
+                            {s.startDate && <span style={{ color: C.t4, fontSize: 11 }}>{formatDate(s.startDate)} — {formatDate(s.endDate)}</span>}
+                          </div>
+                          {issueCount > 0 && (
+                            <div style={{ marginTop: 8 }}>
+                              <Progress percent={progress} size="small" strokeColor={C.acc} showInfo={false} />
+                            </div>
+                          )}
+                        </div>
+                        {canManage && (
+                          <Popconfirm
+                            title="Убрать спринт из релиза?"
+                            onConfirm={() => handleRemoveSprint(s.id)}
+                            okText="Да" cancelText="Нет"
+                          >
+                            <button style={{ border: 'none', background: 'transparent', cursor: 'pointer', color: C.t4, padding: 4 }}>
+                              <DeleteOutlined />
+                            </button>
+                          </Popconfirm>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ── Readiness tab ─────────────────────────────── */}
+        {tab === 'readiness' && (
+          <div>
+            {loadingReadiness ? (
+              <div style={{ textAlign: 'center', padding: 40 }}><Spin /></div>
+            ) : readiness ? (
+              <div>
+                {/* Main metrics */}
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 20 }}>
+                  {[
+                    { label: 'Готовность', value: `${readiness.completionPercent}%`, icon: <CheckCircleOutlined style={{ color: '#4ADE80' }} /> },
+                    { label: 'Задачи', value: `${readiness.doneItems} / ${readiness.totalItems}`, icon: <ClockCircleOutlined style={{ color: C.acc }} /> },
+                    { label: 'Спринты закрыты', value: `${readiness.closedSprints} / ${readiness.totalSprints}`, icon: <CheckCircleOutlined style={{ color: C.acc }} /> },
+                    { label: 'В работе', value: String(readiness.inProgressItems), icon: <MinusCircleOutlined style={{ color: '#F97316' }} /> },
+                  ].map(({ label, value, icon }) => (
+                    <div key={label} style={{
+                      border: `1px solid ${C.border}`, borderRadius: 8,
+                      padding: '14px 16px', background: C.bgCard,
+                      display: 'flex', alignItems: 'center', gap: 12,
+                    }}>
+                      <span style={{ fontSize: 18 }}>{icon}</span>
+                      <div>
+                        <div style={{ color: C.t3, fontSize: 11, marginBottom: 2 }}>{label}</div>
+                        <div style={{ color: C.t1, fontSize: 18, fontWeight: 700, fontFamily: F.display }}>{value}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                {/* Progress bar */}
+                <div style={{ marginBottom: 20 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+                    <span style={{ color: C.t2, fontSize: 13 }}>Прогресс завершения</span>
+                    <span style={{ color: C.t1, fontWeight: 600 }}>{readiness.completionPercent}%</span>
+                  </div>
+                  <div style={{ height: 8, borderRadius: 4, background: isDark ? '#21262D' : '#E8EAED', overflow: 'hidden' }}>
+                    <div style={{
+                      height: '100%', borderRadius: 4,
+                      background: readiness.completionPercent >= 80 ? '#4ADE80' : readiness.completionPercent >= 50 ? C.acc : '#F97316',
+                      width: `${readiness.completionPercent}%`,
+                      transition: 'width 0.4s ease',
+                    }} />
+                  </div>
+                </div>
+
+                {/* By project (INTEGRATION) */}
+                {readiness.byProject.length > 0 && (
+                  <div>
+                    <div style={{ fontSize: 12, fontWeight: 700, color: C.t3, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 10 }}>
+                      По проектам
+                    </div>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                      {readiness.byProject.map(p => {
+                        const pct = p.total > 0 ? Math.round((p.done / p.total) * 100) : 0;
+                        return (
+                          <div key={p.projectId} style={{
+                            border: `1px solid ${C.border}`, borderRadius: 6, padding: '10px 14px',
+                            background: C.bgCard,
+                          }}>
+                            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+                              <span style={{ color: C.t2, fontSize: 13 }}>
+                                <span style={{ color: C.acc, fontWeight: 600, marginRight: 6 }}>{p.key}</span>{p.name}
+                              </span>
+                              <span style={{ color: C.t3, fontSize: 12 }}>{p.done}/{p.total} ({pct}%)</span>
+                            </div>
+                            <Progress percent={pct} size="small" strokeColor={C.acc} showInfo={false} />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div style={{ color: C.t3, fontSize: 13, textAlign: 'center', padding: 40 }}>
+                Нет данных
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ── History tab ─────────────────────────────── */}
+        {tab === 'history' && (
+          <div>
+            {loadingHistory ? (
+              <div style={{ textAlign: 'center', padding: 40 }}><Spin /></div>
+            ) : history.length === 0 ? (
+              <div style={{ color: C.t3, fontSize: 13, textAlign: 'center', padding: 40 }}>
+                История пуста
+              </div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+                {history.map((entry, idx) => (
+                  <div key={entry.id} style={{
+                    display: 'flex', gap: 12, padding: '10px 0',
+                    borderBottom: idx < history.length - 1 ? `1px solid ${C.border}` : 'none',
+                  }}>
+                    <div style={{
+                      width: 32, height: 32, borderRadius: '50%',
+                      background: isDark ? '#21262D' : '#E8EAED',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      flexShrink: 0, color: C.t2, fontSize: 12, fontWeight: 700,
+                    }}>
+                      {entry.user?.name?.[0]?.toUpperCase() ?? '?'}
+                    </div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
+                        <span style={{ color: C.t1, fontSize: 13, fontWeight: 600 }}>{entry.user?.name ?? 'Система'}</span>
+                        <span style={{ color: C.acc, fontSize: 12, fontWeight: 500 }}>{actionLabel(entry.action)}</span>
+                        <span style={{ color: C.t4, fontSize: 11 }}>{dayjs(entry.createdAt).format('DD.MM.YYYY HH:mm')}</span>
+                      </div>
+                      {entry.details && Object.keys(entry.details).length > 0 && (
+                        <div style={{
+                          marginTop: 4, fontSize: 11, color: C.t3,
+                          background: isDark ? '#0D1117' : '#F6F8FA',
+                          borderRadius: 4, padding: '4px 8px',
+                          fontFamily: 'monospace', wordBreak: 'break-all',
+                        }}>
+                          {JSON.stringify(entry.details, null, 2).slice(0, 200)}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Add Issues Modal */}
+      <Modal
+        open={addIssuesOpen}
+        title="Добавить задачи в релиз"
+        onCancel={() => { setAddIssuesOpen(false); setSelectedIssueIds([]); setIssueSearch(''); }}
+        onOk={handleAddIssues}
+        okText="Добавить"
+        cancelText="Отмена"
+        okButtonProps={{ disabled: selectedIssueIds.length === 0 }}
+        width={600}
+      >
+        <Input
+          placeholder="Поиск задач..."
+          prefix={<SearchOutlined />}
+          value={issueSearch}
+          onChange={e => setIssueSearch(e.target.value)}
+          style={{ marginBottom: 12 }}
+        />
+        <div style={{ maxHeight: 400, overflow: 'auto' }}>
+          {filteredIssues.map(issue => (
+            <div key={issue.id} style={{
+              display: 'flex', alignItems: 'center', gap: 10,
+              padding: '8px 12px', borderRadius: 6, cursor: 'pointer',
+              background: selectedIssueIds.includes(issue.id)
+                ? (isDark ? '#4F6EF71A' : '#4F6EF70D')
+                : 'transparent',
+              marginBottom: 4,
+            }} onClick={() => {
+              setSelectedIssueIds(prev =>
+                prev.includes(issue.id) ? prev.filter(id => id !== issue.id) : [...prev, issue.id]
+              );
+            }}>
+              <input
+                type="checkbox"
+                checked={selectedIssueIds.includes(issue.id)}
+                onChange={() => {}}
+                style={{ cursor: 'pointer' }}
+              />
+              <span style={{ color: C.t3, fontSize: 12, fontFamily: 'monospace' }}>#{issue.number}</span>
+              <span style={{ color: C.t1, fontSize: 13, flex: 1 }}>{issue.title}</span>
+              <span style={{ color: C.t4, fontSize: 11 }}>{issue.status}</span>
+            </div>
+          ))}
+        </div>
+      </Modal>
+
+      {/* Add Sprints Modal */}
+      <Modal
+        open={addSprintsOpen}
+        title="Добавить спринты в релиз"
+        onCancel={() => { setAddSprintsOpen(false); setSelectedSprintIds([]); }}
+        onOk={handleAddSprints}
+        okText="Добавить"
+        cancelText="Отмена"
+        okButtonProps={{ disabled: selectedSprintIds.length === 0 }}
+        width={500}
+      >
+        <div style={{ maxHeight: 400, overflow: 'auto' }}>
+          {allSprints.map(sprint => (
+            <div key={sprint.id} style={{
+              display: 'flex', alignItems: 'center', gap: 10,
+              padding: '8px 12px', borderRadius: 6, cursor: 'pointer',
+              background: selectedSprintIds.includes(sprint.id)
+                ? (isDark ? '#4F6EF71A' : '#4F6EF70D')
+                : 'transparent',
+              marginBottom: 4,
+            }} onClick={() => {
+              setSelectedSprintIds(prev =>
+                prev.includes(sprint.id) ? prev.filter(id => id !== sprint.id) : [...prev, sprint.id]
+              );
+            }}>
+              <input
+                type="checkbox"
+                checked={selectedSprintIds.includes(sprint.id)}
+                onChange={() => {}}
+                style={{ cursor: 'pointer' }}
+              />
+              <span style={{ color: C.t1, fontSize: 13, flex: 1 }}>{sprint.name}</span>
+              <span style={{ color: C.t3, fontSize: 12 }}>{sprint.state}</span>
+            </div>
+          ))}
+        </div>
+      </Modal>
+    </div>
+  );
+}
+
+// ─── Issue table inside detail panel ─────────────────────────────────────────
+
+function IssueTable({
+  items,
+  C,
+  isDark,
+  canManage,
+  onRemove,
+}: {
+  items: ReleaseItem[];
+  C: typeof DARK_C;
+  isDark: boolean;
+  canManage: boolean;
+  onRemove: (issueId: string) => void;
+}) {
+  const prioColor: Record<string, string> = {
+    CRITICAL: '#F87171', HIGH: '#F97316', MEDIUM: '#FBBF24', LOW: '#4ADE80',
+  };
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {items.map(item => {
+        const issue = item.issue;
+        const ws = issue.workflowStatus;
+        const wsColor = ws?.color || C.t4;
+        return (
+          <div key={item.id} style={{
+            display: 'flex', alignItems: 'center', gap: 10,
+            padding: '8px 12px', borderRadius: 6,
+            background: isDark ? '#0D111B' : '#F6F8FA',
+            border: `1px solid ${C.border}`,
+          }}>
+            <span style={{
+              width: 8, height: 8, borderRadius: '50%',
+              background: prioColor[issue.priority] || C.t4,
+              flexShrink: 0,
+            }} />
+            <span style={{ color: C.t3, fontSize: 11, fontFamily: 'monospace', flexShrink: 0 }}>
+              {issue.project.key}-{issue.number}
+            </span>
+            <span style={{ color: C.t1, fontSize: 12, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {issue.title}
+            </span>
+            {ws && (
+              <span style={{
+                fontSize: 11, padding: '1px 6px', borderRadius: 3,
+                background: `${wsColor}1F`, color: wsColor,
+                flexShrink: 0,
+              }}>{ws.name}</span>
+            )}
+            {issue.assignee && (
+              <Tooltip title={issue.assignee.name}>
+                <span style={{
+                  width: 22, height: 22, borderRadius: '50%',
+                  background: isDark ? '#21262D' : '#E8EAED',
+                  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 10, fontWeight: 700, color: C.t2, flexShrink: 0,
+                }}>
+                  {issue.assignee.name[0].toUpperCase()}
+                </span>
+              </Tooltip>
+            )}
+            {canManage && (
+              <Popconfirm
+                title="Убрать задачу из релиза?"
+                onConfirm={() => onRemove(issue.id)}
+                okText="Да" cancelText="Нет"
+              >
+                <button style={{ border: 'none', background: 'transparent', cursor: 'pointer', color: C.t4, padding: 2 }}>
+                  <DeleteOutlined style={{ fontSize: 12 }} />
+                </button>
+              </Popconfirm>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Main page ───────────────────────────────────────────────────────────────
+
+export default function GlobalReleasesPage() {
+  const { user } = useAuthStore();
+  const { mode } = useThemeStore();
+  const isDark = mode !== 'light';
+  const C = isDark ? DARK_C : LIGHT_C;
+  const canManage = user?.role === 'ADMIN' || user?.role === 'MANAGER';
+
+  // ─── State ───────────────────────────────────────────────
+  const [releases, setReleases] = useState<Release[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+
+  const [filterType, setFilterType] = useState<'ALL' | 'ATOMIC' | 'INTEGRATION'>('ALL');
+  const [filterProjectId, setFilterProjectId] = useState<string | undefined>();
+  const [filterSearch, setFilterSearch] = useState('');
+  const [filterFrom, setFilterFrom] = useState<string | undefined>();
+  const [filterTo, setFilterTo] = useState<string | undefined>();
+
+  const [sortBy, setSortBy] = useState('createdAt');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedRelease, setSelectedRelease] = useState<Release | null>(null);
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createForm] = Form.useForm();
+  const [createType, setCreateType] = useState<'ATOMIC' | 'INTEGRATION'>('ATOMIC');
+  const [createLoading, setCreateLoading] = useState(false);
+
+  const searchTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  // ─── Load ─────────────────────────────────────────────────
+  const loadReleases = useCallback(async (pg = page) => {
+    setLoading(true);
+    try {
+      const query: releasesApi.ListReleasesQuery = {
+        page: pg,
+        limit: 20,
+        sortBy,
+        sortDir,
+      };
+      if (filterType !== 'ALL') query.type = filterType;
+      if (filterProjectId) query.projectId = filterProjectId;
+      if (filterSearch) query.search = filterSearch;
+      if (filterFrom) query.from = filterFrom;
+      if (filterTo) query.to = filterTo;
+      const res = await releasesApi.listReleasesGlobal(query);
+      setReleases(res.data);
+      setTotal(res.total);
+      setPage(pg);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, sortBy, sortDir, filterType, filterProjectId, filterSearch, filterFrom, filterTo]);
+
+  useEffect(() => { loadReleases(1); }, [filterType, filterProjectId, filterFrom, filterTo, sortBy, sortDir]);
+
+  useEffect(() => {
+    clearTimeout(searchTimer.current);
+    searchTimer.current = setTimeout(() => loadReleases(1), 400);
+    return () => clearTimeout(searchTimer.current);
+  }, [filterSearch]);
+
+  useEffect(() => {
+    projectsApi.listProjects().then(setProjects).catch(() => {});
+  }, []);
+
+  // ─── Handlers ─────────────────────────────────────────────
+  const handleCreate = async (vals: {
+    type: 'ATOMIC' | 'INTEGRATION';
+    projectId?: string;
+    name: string;
+    description?: string;
+    level: 'MINOR' | 'MAJOR';
+    plannedDate?: dayjs.Dayjs;
+  }) => {
+    setCreateLoading(true);
+    try {
+      await releasesApi.createReleaseGlobal({
+        type: vals.type,
+        projectId: vals.type === 'ATOMIC' ? vals.projectId : undefined,
+        name: vals.name,
+        description: vals.description,
+        level: vals.level,
+        plannedDate: vals.plannedDate ? vals.plannedDate.format('YYYY-MM-DD') : undefined,
+      });
+      message.success('Релиз создан');
+      setCreateOpen(false);
+      createForm.resetFields();
+      loadReleases(1);
+    } catch (e) {
+      const err = e as AxiosError<{ error?: string }>;
+      message.error(err.response?.data?.error || 'Ошибка создания');
+    } finally {
+      setCreateLoading(false);
+    }
+  };
+
+  const handleTransition = async (releaseId: string, transitionId: string) => {
+    await releasesApi.executeTransition(releaseId, transitionId);
+    message.success('Статус обновлён');
+  };
+
+  // ─── Table columns ────────────────────────────────────────
+  const columns: ColumnsType<Release> = [
+    {
+      title: 'Название',
+      dataIndex: 'name',
+      sorter: true,
+      render: (name: string, row) => (
+        <div>
+          <div style={{ color: C.t1, fontWeight: 600, fontSize: 13, fontFamily: F.display }}>{name}</div>
+          {row.description && (
+            <div style={{ color: C.t3, fontSize: 11, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 200 }}>
+              {row.description}
+            </div>
+          )}
+        </div>
+      ),
+    },
+    {
+      title: 'Тип',
+      dataIndex: 'type',
+      width: 130,
+      render: (type: string) => typeBadge(type),
+    },
+    {
+      title: 'Проекты',
+      width: 140,
+      render: (_: unknown, row) => {
+        if (row.type === 'ATOMIC') {
+          return row.project ? (
+            <span style={{ color: C.acc, fontWeight: 600, fontSize: 12 }}>{row.project.key}</span>
+          ) : '—';
+        }
+        const projects = row._projects ?? [];
+        return projects.length > 0 ? (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+            {projects.map((k: string) => (
+              <span key={k} style={{
+                fontSize: 11, padding: '1px 6px', borderRadius: 3,
+                background: isDark ? '#21262D' : '#E8EAED', color: C.t2,
+              }}>{k}</span>
+            ))}
+          </div>
+        ) : <span style={{ color: C.t4 }}>—</span>;
+      },
+    },
+    {
+      title: 'Статус',
+      width: 140,
+      render: (_: unknown, row) => statusBadge(row.status, C),
+    },
+    {
+      title: 'Уровень',
+      dataIndex: 'level',
+      width: 90,
+      render: (level: string) => levelBadge(level, isDark),
+    },
+    {
+      title: 'Задачи',
+      width: 120,
+      render: (_: unknown, row) => {
+        const total = row._count?.items ?? 0;
+        return (
+          <div style={{ fontSize: 12, color: C.t2 }}>{total} задач</div>
+        );
+      },
+    },
+    {
+      title: 'Плановая дата',
+      dataIndex: 'plannedDate',
+      width: 120,
+      sorter: true,
+      render: (d: string | null) => (
+        <span style={{ color: d ? C.t2 : C.t4, fontSize: 12 }}>{formatDate(d)}</span>
+      ),
+    },
+    {
+      title: 'Дата выпуска',
+      dataIndex: 'releaseDate',
+      width: 120,
+      sorter: true,
+      render: (d: string | null) => (
+        <span style={{ color: d ? '#4ADE80' : C.t4, fontSize: 12 }}>{formatDate(d)}</span>
+      ),
+    },
+    {
+      title: 'Автор',
+      width: 120,
+      render: (_: unknown, row) => row.createdBy ? (
+        <Tooltip title={row.createdBy.name}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{
+              width: 22, height: 22, borderRadius: '50%',
+              background: isDark ? '#21262D' : '#E8EAED',
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: 10, fontWeight: 700, color: C.t2,
+            }}>
+              {row.createdBy.name[0]?.toUpperCase()}
+            </span>
+            <span style={{ color: C.t3, fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 80 }}>
+              {row.createdBy.name}
+            </span>
+          </div>
+        </Tooltip>
+      ) : <span style={{ color: C.t4 }}>—</span>,
+    },
+  ];
+
+  const TYPE_TABS: { key: 'ALL' | 'ATOMIC' | 'INTEGRATION'; label: string }[] = [
+    { key: 'ALL', label: 'Все' },
+    { key: 'ATOMIC', label: 'Атомарные' },
+    { key: 'INTEGRATION', label: 'Интеграционные' },
+  ];
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: C.bg,
+      fontFamily: F.sans,
+      padding: '24px 32px',
+    }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        marginBottom: 24,
+      }}>
+        <div>
+          <h1 style={{
+            margin: 0, color: C.t1, fontSize: 22, fontWeight: 700,
+            fontFamily: F.display, lineHeight: 1.2,
+          }}>
+            Релизы
+          </h1>
+          <p style={{ margin: '4px 0 0', color: C.t3, fontSize: 13 }}>
+            Управление релизами всех проектов
+          </p>
+        </div>
+        {canManage && (
+          <button
+            onClick={() => setCreateOpen(true)}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              background: C.acc, color: '#fff',
+              border: 'none', borderRadius: 8,
+              padding: '8px 16px', fontSize: 13, fontWeight: 600,
+              fontFamily: F.display, cursor: 'pointer',
+            }}
+          >
+            <PlusOutlined /> Создать релиз
+          </button>
+        )}
+      </div>
+
+      {/* Type tabs */}
+      <div style={{
+        display: 'flex', gap: 0, marginBottom: 16,
+        borderBottom: `1px solid ${C.border}`,
+      }}>
+        {TYPE_TABS.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setFilterType(key)}
+            style={{
+              border: 'none',
+              borderBottom: filterType === key ? `2px solid ${C.acc}` : '2px solid transparent',
+              background: 'transparent',
+              color: filterType === key ? C.tabActiveText : C.tabText,
+              padding: '8px 18px',
+              fontSize: 13, fontWeight: filterType === key ? 600 : 400,
+              fontFamily: F.sans, cursor: 'pointer', marginBottom: -1,
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Filters */}
+      <div style={{
+        display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: 16, alignItems: 'center',
+      }}>
+        <div style={{ position: 'relative', flex: '1 1 220px', minWidth: 180 }}>
+          <SearchOutlined style={{
+            position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)',
+            color: C.t4, zIndex: 1, pointerEvents: 'none',
+          }} />
+          <input
+            placeholder="Поиск по названию..."
+            value={filterSearch}
+            onChange={e => setFilterSearch(e.target.value)}
+            style={{
+              width: '100%', paddingLeft: 32, paddingRight: 12,
+              height: 34, border: `1px solid ${C.inputBorder}`,
+              borderRadius: 6, background: C.inputBg, color: C.t1,
+              fontSize: 13, fontFamily: F.sans, boxSizing: 'border-box',
+              outline: 'none',
+            }}
+          />
+        </div>
+
         <Select
-          value={filter}
-          onChange={setFilter}
-          style={{ width: 180 }}
-          options={[
-            { value: 'ALL', label: 'Все состояния' },
-            { value: 'DRAFT', label: 'Черновик' },
-            { value: 'READY', label: 'Готов к выпуску' },
-            { value: 'RELEASED', label: 'Выпущен' },
-          ]}
+          allowClear
+          placeholder="Проект"
+          style={{ width: 160 }}
+          value={filterProjectId}
+          onChange={v => setFilterProjectId(v)}
+          options={projects.map(p => ({ value: p.id, label: `${p.key} — ${p.name}` }))}
+        />
+
+        <DatePicker.RangePicker
+          placeholder={['Период с', 'по']}
+          style={{ width: 240 }}
+          onChange={dates => {
+            setFilterFrom(dates?.[0] ? dates[0].format('YYYY-MM-DD') : undefined);
+            setFilterTo(dates?.[1] ? dates[1].format('YYYY-MM-DD') : undefined);
+          }}
+        />
+
+        <button
+          onClick={() => loadReleases(page)}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 4,
+            border: `1px solid ${C.borderBtn}`, background: 'transparent',
+            color: C.t2, borderRadius: 6, padding: '5px 12px',
+            fontSize: 12, fontFamily: F.sans, cursor: 'pointer',
+          }}
+        >
+          <ReloadOutlined /> Обновить
+        </button>
+      </div>
+
+      {/* Table */}
+      <div style={{
+        background: C.bgCard,
+        border: `1px solid ${C.border}`,
+        borderRadius: 10,
+        overflow: 'hidden',
+      }}>
+        <Table<Release>
+          columns={columns}
+          dataSource={releases}
+          rowKey="id"
+          loading={loading}
+          pagination={{
+            current: page,
+            pageSize: 20,
+            total,
+            showSizeChanger: false,
+            showTotal: (t) => `Всего ${t}`,
+            onChange: (pg) => loadReleases(pg),
+          }}
+          onChange={(_pagination, _filters, sorter) => {
+            if (!Array.isArray(sorter) && sorter.field) {
+              const field = Array.isArray(sorter.field) ? sorter.field.join('.') : String(sorter.field);
+              setSortBy(field);
+              setSortDir(sorter.order === 'ascend' ? 'asc' : 'desc');
+            }
+          }}
+          onRow={(row) => ({
+            onClick: () => setSelectedRelease(row),
+            style: { cursor: 'pointer' },
+          })}
+          scroll={{ x: 900 }}
+          style={{ background: C.bgCard }}
         />
       </div>
 
-      {loading ? (
-        <div className="tt-panel-empty">Загрузка...</div>
-      ) : filtered.length === 0 ? (
-        <div className="tt-panel-empty">Нет релизов.</div>
-      ) : (
-        filtered.map(({ project, releases }) => (
-          <div key={project.id} className="tt-panel" style={{ marginBottom: 16 }}>
-            <div className="tt-panel-header">
-              <span>
-                <span className="tt-mono" style={{ color: 'var(--acc)', marginRight: 8 }}>
-                  {project.key}
-                </span>
-                {project.name}
-              </span>
-              <Link to={`/projects/${project.id}/releases`} style={{ fontSize: 11, color: 'var(--acc)' }}>
-                Все релизы →
-              </Link>
-            </div>
-            <div className="tt-panel-body" style={{ padding: 0 }}>
-              {releases.map((r) => (
-                <div key={r.id} className="tt-panel-row">
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <Typography.Text style={{ fontWeight: 500, color: 'var(--t1)' }}>{r.name}</Typography.Text>
-                    <Tag color={r.level === 'MAJOR' ? 'blue' : 'default'} style={{ marginInlineEnd: 0 }}>
-                      {r.level === 'MAJOR' ? 'Мажорный' : 'Минорный'}
-                    </Tag>
-                    <Tag color={STATE_TONE[r.state]} style={{ marginInlineEnd: 0 }}>
-                      {STATE_LABEL[r.state]}
-                    </Tag>
-                  </div>
-                  <Link to={`/projects/${project.id}/releases`} style={{ fontSize: 12, color: 'var(--t3)' }}>
-                    Открыть
-                  </Link>
-                </div>
-              ))}
-            </div>
-          </div>
-        ))
+      {/* Detail slide panel */}
+      {selectedRelease && (
+        <>
+          {/* Backdrop */}
+          <div
+            onClick={() => setSelectedRelease(null)}
+            style={{
+              position: 'fixed', inset: 0, zIndex: 999,
+              background: 'rgba(0,0,0,0.4)',
+            }}
+          />
+          <DetailPanel
+            release={selectedRelease}
+            C={C}
+            isDark={isDark}
+            canManage={canManage}
+            onClose={() => setSelectedRelease(null)}
+            onTransition={handleTransition}
+            onReleasesRefresh={() => loadReleases(page)}
+          />
+        </>
       )}
+
+      {/* Create Release Modal */}
+      <Modal
+        open={createOpen}
+        title="Создать релиз"
+        onCancel={() => { setCreateOpen(false); createForm.resetFields(); setCreateType('ATOMIC'); }}
+        onOk={() => createForm.submit()}
+        okText="Создать"
+        cancelText="Отмена"
+        confirmLoading={createLoading}
+        width={520}
+      >
+        <Form
+          form={createForm}
+          layout="vertical"
+          onFinish={handleCreate}
+          initialValues={{ type: 'ATOMIC', level: 'MINOR' }}
+        >
+          <Form.Item name="type" label="Тип релиза" rules={[{ required: true }]}>
+            <Radio.Group onChange={e => setCreateType(e.target.value)}>
+              <Radio value="ATOMIC">ATOMIC — один проект</Radio>
+              <Radio value="INTEGRATION">INTEGRATION — кросс-проект</Radio>
+            </Radio.Group>
+          </Form.Item>
+
+          {createType === 'ATOMIC' && (
+            <Form.Item name="projectId" label="Проект" rules={[{ required: true, message: 'Выберите проект' }]}>
+              <Select
+                placeholder="Выберите проект"
+                options={projects.map(p => ({ value: p.id, label: `${p.key} — ${p.name}` }))}
+              />
+            </Form.Item>
+          )}
+
+          <Form.Item name="name" label="Название" rules={[{ required: true, min: 1, max: 100 }]}>
+            <Input placeholder="v1.2.0 — Релиз управления правами" />
+          </Form.Item>
+
+          <Form.Item name="description" label="Описание">
+            <Input.TextArea rows={3} placeholder="Краткое описание релиза..." />
+          </Form.Item>
+
+          <Form.Item name="level" label="Уровень">
+            <Radio.Group>
+              <Radio value="MINOR">Minor</Radio>
+              <Radio value="MAJOR">Major</Radio>
+            </Radio.Group>
+          </Form.Item>
+
+          <Form.Item name="plannedDate" label="Плановая дата выпуска">
+            <DatePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+          </Form.Item>
+        </Form>
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -26,6 +26,7 @@ import LoadingSpinner from '../components/common/LoadingSpinner';
 import { hasAnyRequiredRole, hasRequiredRole } from '../lib/roles';
 import { getProjectIssueTypes } from '../api/issue-type-configs';
 import { IssueTypeBadge } from '../lib/issue-kit';
+import BulkStatusWizardModal from '../components/issues/BulkStatusWizardModal';
 
 // ─── Tokens Dark (Paper FW-0) ────────────────────────────────
 const DARK_C = {
@@ -117,6 +118,24 @@ function getStatusDot(s: IssueStatus, C: typeof DARK_C): string {
     default:            return C.sOpen;
   }
 }
+function getStatusBg(s: IssueStatus, C: typeof DARK_C): string {
+  switch (s) {
+    case 'DONE':        return C.sdDone;
+    case 'IN_PROGRESS': return C.sdProgress;
+    case 'REVIEW':      return C.sdReview;
+    case 'CANCELLED':   return C.sdCancelled;
+    default:            return C.sdOpen;
+  }
+}
+function getStatusLabel(s: IssueStatus): string {
+  switch (s) {
+    case 'IN_PROGRESS': return 'In Progress';
+    case 'DONE':        return 'Done';
+    case 'REVIEW':      return 'Review';
+    case 'CANCELLED':   return 'Cancelled';
+    default:            return 'Open';
+  }
+}
 function getPriorityColor(p: IssuePriority, C: typeof DARK_C): string {
   switch (p) {
     case 'CRITICAL': return C.pCritical;
@@ -160,8 +179,8 @@ export default function ProjectDetailPage() {
   const [form] = Form.useForm();
   const [allUsers, setAllUsers] = useState<User[]>([]);
   const [selectedIssueIds, setSelectedIssueIds] = useState<string[]>([]);
-  const [bulkStatus, setBulkStatus] = useState<IssueStatus | undefined>(undefined);
   const [bulkAssigneeId, setBulkAssigneeId] = useState<string | undefined>(undefined);
+  const [bulkStatusWizardOpen, setBulkStatusWizardOpen] = useState(false);
   const [treeMode, setTreeMode] = useState(true);
   const [issueTypeConfigs, setIssueTypeConfigs] = useState<IssueTypeConfig[]>([]);
 
@@ -192,37 +211,22 @@ export default function ProjectDetailPage() {
     }
   };
 
-  const handleStatusChange = async (issueId: string, status: IssueStatus) => {
-    try {
-      await issuesApi.updateStatus(issueId, status);
-      if (id) fetchIssues(id);
-    } catch {
-      message.error('Failed to update status');
-    }
-  };
-
   const handleApplyFilters = () => { if (id) fetchIssues(id); };
   const handleResetFilters  = () => { if (id) { resetFilters(); fetchIssues(id); } };
 
-  const handleBulkUpdate = async () => {
-    if (!id || selectedIssueIds.length === 0) return;
-    if (!bulkStatus && bulkAssigneeId === undefined) {
-      message.warning('Select status and/or assignee to update');
-      return;
-    }
+  const handleBulkAssigneeUpdate = async () => {
+    if (!id || selectedIssueIds.length === 0 || bulkAssigneeId === undefined) return;
     try {
       await issuesApi.bulkUpdateIssues(id, {
         issueIds:   selectedIssueIds,
-        status:     bulkStatus,
         assigneeId: bulkAssigneeId === 'UNASSIGNED' ? null : bulkAssigneeId,
       });
-      message.success('Issues updated');
+      message.success('Исполнитель обновлён');
       setSelectedIssueIds([]);
-      setBulkStatus(undefined);
       setBulkAssigneeId(undefined);
       fetchIssues(id);
     } catch {
-      message.error('Failed to update issues');
+      message.error('Failed to update assignee');
     }
   };
 
@@ -301,21 +305,19 @@ export default function ProjectDetailPage() {
         </span>
       ),
       dataIndex: 'status',
-      width: 138,
-      render: (s: IssueStatus, r: Issue) => (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-          <span style={{ width: 6, height: 6, borderRadius: '50%', background: getStatusDot(s, C), flexShrink: 0 }} />
-          <Select
-            value={s}
-            size="small"
-            variant="borderless"
-            onChange={(v) => handleStatusChange(r.id, v)}
-            options={(['OPEN', 'IN_PROGRESS', 'REVIEW', 'DONE', 'CANCELLED'] as IssueStatus[]).map((v) => ({
-              value: v, label: v,
-            }))}
-            style={{ fontFamily: F.sans, fontSize: 11 }}
-          />
-        </div>
+      width: 120,
+      render: (s: IssueStatus, _r: Issue) => (
+        <span style={{
+          display: 'inline-flex', alignItems: 'center', gap: 5,
+          background: getStatusBg(s, C),
+          borderRadius: 6,
+          padding: '2px 8px',
+        }}>
+          <span style={{ width: 5, height: 5, borderRadius: '50%', background: getStatusDot(s, C), flexShrink: 0 }} />
+          <span style={{ fontFamily: F.sans, fontSize: 11, fontWeight: 500, color: getStatusDot(s, C) }}>
+            {getStatusLabel(s)}
+          </span>
+        </span>
       ),
     },
     {
@@ -675,17 +677,13 @@ export default function ProjectDetailPage() {
           <>
             <span style={{ width: 1, height: 14, background: C.border }} />
             <Space size={6}>
-              <Select<IssueStatus>
-                allowClear
-                placeholder="Set status"
-                value={bulkStatus}
-                onChange={(value) => setBulkStatus(value)}
-                options={(['OPEN', 'IN_PROGRESS', 'REVIEW', 'DONE', 'CANCELLED'] as IssueStatus[]).map((v) => ({
-                  value: v, label: v,
-                }))}
+              <Button
                 size="small"
-                style={{ minWidth: 120, fontFamily: F.sans, fontSize: 11 }}
-              />
+                onClick={() => setBulkStatusWizardOpen(true)}
+                style={{ fontFamily: F.sans, fontSize: 11, background: C.bgCard, border: `1px solid ${C.border}`, color: C.t2 }}
+              >
+                Изменить статус ({selectedIssueIds.length})
+              </Button>
               <Select
                 allowClear
                 placeholder="Set assignee"
@@ -698,15 +696,16 @@ export default function ProjectDetailPage() {
                 size="small"
                 style={{ minWidth: 130, fontFamily: F.sans, fontSize: 11 }}
               />
-              <Button
-                type="primary"
-                size="small"
-                disabled={!bulkStatus && bulkAssigneeId === undefined}
-                onClick={handleBulkUpdate}
-                style={{ fontFamily: F.sans, fontSize: 11 }}
-              >
-                Apply to {selectedIssueIds.length}
-              </Button>
+              {bulkAssigneeId !== undefined && (
+                <Button
+                  type="primary"
+                  size="small"
+                  onClick={handleBulkAssigneeUpdate}
+                  style={{ fontFamily: F.sans, fontSize: 11 }}
+                >
+                  Назначить
+                </Button>
+              )}
               {hasRequiredRole(user?.role, 'ADMIN') && (
                 <Popconfirm
                   title={`Удалить ${selectedIssueIds.length} задач?`}
@@ -825,6 +824,20 @@ export default function ProjectDetailPage() {
           </Form.Item>
         </Form>
       </Modal>
+
+      {/* ── Bulk Status Wizard ── */}
+      {bulkStatusWizardOpen && (
+        <BulkStatusWizardModal
+          open={bulkStatusWizardOpen}
+          issueIds={selectedIssueIds}
+          onSuccess={() => {
+            setBulkStatusWizardOpen(false);
+            setSelectedIssueIds([]);
+            if (id) fetchIssues(id);
+          }}
+          onCancel={() => setBulkStatusWizardOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -306,7 +306,7 @@ export default function ProjectDetailPage() {
       ),
       dataIndex: 'status',
       width: 120,
-      render: (s: IssueStatus, _r: Issue) => (
+      render: (s: IssueStatus) => (
         <span style={{
           display: 'inline-flex', alignItems: 'center', gap: 5,
           background: getStatusBg(s, C),

--- a/frontend/src/pages/ReleasesPage.tsx
+++ b/frontend/src/pages/ReleasesPage.tsx
@@ -163,7 +163,7 @@ export default function ReleasesPage() {
 
   const loadSelectedRelease = useCallback(async (releaseId: string) => {
     const full = await releasesApi.getReleaseWithIssues(releaseId);
-    setSelectedRelease(full);
+    setSelectedRelease(full as typeof full & { issues?: Issue[] });
     const r = await releasesApi.getReleaseReadiness(releaseId);
     setReadiness(r);
   }, []);
@@ -302,8 +302,10 @@ export default function ReleasesPage() {
     const parts: string[] = [];
     if (readiness.totalSprints > readiness.closedSprints)
       parts.push(`${readiness.totalSprints - readiness.closedSprints} спринт(ов) не закрыто`);
-    if (readiness.totalIssues > readiness.doneIssues)
-      parts.push(`${readiness.totalIssues - readiness.doneIssues} задач(и) не выполнено`);
+    const totalIssues = readiness.totalIssues ?? readiness.totalItems ?? 0;
+    const doneIssues = readiness.doneIssues ?? readiness.doneItems ?? 0;
+    if (totalIssues > doneIssues)
+      parts.push(`${totalIssues - doneIssues} задач(и) не выполнено`);
     return parts.join(', ');
   };
 
@@ -682,12 +684,12 @@ export default function ReleasesPage() {
                 </div>
                 <div style={{ flex: 1 }}>
                   <div style={{ fontFamily: F.sans, fontSize: 11, color: C.t3, marginBottom: 4 }}>
-                    Задачи выполнены: {readiness.doneIssues}/{readiness.totalIssues}
+                    Задачи выполнены: {(readiness.doneIssues ?? readiness.doneItems ?? 0)}/{(readiness.totalIssues ?? readiness.totalItems ?? 0)}
                   </div>
                   <Progress
-                    percent={readiness.totalIssues > 0 ? Math.round((readiness.doneIssues / readiness.totalIssues) * 100) : 0}
+                    percent={(readiness.totalIssues ?? readiness.totalItems ?? 0) > 0 ? Math.round(((readiness.doneIssues ?? readiness.doneItems ?? 0) / (readiness.totalIssues ?? readiness.totalItems ?? 0)) * 100) : 0}
                     size="small"
-                    status={readiness.doneIssues === readiness.totalIssues && readiness.totalIssues > 0 ? 'success' : 'active'}
+                    status={(readiness.doneIssues ?? readiness.doneItems ?? 0) === (readiness.totalIssues ?? readiness.totalItems ?? 0) && (readiness.totalIssues ?? readiness.totalItems ?? 0) > 0 ? 'success' : 'active'}
                   />
                 </div>
               </div>

--- a/frontend/src/pages/ReleasesPage.tsx
+++ b/frontend/src/pages/ReleasesPage.tsx
@@ -14,9 +14,9 @@ import {
   Select,
   Table,
   Tag,
-  Tooltip,
   Progress,
   Button,
+  Spin,
 } from 'antd';
 import {
   DeleteOutlined,
@@ -28,7 +28,7 @@ import * as projectsApi from '../api/projects';
 import * as sprintsApi from '../api/sprints';
 import { useAuthStore } from '../store/auth.store';
 import { useThemeStore } from '../store/theme.store';
-import type { Release, Issue, ReleaseLevel, ReleaseState, SprintInRelease, ReleaseReadiness, Sprint } from '../types';
+import type { Release, Issue, ReleaseLevel, ReleaseState, SprintInRelease, ReleaseReadiness, Sprint, ReleaseTransition, ReleaseStatus } from '../types';
 
 // ─── Tokens Dark (Paper 4EO-0) ──────────────────────────
 const DARK_C = {
@@ -88,7 +88,7 @@ const SPRINT_STATE_COLOR: Record<string, string> = {
   CLOSED:  'success',
 };
 
-type FilterTab = 'ALL' | ReleaseState;
+type FilterTab = 'ALL' | 'TODO' | 'IN_PROGRESS' | 'DONE';
 
 export default function ReleasesPage() {
   const { id: projectId } = useParams<{ id: string }>();
@@ -98,8 +98,8 @@ export default function ReleasesPage() {
   const isDark = mode !== 'light';
   const C = isDark ? DARK_C : LIGHT_C;
 
-  // ─── Status badge configs (theme-aware) ──────────────────
-  const STATUS_CFG: Record<ReleaseState, { bg: string; text: string; label: string }> = {
+  // ─── Status badge — dynamic from workflow ────────────────
+  const legacyStatusCfg: Record<ReleaseState, { bg: string; text: string; label: string }> = {
     RELEASED: isDark
       ? { bg: '#4ADE801F', text: '#4ADE80',  label: 'RELEASED' }
       : { bg: '#1A7F371A', text: '#1A7F37',  label: 'RELEASED' },
@@ -110,6 +110,18 @@ export default function ReleasesPage() {
       ? { bg: '#8B949E1F', text: '#8B949E',  label: 'DRAFT' }
       : { bg: '#8C959F1A', text: '#8C959F',  label: 'DRAFT' },
   };
+
+  const getStatusBadge = (r: Release): { bg: string; text: string; label: string } => {
+    if (r.status?.color && r.status?.name) {
+      const c = r.status.color;
+      return { bg: `${c}26`, text: c, label: r.status.name };
+    }
+    return legacyStatusCfg[r.state] ?? legacyStatusCfg.DRAFT;
+  };
+
+  const getReleaseCategory = (r: Release): string => r.status?.category ?? (
+    r.state === 'RELEASED' ? 'DONE' : r.state === 'READY' ? 'IN_PROGRESS' : 'TODO'
+  );
 
   const LEVEL_CFG: Record<ReleaseLevel, { bg: string; text: string }> = {
     MAJOR: isDark
@@ -133,8 +145,13 @@ export default function ReleasesPage() {
   const [addSprintsModalOpen, setAddSprintsModalOpen] = useState(false);
   const [selectedIssueIds, setSelectedIssueIds] = useState<string[]>([]);
   const [selectedSprintIds, setSelectedSprintIds] = useState<string[]>([]);
+  const [transitions, setTransitions] = useState<ReleaseTransition[]>([]);
+  const [currentStatus, setCurrentStatus] = useState<ReleaseStatus | null>(null);
+  const [transitioning, setTransitioning] = useState<string | null>(null);
+  const [loadingTransitions, setLoadingTransitions] = useState(false);
+  const [integrationReleases, setIntegrationReleases] = useState<Release[]>([]);
   const [form] = Form.useForm();
-  const canManage = user?.role === 'ADMIN' || user?.role === 'MANAGER';
+  const canManage = user?.role === 'ADMIN' || user?.role === 'MANAGER' || user?.role === 'SUPER_ADMIN';
 
   // ─── Load ─────────────────────────────────────────────────
   const loadReleases = useCallback(async () => {
@@ -168,16 +185,45 @@ export default function ReleasesPage() {
     setReadiness(r);
   }, []);
 
-  useEffect(() => { loadProject(); loadReleases(); }, [loadProject, loadReleases]);
+  const loadTransitions = useCallback(async (releaseId: string) => {
+    setLoadingTransitions(true);
+    try {
+      const r = await releasesApi.getAvailableTransitions(releaseId);
+      setTransitions(r.transitions);
+      setCurrentStatus(r.currentStatus);
+    } catch {
+      setTransitions([]);
+      setCurrentStatus(null);
+    } finally {
+      setLoadingTransitions(false);
+    }
+  }, []);
+
+  const loadIntegrationReleases = useCallback(async () => {
+    if (!projectId) return;
+    try {
+      const r = await releasesApi.listReleasesGlobal({ type: 'INTEGRATION', limit: 50 });
+      setIntegrationReleases(r.data.filter(rel =>
+        !rel._projects || rel._projects.includes(projectId) || rel._projects.length === 0
+      ));
+    } catch {
+      setIntegrationReleases([]);
+    }
+  }, [projectId]);
+
+  useEffect(() => { loadProject(); loadReleases(); loadIntegrationReleases(); }, [loadProject, loadReleases, loadIntegrationReleases]);
 
   useEffect(() => {
     if (selectedRelease?.id) {
       loadSelectedRelease(selectedRelease.id);
+      loadTransitions(selectedRelease.id);
     } else {
       setSelectedRelease(null);
       setReadiness(null);
+      setTransitions([]);
+      setCurrentStatus(null);
     }
-  }, [selectedRelease?.id, loadSelectedRelease]);
+  }, [selectedRelease?.id, loadSelectedRelease, loadTransitions]);
 
   useEffect(() => {
     if (projectId && (addModalOpen || (selectedRelease && canManage))) loadProjectIssues();
@@ -202,27 +248,20 @@ export default function ReleasesPage() {
     }
   };
 
-  const handleMarkReady = async (releaseId: string) => {
+  const handleTransition = async (transitionId: string) => {
+    if (!selectedRelease) return;
+    setTransitioning(transitionId);
     try {
-      await releasesApi.markReleaseReady(releaseId);
-      message.success('Релиз помечен как готовый к выпуску');
+      await releasesApi.executeTransition(selectedRelease.id, transitionId);
+      message.success('Статус обновлён');
       loadReleases();
-      if (selectedRelease?.id === releaseId) loadSelectedRelease(releaseId);
+      loadSelectedRelease(selectedRelease.id);
+      loadTransitions(selectedRelease.id);
     } catch (e) {
       const err = e as AxiosError<{ error?: string }>;
       message.error(err.response?.data?.error || 'Ошибка');
-    }
-  };
-
-  const handleMarkReleased = async (releaseId: string) => {
-    try {
-      await releasesApi.markReleaseReleased(releaseId);
-      message.success('Релиз выпущен');
-      loadReleases();
-      if (selectedRelease?.id === releaseId) loadSelectedRelease(releaseId);
-    } catch (e) {
-      const err = e as AxiosError<{ error?: string }>;
-      message.error(err.response?.data?.error || 'Ошибка');
+    } finally {
+      setTransitioning(null);
     }
   };
 
@@ -279,34 +318,15 @@ export default function ReleasesPage() {
 
   const filteredReleases = filterTab === 'ALL'
     ? releases
-    : releases.filter((r) => r.state === filterTab);
+    : releases.filter((r) => getReleaseCategory(r) === filterTab);
 
-  // First RELEASED in filtered list — not dimmed; rest are dimmed
-  const firstReleasedId = filteredReleases.find((r) => r.state === 'RELEASED')?.id;
+  // First DONE in filtered list — not dimmed; rest are dimmed
+  const firstReleasedId = filteredReleases.find((r) => getReleaseCategory(r) === 'DONE')?.id;
 
   const formatDate = (iso?: string | null) => {
     if (!iso) return '—';
     const d = new Date(iso);
     return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString('ru-RU', { day: 'numeric', month: 'short', year: 'numeric' });
-  };
-
-  const getReadyTooltip = () => {
-    if (!readiness) return '';
-    if (readiness.totalSprints === 0) return 'Добавьте хотя бы один спринт с задачами';
-    if (readiness.totalIssues === 0) return 'В спринтах нет задач';
-    return '';
-  };
-
-  const getReleaseTooltip = () => {
-    if (!readiness) return '';
-    const parts: string[] = [];
-    if (readiness.totalSprints > readiness.closedSprints)
-      parts.push(`${readiness.totalSprints - readiness.closedSprints} спринт(ов) не закрыто`);
-    const totalIssues = readiness.totalIssues ?? readiness.totalItems ?? 0;
-    const doneIssues = readiness.doneIssues ?? readiness.doneItems ?? 0;
-    if (totalIssues > doneIssues)
-      parts.push(`${totalIssues - doneIssues} задач(и) не выполнено`);
-    return parts.join(', ');
   };
 
   // ─── Sub-table columns ────────────────────────────────────
@@ -336,7 +356,7 @@ export default function ReleasesPage() {
       render: (_: unknown, r: SprintInRelease) =>
         r.startDate ? `${formatDate(r.startDate)} — ${formatDate(r.endDate)}` : '—',
     },
-    ...(canManage && selectedRelease?.state !== 'RELEASED'
+    ...(canManage && getReleaseCategory(selectedRelease ?? { state: 'DRAFT' } as Release) !== 'DONE'
       ? [{
           title: '', width: 40,
           render: (_: unknown, r: SprintInRelease) => (
@@ -359,11 +379,6 @@ export default function ReleasesPage() {
     display: 'inline-block', paddingBlock: 4, paddingInline: 10,
     border: `1px solid ${C.borderBtn}`, borderRadius: 6, cursor: 'pointer',
     background: isDark ? 'transparent' : C.btnBg,
-  };
-
-  const btnPrimary: React.CSSProperties = {
-    display: 'inline-block', paddingBlock: 4, paddingInline: 10,
-    backgroundImage: LOGO_GRAD, borderRadius: 6, cursor: 'pointer',
   };
 
   // ─── JSX ─────────────────────────────────────────────────
@@ -397,7 +412,7 @@ export default function ReleasesPage() {
             Релизы
           </div>
           <div style={{ fontFamily: F.sans, fontSize: 13, color: C.t3, lineHeight: '16px' }}>
-            {project?.name ?? '...'} · {releases.length} релизов · {releases.filter(r => r.state !== 'RELEASED').length} в работе
+            {project?.name ?? '...'} · {releases.length} релизов · {releases.filter(r => getReleaseCategory(r) !== 'DONE').length} в работе
           </div>
         </div>
         {canManage && (
@@ -414,23 +429,28 @@ export default function ReleasesPage() {
 
       {/* Filter tabs */}
       <div style={{ display: 'flex', gap: 4, marginBottom: 16 }}>
-        {(['ALL', 'DRAFT', 'READY', 'RELEASED'] as const).map((tab) => {
-          const isActive = filterTab === tab;
+        {([
+          { key: 'ALL',         label: 'Все' },
+          { key: 'TODO',        label: 'Открытые' },
+          { key: 'IN_PROGRESS', label: 'В работе' },
+          { key: 'DONE',        label: 'Завершённые' },
+        ] as const).map(({ key, label }) => {
+          const isActive = filterTab === key;
           return (
             <div
-              key={tab}
+              key={key}
               style={{
                 borderRadius: 6, paddingBlock: 6, paddingInline: 14, cursor: 'pointer',
                 backgroundImage: isActive && isDark ? C.tabActiveBg : undefined,
                 backgroundColor: isActive && !isDark ? C.tabActiveBg as string : undefined,
               }}
-              onClick={() => setFilterTab(tab)}
+              onClick={() => setFilterTab(key)}
             >
               <span style={{
                 fontFamily: F.sans, fontSize: 12, fontWeight: isActive ? 500 : 400,
                 color: isActive ? C.tabActiveText : C.tabText,
               }}>
-                {tab === 'ALL' ? 'Все' : tab}
+                {label}
               </span>
             </div>
           );
@@ -469,12 +489,13 @@ export default function ReleasesPage() {
           </div>
         ) : (
           filteredReleases.map((r, idx) => {
-            const isDimmed = r.state === 'RELEASED' && r.id !== firstReleasedId;
-            const isHighlighted = r.state === 'READY';
+            const cat = getReleaseCategory(r);
+            const isDimmed = cat === 'DONE' && r.id !== firstReleasedId;
+            const isHighlighted = cat === 'IN_PROGRESS';
             const isLast = idx === filteredReleases.length - 1;
             const isSelected = selectedRelease?.id === r.id;
             const levelCfg = LEVEL_CFG[r.level] ?? LEVEL_CFG.MINOR;
-            const statusCfg = STATUS_CFG[r.state];
+            const statusCfg = getStatusBadge(r);
 
             return (
               <div
@@ -561,7 +582,7 @@ export default function ReleasesPage() {
                 <div style={{
                   flexShrink: 0, width: 130,
                   fontFamily: F.sans, fontSize: 12, lineHeight: '16px',
-                  color: r.state === 'READY'
+                  color: cat === 'IN_PROGRESS'
                     ? (isDark ? '#4ADE80' : '#1A7F37')
                     : isDimmed ? C.t4 : C.t3,
                 }}>
@@ -570,18 +591,7 @@ export default function ReleasesPage() {
 
                 {/* Actions */}
                 <div style={{ flex: 1, display: 'flex', gap: 6, alignItems: 'center' }}>
-                  {/* READY: Выпустить + Открыть */}
-                  {r.state === 'READY' && canManage && (
-                    <Popconfirm title="Выпустить релиз?" onConfirm={() => handleMarkReleased(r.id)}>
-                      <div style={{ ...btnPrimary }}>
-                        <span style={{ fontFamily: F.sans, fontSize: 11, color: '#FFFFFF', lineHeight: '14px' }}>
-                          Выпустить
-                        </span>
-                      </div>
-                    </Popconfirm>
-                  )}
-
-                  {/* Открыть */}
+                  {/* Открыть/Закрыть — transitions available in detail panel */}
                   <div style={{ ...btnOutlined }} onClick={() => {
                     if (isSelected) {
                       setSelectedRelease(null);
@@ -593,17 +603,6 @@ export default function ReleasesPage() {
                       {isSelected ? 'Закрыть' : 'Открыть'}
                     </span>
                   </div>
-
-                  {/* DRAFT: … (mark ready) */}
-                  {r.state === 'DRAFT' && canManage && (
-                    <Popconfirm title="Отметить релиз готовым к выпуску?" onConfirm={() => handleMarkReady(r.id)}>
-                      <div style={{ ...btnOutlined }}>
-                        <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t3, lineHeight: '14px' }}>
-                          …
-                        </span>
-                      </div>
-                    </Popconfirm>
-                  )}
                 </div>
               </div>
             );
@@ -619,57 +618,76 @@ export default function ReleasesPage() {
         }}>
           {/* Detail header */}
           <div style={{
-            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
             backgroundColor: isDark ? '#161B22' : C.bgHeaderRow,
             borderBottom: `1px solid ${C.border}`,
             paddingInline: 20, paddingBlock: 12,
           }}>
-            <span style={{ fontFamily: F.display, fontSize: 14, fontWeight: 700, color: C.t1 }}>
-              {selectedRelease.name}
-            </span>
-            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-              {/* Readiness progress */}
-              {readiness && selectedRelease.state !== 'RELEASED' && (
-                <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t3 }}>
-                  Спринтов: {readiness.closedSprints}/{readiness.totalSprints} · Задач: {readiness.doneIssues}/{readiness.totalIssues}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: transitions.length > 0 || loadingTransitions ? 10 : 0 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <span style={{ fontFamily: F.display, fontSize: 14, fontWeight: 700, color: C.t1 }}>
+                  {selectedRelease.name}
                 </span>
-              )}
-              {canManage && selectedRelease.state === 'DRAFT' && readiness && (
-                <Tooltip title={getReadyTooltip()}>
-                  <div
-                    style={{
-                      ...btnOutlined,
-                      opacity: readiness.canMarkReady ? 1 : 0.5,
-                      cursor: readiness.canMarkReady ? 'pointer' : 'not-allowed',
-                    }}
-                    onClick={() => { if (readiness.canMarkReady) handleMarkReady(selectedRelease.id); }}
-                  >
-                    <span style={{ fontFamily: F.sans, fontSize: 11, color: C.btnText, lineHeight: '14px' }}>
-                      Отметить готовым
+                {currentStatus && (
+                  <div style={{
+                    display: 'inline-block',
+                    backgroundColor: `${currentStatus.color}26`,
+                    borderRadius: 20, paddingBlock: 3, paddingInline: 10,
+                  }}>
+                    <span style={{
+                      fontFamily: F.sans, fontSize: 10, fontWeight: 600,
+                      letterSpacing: '0.3px', color: currentStatus.color,
+                    }}>
+                      {currentStatus.name}
                     </span>
                   </div>
-                </Tooltip>
-              )}
-              {canManage && selectedRelease.state === 'READY' && readiness && (
-                <Tooltip title={getReleaseTooltip()}>
-                  <Popconfirm title="Выпустить релиз?" onConfirm={() => handleMarkReleased(selectedRelease.id)} disabled={!readiness.canRelease}>
-                    <div style={{
-                      ...btnPrimary,
-                      opacity: readiness.canRelease ? 1 : 0.5,
-                      cursor: readiness.canRelease ? 'pointer' : 'not-allowed',
-                    }}>
-                      <span style={{ fontFamily: F.sans, fontSize: 11, color: '#FFFFFF', lineHeight: '14px' }}>
-                        Выпустить релиз
-                      </span>
-                    </div>
-                  </Popconfirm>
-                </Tooltip>
+                )}
+              </div>
+              {readiness && getReleaseCategory(selectedRelease) !== 'DONE' && (
+                <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t3 }}>
+                  Спринтов: {readiness.closedSprints}/{readiness.totalSprints} · Задач: {readiness.doneIssues ?? readiness.doneItems ?? 0}/{readiness.totalIssues ?? readiness.totalItems ?? 0}
+                </span>
               )}
             </div>
+            {/* Transition buttons */}
+            {canManage && (
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                {loadingTransitions ? (
+                  <Spin size="small" />
+                ) : transitions.map(t => {
+                  const tColor = t.toStatus.color || C.acc;
+                  return (
+                    <Popconfirm
+                      key={t.id}
+                      title={`Перейти в статус «${t.toStatus.name}»?`}
+                      onConfirm={() => handleTransition(t.id)}
+                      okText="Да"
+                      cancelText="Отмена"
+                    >
+                      <div
+                        style={{
+                          border: `1px solid ${tColor}60`,
+                          background: `${tColor}15`,
+                          borderRadius: 6,
+                          paddingBlock: 4, paddingInline: 12,
+                          cursor: transitioning === t.id ? 'not-allowed' : 'pointer',
+                          opacity: transitioning === t.id ? 0.6 : 1,
+                        }}
+                      >
+                        <span style={{
+                          fontFamily: F.display, fontSize: 12, fontWeight: 600, color: tColor,
+                        }}>
+                          → {t.toStatus.name}
+                        </span>
+                      </div>
+                    </Popconfirm>
+                  );
+                })}
+              </div>
+            )}
           </div>
 
           {/* Readiness progress bars */}
-          {readiness && selectedRelease.state !== 'RELEASED' && (
+          {readiness && getReleaseCategory(selectedRelease) !== 'DONE' && (
             <div style={{ paddingInline: 20, paddingBlock: 12, borderBottom: `1px solid ${isDark ? C.border : '#EAEEF2'}` }}>
               <div style={{ display: 'flex', gap: 32 }}>
                 <div style={{ flex: 1 }}>
@@ -702,7 +720,7 @@ export default function ReleasesPage() {
               <span style={{ fontFamily: F.display, fontSize: 13, fontWeight: 700, color: C.t1 }}>
                 Спринты
               </span>
-              {canManage && selectedRelease.state !== 'RELEASED' && (
+              {canManage && getReleaseCategory(selectedRelease) !== 'DONE' && (
                 <div style={{ ...btnOutlined, cursor: 'pointer' }} onClick={() => setAddSprintsModalOpen(true)}>
                   <span style={{ fontFamily: F.sans, fontSize: 11, color: C.btnText, lineHeight: '14px' }}>
                     + Добавить спринт
@@ -726,7 +744,7 @@ export default function ReleasesPage() {
               <span style={{ fontFamily: F.display, fontSize: 13, fontWeight: 700, color: C.t1 }}>
                 Задачи
               </span>
-              {canManage && selectedRelease.state !== 'RELEASED' && (
+              {canManage && getReleaseCategory(selectedRelease) !== 'DONE' && (
                 <div style={{ ...btnOutlined, cursor: 'pointer' }} onClick={() => setAddModalOpen(true)}>
                   <span style={{ fontFamily: F.sans, fontSize: 11, color: C.btnText, lineHeight: '14px' }}>
                     <UserOutlined style={{ marginRight: 4 }} />Добавить задачи
@@ -742,6 +760,125 @@ export default function ReleasesPage() {
               pagination={false}
             />
           </div>
+        </div>
+      )}
+
+      {/* Integration releases section (TTMP-212) */}
+      {integrationReleases.length > 0 && (
+        <div style={{
+          backgroundColor: C.bgCard, border: `1px solid ${C.border}`,
+          borderRadius: 12, overflow: 'hidden', marginBottom: 16,
+        }}>
+          {/* Section header */}
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 10,
+            backgroundColor: C.bgHeaderRow,
+            borderBottom: `1px solid ${C.border}`,
+            paddingInline: 20, paddingBlock: 10,
+          }}>
+            <span style={{ fontFamily: F.display, fontSize: 13, fontWeight: 700, color: C.t1 }}>
+              Интеграционные релизы
+            </span>
+            <div style={{
+              backgroundColor: isDark ? '#A78BFA26' : '#7C3AED1A',
+              borderRadius: 4, paddingBlock: 2, paddingInline: 7,
+            }}>
+              <span style={{ fontFamily: F.sans, fontSize: 10, fontWeight: 600, color: isDark ? '#A78BFA' : '#7C3AED' }}>
+                {integrationReleases.length}
+              </span>
+            </div>
+            <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t3 }}>
+              Только просмотр · Управление в разделе{' '}
+              <Link to="/releases" style={{ color: C.acc }}>Релизы</Link>
+            </span>
+          </div>
+
+          {/* Rows */}
+          {integrationReleases.map((r, idx) => {
+            const statusCfg = getStatusBadge(r);
+            const isLast = idx === integrationReleases.length - 1;
+            return (
+              <div
+                key={r.id}
+                style={{
+                  display: 'flex', alignItems: 'center',
+                  paddingInline: 20, paddingBlock: 10,
+                  borderBottom: isLast ? undefined : `1px solid ${isDark ? C.border : '#EAEEF2'}`,
+                }}
+              >
+                {/* Name */}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{
+                    fontFamily: F.display, fontSize: 13, fontWeight: 700,
+                    letterSpacing: '-0.01em', color: C.t1, lineHeight: '16px',
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                  }}>
+                    {r.name}
+                  </div>
+                  {r.description && (
+                    <div style={{
+                      fontFamily: F.sans, fontSize: 11, color: C.t3,
+                      lineHeight: '14px', marginTop: 2,
+                      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    }}>
+                      {r.description}
+                    </div>
+                  )}
+                </div>
+
+                {/* Status badge */}
+                <div style={{ flexShrink: 0, marginLeft: 16 }}>
+                  <div style={{
+                    display: 'inline-block',
+                    backgroundColor: statusCfg.bg,
+                    borderRadius: 20, paddingBlock: 3, paddingInline: 10,
+                  }}>
+                    <span style={{
+                      fontFamily: F.sans, fontSize: 10, fontWeight: 600,
+                      letterSpacing: '0.3px', color: statusCfg.text,
+                    }}>
+                      {statusCfg.label}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Integration badge */}
+                <div style={{ flexShrink: 0, marginLeft: 8 }}>
+                  <div style={{
+                    display: 'inline-block',
+                    backgroundColor: isDark ? '#A78BFA26' : '#7C3AED1A',
+                    borderRadius: 4, paddingBlock: 3, paddingInline: 8,
+                  }}>
+                    <span style={{
+                      fontFamily: F.sans, fontSize: 10, fontWeight: 600,
+                      color: isDark ? '#A78BFA' : '#7C3AED',
+                    }}>
+                      Интеграционный
+                    </span>
+                  </div>
+                </div>
+
+                {/* Planned date */}
+                <div style={{
+                  flexShrink: 0, width: 130, marginLeft: 16,
+                  fontFamily: F.sans, fontSize: 12, color: C.t3, textAlign: 'right',
+                }}>
+                  {r.plannedDate ? formatDate(r.plannedDate) : '—'}
+                </div>
+
+                {/* Link to /releases */}
+                <div style={{ flexShrink: 0, marginLeft: 12 }}>
+                  <Link to="/releases" style={{ textDecoration: 'none' }}>
+                    <div style={{ ...btnOutlined }}>
+                      <span style={{ fontFamily: F.sans, fontSize: 11, color: C.t3, lineHeight: '14px' }}>
+                        Подробнее
+                      </span>
+                    </div>
+                  </Link>
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/frontend/src/pages/admin/AdminReleaseWorkflowEditorPage.tsx
+++ b/frontend/src/pages/admin/AdminReleaseWorkflowEditorPage.tsx
@@ -1,0 +1,822 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  addEdge,
+  useNodesState,
+  useEdgesState,
+  MarkerType,
+  type Node,
+  type Edge,
+  type NodeTypes,
+  type Connection,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import {
+  Button, Drawer, Form, Input, Select, Switch, Space, Tag, Alert,
+  Typography, Tooltip, Popconfirm, message, Spin,
+} from 'antd';
+import {
+  ArrowLeftOutlined, PlusOutlined, StarOutlined, DeleteOutlined,
+  CheckCircleOutlined, WarningOutlined, ReloadOutlined,
+} from '@ant-design/icons';
+import * as rwApi from '../../api/release-workflows-admin';
+import type {
+  ReleaseWorkflow, ReleaseWorkflowStep, ReleaseWorkflowTransition, ReleaseStatus,
+  ValidationReport,
+} from '../../api/release-workflows-admin';
+
+// ─── Category colours ─────────────────────────────────────────────────────────
+
+const CATEGORY_COLOR: Record<string, string> = {
+  PLANNING: '#2196F3',
+  IN_PROGRESS: '#FF9800',
+  DONE: '#4CAF50',
+  CANCELLED: '#9E9E9E',
+};
+
+const CATEGORY_LABEL: Record<string, string> = {
+  PLANNING: 'Планирование',
+  IN_PROGRESS: 'В работе',
+  DONE: 'Завершён',
+  CANCELLED: 'Отменён',
+};
+
+const RELEASE_TYPE_LABEL: Record<string, string> = {
+  ATOMIC: 'Атомарные',
+  INTEGRATION: 'Интеграционные',
+};
+
+// ─── Custom node ──────────────────────────────────────────────────────────────
+
+interface StatusNodeData {
+  label: string;
+  category: string;
+  color: string;
+  isInitial: boolean;
+  stepId: string;
+  statusId: string;
+  errorHighlight?: boolean;
+  warnHighlight?: boolean;
+  onSetInitial: (stepId: string) => void;
+  onDeleteStep: (stepId: string) => void;
+  [key: string]: unknown;
+}
+
+function StatusNode({ data }: { data: StatusNodeData }) {
+  const borderColor = data.errorHighlight
+    ? '#f5222d'
+    : data.warnHighlight
+    ? '#faad14'
+    : data.color;
+
+  return (
+    <div
+      style={{
+        background: '#fff',
+        border: `2px solid ${borderColor}`,
+        borderRadius: 8,
+        padding: '8px 12px',
+        minWidth: 140,
+        boxShadow: '0 2px 8px rgba(0,0,0,0.12)',
+        position: 'relative',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            background: data.color,
+            flexShrink: 0,
+          }}
+        />
+        <span style={{ fontWeight: 600, fontSize: 13 }}>{data.label}</span>
+        {data.isInitial && (
+          <Tooltip title="Начальный статус">
+            <StarOutlined style={{ color: '#faad14', fontSize: 12 }} />
+          </Tooltip>
+        )}
+      </div>
+      <div style={{ marginTop: 4 }}>
+        <Tag
+          color={CATEGORY_COLOR[data.category]}
+          style={{ fontSize: 10, padding: '0 4px', lineHeight: '16px' }}
+        >
+          {CATEGORY_LABEL[data.category] ?? data.category}
+        </Tag>
+      </div>
+      <div
+        style={{
+          position: 'absolute',
+          top: 4,
+          right: 4,
+          display: 'flex',
+          gap: 2,
+        }}
+        // prevent drag on action buttons
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {!data.isInitial && (
+          <Tooltip title="Сделать начальным">
+            <Button
+              size="small"
+              type="text"
+              icon={<StarOutlined />}
+              style={{ width: 20, height: 20, minWidth: 0, padding: 0 }}
+              onClick={() => data.onSetInitial(data.stepId)}
+            />
+          </Tooltip>
+        )}
+        <Popconfirm
+          title="Удалить шаг?"
+          onConfirm={() => data.onDeleteStep(data.stepId)}
+          okText="Удалить"
+          okButtonProps={{ danger: true }}
+        >
+          <Button
+            size="small"
+            type="text"
+            danger
+            icon={<DeleteOutlined />}
+            style={{ width: 20, height: 20, minWidth: 0, padding: 0 }}
+          />
+        </Popconfirm>
+      </div>
+    </div>
+  );
+}
+
+const nodeTypes: NodeTypes = { statusNode: StatusNode as unknown as NodeTypes['statusNode'] };
+
+// ─── Layout helpers ───────────────────────────────────────────────────────────
+
+function buildLayout(
+  steps: ReleaseWorkflowStep[],
+  validationHighlights: { errors: Set<string>; warnings: Set<string> },
+  onSetInitial: (stepId: string) => void,
+  onDeleteStep: (stepId: string) => void,
+): Node[] {
+  return steps.map((step, i) => ({
+    id: step.id,
+    type: 'statusNode',
+    position: { x: 200 * (i % 4), y: 160 * Math.floor(i / 4) },
+    data: {
+      label: step.status.name,
+      category: step.status.category,
+      color: step.status.color ?? CATEGORY_COLOR[step.status.category] ?? '#999',
+      isInitial: step.isInitial,
+      stepId: step.id,
+      statusId: step.statusId,
+      errorHighlight: validationHighlights.errors.has(step.statusId),
+      warnHighlight: validationHighlights.warnings.has(step.statusId),
+      onSetInitial,
+      onDeleteStep,
+    },
+  }));
+}
+
+function buildEdges(transitions: ReleaseWorkflowTransition[], steps: ReleaseWorkflowStep[]): Edge[] {
+  const stepById = new Map(steps.map((s) => [s.id, s]));
+  const stepByStatusId = new Map(steps.map((s) => [s.statusId, s]));
+
+  return transitions.map((t) => {
+    const fromStep = stepByStatusId.get(t.fromStatusId);
+    const toStep = stepByStatusId.get(t.toStatusId);
+    if (!fromStep || !toStep) return null;
+    void stepById;
+    return {
+      id: t.id,
+      source: fromStep.id,
+      target: toStep.id,
+      label: t.name,
+      type: 'smoothstep',
+      animated: t.isGlobal,
+      style: { strokeWidth: t.isGlobal ? 2 : 1.5 },
+      markerEnd: { type: MarkerType.ArrowClosed },
+      data: { transition: t },
+    };
+  }).filter(Boolean) as Edge[];
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function AdminReleaseWorkflowEditorPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [workflow, setWorkflow] = useState<ReleaseWorkflow | null>(null);
+  const [allStatuses, setAllStatuses] = useState<ReleaseStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [validation, setValidation] = useState<ValidationReport | null>(null);
+  const [validating, setValidating] = useState(false);
+
+  // React Flow state
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+
+  // Drawers
+  const [stepDrawerOpen, setStepDrawerOpen] = useState(false);
+  const [stepForm] = Form.useForm();
+
+  const [transitionDrawerOpen, setTransitionDrawerOpen] = useState(false);
+  const [editingTransition, setEditingTransition] = useState<ReleaseWorkflowTransition | null>(null);
+  const [transitionForm] = Form.useForm();
+
+  // Header edit
+  const [headerDrawerOpen, setHeaderDrawerOpen] = useState(false);
+  const [headerForm] = Form.useForm();
+
+  // Keep stable refs for node callbacks
+  const workflowRef = useRef<ReleaseWorkflow | null>(null);
+  workflowRef.current = workflow;
+
+  const validationHighlights = useCallback((): { errors: Set<string>; warnings: Set<string> } => {
+    if (!validation) return { errors: new Set(), warnings: new Set() };
+    return {
+      errors: new Set(
+        validation.errors
+          .filter((e) => e.type === 'NO_INITIAL_STATUS' || e.type === 'NO_DONE_STATUS')
+          .flatMap(() => (workflowRef.current?.steps ?? []).map((s) => s.statusId)),
+      ),
+      warnings: new Set(
+        validation.warnings.filter((w) => w.statusId).map((w) => w.statusId!),
+      ),
+    };
+  }, [validation]);
+
+  const rebuildGraph = useCallback(
+    (wf: ReleaseWorkflow, hl: { errors: Set<string>; warnings: Set<string> }) => {
+      const newNodes = buildLayout(wf.steps, hl, handleSetInitial, handleDeleteStep);
+      const newEdges = buildEdges(wf.transitions, wf.steps);
+      setNodes(newNodes);
+      setEdges(newEdges);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const handleSetInitial = useCallback(async (stepId: string) => {
+    const wf = workflowRef.current;
+    if (!wf) return;
+    try {
+      await rwApi.updateReleaseWorkflowStep(wf.id, stepId, { isInitial: true });
+      message.success('Начальный статус обновлён');
+      load();
+    } catch {
+      message.error('Не удалось обновить');
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleDeleteStep = useCallback(async (stepId: string) => {
+    const wf = workflowRef.current;
+    if (!wf) return;
+    try {
+      await rwApi.deleteReleaseWorkflowStep(wf.id, stepId);
+      message.success('Шаг удалён');
+      load();
+    } catch {
+      message.error('Нельзя удалить: есть переходы от/до этого статуса');
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const runValidation = useCallback(async (wfId: string) => {
+    setValidating(true);
+    try {
+      const report = await rwApi.validateReleaseWorkflow(wfId);
+      setValidation(report);
+      return report;
+    } finally {
+      setValidating(false);
+    }
+  }, []);
+
+  // Defined after helpers are available
+  // eslint-disable-next-line prefer-const
+  let load: () => Promise<void>;
+  load = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    try {
+      const [wf, statuses, report] = await Promise.all([
+        rwApi.getReleaseWorkflow(id),
+        rwApi.listReleaseStatuses(),
+        rwApi.validateReleaseWorkflow(id),
+      ]);
+      setWorkflow(wf);
+      setAllStatuses(statuses);
+      setValidation(report);
+      const hl = {
+        errors: new Set(
+          report.errors
+            .filter((e) => e.type === 'NO_INITIAL_STATUS' || e.type === 'NO_DONE_STATUS')
+            .flatMap(() => wf.steps.map((s) => s.statusId)),
+        ),
+        warnings: new Set(
+          report.warnings.filter((w) => w.statusId).map((w) => w.statusId!),
+        ),
+      };
+      rebuildGraph(wf, hl);
+    } finally {
+      setLoading(false);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, rebuildGraph]);
+
+  useEffect(() => { load(); }, [load]);
+
+  // Rebuild graph when validation changes (without re-fetching workflow)
+  useEffect(() => {
+    if (workflow && validation) {
+      rebuildGraph(workflow, validationHighlights());
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [validation]);
+
+  // ─── Add step ─────────────────────────────────────────────────────────────
+
+  const handleAddStep = async (vals: { statusId: string; isInitial?: boolean }) => {
+    if (!id) return;
+    try {
+      await rwApi.addReleaseWorkflowStep(id, {
+        statusId: vals.statusId,
+        isInitial: vals.isInitial ?? false,
+      });
+      message.success('Статус добавлен');
+      setStepDrawerOpen(false);
+      stepForm.resetFields();
+      await load();
+      runValidation(id);
+    } catch (err) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      message.error(msg === 'Status already in workflow' ? 'Статус уже добавлен' : 'Ошибка добавления');
+    }
+  };
+
+  // ─── Transition drawer ────────────────────────────────────────────────────
+
+  const openAddTransition = () => {
+    setEditingTransition(null);
+    transitionForm.resetFields();
+    setTransitionDrawerOpen(true);
+  };
+
+  const openEditTransition = (t: ReleaseWorkflowTransition) => {
+    setEditingTransition(t);
+    transitionForm.setFieldsValue({
+      name: t.name,
+      fromStatusId: t.fromStatusId,
+      toStatusId: t.toStatusId,
+      isGlobal: t.isGlobal,
+      conditions: t.conditions ? JSON.stringify(t.conditions, null, 2) : '',
+    });
+    setTransitionDrawerOpen(true);
+  };
+
+  // Click on edge → open edit drawer
+  const onEdgeClick = useCallback(
+    (_: React.MouseEvent, edge: Edge) => {
+      const t = (edge.data as { transition: ReleaseWorkflowTransition })?.transition;
+      if (t) openEditTransition(t);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  // Drag connection from handle → create transition
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      // Find steps by node id
+      const fromStep = workflow?.steps.find((s) => s.id === connection.source);
+      const toStep = workflow?.steps.find((s) => s.id === connection.target);
+      if (!fromStep || !toStep) return;
+      setTransitionDrawerOpen(true);
+      setEditingTransition(null);
+      transitionForm.setFieldsValue({
+        fromStatusId: fromStep.statusId,
+        toStatusId: toStep.statusId,
+      });
+      setEdges((eds) => addEdge(connection, eds));
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [workflow],
+  );
+
+  const handleSaveTransition = async (vals: {
+    name: string;
+    fromStatusId?: string;
+    toStatusId: string;
+    isGlobal?: boolean;
+    conditions?: string;
+  }) => {
+    if (!id) return;
+    let conditions: unknown[] | null = null;
+    if (vals.conditions?.trim()) {
+      try {
+        conditions = JSON.parse(vals.conditions) as unknown[];
+      } catch {
+        message.error('Условия: невалидный JSON');
+        return;
+      }
+    }
+    const body = {
+      name: vals.name,
+      fromStatusId: vals.fromStatusId!,
+      toStatusId: vals.toStatusId,
+      isGlobal: vals.isGlobal ?? false,
+      conditions,
+    };
+    try {
+      if (editingTransition) {
+        await rwApi.updateReleaseWorkflowTransition(id, editingTransition.id, body);
+        message.success('Переход обновлён');
+      } else {
+        await rwApi.createReleaseWorkflowTransition(id, body);
+        message.success('Переход создан');
+      }
+      setTransitionDrawerOpen(false);
+      await load();
+      runValidation(id);
+    } catch (err) {
+      const code = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      if (code === 'TRANSITION_ALREADY_EXISTS') {
+        message.error('Такой переход уже существует');
+      } else {
+        message.error('Не удалось сохранить');
+      }
+    }
+  };
+
+  const handleDeleteTransition = async (transitionId: string) => {
+    if (!id) return;
+    try {
+      await rwApi.deleteReleaseWorkflowTransition(id, transitionId);
+      message.success('Переход удалён');
+      setTransitionDrawerOpen(false);
+      await load();
+      runValidation(id);
+    } catch {
+      message.error('Не удалось удалить');
+    }
+  };
+
+  // ─── Header edit ──────────────────────────────────────────────────────────
+
+  const openHeader = () => {
+    if (!workflow) return;
+    headerForm.setFieldsValue({
+      name: workflow.name,
+      description: workflow.description ?? '',
+      releaseType: workflow.releaseType ?? 'universal',
+      isDefault: workflow.isDefault,
+      isActive: workflow.isActive,
+    });
+    setHeaderDrawerOpen(true);
+  };
+
+  const handleSaveHeader = async (vals: {
+    name: string;
+    description?: string;
+    releaseType?: string;
+    isDefault: boolean;
+    isActive: boolean;
+  }) => {
+    if (!id) return;
+    const releaseType = vals.releaseType === 'universal'
+      ? null
+      : (vals.releaseType as 'ATOMIC' | 'INTEGRATION' | null);
+    try {
+      await rwApi.updateReleaseWorkflow(id, {
+        name: vals.name,
+        description: vals.description || null,
+        releaseType,
+        isDefault: vals.isDefault,
+        isActive: vals.isActive,
+      });
+      message.success('Workflow обновлён');
+      setHeaderDrawerOpen(false);
+      load();
+    } catch {
+      message.error('Не удалось сохранить');
+    }
+  };
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+
+  if (loading || !workflow) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 400 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  const stepStatusIds = new Set(workflow.steps.map((s) => s.statusId));
+  const availableStatuses = allStatuses.filter((s) => !stepStatusIds.has(s.id));
+  const stepByStatusId = new Map(workflow.steps.map((s) => [s.statusId, s]));
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 64px)' }}>
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '12px 20px',
+          borderBottom: '1px solid #f0f0f0',
+          background: '#fff',
+          flexShrink: 0,
+        }}
+      >
+        <Button
+          type="text"
+          icon={<ArrowLeftOutlined />}
+          onClick={() => navigate('/admin/release-workflows')}
+        >
+          Назад
+        </Button>
+        <Typography.Title level={4} style={{ margin: 0 }}>
+          {workflow.name}
+        </Typography.Title>
+        {workflow.isDefault && <Tag color="blue">По умолчанию</Tag>}
+        {workflow.releaseType ? (
+          <Tag color="purple">{RELEASE_TYPE_LABEL[workflow.releaseType]}</Tag>
+        ) : (
+          <Tag>Универсальный</Tag>
+        )}
+        {!workflow.isActive && <Tag color="red">Неактивен</Tag>}
+
+        {/* Validation badge */}
+        {validating ? (
+          <Spin size="small" />
+        ) : validation ? (
+          validation.isValid ? (
+            <Tag icon={<CheckCircleOutlined />} color="success">
+              Граф валидный
+            </Tag>
+          ) : (
+            <Tag icon={<WarningOutlined />} color="error">
+              {validation.errors.length} ошибок
+            </Tag>
+          )
+        ) : null}
+
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+          <Tooltip title="Перепроверить граф">
+            <Button
+              icon={<ReloadOutlined />}
+              size="small"
+              onClick={() => runValidation(id!)}
+              loading={validating}
+            />
+          </Tooltip>
+          <Button size="small" onClick={openHeader}>Настройки</Button>
+          <Button
+            size="small"
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => { stepForm.resetFields(); setStepDrawerOpen(true); }}
+            disabled={availableStatuses.length === 0}
+          >
+            Добавить статус
+          </Button>
+          <Button size="small" icon={<PlusOutlined />} onClick={openAddTransition}>
+            Добавить переход
+          </Button>
+        </div>
+      </div>
+
+      {/* Validation panel */}
+      {validation && (!validation.isValid || validation.warnings.length > 0) && (
+        <div style={{ padding: '8px 20px', background: '#fff', borderBottom: '1px solid #f0f0f0', flexShrink: 0 }}>
+          {validation.errors.map((e, i) => (
+            <Alert key={i} type="error" message={e.message} style={{ marginBottom: 4 }} showIcon />
+          ))}
+          {validation.warnings.map((w, i) => (
+            <Alert key={i} type="warning" message={w.message} style={{ marginBottom: 4 }} showIcon />
+          ))}
+        </div>
+      )}
+
+      {/* React Flow canvas */}
+      <div style={{ flex: 1, background: '#fafafa' }}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onEdgeClick={onEdgeClick}
+          fitView
+          fitViewOptions={{ padding: 0.3 }}
+        >
+          <Background />
+          <Controls />
+          <MiniMap
+            nodeColor={(n) => {
+              const data = n.data as StatusNodeData;
+              return data?.color ?? '#999';
+            }}
+          />
+        </ReactFlow>
+      </div>
+
+      {/* Add step drawer */}
+      <Drawer
+        title="Добавить статус"
+        open={stepDrawerOpen}
+        onClose={() => setStepDrawerOpen(false)}
+        width={360}
+      >
+        <Form form={stepForm} layout="vertical" onFinish={handleAddStep}>
+          <Form.Item name="statusId" label="Статус" rules={[{ required: true, message: 'Выберите статус' }]}>
+            <Select
+              showSearch
+              optionFilterProp="label"
+              options={availableStatuses.map((s) => ({
+                value: s.id,
+                label: (
+                  <Space>
+                    <span
+                      style={{ width: 10, height: 10, borderRadius: '50%', background: s.color, display: 'inline-block' }}
+                    />
+                    {s.name}
+                    <Tag style={{ fontSize: 10 }}>{CATEGORY_LABEL[s.category] ?? s.category}</Tag>
+                  </Space>
+                ),
+              }))}
+            />
+          </Form.Item>
+          <Form.Item name="isInitial" label="Начальный статус" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+          <Space>
+            <Button type="primary" htmlType="submit">Добавить</Button>
+            <Button onClick={() => setStepDrawerOpen(false)}>Отмена</Button>
+          </Space>
+        </Form>
+      </Drawer>
+
+      {/* Transition drawer */}
+      <Drawer
+        title={editingTransition ? 'Редактировать переход' : 'Добавить переход'}
+        open={transitionDrawerOpen}
+        onClose={() => setTransitionDrawerOpen(false)}
+        width={420}
+        extra={
+          editingTransition && (
+            <Popconfirm
+              title="Удалить переход?"
+              onConfirm={() => handleDeleteTransition(editingTransition.id)}
+              okText="Удалить"
+              okButtonProps={{ danger: true }}
+            >
+              <Button danger icon={<DeleteOutlined />} size="small">
+                Удалить
+              </Button>
+            </Popconfirm>
+          )
+        }
+      >
+        <Form
+          form={transitionForm}
+          layout="vertical"
+          onFinish={handleSaveTransition}
+          initialValues={{ isGlobal: false }}
+        >
+          <Form.Item name="name" label="Название" rules={[{ required: true, message: 'Введите название' }]}>
+            <Input placeholder="Начать тестирование" />
+          </Form.Item>
+          <Form.Item name="isGlobal" label="Глобальный (из любого статуса)" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+          <Form.Item noStyle shouldUpdate={(prev, curr) => prev.isGlobal !== curr.isGlobal}>
+            {({ getFieldValue }) =>
+              !getFieldValue('isGlobal') ? (
+                <Form.Item
+                  name="fromStatusId"
+                  label="Из статуса"
+                  rules={[{ required: true, message: 'Выберите исходный статус' }]}
+                >
+                  <Select
+                    options={workflow.steps.map((s) => ({
+                      value: s.statusId,
+                      label: s.status.name,
+                    }))}
+                  />
+                </Form.Item>
+              ) : null
+            }
+          </Form.Item>
+          <Form.Item name="toStatusId" label="В статус" rules={[{ required: true, message: 'Выберите целевой статус' }]}>
+            <Select
+              options={workflow.steps.map((s) => ({
+                value: s.statusId,
+                label: s.status.name,
+              }))}
+            />
+          </Form.Item>
+          <Form.Item name="conditions" label="Условия (JSON)">
+            <Input.TextArea
+              rows={4}
+              placeholder='[{"type": "user-in-role", "value": "MANAGER"}]'
+              style={{ fontFamily: 'monospace', fontSize: 12 }}
+            />
+          </Form.Item>
+          <Space>
+            <Button type="primary" htmlType="submit">Сохранить</Button>
+            <Button onClick={() => setTransitionDrawerOpen(false)}>Отмена</Button>
+          </Space>
+        </Form>
+      </Drawer>
+
+      {/* Header/settings drawer */}
+      <Drawer
+        title="Настройки workflow"
+        open={headerDrawerOpen}
+        onClose={() => setHeaderDrawerOpen(false)}
+        width={380}
+      >
+        <Form
+          form={headerForm}
+          layout="vertical"
+          onFinish={handleSaveHeader}
+          initialValues={{ isDefault: false, isActive: true, releaseType: 'universal' }}
+        >
+          <Form.Item name="name" label="Название" rules={[{ required: true }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="description" label="Описание">
+            <Input.TextArea rows={2} />
+          </Form.Item>
+          <Form.Item name="releaseType" label="Тип релиза">
+            <Select
+              options={[
+                { value: 'universal', label: 'Универсальный (все типы)' },
+                { value: 'ATOMIC', label: 'Атомарные релизы' },
+                { value: 'INTEGRATION', label: 'Интеграционные релизы' },
+              ]}
+            />
+          </Form.Item>
+          <Form.Item name="isDefault" label="По умолчанию" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+          <Form.Item name="isActive" label="Активен" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+          <Space>
+            <Button type="primary" htmlType="submit">Сохранить</Button>
+            <Button onClick={() => setHeaderDrawerOpen(false)}>Отмена</Button>
+          </Space>
+        </Form>
+      </Drawer>
+
+      {/* Legend */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 80,
+          left: 24,
+          background: 'rgba(255,255,255,0.95)',
+          border: '1px solid #e8e8e8',
+          borderRadius: 6,
+          padding: '8px 12px',
+          fontSize: 12,
+          zIndex: 10,
+          pointerEvents: 'none',
+        }}
+      >
+        <div style={{ fontWeight: 600, marginBottom: 4 }}>Категории:</div>
+        {Object.entries(CATEGORY_LABEL).map(([key, label]) => (
+          <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
+            <span
+              style={{ width: 10, height: 10, borderRadius: '50%', background: CATEGORY_COLOR[key], display: 'inline-block' }}
+            />
+            {label}
+          </div>
+        ))}
+        <div style={{ marginTop: 6, color: '#999' }}>
+          <span style={{ color: '#f5222d' }}>■</span> Ошибка&nbsp;&nbsp;
+          <span style={{ color: '#faad14' }}>■</span> Предупреждение
+        </div>
+      </div>
+
+      {/* Переходы ниже — для screenreader / доступности */}
+      <div style={{ display: 'none' }}>
+        {/* Transitions list used internally */}
+        {workflow.transitions.map((t) => {
+          void stepByStatusId;
+          return <span key={t.id}>{t.name}</span>;
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminReleaseWorkflowsPage.tsx
+++ b/frontend/src/pages/admin/AdminReleaseWorkflowsPage.tsx
@@ -1,0 +1,232 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Button, Table, Tag, Space, Form, Input, Select, Switch, Modal, message,
+  Popconfirm, Typography, Badge,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { PlusOutlined, EditOutlined, DeleteOutlined, ApartmentOutlined } from '@ant-design/icons';
+import * as rwApi from '../../api/release-workflows-admin';
+import type { ReleaseWorkflow } from '../../api/release-workflows-admin';
+
+const RELEASE_TYPE_LABEL: Record<string, string> = {
+  ATOMIC: 'Атомарные',
+  INTEGRATION: 'Интеграционные',
+};
+
+export default function AdminReleaseWorkflowsPage() {
+  const navigate = useNavigate();
+  const [workflows, setWorkflows] = useState<ReleaseWorkflow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<ReleaseWorkflow | null>(null);
+  const [form] = Form.useForm();
+  const [saving, setSaving] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      setWorkflows(await rwApi.listReleaseWorkflows());
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const openCreate = () => {
+    setEditing(null);
+    form.resetFields();
+    setModalOpen(true);
+  };
+
+  const openEdit = (wf: ReleaseWorkflow) => {
+    setEditing(wf);
+    form.setFieldsValue({
+      name: wf.name,
+      description: wf.description ?? '',
+      releaseType: wf.releaseType ?? 'universal',
+      isDefault: wf.isDefault,
+      isActive: wf.isActive,
+    });
+    setModalOpen(true);
+  };
+
+  const handleSave = async (vals: {
+    name: string;
+    description?: string;
+    releaseType?: string;
+    isDefault: boolean;
+    isActive: boolean;
+  }) => {
+    setSaving(true);
+    try {
+      const releaseType = vals.releaseType === 'universal' ? null : (vals.releaseType as 'ATOMIC' | 'INTEGRATION' | null);
+      if (editing) {
+        await rwApi.updateReleaseWorkflow(editing.id, {
+          name: vals.name,
+          description: vals.description || null,
+          releaseType,
+          isDefault: vals.isDefault,
+          isActive: vals.isActive,
+        });
+        message.success('Workflow обновлён');
+      } else {
+        await rwApi.createReleaseWorkflow({
+          name: vals.name,
+          description: vals.description,
+          releaseType,
+          isDefault: vals.isDefault,
+          isActive: vals.isActive,
+        });
+        message.success('Workflow создан');
+      }
+      setModalOpen(false);
+      load();
+    } catch {
+      message.error('Не удалось сохранить');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await rwApi.deleteReleaseWorkflow(id);
+      message.success('Workflow удалён');
+      load();
+    } catch (err) {
+      const code = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      if (code === 'RELEASE_WORKFLOW_IN_USE') {
+        message.error('Нельзя удалить: workflow используется релизами');
+      } else {
+        message.error('Не удалось удалить');
+      }
+    }
+  };
+
+  const columns: ColumnsType<ReleaseWorkflow> = [
+    {
+      title: 'Название',
+      dataIndex: 'name',
+      render: (name, wf) => (
+        <Space>
+          <Button
+            type="link"
+            style={{ padding: 0, fontWeight: 500 }}
+            onClick={() => navigate(`/admin/release-workflows/${wf.id}`)}
+            icon={<ApartmentOutlined />}
+          >
+            {name}
+          </Button>
+          {wf.isDefault && <Tag color="blue">По умолчанию</Tag>}
+        </Space>
+      ),
+    },
+    {
+      title: 'Тип релиза',
+      dataIndex: 'releaseType',
+      render: (t) => t ? <Tag>{RELEASE_TYPE_LABEL[t] ?? t}</Tag> : <Tag>Универсальный</Tag>,
+    },
+    {
+      title: 'Статусов',
+      render: (_, wf) => wf.steps.length,
+      width: 100,
+    },
+    {
+      title: 'Переходов',
+      render: (_, wf) => wf.transitions.length,
+      width: 100,
+    },
+    {
+      title: 'Релизов',
+      render: (_, wf) => wf._count.releases,
+      width: 100,
+    },
+    {
+      title: 'Активен',
+      dataIndex: 'isActive',
+      width: 90,
+      render: (v) => <Badge status={v ? 'success' : 'default'} text={v ? 'Да' : 'Нет'} />,
+    },
+    {
+      title: '',
+      width: 100,
+      render: (_, wf) => (
+        <Space>
+          <Button size="small" icon={<EditOutlined />} onClick={() => openEdit(wf)} />
+          <Popconfirm
+            title="Удалить workflow?"
+            onConfirm={() => handleDelete(wf.id)}
+            okText="Удалить"
+            okButtonProps={{ danger: true }}
+          >
+            <Button size="small" danger icon={<DeleteOutlined />} />
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div className="tt-page">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+        <Typography.Title level={4} style={{ margin: 0 }}>Workflow релизов</Typography.Title>
+        <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
+          Создать workflow
+        </Button>
+      </div>
+
+      <Table
+        rowKey="id"
+        dataSource={workflows}
+        columns={columns}
+        loading={loading}
+        pagination={false}
+        size="small"
+      />
+
+      <Modal
+        title={editing ? 'Редактировать workflow' : 'Создать workflow'}
+        open={modalOpen}
+        onCancel={() => setModalOpen(false)}
+        footer={null}
+        destroyOnClose
+      >
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={handleSave}
+          initialValues={{ isDefault: false, isActive: true, releaseType: 'universal' }}
+        >
+          <Form.Item name="name" label="Название" rules={[{ required: true, message: 'Введите название' }]}>
+            <Input placeholder="Стандартный workflow" />
+          </Form.Item>
+          <Form.Item name="description" label="Описание">
+            <Input.TextArea rows={2} />
+          </Form.Item>
+          <Form.Item name="releaseType" label="Тип релиза">
+            <Select
+              options={[
+                { value: 'universal', label: 'Универсальный (все типы)' },
+                { value: 'ATOMIC', label: 'Атомарные релизы' },
+                { value: 'INTEGRATION', label: 'Интеграционные релизы' },
+              ]}
+            />
+          </Form.Item>
+          <Form.Item name="isDefault" label="По умолчанию" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+          <Form.Item name="isActive" label="Активен" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+          <Space>
+            <Button type="primary" htmlType="submit" loading={saving}>Сохранить</Button>
+            <Button onClick={() => setModalOpen(false)}>Отмена</Button>
+          </Space>
+        </Form>
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -50,10 +50,16 @@ export type { SprintState, Sprint, SprintDetailsResponse } from './sprint.types'
 export type { TeamMember, Team } from './team.types';
 
 export type {
+  ReleaseType,
   ReleaseLevel,
   ReleaseState,
+  ReleaseStatus,
   SprintInRelease,
   ReleaseReadiness,
+  ReleaseTransition,
+  ReleaseTransitionsResponse,
+  ReleaseAuditEntry,
+  ReleaseItem,
   Release,
 } from './release.types';
 

--- a/frontend/src/types/release.types.ts
+++ b/frontend/src/types/release.types.ts
@@ -1,8 +1,16 @@
-/** Release domain types — TTUI-125 */
+/** Release domain types — TTMP-178 */
 import type { SprintState } from './sprint.types';
 
+export type ReleaseType = 'ATOMIC' | 'INTEGRATION';
 export type ReleaseLevel = 'MINOR' | 'MAJOR';
-export type ReleaseState = 'DRAFT' | 'READY' | 'RELEASED';
+export type ReleaseState = 'DRAFT' | 'READY' | 'RELEASED'; // legacy field
+
+export interface ReleaseStatus {
+  id: string;
+  name: string;
+  category: string;
+  color: string;
+}
 
 export interface SprintInRelease {
   id: string;
@@ -17,23 +25,76 @@ export interface SprintInRelease {
 export interface ReleaseReadiness {
   totalSprints: number;
   closedSprints: number;
-  totalIssues: number;
-  doneIssues: number;
-  canMarkReady: boolean;
-  canRelease: boolean;
+  totalItems: number;
+  doneItems: number;
+  cancelledItems: number;
+  inProgressItems: number;
+  completionPercent: number;
+  byProject: Array<{ projectId: string; key: string; name: string; total: number; done: number }>;
+  // legacy fields
+  totalIssues?: number;
+  doneIssues?: number;
+  canMarkReady?: boolean;
+  canRelease?: boolean;
+}
+
+export interface ReleaseTransition {
+  id: string;
+  name: string;
+  toStatus: ReleaseStatus;
+}
+
+export interface ReleaseTransitionsResponse {
+  currentStatus: ReleaseStatus | null;
+  transitions: ReleaseTransition[];
+}
+
+export interface ReleaseAuditEntry {
+  id: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  details: Record<string, unknown> | null;
+  createdAt: string;
+  user: { id: string; name: string } | null;
+}
+
+export interface ReleaseItem {
+  id: string;
+  releaseId: string;
+  issueId: string;
+  issue: {
+    id: string;
+    number: number;
+    title: string;
+    status: string;
+    priority: string;
+    projectId: string;
+    project: { id: string; name: string; key: string };
+    assignee: { id: string; name: string } | null;
+    issueTypeConfig: { id: string; name: string; systemKey: string; iconColor: string };
+    workflowStatus: { id: string; name: string; category: string; color: string } | null;
+  };
 }
 
 export interface Release {
   id: string;
-  projectId: string;
+  projectId?: string | null;
+  type: ReleaseType;
   name: string;
   description?: string | null;
   level: ReleaseLevel;
   state: ReleaseState;
+  statusId?: string | null;
+  status?: ReleaseStatus | null;
+  workflowId?: string | null;
   releaseDate?: string | null;
+  plannedDate?: string | null;
   createdAt: string;
   updatedAt: string;
-  _count?: { issues: number; sprints?: number };
-  project?: { id: string; name: string; key: string };
+  createdBy?: { id: string; name: string } | null;
+  project?: { id: string; name: string; key: string } | null;
+  _count?: { issues?: number; sprints?: number; items?: number };
+  _projects?: string[];
   sprints?: SprintInRelease[];
 }


### PR DESCRIPTION
## Summary

- **[RM-01.1]** Новые enum (`ReleaseType`, `ReleaseStatusCategory`) и модели (`ReleaseStatus`, `ReleaseWorkflow`, `ReleaseWorkflowStep`, `ReleaseWorkflowTransition`) в `schema.prisma`
- **[RM-01.2]** Модель `ReleaseItem` — промежуточная таблица release↔issue (поддержка одной задачи в нескольких релизах)
- **[RM-01.3]** Модель `Release` расширена: `type`, `statusId`, `workflowId`, `plannedDate`, `createdById`; `projectId` стал nullable для интеграционных релизов
- **[RM-01.4]** `RELEASE_MANAGER` добавлен в `UserRole`; исправлен `RoleChangeActor` type в `users.service.ts`
- **[RM-01.5]** Seed 6 дефолтных статусов + workflow с 6 переходами (в миграции и в `seed-release-workflow.ts`)
- **[RM-01.6]** Data migration: `state→statusId` маппинг, `Issue.releaseId→ReleaseItem`

## Миграция

`backend/src/prisma/migrations/20260411000000_release_management_models/migration.sql` — содержит DDL + seed + data migration в одном файле.

## Test plan

- [ ] `npx prisma migrate deploy` проходит без ошибок
- [ ] `npm run db:seed:release-workflow` создаёт 6 статусов и 1 workflow
- [ ] `npm run typecheck` — 0 ошибок
- [ ] Существующие релизы получают `statusId` и `workflowId` после миграции
- [ ] Задачи с `releaseId` мигрированы в `release_items`

🤖 Generated with [Claude Code](https://claude.com/claude-code)