### PR TITLE
fix(auth): block requests after Redis session expiry

### DIFF
--- a/backend/src/modules/auth/auth.dto.ts
+++ b/backend/src/modules/auth/auth.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { SYSTEM_ACCOUNT_DOMAIN } from '../../shared/utils/session-settings.js';
 
 // CVE-11: Password must be 8+ chars with at least 1 uppercase and 1 digit
 const passwordSchema = z.string().min(8).max(128)
@@ -6,7 +7,10 @@ const passwordSchema = z.string().min(8).max(128)
   .refine((p) => /\d/.test(p), { message: 'Password must contain at least one digit' });
 
 export const registerDto = z.object({
-  email: z.string().email(),
+  email: z.string().email().refine(
+    (e) => !e.endsWith(SYSTEM_ACCOUNT_DOMAIN),
+    { message: 'Email domain is reserved' },
+  ),
   password: passwordSchema,
   name: z.string().min(1).max(255),
 });

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -4,6 +4,7 @@ import { hashPassword, comparePassword } from '../../shared/utils/password.js';
 import { signAccessToken, signRefreshToken, verifyRefreshToken } from '../../shared/utils/jwt.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { setUserSession, deleteUserSession, getCachedJson, setCachedJson } from '../../shared/redis.js';
+import { getSessionLifetimeMinutes } from '../../shared/utils/session-settings.js';
 import type { RegisterDto, LoginDto } from './auth.dto.js';
 import type { SystemRoleType } from '@prisma/client';
 
@@ -83,12 +84,13 @@ export async function register(dto: RegisterDto) {
   });
 
   const nowIso = new Date().toISOString();
+  const sessionTtl = await getSessionLifetimeMinutes();
   void setUserSession(user.id, {
     email: user.email,
     systemRoles: roles,
     createdAt: nowIso,
     lastSeenAt: nowIso,
-  });
+  }, sessionTtl * 60);
 
   return { user: { id: user.id, email: user.email, name: user.name, systemRoles: roles }, accessToken, refreshToken };
 }
@@ -141,12 +143,13 @@ export async function login(dto: LoginDto) {
   });
 
   const nowIso = new Date().toISOString();
+  const sessionTtl = await getSessionLifetimeMinutes();
   void setUserSession(user.id, {
     email: user.email,
     systemRoles: roles,
     createdAt: nowIso,
     lastSeenAt: nowIso,
-  });
+  }, sessionTtl * 60);
 
   return {
     user: {
@@ -214,12 +217,13 @@ export async function refresh(refreshToken: string) {
   });
 
   const nowIso = new Date().toISOString();
+  const sessionTtl = await getSessionLifetimeMinutes();
   void setUserSession(user.id, {
     email: user.email,
     systemRoles: roles,
     createdAt: stored.createdAt.toISOString(),
     lastSeenAt: nowIso,
-  });
+  }, sessionTtl * 60);
 
   return { accessToken: newAccessToken, refreshToken: newRefreshToken };
 }

--- a/backend/src/shared/middleware/auth.ts
+++ b/backend/src/shared/middleware/auth.ts
@@ -3,31 +3,11 @@ import type { SystemRoleType } from '@prisma/client';
 import { verifyAccessToken } from '../utils/jwt.js';
 import { AppError } from './error-handler.js';
 import type { AuthRequest } from '../types/index.js';
-import { getUserSession, touchUserSession, getCachedJson, setCachedJson, isRedisAvailable } from '../redis.js';
-import { prisma } from '../../prisma/client.js';
-
-const DEFAULT_SESSION_LIFETIME_MINUTES = 60;
+import { getUserSession, touchUserSession, isRedisAvailable } from '../redis.js';
+import { getSessionLifetimeMinutes } from '../utils/session-settings.js';
 
 // In-process counter — exported so health/metrics endpoints can expose it.
 export const sessionFallbackCounter = { total: 0, redis_unavailable: 0, session_missing: 0 };
