### PR TITLE
fix: BACKEND_INTERNAL_URL внешний для MCP

### DIFF
--- a/.github/workflows/restart-mcp-production.yml
+++ b/.github/workflows/restart-mcp-production.yml
@@ -64,6 +64,7 @@ jobs:
             -e BACKEND_INTERNAL_URL="$BACKEND_URL" \
             -e MCP_AGENT_EMAIL="$AGENT_EMAIL" \
             -e MCP_AGENT_PASSWORD="$NEW_PASS" \
+            -e BACKEND_INTERNAL_URL="https://flowuniverse.ru" \
             "$IMAGE" node dist/mcp/server.js
 
           # Wait and verify

--- a/.github/workflows/restart-mcp-production.yml
+++ b/.github/workflows/restart-mcp-production.yml
@@ -57,6 +57,8 @@ jobs:
             -p 3002:3002 \
             -e MCP_TRANSPORT=http \
             -e MCP_HTTP_PORT=3002 \
+            -e MCP_ENV=production \
+            -e NODE_ENV=production \
             -e DATABASE_URL="$DB_URL" \
             -e MCP_SERVICE_TOKEN="$SVC_TOKEN" \
             -e BACKEND_INTERNAL_URL="$BACKEND_URL" \


### PR DESCRIPTION
Внутренний http://backend:3000 не работает для агентского логина — переключаем на https://flowuniverse.ru.