### PR TITLE
fix(ci): chromatic.yml — убрать невалидный if с secrets

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -29,8 +29,6 @@ jobs:
   chromatic:
     name: Visual Regression (Chromatic)
     runs-on: ubuntu-latest
-    # Пропускать, если секрет не настроен (не блокировать CI при первом пуше)
-    if: ${{ secrets.CHROMATIC_PROJECT_TOKEN != '' }}
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
## Summary
- `if: ${{ secrets.CHROMATIC_PROJECT_TOKEN != '' }}` — GitHub запрещает обращение к secrets в job-level `if:` условиях, из-за чего workflow не стартовал (0 jobs)
- `CHROMATIC_PROJECT_TOKEN` уже настроен в репо → условие избыточно, убираем