-const SETTING_CACHE_TTL_SECONDS = 60;
-const SESSION_LIFETIME_SETTING_KEY = 'session_lifetime_minutes';
-const SESSION_LIFETIME_CACHE_KEY = `settings:${SESSION_LIFETIME_SETTING_KEY}`;
-
-async function getSessionLifetimeMinutes(): Promise<number> {
-  const cached = await getCachedJson<number>(SESSION_LIFETIME_CACHE_KEY);
-  if (cached !== null) return cached;
-
-  try {
-    const setting = await prisma.systemSetting.findUnique({ where: { key: SESSION_LIFETIME_SETTING_KEY } });
-    const value = setting ? parseInt(setting.value, 10) : DEFAULT_SESSION_LIFETIME_MINUTES;
-    const result = isNaN(value) || value < 5 ? DEFAULT_SESSION_LIFETIME_MINUTES : value;
-    await setCachedJson(SESSION_LIFETIME_CACHE_KEY, result, SETTING_CACHE_TTL_SECONDS);
-    return result;
-  } catch {
-    return DEFAULT_SESSION_LIFETIME_MINUTES;
-  }
-}
 
 export async function authenticate(req: AuthRequest, _res: Response, next: NextFunction) {
   const header = req.headers.authorization;
@@ -74,16 +54,26 @@ export async function authenticate(req: AuthRequest, _res: Response, next: NextF
       return next(new AppError(401, 'Session expired due to inactivity', { code: 'SESSION_EXPIRED' }));
     }
   } else {
-    // session===null has three causes: (1) Redis unavailable, (2) session key expired/missing,
-    // (3) session was never created (system accounts). Degrade gracefully — rely on JWT expiry.
-    const reason = (await isRedisAvailable()) ? 'session_missing' : 'redis_unavailable';
-    sessionFallbackCounter.total += 1;
-    sessionFallbackCounter[reason] += 1;
-    console.warn('[auth] sliding-session fallback', {
-      userId: payload.userId,
-      reason,
-      counter: sessionFallbackCounter,
-    });
+    // session===null: (1) Redis unavailable, (2) session key expired, (3) system accounts.
+    if (await isRedisAvailable()) {
+      // Redis is up — session key is gone, meaning it expired or was never created.
+      // System accounts (agent@) never get a session key; allow them through.
+      // Regular users with an expired key must re-authenticate.
+      const isSystemAccount = payload.email.endsWith('@flow-universe.internal');
+      if (!isSystemAccount) {
+        sessionFallbackCounter.total += 1;
+        sessionFallbackCounter['session_missing'] += 1;
+        return next(new AppError(401, 'Session expired due to inactivity', { code: 'SESSION_EXPIRED' }));
+      }
+    } else {
+      // Redis is unavailable — degrade gracefully, rely on JWT expiry.
+      sessionFallbackCounter.total += 1;
+      sessionFallbackCounter['redis_unavailable'] += 1;
+      console.warn('[auth] sliding-session fallback: redis unavailable', {
+        userId: payload.userId,
+        counter: sessionFallbackCounter,
+      });
+    }
   }
 
   next();

--- a/backend/src/shared/middleware/auth.ts
+++ b/backend/src/shared/middleware/auth.ts
@@ -4,7 +4,7 @@ import { verifyAccessToken } from '../utils/jwt.js';
 import { AppError } from './error-handler.js';
 import type { AuthRequest } from '../types/index.js';
 import { getUserSession, touchUserSession, isRedisAvailable } from '../redis.js';
-import { getSessionLifetimeMinutes } from '../utils/session-settings.js';
+import { getSessionLifetimeMinutes, SYSTEM_ACCOUNT_DOMAIN } from '../utils/session-settings.js';
 
 // In-process counter — exported so health/metrics endpoints can expose it.
 export const sessionFallbackCounter = { total: 0, redis_unavailable: 0, session_missing: 0 };
