### PR TITLE
perf(projects): N+1 → батч-запрос для ProjectsPage

### DIFF
--- a/backend/src/modules/projects/projects.router.ts
+++ b/backend/src/modules/projects/projects.router.ts
@@ -14,8 +14,13 @@ router.use(authenticate);
 router.get('/', async (req: AuthRequest, res, next) => {
   try {
     const user = req.user!;
-    const projects = await projectsService.listProjectsForUser(user.userId, user.systemRoles);
-    res.json(projects);
+    if (req.query.withDashboard === 'true') {
+      const projects = await projectsService.listProjectsWithDashboardsForUser(user.userId, user.systemRoles);
+      res.json(projects);
+    } else {
+      const projects = await projectsService.listProjectsForUser(user.userId, user.systemRoles);
+      res.json(projects);
+    }
   } catch (err) {
     next(err);
   }

--- a/backend/src/modules/projects/projects.service.ts
+++ b/backend/src/modules/projects/projects.service.ts
@@ -78,6 +78,103 @@ export async function deleteProject(id: string) {
   await prisma.project.delete({ where: { id } });
 }
 
+async function fetchProjectsForUser(userId: string, systemRoles: SystemRoleType[]) {
+  if (hasGlobalProjectReadAccess(systemRoles)) {
+    return prisma.project.findMany({
+      include: projectInclude,
+      orderBy: { createdAt: 'desc' },
+      take: 500,
+    });
+  }
+  const memberships = await prisma.userProjectRole.findMany({
+    where: { userId },
+    select: { projectId: true },
+  });
+  const projectIds = [...new Set(memberships.map((m) => m.projectId))];
+  return prisma.project.findMany({
+    where: { id: { in: projectIds } },
+    include: projectInclude,
+    orderBy: { createdAt: 'desc' },
+    take: 500,
+  });
+}
+
+export async function listProjectsWithDashboardsForUser(userId: string, systemRoles: SystemRoleType[]) {
+  const projects = await fetchProjectsForUser(userId, systemRoles);
+
+  if (projects.length === 0) return [];
+
+  const projectIds = projects.map((p) => p.id);
+
+  const [totalCounts, doneCounts, activeSprints] = await Promise.all([
+    prisma.issue.groupBy({
+      by: ['projectId'],
+      _count: { _all: true },
+      where: { projectId: { in: projectIds } },
+    }),
+    prisma.issue.groupBy({
+      by: ['projectId'],
+      _count: { _all: true },
+      where: { projectId: { in: projectIds }, status: 'DONE' },
+    }),
+    prisma.sprint.findMany({
+      where: { projectId: { in: projectIds }, state: 'ACTIVE' },
+      select: {
+        id: true,
+        name: true,
+        state: true,
+        projectId: true,
+        _count: { select: { issues: true } },
+      },
+    }),
+  ]);
+
+  const activeSprintIds = activeSprints.map((s) => s.id);
+  const doneInSprints =
+    activeSprintIds.length > 0
+      ? await prisma.issue.groupBy({
+          by: ['sprintId'],
+          _count: { _all: true },
+          where: { sprintId: { in: activeSprintIds }, status: 'DONE' },
+        })
+      : [];
+
+  const totalByProject: Record<string, number> = Object.fromEntries(
+    totalCounts.map((r) => [r.projectId, r._count._all]),
+  );
+  const doneByProject: Record<string, number> = Object.fromEntries(
+    doneCounts.map((r) => [r.projectId, r._count._all]),
+  );
+  const sprintByProject: Record<string, (typeof activeSprints)[number]> = Object.fromEntries(
+    activeSprints.map((s) => [s.projectId, s]),
+  );
+  const doneBySprintId: Record<string, number> = Object.fromEntries(
+    doneInSprints.map((r) => [r.sprintId as string, r._count._all]),
+  );
+
+  return projects.map((project) => {
+    const sprint = sprintByProject[project.id];
+    return {
+      ...project,
+      dashboard: {
+        totals: {
+          totalIssues: totalByProject[project.id] ?? 0,
+          doneIssues: doneByProject[project.id] ?? 0,
+        },
+        activeSprint: sprint
+          ? {
+              id: sprint.id,
+              name: sprint.name,
+              state: sprint.state,
+              totalIssues: sprint._count.issues,
+              doneIssues: doneBySprintId[sprint.id] ?? 0,
+            }
+          : null,
+      },
+    };
+  });
+}
+
 export async function getProjectDashboard(projectId: string) {
   const cacheKey = `project:dashboard:${projectId}`;
   const cached = await getCachedJson<{

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -60,3 +60,24 @@ export async function getProjectDashboard(id: string): Promise<ProjectDashboard>
   const { data } = await api.get<ProjectDashboard>(`/projects/${id}/dashboard`);
   return data;
 }
+
+export interface ProjectDashboardSummary {
+  totals: {
+    totalIssues: number;
+    doneIssues: number;
+  };
+  activeSprint: {
+    id: string;
+    name: string;
+    state: string;
+    totalIssues: number;
+    doneIssues: number;
+  } | null;
+}
+
+export type ProjectWithDashboard = Project & { dashboard: ProjectDashboardSummary };
+
+export async function listProjectsWithDashboards(): Promise<ProjectWithDashboard[]> {
+  const { data } = await api.get<ProjectWithDashboard[]>('/projects?withDashboard=true');
+  return data;
+}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -7,12 +7,11 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Modal, Form, Input, message } from 'antd';
 import { useNavigate } from 'react-router-dom';
-import { useProjectsStore } from '../store/projects.store';
 import { useAuthStore } from '../store/auth.store';
 import { useThemeStore } from '../store/theme.store';
 import * as projectsApi from '../api/projects';
 import type { Project } from '../types';
-import type { ProjectDashboard } from '../api/projects';
+import type { ProjectDashboardSummary } from '../api/projects';
 import { hasAnyRequiredRole } from '../lib/roles';
 
 // ─── Tokens Dark (Paper 1-0) ─────────────────────────────────────────────
@@ -100,13 +99,12 @@ function timeAgo(d?: string): string {
 // ─── Types ──────────────────────────────────────────────────────────────────
 interface CardData {
   project: Project;
-  dashboard: ProjectDashboard | null;
+  dashboard: ProjectDashboardSummary | null;
   loading: boolean;
 }
 
 // ─── Component ──────────────────────────────────────────────────────────────
 export default function ProjectsPage() {
-  const { projects, loading, fetchProjects } = useProjectsStore();
   const { user } = useAuthStore();
   const { mode } = useThemeStore();
   const C = mode === 'light' ? LIGHT_C : DARK_C;
@@ -125,31 +123,29 @@ export default function ProjectsPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [form] = Form.useForm();
   const [cards, setCards] = useState<CardData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [filter, setFilter] = useState<FilterType>('all');
   const [hoveredFilter, setHoveredFilter] = useState<FilterType | null>(null);
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
 
   const canCreate = hasAnyRequiredRole(user?.systemRoles, ['ADMIN']);
 
-  useEffect(() => { fetchProjects(); }, [fetchProjects]);
-
-  const loadDashboards = useCallback(async (ps: Project[]) => {
-    setCards(ps.map((p) => ({ project: p, dashboard: null, loading: true })));
-    const results = await Promise.allSettled(
-      ps.map((p) => projectsApi.getProjectDashboard(p.id)),
-    );
-    setCards(
-      ps.map((p, i) => ({
-        project: p,
-        dashboard: results[i].status === 'fulfilled' ? results[i].value : null,
-        loading: false,
-      })),
-    );
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setFetchError(null);
+    try {
+      const data = await projectsApi.listProjectsWithDashboards();
+      setCards(data.map((item) => ({ project: item, dashboard: item.dashboard, loading: false })));
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { error?: string } }; message?: string };
+      setFetchError(e.response?.data?.error ?? e.message ?? 'Не удалось загрузить проекты');
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  useEffect(() => {
-    if (projects.length > 0) loadDashboards(projects);
-  }, [projects, loadDashboards]);
+  useEffect(() => { fetchAll(); }, [fetchAll]);
 
   const handleCreate = async (values: { name: string; key: string; description?: string }) => {
     try {
@@ -157,14 +153,14 @@ export default function ProjectsPage() {
       message.success('Проект создан');
       setModalOpen(false);
       form.resetFields();
-      fetchProjects();
+      fetchAll();
     } catch (err: unknown) {
       const error = err as { response?: { data?: { error?: string } } };
       message.error(error.response?.data?.error || 'Ошибка создания проекта');
     }
   };
 
-  const getStatus = (d: ProjectDashboard | null): ProjectStatus => {
+  const getStatus = (d: ProjectDashboardSummary | null): ProjectStatus => {
     if (!d) return 'active';
     if (d.activeSprint) return 'active';
     if (d.totals.totalIssues === 0) return 'archived';
@@ -390,7 +386,7 @@ export default function ProjectsPage() {
           </div>
           {/* Inter 12px #3D4D6B */}
           <div style={{ color: C.t3, fontFamily: F.sans, fontSize: 12, lineHeight: '16px', marginTop: 1 }}>
-            {loading ? '…' : `${projects.length} projects · ${activeCount} active`}
+            {loading ? '…' : `${cards.length} projects · ${activeCount} active`}
           </div>
         </div>
         {/* Search — 240px, bg #0F1320, border #1E2640, px-3.5 py-2 */}
@@ -452,6 +448,13 @@ export default function ProjectsPage() {
             );
           })}
         </div>
+
+        {/* Error banner */}
+        {fetchError && (
+          <div style={{ marginBottom: 20, padding: '10px 16px', borderRadius: 8, backgroundColor: mode === 'light' ? '#FEF2F2' : '#7F1D1D33', border: `1px solid ${mode === 'light' ? '#FECACA' : '#7F1D1D'}`, color: mode === 'light' ? '#DC2626' : '#FCA5A5', fontFamily: F.sans, fontSize: 13 }}>
+            {fetchError}
+          </div>
+        )}
 
         {/* Card grid */}
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 20 }}>


### PR DESCRIPTION
## Проблема

При каждом открытии `/projects` фронтенд делал **1 + N HTTP запросов**:
- `GET /api/projects` — список проектов
- `GET /api/projects/:id/dashboard` × N — по одному на каждый проект

При 15 проектах = 16 запросов при каждом переходе на страницу.

## Решение

Новый эндпоинт `GET /api/projects?withDashboard=true` возвращает все проекты с агрегатами в одном ответе.

**Backend** — `~4 запроса к БД` вместо `1 + N`:
1. `findMany` проектов
2. `groupBy projectId` — total issues
3. `groupBy projectId, status=DONE` — done issues  
4. `findMany` активных спринтов по всем проектам
5. (условно) `groupBy sprintId` — done в спринтах

**Frontend** — один `fetchAll()` вместо `useProjectsStore + loadDashboards` каскада.

## Изменённые файлы

| Файл | Что изменилось |
|------|---------------|
| `backend/src/modules/projects/projects.service.ts` | Новая функция `listProjectsWithDashboards()` |
| `backend/src/modules/projects/projects.router.ts` | `?withDashboard=true` ветка в `GET /` |
| `frontend/src/api/projects.ts` | Тип `ProjectDashboardSummary`, `ProjectWithDashboard`, `listProjectsWithDashboards()` |
| `frontend/src/pages/ProjectsPage.tsx` | Убраны `useProjectsStore`, `loadDashboards`, два `useEffect` → один `fetchAll()` |

## Test plan

- [ ] Открыть `/projects` — карточки загружаются, статусы (Active/On Hold/Archived) корректны
- [ ] Проверить в DevTools Network: только один запрос `GET /api/projects?withDashboard=true`
- [ ] Создать проект → список обновляется через `fetchAll()`
- [ ] Скелетон-плейсхолдер при загрузке отображается
- [ ] Счётчик `N projects · M active` показывает верные цифры

🤖 Generated with [Claude Code](https://claude.com/claude-code)