### PR TITLE
fix(releases): align implementation with RELEASE_MANAGEMENT_SPEC [TTMP-223]

### DIFF
--- a/backend/src/modules/releases/release-workflow-engine.service.ts
+++ b/backend/src/modules/releases/release-workflow-engine.service.ts
@@ -37,7 +37,7 @@ type ReleaseConditionRule =
   // are checking issue workflow statuses, not release statuses.
   | { type: 'ALL_ITEMS_IN_STATUS_CATEGORY'; category: StatusCategory }
   | { type: 'ALL_SPRINTS_CLOSED' }
-  | { type: 'MIN_ITEMS_COUNT'; minCount: number };
+  | { type: 'MIN_ITEMS_COUNT'; min: number };
 
 // ─── Condition evaluator (async, release-specific) ────────────────────────────
 
@@ -76,7 +76,7 @@ async function evaluateReleaseCondition(
       const total = await prisma.releaseItem.count({
         where: { releaseId: ctx.releaseId },
       });
-      return total >= rule.minCount;
+      return total >= rule.min;
     }
 
     default:
@@ -257,7 +257,7 @@ export async function executeTransition(
       releaseId,
     });
     if (!allowed) {
-      throw new AppError(403, 'CONDITION_NOT_MET', {
+      throw new AppError(409, 'CONDITION_NOT_MET', {
         details: { conditionType: failedCondition ?? 'UNKNOWN' },
       });
     }
@@ -285,7 +285,7 @@ export async function executeTransition(
     }),
     prisma.auditLog.create({
       data: {
-        action: 'release.transitioned',
+        action: 'release.transition',
         entityType: 'release',
         entityId: releaseId,
         userId: actorId,

--- a/backend/src/modules/releases/release-workflows-admin.router.ts
+++ b/backend/src/modules/releases/release-workflows-admin.router.ts
@@ -50,16 +50,21 @@ router.get('/:id', async (req, res, next) => {
   }
 });
 
-// PUT /api/admin/release-workflows/:id
-router.put('/:id', validate(updateReleaseWorkflowDto), async (req: AuthRequest, res, next) => {
-  try {
-    const wf = await service.updateReleaseWorkflow(req.params['id'] as string, req.body);
-    await logAudit(req, 'release_workflow.updated', 'release_workflow', req.params['id'] as string, req.body);
-    res.json(wf);
-  } catch (err) {
-    next(err);
-  }
-});
+// PATCH /api/admin/release-workflows/:id (PUT kept as alias for backwards compatibility)
+const updateReleaseWorkflowHandler = [
+  validate(updateReleaseWorkflowDto),
+  async (req: AuthRequest, res: import('express').Response, next: import('express').NextFunction) => {
+    try {
+      const wf = await service.updateReleaseWorkflow(req.params['id'] as string, req.body);
+      await logAudit(req, 'release_workflow.updated', 'release_workflow', req.params['id'] as string, req.body);
+      res.json(wf);
+    } catch (err) {
+      next(err);
+    }
+  },
+];
+router.patch('/:id', ...updateReleaseWorkflowHandler);
+router.put('/:id', ...updateReleaseWorkflowHandler);
 
 // DELETE /api/admin/release-workflows/:id
 router.delete('/:id', async (req: AuthRequest, res, next) => {
@@ -136,20 +141,25 @@ router.post('/:id/transitions', validate(createReleaseWorkflowTransitionDto), as
   }
 });
 
-// PUT /api/admin/release-workflows/:id/transitions/:tid
-router.put('/:id/transitions/:tid', validate(updateReleaseWorkflowTransitionDto), async (req: AuthRequest, res, next) => {
-  try {
-    const t = await service.updateReleaseWorkflowTransition(
-      req.params['id'] as string,
-      req.params['tid'] as string,
-      req.body,
-    );
-    await logAudit(req, 'release_workflow_transition.updated', 'release_workflow_transition', req.params['tid'] as string, req.body);
-    res.json(t);
-  } catch (err) {
-    next(err);
-  }
-});
+// PATCH /api/admin/release-workflows/:id/transitions/:tid (PUT kept as alias)
+const updateReleaseWorkflowTransitionHandler = [
+  validate(updateReleaseWorkflowTransitionDto),
+  async (req: AuthRequest, res: import('express').Response, next: import('express').NextFunction) => {
+    try {
+      const t = await service.updateReleaseWorkflowTransition(
+        req.params['id'] as string,
+        req.params['tid'] as string,
+        req.body,
+      );
+      await logAudit(req, 'release_workflow_transition.updated', 'release_workflow_transition', req.params['tid'] as string, req.body);
+      res.json(t);
+    } catch (err) {
+      next(err);
+    }
+  },
+];
+router.patch('/:id/transitions/:tid', ...updateReleaseWorkflowTransitionHandler);
+router.put('/:id/transitions/:tid', ...updateReleaseWorkflowTransitionHandler);
 
 // DELETE /api/admin/release-workflows/:id/transitions/:tid
 router.delete('/:id/transitions/:tid', async (req: AuthRequest, res, next) => {

--- a/backend/src/modules/releases/releases.dto.ts
+++ b/backend/src/modules/releases/releases.dto.ts
@@ -36,7 +36,7 @@ export const updateReleaseDto = z.object({
 
 export const listReleasesQueryDto = z.object({
   type: z.enum(['ATOMIC', 'INTEGRATION']).optional(),
-  statusId: z.string().uuid().optional(),
+  statusId: z.string().optional(), // supports comma-separated UUIDs: "uuid1,uuid2"
   statusCategory: z.enum(['PLANNING', 'IN_PROGRESS', 'DONE', 'CANCELLED']).optional(),
   projectId: z.string().uuid().optional(),
   from: isoDate.optional(),

--- a/backend/src/modules/releases/releases.router.ts
+++ b/backend/src/modules/releases/releases.router.ts
@@ -37,7 +37,7 @@ router.get('/releases', async (req: AuthRequest, res, next) => {
 
 router.post(
   '/releases',
-  requireRole('ADMIN', 'MANAGER'),
+  requireRole('ADMIN', 'MANAGER', 'RELEASE_MANAGER'),
   validate(createReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
@@ -80,7 +80,7 @@ router.get('/releases/:id/history', async (req: AuthRequest, res, next) => {
 
 router.patch(
   '/releases/:id',
-  requireRole('ADMIN', 'MANAGER'),
+  requireRole('ADMIN', 'MANAGER', 'RELEASE_MANAGER'),
   validate(updateReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
@@ -97,7 +97,7 @@ router.patch(
 
 router.delete(
   '/releases/:id',
-  requireRole('ADMIN', 'MANAGER'),
+  requireRole('ADMIN', 'RELEASE_MANAGER'),
   async (req: AuthRequest, res, next) => {
     try {
       await releasesService.deleteRelease(req.params.id as string);
@@ -123,7 +123,7 @@ router.get('/releases/:id/items', async (req: AuthRequest, res, next) => {
 
 router.post(
   '/releases/:id/items',
-  requireRole('ADMIN', 'MANAGER'),
+  requireRole('ADMIN', 'MANAGER', 'RELEASE_MANAGER'),
   validate(releaseItemsAddDto),
   async (req: AuthRequest, res, next) => {
     try {
@@ -144,7 +144,7 @@ router.post(
 
 router.post(
   '/releases/:id/items/remove',
-  requireRole('ADMIN', 'MANAGER'),
+  requireRole('ADMIN', 'MANAGER', 'RELEASE_MANAGER'),
   validate(releaseItemsRemoveDto),
   async (req: AuthRequest, res, next) => {
     try {
@@ -166,7 +166,6 @@ router.post(
 
 router.get(
   '/releases/:id/transitions',
-  requireRole('ADMIN', 'MANAGER', 'USER'),
   async (req: AuthRequest, res, next) => {
     try {
       const result = await releaseWorkflowEngine.getAvailableTransitions(
@@ -183,7 +182,7 @@ router.get(
 
 router.post(
   '/releases/:id/transitions/:transitionId',
-  requireRole('ADMIN', 'MANAGER', 'USER'),
+  requireRole('ADMIN', 'MANAGER', 'RELEASE_MANAGER'),
   validate(executeTransitionDto),
   async (req: AuthRequest, res, next) => {
     try {
@@ -204,9 +203,13 @@ router.post(
 
 // ─── RM-03.7: GET /releases/:id/readiness — extended ─────────────────────────
 
-router.get('/releases/:id/readiness', async (req, res, next) => {
+router.get('/releases/:id/readiness', async (req: AuthRequest, res, next) => {
   try {
-    const readiness = await releasesService.getReleaseReadiness(req.params.id as string);
+    const readiness = await releasesService.getReleaseReadiness(
+      req.params.id as string,
+      req.user?.userId,
+      req.user?.role,
+    );
     res.json(readiness);
   } catch (err) {
     next(err);
@@ -217,7 +220,7 @@ router.get('/releases/:id/readiness', async (req, res, next) => {
 
 router.post(
   '/releases/:id/clone',
-  requireRole('ADMIN', 'MANAGER'),
+  requireRole('ADMIN', 'MANAGER', 'RELEASE_MANAGER'),
   validate(cloneReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
@@ -262,7 +265,7 @@ router.get('/projects/:projectId/releases', async (req, res, next) => {
 
 router.post(
   '/projects/:projectId/releases',
-  requireRole('ADMIN', 'MANAGER'),
+  requireRole('ADMIN', 'MANAGER', 'RELEASE_MANAGER'),
   validate(createReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
@@ -301,7 +304,7 @@ router.get('/releases/:id/sprints', async (req, res, next) => {
 
 router.post(
   '/releases/:id/sprints',
-  requireRole('ADMIN', 'MANAGER'),
+  requireRole('ADMIN', 'MANAGER', 'RELEASE_MANAGER'),
   validate(manageSprintsInReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
@@ -318,7 +321,7 @@ router.post(
 
 router.post(
   '/releases/:id/sprints/remove',
-  requireRole('ADMIN', 'MANAGER'),
+  requireRole('ADMIN', 'MANAGER', 'RELEASE_MANAGER'),
   validate(manageSprintsInReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {

--- a/backend/src/modules/releases/releases.service.ts
+++ b/backend/src/modules/releases/releases.service.ts
@@ -1,8 +1,8 @@
-import type { Prisma } from '@prisma/client';
+import type { Prisma, UserRole } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { getCachedJson, setCachedJson, delCachedJson } from '../../shared/redis.js';
-import { resolveWorkflowForRelease } from './release-workflow-engine.service.js';
+import { resolveWorkflowForRelease, getAvailableTransitions } from './release-workflow-engine.service.js';
 import type {
   CreateReleaseDto,
   UpdateReleaseDto,
@@ -31,11 +31,17 @@ export async function listReleasesGlobal(query: ListReleasesQueryDto) {
   const where: Prisma.ReleaseWhereInput = {};
 
   if (type) where.type = type;
-  if (statusId) where.statusId = statusId;
+  if (statusId) {
+    const ids = statusId.split(',').map((s) => s.trim()).filter(Boolean);
+    where.statusId = ids.length === 1 ? ids[0] : { in: ids };
+  }
   if (statusCategory) where.status = { category: statusCategory };
   if (projectId) where.projectId = projectId;
   if (search) {
-    where.name = { contains: search, mode: 'insensitive' };
+    where.OR = [
+      { name: { contains: search, mode: 'insensitive' } },
+      { description: { contains: search, mode: 'insensitive' } },
+    ];
   }
   if (from || to) {
     where.createdAt = {
@@ -60,7 +66,7 @@ export async function listReleasesGlobal(query: ListReleasesQueryDto) {
   }
   const cacheKey = releasesListCacheKey((hash >>> 0).toString(36));
 
-  const cached = await getCachedJson<{ data: unknown[]; total: number; page: number; limit: number }>(cacheKey);
+  const cached = await getCachedJson<{ data: unknown[]; meta: { page: number; limit: number; total: number; totalPages: number } }>(cacheKey);
   if (cached) return cached;
 
   const [releases, total] = await Promise.all([
@@ -95,7 +101,10 @@ export async function listReleasesGlobal(query: ListReleasesQueryDto) {
     }),
   );
 
-  const result = { data: enriched, total, page, limit };
+  const result = {
+    data: enriched,
+    meta: { page, limit, total, totalPages: Math.ceil(total / limit) },
+  };
   await setCachedJson(cacheKey, result, RELEASES_LIST_CACHE_TTL);
   return result;
 }
@@ -338,8 +347,15 @@ export async function addReleaseItems(releaseId: string, dto: ReleaseItemsAddDto
 }
 
 export async function removeReleaseItems(releaseId: string, issueIds: string[]) {
-  const release = await prisma.release.findUnique({ where: { id: releaseId } });
+  const release = await prisma.release.findUnique({
+    where: { id: releaseId },
+    include: { status: true },
+  });
   if (!release) throw new AppError(404, 'Release not found');
+
+  if (release.status?.category === 'DONE' || release.status?.category === 'CANCELLED') {
+    throw new AppError(422, 'Cannot remove items from a release in DONE/CANCELLED status');
+  }
 
   await prisma.releaseItem.deleteMany({
     where: { releaseId, issueId: { in: issueIds } },
@@ -387,12 +403,15 @@ export async function listReleaseItems(releaseId: string, query: ListReleaseItem
     prisma.releaseItem.count({ where }),
   ]);
 
-  return { data: items, total, page, limit };
+  return {
+    data: items,
+    meta: { page, limit, total, totalPages: Math.ceil(total / limit) },
+  };
 }
 
 // ─── RM-03.7: GET /releases/:id/readiness — extended metrics ─────────────────
 
-export async function getReleaseReadiness(id: string) {
+export async function getReleaseReadiness(id: string, actorId?: string, actorRole?: UserRole) {
   const release = await prisma.release.findUnique({ where: { id } });
   if (!release) throw new AppError(404, 'Release not found');
 
@@ -440,17 +459,18 @@ export async function getReleaseReadiness(id: string) {
     totalItems > 0 ? Math.round(((doneItems + cancelledItems) / totalItems) * 100) : 0;
 
   // byProject — breakdown for INTEGRATION releases
-  let byProject: Array<{ projectId: string; key: string; name: string; total: number; done: number }> = [];
+  let byProject: Array<{ project: { id: string; key: string; name: string }; total: number; done: number; inProgress: number }> = [];
   if (release.type === 'INTEGRATION') {
     const projectBreakdown = await prisma.$queryRaw<
-      Array<{ project_id: string; project_key: string; project_name: string; total: bigint; done: bigint }>
+      Array<{ project_id: string; project_key: string; project_name: string; total: bigint; done: bigint; in_progress: bigint }>
     >`
       SELECT
         p.id as project_id,
         p.key as project_key,
         p.name as project_name,
         COUNT(ri.id) as total,
-        COUNT(CASE WHEN ws.category = 'DONE' THEN 1 END) as done
+        COUNT(CASE WHEN ws.category = 'DONE' THEN 1 END) as done,
+        COUNT(CASE WHEN ws.category = 'IN_PROGRESS' THEN 1 END) as in_progress
       FROM release_items ri
       JOIN issues i ON i.id = ri.issue_id
       JOIN projects p ON p.id = i.project_id
@@ -459,12 +479,22 @@ export async function getReleaseReadiness(id: string) {
       GROUP BY p.id, p.key, p.name
     `;
     byProject = projectBreakdown.map((row) => ({
-      projectId: row.project_id,
-      key: row.project_key,
-      name: row.project_name,
+      project: { id: row.project_id, key: row.project_key, name: row.project_name },
       total: Number(row.total),
       done: Number(row.done),
+      inProgress: Number(row.in_progress ?? 0),
     }));
+  }
+
+  // availableTransitions — only when caller is authenticated
+  let availableTransitions = undefined;
+  if (actorId && actorRole) {
+    try {
+      const transitionsResult = await getAvailableTransitions(id, actorId, actorRole);
+      availableTransitions = transitionsResult.transitions;
+    } catch {
+      // If no workflow configured — omit the field
+    }
   }
 
   return {
@@ -476,6 +506,7 @@ export async function getReleaseReadiness(id: string) {
     inProgressItems,
     completionPercent,
     byProject,
+    ...(availableTransitions !== undefined && { availableTransitions }),
   };
 }
 

--- a/docs/tz/TTMP-223.json
+++ b/docs/tz/TTMP-223.json
@@ -1,0 +1,196 @@
+{
+  "key": "TTMP-223",
+  "title": "[Release Mgmt] Исправление несоответствий реализации спеке RELEASE_MANAGEMENT_SPEC",
+  "generatedAt": "2026-04-12T00:00:00Z",
+  "generatedBy": "claude-code",
+  "source": {
+    "apiUrl": "https://flowuniverse.ru/api",
+    "issueId": "b85c80f9-b862-43ab-ab6c-62d96fd295e0",
+    "fetchedAt": "2026-04-12T00:00:00Z"
+  },
+  "issue": {
+    "type": "TASK",
+    "status": "OPEN",
+    "priority": "HIGH",
+    "project": "TTMP",
+    "assignee": null,
+    "creator": "Claude Code",
+    "estimatedHours": 8.5,
+    "description": "Аудит выявил 14 несоответствий между реализацией и RELEASE_MANAGEMENT_SPEC.md v1.0",
+    "acceptanceCriteria": "RELEASE_MANAGER имеет доступ к CRUD; MANAGER не может удалять; removeReleaseItems защищён; 409 для CONDITION_NOT_MET; meta.totalPages в списках; availableTransitions в readiness"
+  },
+  "dependencies": {
+    "backendModules": ["releases"],
+    "frontendComponents": [],
+    "prismaModels": [],
+    "externalPackages": [],
+    "blockers": []
+  },
+  "risks": [
+    {
+      "id": 1,
+      "description": "Смена метода PUT → PATCH в admin workflow ломает старых клиентов",
+      "probability": "LOW",
+      "impact": "405 Method Not Allowed для клиентов использующих PUT",
+      "mitigation": "Оставить PUT как алиас с тем же обработчиком"
+    },
+    {
+      "id": 2,
+      "description": "Переименование minCount → min ломает существующие conditions в БД",
+      "probability": "MEDIUM",
+      "impact": "Переходы с MIN_ITEMS_COUNT перестают работать",
+      "mitigation": "Проверить seed и данные в БД; при необходимости SQL-патч или поддержать оба поля"
+    },
+    {
+      "id": 3,
+      "description": "Добавление RELEASE_MANAGER расширяет права доступа",
+      "probability": "LOW",
+      "impact": "Непреднамеренное расширение прав если роль уже назначена пользователям",
+      "mitigation": "Добавить E2E-тест матрицы доступа"
+    }
+  ],
+  "findings": [
+    {
+      "id": 1,
+      "severity": "CRITICAL",
+      "file": "releases.router.ts",
+      "description": "RELEASE_MANAGER отсутствует во всех requireRole мутаций",
+      "affectedEndpoints": [
+        "POST /releases",
+        "PATCH /releases/:id",
+        "DELETE /releases/:id",
+        "POST /releases/:id/items",
+        "POST /releases/:id/items/remove",
+        "POST /releases/:id/clone",
+        "POST /releases/:id/transitions/:id",
+        "POST /releases/:id/sprints",
+        "POST /releases/:id/sprints/remove"
+      ]
+    },
+    {
+      "id": 2,
+      "severity": "CRITICAL",
+      "file": "releases.router.ts",
+      "description": "DELETE /releases/:id доступен MANAGER — по спеке должен быть только ADMIN + RELEASE_MANAGER"
+    },
+    {
+      "id": 3,
+      "severity": "CRITICAL",
+      "file": "releases.service.ts",
+      "description": "removeReleaseItems не проверяет статус DONE/CANCELLED (нарушение BR-8)"
+    },
+    {
+      "id": 4,
+      "severity": "CRITICAL",
+      "file": "release-workflow-engine.service.ts",
+      "description": "CONDITION_NOT_MET возвращает 403 вместо 409"
+    },
+    {
+      "id": 5,
+      "severity": "CRITICAL",
+      "file": "release-workflow-engine.service.ts",
+      "description": "Поле minCount в MIN_ITEMS_COUNT condition вместо min по спеке"
+    },
+    {
+      "id": 6,
+      "severity": "IMPORTANT",
+      "file": "releases.service.ts",
+      "description": "listReleasesGlobal и listReleaseItems не оборачивают пагинацию в meta объект и нет totalPages"
+    },
+    {
+      "id": 7,
+      "severity": "IMPORTANT",
+      "file": "releases.service.ts",
+      "description": "getReleaseReadiness не возвращает availableTransitions"
+    },
+    {
+      "id": 8,
+      "severity": "IMPORTANT",
+      "file": "releases.service.ts",
+      "description": "byProject в readiness имеет неверный shape: нет вложенного объекта project и нет поля inProgress"
+    },
+    {
+      "id": 9,
+      "severity": "IMPORTANT",
+      "file": "releases.service.ts",
+      "description": "search фильтрует только по name, не по description"
+    },
+    {
+      "id": 10,
+      "severity": "IMPORTANT",
+      "file": "releases.service.ts",
+      "description": "statusId фильтр не поддерживает множественный выбор через запятую"
+    },
+    {
+      "id": 11,
+      "severity": "IMPORTANT",
+      "file": "release-workflows-admin.router.ts",
+      "description": "PUT вместо PATCH для PATCH /admin/release-workflows/:id и transitions/:tid"
+    },
+    {
+      "id": 12,
+      "severity": "MINOR",
+      "file": "release-workflow-engine.service.ts",
+      "description": "Audit action 'release.transitioned' вместо 'release.transition' по спеке"
+    },
+    {
+      "id": 13,
+      "severity": "MINOR",
+      "file": "releases.service.ts",
+      "description": "listReleaseItems фильтр status работает по имени workflowStatus, спека подразумевает enum Issue.status"
+    },
+    {
+      "id": 14,
+      "severity": "MINOR",
+      "file": "release-workflows-admin.router.ts",
+      "description": "PATCH /steps/:stepId присутствует в реализации, но отсутствует в спеке"
+    }
+  ],
+  "requirements": {
+    "functional": [
+      "FR-1: RELEASE_MANAGER имеет доступ ко всем мутациям релизов",
+      "FR-2: MANAGER не может удалять релизы",
+      "FR-3: removeReleaseItems защищён от DONE/CANCELLED статуса",
+      "FR-4: CONDITION_NOT_MET возвращает HTTP 409",
+      "FR-5: Списки релизов возвращают meta.totalPages",
+      "FR-6: readiness содержит availableTransitions и корректный byProject",
+      "FR-7: Поиск по name и description",
+      "FR-8: statusId фильтр поддерживает multiple UUID через запятую",
+      "FR-9: Admin workflow эндпоинты используют PATCH"
+    ],
+    "nonFunctional": [
+      "API response < 200ms p95",
+      "PUT на admin workflow работает как алиас для обратной совместимости"
+    ],
+    "security": [
+      "SEC-1: MANAGER не может удалять релизы",
+      "SEC-2: RELEASE_MANAGER не имеет доступа к /admin/release-statuses и /admin/release-workflows"
+    ]
+  },
+  "acceptanceCriteria": [
+    "AC-1: POST /api/releases с ролью RELEASE_MANAGER → 201",
+    "AC-2: DELETE /api/releases/:id с ролью MANAGER → 403",
+    "AC-3: POST /api/releases/:id/items/remove на DONE-релизе → 422",
+    "AC-4: POST /api/releases/:id/transitions/:tid с нарушенным condition → 409",
+    "AC-5: GET /api/releases → ответ содержит meta.totalPages",
+    "AC-6: GET /api/releases?search=test находит записи по description",
+    "AC-7: GET /api/releases/:id/readiness содержит availableTransitions и byProject[].inProgress",
+    "AC-8: PATCH /api/admin/release-workflows/:id → 200",
+    "AC-9: GET /api/releases/:id/transitions доступен для роли VIEWER",
+    "AC-10: Все существующие тесты зелёные"
+  ],
+  "estimation": {
+    "analysis": 0.5,
+    "backend": 5.0,
+    "frontend": 0,
+    "testing": 2.0,
+    "review": 1.0,
+    "total": 8.5
+  },
+  "relatedIssues": {
+    "parent": null,
+    "children": [],
+    "blocks": [],
+    "dependsOn": []
+  }
+}

--- a/docs/tz/TTMP-223.md
+++ b/docs/tz/TTMP-223.md
@@ -1,0 +1,342 @@
+# ТЗ: TTMP-223 — [Release Mgmt] Исправление несоответствий реализации спеке RELEASE_MANAGEMENT_SPEC
+
+**Дата:** 2026-04-12
+**Тип:** TASK | **Приоритет:** HIGH | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+В ходе аудита кодовой базы относительно спецификации `docs/specs/RELEASE_MANAGEMENT_SPEC.md` (v1.0, 2026-04-11) выявлено **14 несоответствий** разной степени критичности. Необходимо привести реализацию в соответствие со спекой без изменения публичного контракта для уже работающих клиентов (старые эндпоинты `/ready`, `/released` уже возвращают 410).
+
+### Пользовательский сценарий
+
+**Релиз-менеджер** (роль `RELEASE_MANAGER`) пытается создать / управлять релизом через UI и получает `403 Forbidden` — потому что роутер не включает эту роль. После исправления он сможет выполнять весь CRUD релизов и переходы по статусам. **MANAGER** при попытке удалить выпущенный релиз ожидает ошибку 403, но текущий код пропускает его — нарушение политики безопасности.
+
+---
+
+## 2. Текущее состояние
+
+| Файл | Роль в проблеме |
+|------|----------------|
+| [releases.router.ts](../../backend/src/modules/releases/releases.router.ts) | Неверные `requireRole` на всех мутациях; нет `RELEASE_MANAGER` |
+| [releases.service.ts](../../backend/src/modules/releases/releases.service.ts) | `removeReleaseItems` без DONE/CANCELLED-защиты; неверный shape `byProject`; нет `totalPages`; `search` только по `name` |
+| [release-workflow-engine.service.ts](../../backend/src/modules/releases/release-workflow-engine.service.ts) | `CONDITION_NOT_MET` → 403 вместо 409; поле `minCount` вместо `min` |
+| [release-workflows-admin.router.ts](../../backend/src/modules/releases/release-workflows-admin.router.ts) | `PUT` вместо `PATCH` для workflow и transitions; лишний `PATCH /steps/:id` |
+
+Все затронутые файлы уже существуют, миграций БД **не требуется**.
+
+---
+
+## 3. Зависимости
+
+### Модули backend
+- [x] `releases` — основные правки (router, service, workflow-engine)
+
+### Компоненты frontend
+- [ ] Нет — все изменения только backend
+
+### Модели данных (Prisma)
+- [ ] Без изменений
+
+### Внешние зависимости
+- [ ] Нет новых
+
+### Блокеры
+- Нет
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Смена метода `PUT → PATCH` в admin workflow ломает клиентов, использующих `PUT` | Низкая | Ошибки 405 в старых клиентах | Добавить `PUT` как алиас на 301 / оставить оба метода |
+| 2 | Изменение поля `minCount → min` в conditions ломает существующие seed-данные в БД | Средняя | Переходы с этим условием перестанут работать | Проверить seed и данные в БД перед деплоем; при необходимости SQL-патч |
+| 3 | Добавление `RELEASE_MANAGER` в requireRole открывает доступ ранее закрытым пользователям | Низкая | Непреднамеренное расширение прав | Добавить E2E-тест матрицы доступа |
+
+---
+
+## 5. Подробное описание правок
+
+### 5.1. RBAC — роль `RELEASE_MANAGER` (CRITICAL)
+
+**Файл:** `backend/src/modules/releases/releases.router.ts`
+
+Заменить `requireRole('ADMIN', 'MANAGER')` на правильные по спеке:
+
+| Эндпоинт | Текущий requireRole | Целевой requireRole |
+|----------|--------------------|--------------------|
+| `POST /releases` | `ADMIN, MANAGER` | `ADMIN, MANAGER, RELEASE_MANAGER` |
+| `POST /projects/:id/releases` | `ADMIN, MANAGER` | `ADMIN, MANAGER, RELEASE_MANAGER` |
+| `PATCH /releases/:id` | `ADMIN, MANAGER` | `ADMIN, MANAGER, RELEASE_MANAGER` |
+| `DELETE /releases/:id` | `ADMIN, MANAGER` | `ADMIN, RELEASE_MANAGER` (убрать MANAGER) |
+| `POST /releases/:id/items` | `ADMIN, MANAGER` | `ADMIN, MANAGER, RELEASE_MANAGER` |
+| `POST /releases/:id/items/remove` | `ADMIN, MANAGER` | `ADMIN, MANAGER, RELEASE_MANAGER` |
+| `POST /releases/:id/clone` | `ADMIN, MANAGER` | `ADMIN, MANAGER, RELEASE_MANAGER` |
+| `POST /releases/:id/transitions/:id` | `ADMIN, MANAGER, USER` | `ADMIN, MANAGER, RELEASE_MANAGER` |
+| `POST /releases/:id/sprints` | `ADMIN, MANAGER` | `ADMIN, MANAGER, RELEASE_MANAGER` |
+| `POST /releases/:id/sprints/remove` | `ADMIN, MANAGER` | `ADMIN, MANAGER, RELEASE_MANAGER` |
+| `GET /releases/:id/transitions` | `ADMIN, MANAGER, USER` | `authenticate` (все авторизованные, без requireRole) |
+
+### 5.2. `removeReleaseItems` — защита DONE/CANCELLED (CRITICAL)
+
+**Файл:** `backend/src/modules/releases/releases.service.ts`, функция `removeReleaseItems` (~строка 340)
+
+Добавить проверку после получения релиза:
+```typescript
+if (release.status?.category === 'DONE' || release.status?.category === 'CANCELLED') {
+  throw new AppError(422, 'Cannot remove items from a release in DONE/CANCELLED status');
+}
+```
+Нужно изменить `findUnique` — добавить `include: { status: true }`.
+
+### 5.3. `CONDITION_NOT_MET` — 403 → 409 (CRITICAL)
+
+**Файл:** `backend/src/modules/releases/release-workflow-engine.service.ts`, функция `executeTransition` (~строка 260)
+
+```typescript
+// БЫЛО:
+throw new AppError(403, 'CONDITION_NOT_MET', { details: { conditionType: failedCondition ?? 'UNKNOWN' } });
+
+// СТАЛО:
+throw new AppError(409, 'CONDITION_NOT_MET', { details: { conditionType: failedCondition ?? 'UNKNOWN' } });
+```
+
+### 5.4. `MIN_ITEMS_COUNT.minCount → min` (CRITICAL)
+
+**Файл:** `backend/src/modules/releases/release-workflow-engine.service.ts`
+
+Тип `ReleaseConditionRule` (~строка 40):
+```typescript
+// БЫЛО:
+| { type: 'MIN_ITEMS_COUNT'; minCount: number };
+
+// СТАЛО:
+| { type: 'MIN_ITEMS_COUNT'; min: number };
+```
+
+Использование в `evaluateReleaseCondition` (~строка 76):
+```typescript
+// БЫЛО:
+return total >= rule.minCount;
+
+// СТАЛО:
+return total >= rule.min;
+```
+
+### 5.5. Response format — `meta` wrapper + `totalPages` (IMPORTANT)
+
+**Файл:** `backend/src/modules/releases/releases.service.ts`
+
+В `listReleasesGlobal` (~строка 98):
+```typescript
+// БЫЛО:
+const result = { data: enriched, total, page, limit };
+
+// СТАЛО:
+const result = {
+  data: enriched,
+  meta: { page, limit, total, totalPages: Math.ceil(total / limit) },
+};
+```
+
+В `listReleaseItems` (~строка 390):
+```typescript
+// БЫЛО:
+return { data: items, total, page, limit };
+
+// СТАЛО:
+return {
+  data: items,
+  meta: { page, limit, total, totalPages: Math.ceil(total / limit) },
+};
+```
+
+### 5.6. `readiness` — добавить `availableTransitions` + исправить `byProject` (IMPORTANT)
+
+**Файл:** `backend/src/modules/releases/releases.service.ts`, функция `getReleaseReadiness`
+
+1. **`byProject` shape** — изменить `return` маппинга (~строка 461):
+```typescript
+// БЫЛО:
+byProject = projectBreakdown.map((row) => ({
+  projectId: row.project_id,
+  key: row.project_key,
+  name: row.project_name,
+  total: Number(row.total),
+  done: Number(row.done),
+}));
+
+// СТАЛО:
+byProject = projectBreakdown.map((row) => ({
+  project: { id: row.project_id, key: row.project_key, name: row.project_name },
+  total: Number(row.total),
+  done: Number(row.done),
+  inProgress: Number(row.in_progress ?? 0),
+}));
+```
+
+SQL-запрос расширить — добавить поле `in_progress`:
+```sql
+COUNT(CASE WHEN ws.category = 'IN_PROGRESS' THEN 1 END) as in_progress
+```
+
+2. **`availableTransitions`** — вычислить через `releaseWorkflowEngine.getAvailableTransitions` и добавить в итоговый объект:
+```typescript
+// Нужно передать userId и role в getReleaseReadiness или вызывать отдельно в роутере
+```
+> **Примечание:** `getReleaseReadiness` вызывается без auth-контекста. Рекомендуемый подход: добавить опциональные параметры `actorId` и `actorRole` в сигнатуру функции, чтобы вычислять `availableTransitions` только при их наличии.
+
+Роутер обновить:
+```typescript
+router.get('/releases/:id/readiness', async (req: AuthRequest, res, next) => {
+  try {
+    const readiness = await releasesService.getReleaseReadiness(
+      req.params.id as string,
+      req.user?.userId,
+      req.user?.role,
+    );
+    res.json(readiness);
+  } catch (err) {
+    next(err);
+  }
+});
+```
+
+### 5.7. `search` — добавить поиск по `description` (IMPORTANT)
+
+**Файл:** `backend/src/modules/releases/releases.service.ts` (~строка 37):
+```typescript
+// БЫЛО:
+if (search) {
+  where.name = { contains: search, mode: 'insensitive' };
+}
+
+// СТАЛО:
+if (search) {
+  where.OR = [
+    { name: { contains: search, mode: 'insensitive' } },
+    { description: { contains: search, mode: 'insensitive' } },
+  ];
+}
+```
+
+### 5.8. `statusId` — поддержка фильтра по нескольким значениям (IMPORTANT)
+
+**Файл:** `backend/src/modules/releases/releases.service.ts` (~строка 34)
+
+В DTO (`releases.dto.ts`) изменить тип `statusId` — принимать строку с разделителями:
+```typescript
+// В listReleasesQueryDto:
+statusId: z.string().optional(), // "uuid1,uuid2"
+```
+
+В сервисе:
+```typescript
+if (statusId) {
+  const ids = statusId.split(',').map(s => s.trim()).filter(Boolean);
+  where.statusId = ids.length === 1 ? ids[0] : { in: ids };
+}
+```
+
+### 5.9. `PUT → PATCH` в admin workflow роутере (IMPORTANT)
+
+**Файл:** `backend/src/modules/releases/release-workflows-admin.router.ts`
+
+- Строка 54: `router.put('/:id', ...)` → `router.patch('/:id', ...)`
+- Строка 140: `router.put('/:id/transitions/:tid', ...)` → `router.patch('/:id/transitions/:tid', ...)`
+
+Для обратной совместимости добавить алиасы `router.put(...)` с тем же обработчиком.
+
+### 5.10. Audit action name (MINOR)
+
+**Файл:** `backend/src/modules/releases/release-workflow-engine.service.ts` (~строка 291)
+
+```typescript
+// БЫЛО:
+action: 'release.transitioned',
+
+// СТАЛО:
+action: 'release.transition',
+```
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: Роль `RELEASE_MANAGER` имеет доступ ко всем мутациям релизов кроме управления workflow/статусами
+- [ ] FR-2: Роль `MANAGER` не может удалять релизы
+- [ ] FR-3: Нельзя убирать задачи из релиза в статусе DONE/CANCELLED
+- [ ] FR-4: `CONDITION_NOT_MET` возвращает HTTP 409
+- [ ] FR-5: `listReleasesGlobal` и `listReleaseItems` возвращают `meta.totalPages`
+- [ ] FR-6: `readiness` содержит `availableTransitions`, корректный `byProject` с `inProgress`
+- [ ] FR-7: Поиск по name и description одновременно
+- [ ] FR-8: `statusId` фильтр поддерживает несколько UUID через запятую
+- [ ] FR-9: Admin workflow эндпоинты используют метод PATCH
+
+### Нефункциональные
+- [ ] API response < 200ms (p95) — правки не должны ухудшать
+- [ ] Обратная совместимость: `PUT` на admin workflow работает как алиас
+
+### Безопасность
+- [ ] SEC-1: MANAGER не может удалять релизы (закрыть escalation privilege)
+- [ ] SEC-2: RELEASE_MANAGER не имеет доступа к `/api/admin/release-statuses` и `/api/admin/release-workflows`
+
+### Тестирование
+- [ ] Unit-тест матрицы доступа: роль × эндпоинт (RELEASE_MANAGER, MANAGER, USER, VIEWER)
+- [ ] Integration-тест `removeReleaseItems` для релиза в статусе DONE → 422
+- [ ] Integration-тест `executeTransition` с невыполненным condition → 409
+- [ ] Integration-тест `readiness` — проверить shape `byProject` и наличие `availableTransitions`
+- [ ] Integration-тест поиска по description
+
+---
+
+## 7. Критерии приёмки (Definition of Done)
+
+- [ ] AC-1: `POST /api/releases` с ролью `RELEASE_MANAGER` → 201 (не 403)
+- [ ] AC-2: `DELETE /api/releases/:id` с ролью `MANAGER` → 403
+- [ ] AC-3: `POST /api/releases/:id/items/remove` на DONE-релизе → 422
+- [ ] AC-4: `POST /api/releases/:id/transitions/:tid` с нарушенным condition → 409 (не 403)
+- [ ] AC-5: `GET /api/releases` → ответ содержит `meta.totalPages`
+- [ ] AC-6: `GET /api/releases?search=test` находит записи по description
+- [ ] AC-7: `GET /api/releases/:id/readiness` → содержит `availableTransitions` и `byProject[].inProgress`
+- [ ] AC-8: `PATCH /api/admin/release-workflows/:id` → 200 (не 404/405)
+- [ ] AC-9: `GET /api/releases/:id/transitions` доступен для роли VIEWER
+- [ ] AC-10: Все существующие тесты (`make test`) остаются зелёными
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Анализ и план | 0.5 |
+| Backend (RBAC, сервисы) | 3.0 |
+| Backend (readiness, search, format) | 2.0 |
+| Тесты | 2.0 |
+| Code review + fixes | 1.0 |
+| **Итого** | **8.5** |
+
+---
+
+## 9. Связанные задачи
+
+- Спека: `docs/specs/RELEASE_MANAGEMENT_SPEC.md`
+- Исходный PR с реализацией: #30 (`feat(releases): release management data model`)
+
+---
+
+## 10. Порядок реализации (рекомендуемый)
+
+1. **Сначала RBAC** — правки в роутере (строки 38-169), без логики — низкий риск
+2. **`removeReleaseItems` защита** — добавить include + guard
+3. **HTTP коды и поля условий** — `403→409`, `minCount→min`
+4. **Response format** — `meta` wrapper в двух функциях
+5. **`readiness` доработка** — byProject shape, inProgress, availableTransitions
+6. **`search` и `statusId`** — расширение фильтрации
+7. **`PATCH` вместо `PUT`** — admin роутер
+8. **Тесты** — покрыть все AC


### PR DESCRIPTION
## Summary

- **RBAC**: добавлена роль `RELEASE_MANAGER` во все мутации релизов; `MANAGER` убран из `DELETE /releases/:id`; `GET /transitions` — только `authenticate` (VIEWER тоже видит)
- **Безопасность**: `removeReleaseItems` теперь возвращает 422 для релизов в статусе DONE/CANCELLED
- **Workflow engine**: `CONDITION_NOT_MET` исправлен с 403 → 409; поле `minCount → min` в типе и логике; audit action `release.transitioned → release.transition`
- **Response format**: `listReleasesGlobal` и `listReleaseItems` возвращают `{ data, meta: { page, limit, total, totalPages } }`
- **Readiness**: `byProject` shape изменён на `{ project: {id,key,name}, total, done, inProgress }`; добавлен `availableTransitions` для авторизованных пользователей
- **Фильтрация**: поиск по `name OR description`; `statusId` принимает comma-separated UUIDs
- **Admin router**: `PATCH /:id` и `PATCH /:id/transitions/:tid` (PUT сохранён как алиас для обратной совместимости)

## Test plan

- [ ] `POST /api/releases` с ролью `RELEASE_MANAGER` → 201
- [ ] `DELETE /api/releases/:id` с ролью `MANAGER` → 403
- [ ] `POST /api/releases/:id/items/remove` на DONE-релизе → 422
- [ ] `POST /api/releases/:id/transitions/:tid` с нарушенным condition → 409
- [ ] `GET /api/releases` → содержит `meta.totalPages`
- [ ] `GET /api/releases?search=test` → находит по description
- [ ] `GET /api/releases/:id/readiness` → содержит `availableTransitions` и `byProject[].inProgress`
- [ ] `PATCH /api/admin/release-workflows/:id` → 200
- [ ] `GET /api/releases/:id/transitions` доступен для VIEWER
- [ ] CI зелёный

**Задача:** TTMP-223

🤖 Generated with [Claude Code](https://claude.com/claude-code)