@@ -59,7 +59,7 @@ export async function authenticate(req: AuthRequest, _res: Response, next: NextF
       // Redis is up — session key is gone, meaning it expired or was never created.
       // System accounts (agent@) never get a session key; allow them through.
       // Regular users with an expired key must re-authenticate.
-      const isSystemAccount = payload.email.endsWith('@flow-universe.internal');
+      const isSystemAccount = payload.email.endsWith(SYSTEM_ACCOUNT_DOMAIN);
       if (!isSystemAccount) {
         sessionFallbackCounter.total += 1;
         sessionFallbackCounter['session_missing'] += 1;

--- a/backend/src/shared/redis.ts
+++ b/backend/src/shared/redis.ts
@@ -125,7 +125,11 @@ export async function isRedisAvailable(): Promise<boolean> {
   return redis !== null;
 }
 
-export async function setUserSession(userId: string, session: Omit<UserSession, 'userId'>): Promise<void> {
+export async function setUserSession(
+  userId: string,
+  session: Omit<UserSession, 'userId'>,
+  ttlSeconds: number = SESSION_TTL_SECONDS,
+): Promise<void> {
   const redis = await getRedisClientInternal();
   if (!redis) return;
 
@@ -135,7 +139,7 @@ export async function setUserSession(userId: string, session: Omit<UserSession, 
   };
 
   try {
-    await redis.set(buildSessionKey(userId), JSON.stringify(fullSession), { EX: SESSION_TTL_SECONDS });
+    await redis.set(buildSessionKey(userId), JSON.stringify(fullSession), { EX: ttlSeconds });
   } catch (err) {
     console.error('Failed to write user session to Redis:', err);
   }

--- a/backend/src/shared/utils/session-settings.ts
+++ b/backend/src/shared/utils/session-settings.ts
@@ -1,0 +1,22 @@
+import { getCachedJson, setCachedJson } from '../redis.js';
+import { prisma } from '../../prisma/client.js';
+
+export const DEFAULT_SESSION_LIFETIME_MINUTES = 60;
+const SETTING_CACHE_TTL_SECONDS = 60;
+const SESSION_LIFETIME_SETTING_KEY = 'session_lifetime_minutes';
+export const SESSION_LIFETIME_CACHE_KEY = `settings:${SESSION_LIFETIME_SETTING_KEY}`;
+
+export async function getSessionLifetimeMinutes(): Promise<number> {
+  const cached = await getCachedJson<number>(SESSION_LIFETIME_CACHE_KEY);
+  if (cached !== null) return cached;
+
+  try {
+    const setting = await prisma.systemSetting.findUnique({ where: { key: SESSION_LIFETIME_SETTING_KEY } });
+    const value = setting ? parseInt(setting.value, 10) : DEFAULT_SESSION_LIFETIME_MINUTES;
+    const result = isNaN(value) || value < 5 ? DEFAULT_SESSION_LIFETIME_MINUTES : value;
+    await setCachedJson(SESSION_LIFETIME_CACHE_KEY, result, SETTING_CACHE_TTL_SECONDS);
+    return result;
+  } catch {
+    return DEFAULT_SESSION_LIFETIME_MINUTES;
+  }
+}

--- a/backend/src/shared/utils/session-settings.ts
+++ b/backend/src/shared/utils/session-settings.ts
@@ -1,6 +1,10 @@
 import { getCachedJson, setCachedJson } from '../redis.js';
 import { prisma } from '../../prisma/client.js';
 
+// Reserved domain for internal system accounts (MCP agent, etc.).
+// Must never be available for self-registration.
+export const SYSTEM_ACCOUNT_DOMAIN = '@flow-universe.internal';
+
 export const DEFAULT_SESSION_LIFETIME_MINUTES = 60;
 const SETTING_CACHE_TTL_SECONDS = 60;
 const SESSION_LIFETIME_SETTING_KEY = 'session_lifetime_minutes';
@@ -16,7 +20,10 @@ export async function getSessionLifetimeMinutes(): Promise<number> {
     const result = isNaN(value) || value < 5 ? DEFAULT_SESSION_LIFETIME_MINUTES : value;
     await setCachedJson(SESSION_LIFETIME_CACHE_KEY, result, SETTING_CACHE_TTL_SECONDS);
     return result;
-  } catch {
+  } catch (err) {
+    console.warn('[session-settings] getSessionLifetimeMinutes failed, using default', {
+      error: err instanceof Error ? err.message : String(err),
+    });
     return DEFAULT_SESSION_LIFETIME_MINUTES;
   }
 }


### PR DESCRIPTION
## Summary

- **Критический баг:** `authenticate()` при `session === null` (ключ в Redis истёк по TTL) вызывал `next()` вместо 401, позволяя пользователю работать на JWT до конца его lifetime (1 час), игнорируя `session_lifetime_minutes`
- Fallback на JWT теперь срабатывает **только** при недоступном Redis; при `session_missing` возвращается `401 SESSION_EXPIRED`
- Системные аккаунты (`@flow-universe.internal`) освобождены от проверки сессии
- `getSessionLifetimeMinutes` вынесена в `shared/utils/session-settings.ts`, используется как в middleware так и в auth.service.ts
- `setUserSession` в login / register / refresh теперь выставляет TTL = `session_lifetime_minutes * 60` вместо хардкода 7 дней

## Changed files

- `backend/src/shared/middleware/auth.ts` — ключевой фикс fallback-логики
- `backend/src/shared/utils/session-settings.ts` — новый shared util (extracted)
- `backend/src/shared/redis.ts` — опциональный `ttlSeconds` в `setUserSession`
- `backend/src/modules/auth/auth.service.ts` — login / register / refresh передают правильный TTL

## Test plan

- [ ] Залогиниться, выставить `session_lifetime_minutes = 1`, подождать 61 с → следующий запрос должен вернуть `401 SESSION_EXPIRED`
- [ ] При недоступном Redis запросы с валидным JWT должны проходить (деградация)
- [ ] MCP-агент (`agent@flow-universe.internal`) не должен получать 401 при отсутствии сессии
- [ ] `npm run typecheck` — без ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)