### PR TITLE
ci: allow e2e-staging to run on workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, claude/*, cursor/*]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -262,9 +263,13 @@ jobs:
           ssh "${{ secrets.STAGING_DEPLOY_USER }}@${{ secrets.STAGING_DEPLOY_HOST }}" \
             "cd '${{ secrets.STAGING_DEPLOY_PATH }}' && chmod +x deploy/scripts/*.sh && ./deploy/scripts/deploy.sh staging '${{ github.sha }}'"
 
-  # --- E2E tests against staging (main branch only, after deploy) ---
+  # --- E2E tests against staging (main branch only, after deploy or manual dispatch) ---
   e2e-staging:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: |
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      (needs.deploy-staging.result == 'success' || needs.deploy-staging.result == 'skipped')
     runs-on: ubuntu-latest
     needs: [deploy-staging]
     permissions:


### PR DESCRIPTION
## Summary

- Добавлен триггер `workflow_dispatch` в CI workflow
- `e2e-staging` теперь запускается и при ручном запуске CI (не только на `push`)
- При `workflow_dispatch` `deploy-staging` пропускается (его `if` требует `push`), `e2e-staging` проверяет `needs.deploy-staging.result == 'skipped'` и стартует напрямую против уже задеплоенного staging

## Test plan

- [ ] CI зелёный
- [ ] После мёрджа запустить вручную: Actions → CI → Run workflow → выбрать `main`
- [ ] Убедиться что `e2e-staging` job запустился и прогнал тесты