### PR TITLE
fix(rbac): filter projects list by membership for USER system role

### DIFF
--- a/backend/src/modules/projects/projects.router.ts
+++ b/backend/src/modules/projects/projects.router.ts
@@ -11,9 +11,10 @@ const router = Router();
 
 router.use(authenticate);
 
-router.get('/', async (_req, res, next) => {
+router.get('/', async (req: AuthRequest, res, next) => {
   try {
-    const projects = await projectsService.listProjects();
+    const user = req.user!;
+    const projects = await projectsService.listProjectsForUser(user.userId, user.systemRoles);
     res.json(projects);
   } catch (err) {
     next(err);
@@ -30,8 +31,10 @@ router.post('/', requireRole('ADMIN'), validate(createProjectDto), async (req: A
   }
 });
 
-router.get('/:id', async (req, res, next) => {
+router.get('/:id', async (req: AuthRequest, res, next) => {
   try {
+    const user = req.user!;
+    await projectsService.checkProjectAccess(req.params.id as string, user.userId, user.systemRoles);
     const project = await projectsService.getProject(req.params.id as string);
     res.json(project);
   } catch (err) {
@@ -39,8 +42,10 @@ router.get('/:id', async (req, res, next) => {
   }
 });
 
-router.get('/:id/dashboard', async (req, res, next) => {
+router.get('/:id/dashboard', async (req: AuthRequest, res, next) => {
   try {
+    const user = req.user!;
+    await projectsService.checkProjectAccess(req.params.id as string, user.userId, user.systemRoles);
     const dashboard = await projectsService.getProjectDashboard(req.params.id as string);
     res.json(dashboard);
   } catch (err) {

--- a/backend/src/modules/projects/projects.service.ts
+++ b/backend/src/modules/projects/projects.service.ts
@@ -1,6 +1,8 @@
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { getCachedJson, setCachedJson } from '../../shared/redis.js';
+import { hasGlobalProjectReadAccess } from '../../shared/auth/roles.js';
+import type { SystemRoleType } from '@prisma/client';
 import type { CreateProjectDto, UpdateProjectDto } from './projects.dto.js';
 
 const projectInclude = {
@@ -15,6 +17,35 @@ export async function listProjects() {
     orderBy: { createdAt: 'desc' },
     take: 500,
   });
+}
+
+export async function listProjectsForUser(userId: string, systemRoles: SystemRoleType[]) {
+  if (hasGlobalProjectReadAccess(systemRoles)) {
+    return listProjects();
+  }
+
+  const memberships = await prisma.userProjectRole.findMany({
+    where: { userId },
+    select: { projectId: true },
+  });
+
+  const projectIds = [...new Set(memberships.map((m) => m.projectId))];
+
+  return prisma.project.findMany({
+    where: { id: { in: projectIds } },
+    include: projectInclude,
+    orderBy: { createdAt: 'desc' },
+    take: 500,
+  });
+}
+
+export async function checkProjectAccess(projectId: string, userId: string, systemRoles: SystemRoleType[]) {
+  if (hasGlobalProjectReadAccess(systemRoles)) return;
+
+  const membership = await prisma.userProjectRole.findFirst({
+    where: { userId, projectId },
+  });
+  if (!membership) throw new AppError(403, 'You do not have access to this project');
 }
 
 export async function getProject(id: string) {


### PR DESCRIPTION
## Summary
- Системная роль USER теперь видит только те проекты, в которых есть запись `UserProjectRole` для этого пользователя
- Роли ADMIN/SUPER_ADMIN/RELEASE_MANAGER/AUDITOR сохраняют глобальный доступ ко всем проектам
- `GET /api/projects/:id` и `GET /api/projects/:id/dashboard` также проверяют доступ (403 если нет членства)

## Changes
- `projects.service.ts`: добавлены `listProjectsForUser()` и `checkProjectAccess()`
- `projects.router.ts`: обновлены GET `/`, `/:id`, `/:id/dashboard` под новую логику

## Test plan
- [ ] Залогиниться под пользователем с системной ролью USER без проектных ролей — список проектов пустой
- [ ] Назначить USER проектную роль в одном проекте — видит только этот проект
- [ ] Залогиниться под ADMIN — видит все проекты
- [ ] Прямой запрос `GET /api/projects/:id` под USER без доступа — 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)