### PR TITLE
fix(admin): fix user display crashes — listAdminUsers wrong type + teams systemRoles

### DIFF
--- a/backend/src/modules/teams/teams.service.ts
+++ b/backend/src/modules/teams/teams.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import type { CreateTeamDto, UpdateTeamDto } from './teams.dto.js';
+import type { SystemRoleType } from '@prisma/client';
 
 export async function listTeams() {
   return prisma.team.findMany({
@@ -25,7 +26,16 @@ export async function getTeam(id: string) {
     },
   });
   if (!team) throw new AppError(404, 'Team not found');
-  return team;
+  return {
+    ...team,
+    members: team.members.map((m) => ({
+      ...m,
+      user: {
+        ...m.user,
+        systemRoles: m.user.systemRoles.map((sr: { role: SystemRoleType }) => sr.role),
+      },
+    })),
+  };
 }
 
 export async function createTeam(dto: CreateTeamDto) {

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,5 +1,5 @@
 import api from './client';
-import type { PaginatedResponse, SystemRoleType } from '../types';
+import type { SystemRoleType } from '../types';
 
 export interface SystemSettings {
   sessionLifetimeMinutes: number;
@@ -124,9 +124,9 @@ export async function getStats(): Promise<AdminStats> {
 }
 
 export async function listAdminUsers(
-  pagination?: { page?: number; limit?: number },
-): Promise<PaginatedResponse<AdminUser>> {
-  const { data } = await api.get<PaginatedResponse<AdminUser>>('/admin/users', {
+  pagination?: { page?: number; pageSize?: number },
+): Promise<AdminUsersResponse> {
+  const { data } = await api.get<AdminUsersResponse>('/admin/users', {
     params: pagination,
   });
   return data;

--- a/frontend/src/components/admin/AdminProjectsTab.tsx
+++ b/frontend/src/components/admin/AdminProjectsTab.tsx
@@ -100,11 +100,11 @@ export default function AdminProjectsTab() {
       const [p, c, u] = await Promise.all([
         projectsApi.listProjects(),
         categoriesApi.listCategories(),
-        adminApi.listAdminUsers(),
+        adminApi.listAdminUsers({ pageSize: 500 }),
       ]);
       setProjects(p);
       setCategories(c);
-      setUsers(u.data);
+      setUsers(u.users);
     } catch {
       void message.error('Ошибка загрузки данных');
     } finally {
@@ -117,8 +117,8 @@ export default function AdminProjectsTab() {
   // Reload categories/users fresh every time the modal opens so edits
   // made in the Categories tab are reflected without a full page refresh.
   const refreshSelectData = () => {
-    Promise.all([categoriesApi.listCategories(), adminApi.listAdminUsers()])
-      .then(([c, u]) => { setCategories(c); setUsers(u.data); })
+    Promise.all([categoriesApi.listCategories(), adminApi.listAdminUsers({ pageSize: 500 })])
+      .then(([c, u]) => { setCategories(c); setUsers(u.users); })
       .catch(() => {});
   };
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -115,7 +115,7 @@ export default function AdminPage() {
       try {
         const [statsData, adminUsersPage, allUsers, allProjects] = await Promise.all([
           adminApi.getStats(),
-          adminApi.listAdminUsers(),
+          adminApi.listAdminUsers({ pageSize: 500 }),
           authApi.listUsers(),
           projectsApi.listProjects(),
         ]);
@@ -124,7 +124,7 @@ export default function AdminPage() {
         allUsers.forEach((u) => { userMap[u.id] = u; });
         setUsersMap(userMap);
         setUsers(
-          adminUsersPage.data.map((u) => ({
+          adminUsersPage.users.map((u) => ({
             id: u.id,
             email: u.email,
             name: u.name,

--- a/frontend/src/pages/admin/AdminDashboardPage.tsx
+++ b/frontend/src/pages/admin/AdminDashboardPage.tsx
@@ -41,7 +41,7 @@ export default function AdminDashboardPage() {
       try {
         const [statsData, adminUsers, allUsers, allProjects] = await Promise.all([
           adminApi.getStats(),
-          adminApi.listAdminUsers(),
+          adminApi.listAdminUsers({ pageSize: 500 }),
           authApi.listUsers(),
           projectsApi.listProjects(),
         ]);
@@ -50,7 +50,7 @@ export default function AdminDashboardPage() {
         allUsers.forEach((u) => { userMap[u.id] = u; });
         setUsersMap(userMap);
         setUsers(
-          adminUsers.data.map((u) => ({
+          adminUsers.users.map((u) => ({
             id: u.id,
             email: u.email,
             name: u.name,


### PR DESCRIPTION
## Summary

- **`listAdminUsers()` crash** — function declared return type as `PaginatedResponse<AdminUser>` (`{data, meta}`) but `GET /admin/users` returns `{users, total, page, pageSize}`. Accessing `.data` on the response was always `undefined` → `TypeError` on `.map()`. Crashed `AdminPage`, `AdminDashboardPage`, `AdminProjectsTab` entirely (error state, no data shown).
- **Fix**: changed `listAdminUsers()` return type to `AdminUsersResponse` and updated all 3 callers to use `.users` instead of `.data`.
- **`teams.service.ts` systemRoles not flattened** — `getTeam()` returned `members[].user.systemRoles` as `[{role: 'ADMIN'}]` objects. Fixed to flatten to `['ADMIN']` strings before returning.

## Test plan
- [ ] Open Admin → Dashboard: no error, user list shows
- [ ] Open Admin → old AdminPage: no error, user list shows  
- [ ] Open Admin → Projects tab: project owner dropdown is populated
- [ ] Open Teams page → team detail: member `systemRoles` is a flat string array

🤖 Generated with [Claude Code](https://claude.com/claude-code)