### PR TITLE
feat(rbac): TTSEC-2 Phase 3 — frontend (user groups, security tab, matrix)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -39,6 +39,8 @@ import workflowEngineRouter from './modules/workflow-engine/workflow-engine.rout
 import releaseStatusesRouter from './modules/releases/release-statuses.router.js';
 import releaseWorkflowsAdminRouter from './modules/releases/release-workflows-admin.router.js';
 import roleSchemesRouter from './modules/project-role-schemes/project-role-schemes.router.js';
+import userGroupsRouter from './modules/user-groups/user-groups.router.js';
+import userSecurityRouter from './modules/user-security/user-security.router.js';
 import { getSchemeForProject } from './modules/workflow-schemes/workflow-schemes.service.js';
 import { getSchemeForProject as getRoleSchemeForProject } from './modules/project-role-schemes/project-role-schemes.service.js';
 import { authenticate } from './shared/middleware/auth.js';
@@ -137,6 +139,8 @@ export function createApp() {
   app.use('/api/admin/release-statuses', releaseStatusesRouter);
   app.use('/api/admin/release-workflows', releaseWorkflowsAdminRouter);
   app.use('/api/admin/role-schemes', roleSchemesRouter);
+  app.use('/api/admin/user-groups', userGroupsRouter);
+  app.use('/api', userSecurityRouter);
   app.use('/api', workflowEngineRouter);
 
   // Public: project workflow scheme

--- a/backend/src/modules/comments/comments.router.ts
+++ b/backend/src/modules/comments/comments.router.ts
@@ -26,14 +26,16 @@ router.post('/issues/:issueId/comments', validate(createCommentDto), async (req:
 
 router.patch('/comments/:id', validate(updateCommentDto), async (req: AuthRequest, res, next) => {
   try {
-    const comment = await commentsService.updateComment(req.params.id as string, req.user!.userId, req.user!.systemRoles, req.body);
+    const comment = await commentsService.updateComment(req.params.id as string, req.user!, req.body);
+    await logAudit(req, 'comment.updated', 'comment', comment.id);
     res.json(comment);
   } catch (err) { next(err); }
 });
 
 router.delete('/comments/:id', async (req: AuthRequest, res, next) => {
   try {
-    await commentsService.deleteComment(req.params.id as string, req.user!.userId, req.user!.systemRoles);
+    await commentsService.deleteComment(req.params.id as string, req.user!);
+    await logAudit(req, 'comment.deleted', 'comment', req.params.id as string);
     res.status(204).send();
   } catch (err) { next(err); }
 });

--- a/backend/src/modules/comments/comments.service.ts
+++ b/backend/src/modules/comments/comments.service.ts
@@ -1,6 +1,7 @@
-import type { SystemRoleType } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
+import type { AuthUser } from '../../shared/types/index.js';
+import { assertProjectPermission } from '../../shared/middleware/rbac.js';
 import type { CreateCommentDto, UpdateCommentDto } from './comments.dto.js';
 
 export async function listComments(issueId: string) {
@@ -21,11 +22,27 @@ export async function createComment(issueId: string, authorId: string, dto: Crea
   });
 }
 
-export async function updateComment(id: string, userId: string, userRoles: SystemRoleType[], dto: UpdateCommentDto) {
-  const comment = await prisma.comment.findUnique({ where: { id } });
+/**
+ * TTSEC-2 Phase 2 authorisation:
+ *   - Author always may edit/delete their own comment (spec §2 — owner control).
+ *   - Otherwise require `COMMENTS_MANAGE` (edit + full admin) for edit.
+ *   - For delete of someone else's: `COMMENTS_DELETE_OTHERS` OR `COMMENTS_MANAGE`.
+ *
+ * SUPER_ADMIN bypass and global project-read bypass are handled inside assertProjectPermission.
+ */
+export async function updateComment(id: string, user: AuthUser, dto: UpdateCommentDto) {
+  const comment = await prisma.comment.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      authorId: true,
+      issue: { select: { projectId: true } },
+    },
+  });
   if (!comment) throw new AppError(404, 'Comment not found');
-  if (comment.authorId !== userId && !userRoles.includes('ADMIN') && !userRoles.includes('SUPER_ADMIN')) {
-    throw new AppError(403, 'Not allowed');
+
+  if (comment.authorId !== user.userId) {
+    await assertProjectPermission(user, comment.issue.projectId, ['COMMENTS_MANAGE']);
   }
 
   return prisma.comment.update({
@@ -35,11 +52,22 @@ export async function updateComment(id: string, userId: string, userRoles: Syste
   });
 }
 
-export async function deleteComment(id: string, userId: string, userRoles: SystemRoleType[]) {
-  const comment = await prisma.comment.findUnique({ where: { id } });
+export async function deleteComment(id: string, user: AuthUser) {
+  const comment = await prisma.comment.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      authorId: true,
+      issue: { select: { projectId: true } },
+    },
+  });
   if (!comment) throw new AppError(404, 'Comment not found');
-  if (comment.authorId !== userId && !userRoles.includes('ADMIN') && !userRoles.includes('SUPER_ADMIN')) {
-    throw new AppError(403, 'Not allowed');
+
+  if (comment.authorId !== user.userId) {
+    await assertProjectPermission(user, comment.issue.projectId, [
+      'COMMENTS_DELETE_OTHERS',
+      'COMMENTS_MANAGE',
+    ]);
   }
 
   await prisma.comment.delete({ where: { id } });

--- a/backend/src/modules/project-role-schemes/project-role-schemes.service.ts
+++ b/backend/src/modules/project-role-schemes/project-role-schemes.service.ts
@@ -3,6 +3,7 @@ import { ProjectRole } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { getCachedJson, setCachedJson, delCachedJson, delCacheByPrefix } from '../../shared/redis.js';
+import { invalidateProjectEffectivePermissions } from '../../shared/middleware/rbac.js';
 import type {
   CreateSchemeDto,
   UpdateSchemeDto,
@@ -24,42 +25,17 @@ async function invalidateSchemeCache(schemeId: string) {
 /** Invalidate per-user permission cache for all projects bound to a scheme.
  * Call after any change that affects permission resolution (permissions matrix, role membership).
  *
- * TTSEC-2 Phase 2: kills both legacy (`rbac:perm:{projectId}:*`) and new group-aware
- * (`rbac:effective:{userId}:{projectId}`) caches for every user who could be affected by the
- * scheme — direct role holders PLUS members of any group bound to a project in this scheme.
- * Per-user scan is necessary because the new key is userId-prefixed, not projectId-prefixed. */
+ * AI review #65 round 4 🟠 — delegates to the exported `invalidateProjectEffectivePermissions`
+ * helper which does a prefix SCAN+DELETE over `rbac:effective:{projectId}:*`. This covers every
+ * cached user for the project, including ones who just lost access via this scheme change. Using
+ * the shared helper also guarantees key-format parity with the rest of rbac.ts — no more
+ * hand-built keys drifting out of sync. */
 async function invalidatePermissionCacheForScheme(schemeId: string) {
   const bindings = await prisma.projectRoleSchemeProject.findMany({
     where: { schemeId },
     select: { projectId: true },
   });
-  const projectIds = bindings.map(b => b.projectId);
-  if (projectIds.length === 0) return;
-
-  const [directUsers, groupUsers] = await Promise.all([
-    prisma.userProjectRole.findMany({
-      where: { projectId: { in: projectIds } },
-      select: { userId: true, projectId: true },
-    }),
-    prisma.userGroupMember.findMany({
-      where: { group: { projectRoles: { some: { projectId: { in: projectIds } } } } },
-      select: { userId: true, group: { select: { projectRoles: { where: { projectId: { in: projectIds } }, select: { projectId: true } } } } },
-    }),
-  ]);
-
-  const pairs = new Set<string>();
-  for (const row of directUsers) pairs.add(`${row.userId}::${row.projectId}`);
-  for (const row of groupUsers) {
-    for (const pr of row.group.projectRoles) pairs.add(`${row.userId}::${pr.projectId}`);
-  }
-
-  await Promise.all([
-    ...projectIds.map(pid => delCacheByPrefix(`rbac:perm:${pid}:`)),
-    ...Array.from(pairs).map(p => {
-      const [uid, pid] = p.split('::');
-      return delCachedJson(`rbac:effective:${uid}:${pid}`);
-    }),
-  ]);
+  await Promise.all(bindings.map(b => invalidateProjectEffectivePermissions(b.projectId)));
 }
 
 const schemeInclude = {

--- a/backend/src/modules/project-role-schemes/project-role-schemes.service.ts
+++ b/backend/src/modules/project-role-schemes/project-role-schemes.service.ts
@@ -22,13 +22,44 @@ async function invalidateSchemeCache(schemeId: string) {
 }
 
 /** Invalidate per-user permission cache for all projects bound to a scheme.
- * Call after any change that affects permission resolution (permissions matrix, role membership). */
+ * Call after any change that affects permission resolution (permissions matrix, role membership).
+ *
+ * TTSEC-2 Phase 2: kills both legacy (`rbac:perm:{projectId}:*`) and new group-aware
+ * (`rbac:effective:{userId}:{projectId}`) caches for every user who could be affected by the
+ * scheme — direct role holders PLUS members of any group bound to a project in this scheme.
+ * Per-user scan is necessary because the new key is userId-prefixed, not projectId-prefixed. */
 async function invalidatePermissionCacheForScheme(schemeId: string) {
   const bindings = await prisma.projectRoleSchemeProject.findMany({
     where: { schemeId },
     select: { projectId: true },
   });
-  await Promise.all(bindings.map(b => delCacheByPrefix(`rbac:perm:${b.projectId}:`)));
+  const projectIds = bindings.map(b => b.projectId);
+  if (projectIds.length === 0) return;
+
+  const [directUsers, groupUsers] = await Promise.all([
+    prisma.userProjectRole.findMany({
+      where: { projectId: { in: projectIds } },
+      select: { userId: true, projectId: true },
+    }),
+    prisma.userGroupMember.findMany({
+      where: { group: { projectRoles: { some: { projectId: { in: projectIds } } } } },
+      select: { userId: true, group: { select: { projectRoles: { where: { projectId: { in: projectIds } }, select: { projectId: true } } } } },
+    }),
+  ]);
+
+  const pairs = new Set<string>();
+  for (const row of directUsers) pairs.add(`${row.userId}::${row.projectId}`);
+  for (const row of groupUsers) {
+    for (const pr of row.group.projectRoles) pairs.add(`${row.userId}::${pr.projectId}`);
+  }
+
+  await Promise.all([
+    ...projectIds.map(pid => delCacheByPrefix(`rbac:perm:${pid}:`)),
+    ...Array.from(pairs).map(p => {
+      const [uid, pid] = p.split('::');
+      return delCachedJson(`rbac:effective:${uid}:${pid}`);
+    }),
+  ]);
 }
 
 const schemeInclude = {

--- a/backend/src/modules/releases/releases.router.ts
+++ b/backend/src/modules/releases/releases.router.ts
@@ -54,7 +54,7 @@ async function assertReleasePermission(
   // INTEGRATION release — no single project; keep system-role gate until a multi-project perm
   // model is designed. ADMIN and RELEASE_MANAGER correspond to the existing requireRole set.
   if (!hasAnySystemRole(req.user!.systemRoles, ['ADMIN', 'RELEASE_MANAGER', 'SUPER_ADMIN'])) {
-    throw new AppError(403, 'Insufficient permissions for integration release');
+    throw new AppError(403, 'Недостаточно прав для межпроектного релиза');
   }
 }
 

--- a/backend/src/modules/releases/releases.router.ts
+++ b/backend/src/modules/releases/releases.router.ts
@@ -2,7 +2,6 @@ import { Router } from 'express';
 import type { ProjectPermission } from '@prisma/client';
 import { authenticate } from '../../shared/middleware/auth.js';
 import {
-  requireRole,
   requireProjectPermission,
   assertProjectPermission,
 } from '../../shared/middleware/rbac.js';
@@ -70,17 +69,23 @@ router.get('/releases', async (req: AuthRequest, res, next) => {
   }
 });
 
-// ─── RM-03.2: POST /releases — create (INTEGRATION spans projects) ──────────
-// Global create retains requireRole — INTEGRATION releases may have no projectId to gate on.
-// ATOMIC releases with projectId additionally pass through the granular check below.
+// ─── RM-03.2: POST /releases — create (ATOMIC | INTEGRATION) ────────────────
+// TTSEC-2 Phase 2 (AI review #65 round 2): gate by context, not by one-size-fits-all role.
+//   - projectId in body  → ATOMIC release, project-scoped → `RELEASES_CREATE` granular check.
+//   - projectId omitted  → INTEGRATION release (multi-project), no single project to gate on →
+//     fall back to system-role `requireRole` equivalent until a multi-project perm model exists.
+// Combining both (requireRole AND granular) used to narrow access for users who had RELEASES_CREATE
+// in a project but no system ADMIN/RELEASE_MANAGER — they could not create project-scoped releases
+// through this endpoint, which contradicts the whole premise of granular permissions.
 router.post(
   '/releases',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(createReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
       if (req.body.projectId) {
         await assertProjectPermission(req.user!, req.body.projectId, ['RELEASES_CREATE']);
+      } else if (!hasAnySystemRole(req.user!.systemRoles, ['ADMIN', 'RELEASE_MANAGER', 'SUPER_ADMIN'])) {
+        throw new AppError(403, 'Недостаточно прав для межпроектного релиза');
       }
       const release = await releasesService.createReleaseGlobal(req.body, req.user!.userId);
       await logAudit(req, 'release.created', 'release', release.id, {

--- a/backend/src/modules/releases/releases.router.ts
+++ b/backend/src/modules/releases/releases.router.ts
@@ -1,6 +1,11 @@
 import { Router } from 'express';
+import type { ProjectPermission } from '@prisma/client';
 import { authenticate } from '../../shared/middleware/auth.js';
-import { requireRole } from '../../shared/middleware/rbac.js';
+import {
+  requireRole,
+  requireProjectPermission,
+  assertProjectPermission,
+} from '../../shared/middleware/rbac.js';
 import { validate } from '../../shared/middleware/validate.js';
 import {
   createReleaseDto,
@@ -16,10 +21,42 @@ import {
 import * as releasesService from './releases.service.js';
 import * as releaseWorkflowEngine from './release-workflow-engine.service.js';
 import { logAudit } from '../../shared/middleware/audit.js';
+import { hasAnySystemRole } from '../../shared/auth/roles.js';
 import type { AuthRequest } from '../../shared/types/index.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import { prisma } from '../../prisma/client.js';
 
 const router = Router();
 router.use(authenticate);
+
+/**
+ * TTSEC-2 Phase 2: gate release mutations on granular `RELEASES_*` permissions.
+ *
+ * Releases may be project-scoped (ATOMIC) or multi-project (INTEGRATION). When projectId is
+ * known, we use `assertProjectPermission`; for INTEGRATION releases (projectId=null) we fall
+ * back to the legacy system-role gate (ADMIN / RELEASE_MANAGER).
+ */
+async function assertReleasePermission(
+  req: AuthRequest,
+  releaseId: string,
+  perms: ProjectPermission[],
+): Promise<void> {
+  const release = await prisma.release.findUnique({
+    where: { id: releaseId },
+    select: { projectId: true },
+  });
+  if (!release) throw new AppError(404, 'Релиз не найден');
+
+  if (release.projectId) {
+    await assertProjectPermission(req.user!, release.projectId, perms);
+    return;
+  }
+  // INTEGRATION release — no single project; keep system-role gate until a multi-project perm
+  // model is designed. ADMIN and RELEASE_MANAGER correspond to the existing requireRole set.
+  if (!hasAnySystemRole(req.user!.systemRoles, ['ADMIN', 'RELEASE_MANAGER', 'SUPER_ADMIN'])) {
+    throw new AppError(403, 'Insufficient permissions for integration release');
+  }
+}
 
 // ─── RM-03.1: GET /releases — global list with filtering ────────────────────
 
@@ -33,14 +70,18 @@ router.get('/releases', async (req: AuthRequest, res, next) => {
   }
 });
 
-// ─── RM-03.2: POST /releases — create with type ATOMIC/INTEGRATION ──────────
-
+// ─── RM-03.2: POST /releases — create (INTEGRATION spans projects) ──────────
+// Global create retains requireRole — INTEGRATION releases may have no projectId to gate on.
+// ATOMIC releases with projectId additionally pass through the granular check below.
 router.post(
   '/releases',
   requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(createReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
+      if (req.body.projectId) {
+        await assertProjectPermission(req.user!, req.body.projectId, ['RELEASES_CREATE']);
+      }
       const release = await releasesService.createReleaseGlobal(req.body, req.user!.userId);
       await logAudit(req, 'release.created', 'release', release.id, {
         name: release.name,
@@ -54,8 +95,6 @@ router.post(
   },
 );
 
-// ─── GET /releases/:id — single release ──────────────────────────────────────
-
 router.get('/releases/:id', async (req: AuthRequest, res, next) => {
   try {
     const release = await releasesService.getRelease(req.params.id as string);
@@ -64,8 +103,6 @@ router.get('/releases/:id', async (req: AuthRequest, res, next) => {
     next(err);
   }
 });
-
-// ─── GET /releases/:id/history — audit log ───────────────────────────────────
 
 router.get('/releases/:id/history', async (req: AuthRequest, res, next) => {
   try {
@@ -76,40 +113,27 @@ router.get('/releases/:id/history', async (req: AuthRequest, res, next) => {
   }
 });
 
-// ─── RM-03.3: PATCH /releases/:id — update (immutable: type, projectId) ─────
+router.patch('/releases/:id', validate(updateReleaseDto), async (req: AuthRequest, res, next) => {
+  try {
+    await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
+    const release = await releasesService.updateRelease(req.params.id as string, req.body);
+    await logAudit(req, 'release.updated', 'release', release.id, req.body);
+    res.json(release);
+  } catch (err) {
+    next(err);
+  }
+});
 
-router.patch(
-  '/releases/:id',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
-  validate(updateReleaseDto),
-  async (req: AuthRequest, res, next) => {
-    try {
-      const release = await releasesService.updateRelease(req.params.id as string, req.body);
-      await logAudit(req, 'release.updated', 'release', release.id, req.body);
-      res.json(release);
-    } catch (err) {
-      next(err);
-    }
-  },
-);
-
-// ─── RM-03.4: DELETE /releases/:id ───────────────────────────────────────────
-
-router.delete(
-  '/releases/:id',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
-  async (req: AuthRequest, res, next) => {
-    try {
-      await releasesService.deleteRelease(req.params.id as string);
-      await logAudit(req, 'release.deleted', 'release', req.params.id as string);
-      res.status(204).send();
-    } catch (err) {
-      next(err);
-    }
-  },
-);
-
-// ─── RM-03.5: ReleaseItem CRUD ────────────────────────────────────────────────
+router.delete('/releases/:id', async (req: AuthRequest, res, next) => {
+  try {
+    await assertReleasePermission(req, req.params.id as string, ['RELEASES_DELETE']);
+    await releasesService.deleteRelease(req.params.id as string);
+    await logAudit(req, 'release.deleted', 'release', req.params.id as string);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.get('/releases/:id/items', async (req: AuthRequest, res, next) => {
   try {
@@ -123,15 +147,11 @@ router.get('/releases/:id/items', async (req: AuthRequest, res, next) => {
 
 router.post(
   '/releases/:id/items',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(releaseItemsAddDto),
   async (req: AuthRequest, res, next) => {
     try {
-      await releasesService.addReleaseItems(
-        req.params.id as string,
-        req.body,
-        req.user!.userId,
-      );
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
+      await releasesService.addReleaseItems(req.params.id as string, req.body, req.user!.userId);
       await logAudit(req, 'release.items_added', 'release', req.params.id as string, {
         issueIds: req.body.issueIds,
       });
@@ -144,14 +164,11 @@ router.post(
 
 router.post(
   '/releases/:id/items/remove',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(releaseItemsRemoveDto),
   async (req: AuthRequest, res, next) => {
     try {
-      await releasesService.removeReleaseItems(
-        req.params.id as string,
-        req.body.issueIds,
-      );
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
+      await releasesService.removeReleaseItems(req.params.id as string, req.body.issueIds);
       await logAudit(req, 'release.items_removed', 'release', req.params.id as string, {
         issueIds: req.body.issueIds,
       });
@@ -162,30 +179,25 @@ router.post(
   },
 );
 
-// ─── RM-03.6: Transitions ────────────────────────────────────────────────────
-
-router.get(
-  '/releases/:id/transitions',
-  async (req: AuthRequest, res, next) => {
-    try {
-      const result = await releaseWorkflowEngine.getAvailableTransitions(
-        req.params.id as string,
-        req.user!.userId,
-        req.user!.systemRoles,
-      );
-      res.json(result);
-    } catch (err) {
-      next(err);
-    }
-  },
-);
+router.get('/releases/:id/transitions', async (req: AuthRequest, res, next) => {
+  try {
+    const result = await releaseWorkflowEngine.getAvailableTransitions(
+      req.params.id as string,
+      req.user!.userId,
+      req.user!.systemRoles,
+    );
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.post(
   '/releases/:id/transitions/:transitionId',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(executeTransitionDto),
   async (req: AuthRequest, res, next) => {
     try {
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
       await releaseWorkflowEngine.executeTransition(
         req.params.id as string,
         req.params.transitionId as string,
@@ -193,15 +205,12 @@ router.post(
         req.user!.systemRoles,
         (req.body as { comment?: string }).comment,
       );
-      // audit is written inside executeTransition via prisma.$transaction
       res.json({ ok: true });
     } catch (err) {
       next(err);
     }
   },
 );
-
-// ─── RM-03.7: GET /releases/:id/readiness — extended ─────────────────────────
 
 router.get('/releases/:id/readiness', async (req: AuthRequest, res, next) => {
   try {
@@ -216,14 +225,13 @@ router.get('/releases/:id/readiness', async (req: AuthRequest, res, next) => {
   }
 });
 
-// ─── RM-03.8: POST /releases/:id/clone ───────────────────────────────────────
-
 router.post(
   '/releases/:id/clone',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(cloneReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
+      // Cloning produces a NEW release; gate on CREATE at the source project boundary.
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_CREATE']);
       const cloned = await releasesService.cloneRelease(
         req.params.id as string,
         req.body,
@@ -235,8 +243,6 @@ router.post(
     }
   },
 );
-
-// ─── RM-03.9: Deprecated endpoints → 410 Gone ────────────────────────────────
 
 router.post('/releases/:id/ready', (_req, res) => {
   res.status(410).json({
@@ -265,7 +271,7 @@ router.get('/projects/:projectId/releases', async (req, res, next) => {
 
 router.post(
   '/projects/:projectId/releases',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
+  requireProjectPermission((req) => req.params.projectId as string, 'RELEASES_CREATE'),
   validate(createReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
@@ -304,10 +310,10 @@ router.get('/releases/:id/sprints', async (req, res, next) => {
 
 router.post(
   '/releases/:id/sprints',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(manageSprintsInReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
       await releasesService.addSprintsToRelease(req.params.id as string, req.body.sprintIds);
       await logAudit(req, 'release.sprints_added', 'release', req.params.id as string, {
         sprintIds: req.body.sprintIds,
@@ -321,10 +327,10 @@ router.post(
 
 router.post(
   '/releases/:id/sprints/remove',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(manageSprintsInReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
       await releasesService.removeSprintsFromRelease(req.params.id as string, req.body.sprintIds);
       await logAudit(req, 'release.sprints_removed', 'release', req.params.id as string, {
         sprintIds: req.body.sprintIds,

--- a/backend/src/modules/sprints/sprints.router.ts
+++ b/backend/src/modules/sprints/sprints.router.ts
@@ -117,25 +117,28 @@ router.post('/sprints/:id/close', async (req: AuthRequest, res, next) => {
 });
 
 // Move issues to a sprint — edit-level change on the target sprint.
+// Pass expectedProjectId = sprint.projectId so the service rejects foreign-project ids.
 router.post('/sprints/:id/issues', validate(moveIssuesToSprintDto), async (req: AuthRequest, res, next) => {
   try {
     const projectId = await projectIdFromSprint(req.params.id as string);
     await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
-    await sprintsService.moveIssuesToSprint(req.params.id as string, req.body.issueIds);
+    await sprintsService.moveIssuesToSprint(req.params.id as string, req.body.issueIds, projectId);
     await logAudit(req, 'sprint.issues_moved', 'sprint', req.params.id as string, { issueIds: req.body.issueIds });
     res.json({ ok: true });
   } catch (err) { next(err); }
 });
 
 // Move issues to backlog — affects sprint membership in a project.
+// Pass expectedProjectId = req.params.projectId so issueIds from other projects are rejected.
 router.post(
   '/projects/:projectId/backlog/issues',
   requireProjectPermission((req) => req.params.projectId as string, 'SPRINTS_EDIT'),
   validate(moveIssuesToSprintDto),
   async (req: AuthRequest, res, next) => {
     try {
-      await sprintsService.moveIssuesToSprint(null, req.body.issueIds);
-      await logAudit(req, 'sprint.issues_moved_to_backlog', 'project', req.params.projectId as string, { issueIds: req.body.issueIds });
+      const projectId = req.params.projectId as string;
+      await sprintsService.moveIssuesToSprint(null, req.body.issueIds, projectId);
+      await logAudit(req, 'sprint.issues_moved_to_backlog', 'project', projectId, { issueIds: req.body.issueIds });
       res.json({ ok: true });
     } catch (err) { next(err); }
   },

--- a/backend/src/modules/sprints/sprints.router.ts
+++ b/backend/src/modules/sprints/sprints.router.ts
@@ -1,15 +1,23 @@
 import { Router } from 'express';
 import { authenticate } from '../../shared/middleware/auth.js';
-import { requireRole } from '../../shared/middleware/rbac.js';
+import { requireProjectPermission, assertProjectPermission } from '../../shared/middleware/rbac.js';
 import { validate } from '../../shared/middleware/validate.js';
 import { createSprintDto, updateSprintDto, moveIssuesToSprintDto } from './sprints.dto.js';
 import * as sprintsService from './sprints.service.js';
 import { logAudit } from '../../shared/middleware/audit.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 import { parsePagination } from '../../shared/utils/params.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import { prisma } from '../../prisma/client.js';
 
 const router = Router();
 router.use(authenticate);
+
+async function projectIdFromSprint(sprintId: string): Promise<string> {
+  const sprint = await prisma.sprint.findUnique({ where: { id: sprintId }, select: { projectId: true } });
+  if (!sprint) throw new AppError(404, 'Sprint not found');
+  return sprint.projectId;
+}
 
 // Global list of sprints with optional filters
 router.get('/sprints', async (req, res, next) => {
@@ -63,64 +71,81 @@ router.get('/projects/:projectId/backlog', async (req, res, next) => {
   } catch (err) { next(err); }
 });
 
-// Create sprint
-router.post('/projects/:projectId/sprints', requireRole('ADMIN'), validate(createSprintDto), async (req: AuthRequest, res, next) => {
-  try {
-    const sprint = await sprintsService.createSprint(req.params.projectId as string, req.body);
-    await logAudit(req, 'sprint.created', 'sprint', sprint.id, { name: sprint.name });
-    res.status(201).json(sprint);
-  } catch (err) { next(err); }
-});
+// Create sprint — TTSEC-2: SPRINTS_CREATE
+router.post(
+  '/projects/:projectId/sprints',
+  requireProjectPermission((req) => req.params.projectId as string, 'SPRINTS_CREATE'),
+  validate(createSprintDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const sprint = await sprintsService.createSprint(req.params.projectId as string, req.body);
+      await logAudit(req, 'sprint.created', 'sprint', sprint.id, { name: sprint.name });
+      res.status(201).json(sprint);
+    } catch (err) { next(err); }
+  },
+);
 
-// Update sprint
-router.patch('/sprints/:id', requireRole('ADMIN'), validate(updateSprintDto), async (req: AuthRequest, res, next) => {
+// Update sprint — TTSEC-2: SPRINTS_EDIT (projectId looked up from sprint)
+router.patch('/sprints/:id', validate(updateSprintDto), async (req: AuthRequest, res, next) => {
   try {
+    const projectId = await projectIdFromSprint(req.params.id as string);
+    await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
     const sprint = await sprintsService.updateSprint(req.params.id as string, req.body);
     await logAudit(req, 'sprint.updated', 'sprint', sprint.id, req.body);
     res.json(sprint);
   } catch (err) { next(err); }
 });
 
-// Start sprint
-router.post('/sprints/:id/start', requireRole('ADMIN'), async (req: AuthRequest, res, next) => {
+router.post('/sprints/:id/start', async (req: AuthRequest, res, next) => {
   try {
+    const projectId = await projectIdFromSprint(req.params.id as string);
+    await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
     const sprint = await sprintsService.startSprint(req.params.id as string);
     await logAudit(req, 'sprint.started', 'sprint', sprint.id);
     res.json(sprint);
   } catch (err) { next(err); }
 });
 
-// Close sprint
-router.post('/sprints/:id/close', requireRole('ADMIN'), async (req: AuthRequest, res, next) => {
+router.post('/sprints/:id/close', async (req: AuthRequest, res, next) => {
   try {
+    const projectId = await projectIdFromSprint(req.params.id as string);
+    await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
     const sprint = await sprintsService.closeSprint(req.params.id as string);
     await logAudit(req, 'sprint.closed', 'sprint', sprint.id);
     res.json(sprint);
   } catch (err) { next(err); }
 });
 
-// Move issues to sprint (or backlog if sprintId=null in body)
-router.post('/sprints/:id/issues', requireRole('ADMIN'), validate(moveIssuesToSprintDto), async (req: AuthRequest, res, next) => {
+// Move issues to a sprint — edit-level change on the target sprint.
+router.post('/sprints/:id/issues', validate(moveIssuesToSprintDto), async (req: AuthRequest, res, next) => {
   try {
+    const projectId = await projectIdFromSprint(req.params.id as string);
+    await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
     await sprintsService.moveIssuesToSprint(req.params.id as string, req.body.issueIds);
     await logAudit(req, 'sprint.issues_moved', 'sprint', req.params.id as string, { issueIds: req.body.issueIds });
     res.json({ ok: true });
   } catch (err) { next(err); }
 });
 
-// Move issues to backlog
-router.post('/projects/:projectId/backlog/issues', requireRole('ADMIN'), validate(moveIssuesToSprintDto), async (req: AuthRequest, res, next) => {
-  try {
-    await sprintsService.moveIssuesToSprint(null, req.body.issueIds);
-    await logAudit(req, 'sprint.issues_moved_to_backlog', 'project', req.params.projectId as string, { issueIds: req.body.issueIds });
-    res.json({ ok: true });
-  } catch (err) { next(err); }
-});
+// Move issues to backlog — affects sprint membership in a project.
+router.post(
+  '/projects/:projectId/backlog/issues',
+  requireProjectPermission((req) => req.params.projectId as string, 'SPRINTS_EDIT'),
+  validate(moveIssuesToSprintDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      await sprintsService.moveIssuesToSprint(null, req.body.issueIds);
+      await logAudit(req, 'sprint.issues_moved_to_backlog', 'project', req.params.projectId as string, { issueIds: req.body.issueIds });
+      res.json({ ok: true });
+    } catch (err) { next(err); }
+  },
+);
 
-// Bulk AI estimate all issues in a sprint
-router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN'), async (req: AuthRequest, res, next) => {
+router.post('/sprints/:id/ai/estimate-all', async (req: AuthRequest, res, next) => {
   try {
     const sprintId = req.params.id as string;
+    const projectId = await projectIdFromSprint(sprintId);
+    await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
     const result = await sprintsService.bulkEstimateIssues(sprintId);
     await logAudit(req, 'sprint.ai_estimate_all', 'sprint', sprintId, {
       total: result.total,

--- a/backend/src/modules/sprints/sprints.service.ts
+++ b/backend/src/modules/sprints/sprints.service.ts
@@ -243,11 +243,33 @@ export async function closeSprint(id: string) {
   return updated;
 }
 
-export async function moveIssuesToSprint(sprintId: string | null, issueIds: string[]) {
-  // Fetch all unique projectIds for correct cache invalidation across projects
+/**
+ * Move a batch of issues to a sprint (or to backlog when sprintId is null).
+ *
+ * TTSEC-2 hardening (AI review #65): `expectedProjectId` forces all issue ids to belong to the
+ * caller-approved project. Without it a user authorised to edit sprints in project A could pass
+ * issueIds from project B and touch them. Routes that have a clear "target project" — the sprint
+ * owner, or the backlog's projectId — MUST supply it.
+ */
+export async function moveIssuesToSprint(
+  sprintId: string | null,
+  issueIds: string[],
+  expectedProjectId?: string,
+) {
   const affectedIssues = issueIds.length > 0
-    ? await prisma.issue.findMany({ where: { id: { in: issueIds } }, select: { projectId: true } })
+    ? await prisma.issue.findMany({ where: { id: { in: issueIds } }, select: { id: true, projectId: true } })
     : [];
+
+  if (expectedProjectId) {
+    if (affectedIssues.length !== issueIds.length) {
+      throw new AppError(400, 'Некоторые задачи не найдены');
+    }
+    const foreign = affectedIssues.filter(i => i.projectId !== expectedProjectId);
+    if (foreign.length > 0) {
+      throw new AppError(403, 'Задачи принадлежат другому проекту');
+    }
+  }
+
   const projectIds = [...new Set(affectedIssues.map((i) => i.projectId))];
 
   await prisma.issue.updateMany({

--- a/backend/src/modules/time/time.router.ts
+++ b/backend/src/modules/time/time.router.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { authenticate } from '../../shared/middleware/auth.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { validate } from '../../shared/middleware/validate.js';
+import { logAudit } from '../../shared/middleware/audit.js';
 import { manualTimeDto } from './time.dto.js';
 import * as timeService from './time.service.js';
 import type { AuthRequest } from '../../shared/types/index.js';
@@ -71,6 +72,15 @@ router.get('/time/active', async (req: AuthRequest, res, next) => {
   try {
     const timer = await timeService.getActiveTimer(req.user!.userId);
     res.json(timer);
+  } catch (err) { next(err); }
+});
+
+// TTSEC-2: DELETE time log (owner OR TIME_LOGS_DELETE_OTHERS OR TIME_LOGS_MANAGE)
+router.delete('/time-logs/:id', async (req: AuthRequest, res, next) => {
+  try {
+    await timeService.deleteTimeLog(req.params.id as string, req.user!);
+    await logAudit(req, 'time_log.deleted', 'time_log', req.params.id as string);
+    res.status(204).send();
   } catch (err) { next(err); }
 });
 

--- a/backend/src/modules/time/time.service.ts
+++ b/backend/src/modules/time/time.service.ts
@@ -1,6 +1,8 @@
 import { Decimal } from '@prisma/client/runtime/library';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
+import type { AuthUser } from '../../shared/types/index.js';
+import { assertProjectPermission } from '../../shared/middleware/rbac.js';
 import type { ManualTimeDto } from './time.dto.js';
 import { buildUserTimeSummary } from './time.domain.js';
 import { getCachedJson, setCachedJson, delCachedJson } from '../../shared/redis.js';
@@ -93,6 +95,32 @@ export async function getUserLogs(userId: string) {
     orderBy: { createdAt: 'desc' },
     take: 100,
   });
+}
+
+/**
+ * TTSEC-2 Phase 2: delete a time log. Owner always may delete their own. Otherwise require
+ * `TIME_LOGS_DELETE_OTHERS` OR `TIME_LOGS_MANAGE` in the log's project.
+ */
+export async function deleteTimeLog(id: string, user: AuthUser) {
+  const log = await prisma.timeLog.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      userId: true,
+      issue: { select: { projectId: true } },
+    },
+  });
+  if (!log) throw new AppError(404, 'Time log not found');
+
+  if (log.userId !== user.userId) {
+    await assertProjectPermission(user, log.issue.projectId, [
+      'TIME_LOGS_DELETE_OTHERS',
+      'TIME_LOGS_MANAGE',
+    ]);
+  }
+
+  await prisma.timeLog.delete({ where: { id } });
+  await delCachedJson(`time:summary:${log.userId}`);
 }
 
 export async function getUserTimeSummary(userId: string) {

--- a/backend/src/modules/user-groups/user-groups.dto.ts
+++ b/backend/src/modules/user-groups/user-groups.dto.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const createUserGroupDto = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).nullable().optional(),
+});
+
+export const updateUserGroupDto = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(2000).nullable().optional(),
+});
+
+export const addMembersDto = z.object({
+  userIds: z.array(z.string().uuid()).min(1).max(500),
+});
+
+export const grantProjectRoleDto = z.object({
+  projectId: z.string().uuid(),
+  roleId: z.string().uuid(),
+});
+
+export type CreateUserGroupDto = z.infer<typeof createUserGroupDto>;
+export type UpdateUserGroupDto = z.infer<typeof updateUserGroupDto>;
+export type AddMembersDto = z.infer<typeof addMembersDto>;
+export type GrantProjectRoleDto = z.infer<typeof grantProjectRoleDto>;

--- a/backend/src/modules/user-groups/user-groups.router.ts
+++ b/backend/src/modules/user-groups/user-groups.router.ts
@@ -1,0 +1,136 @@
+import { Router } from 'express';
+import { authenticate } from '../../shared/middleware/auth.js';
+import { requireRole } from '../../shared/middleware/rbac.js';
+import { validate } from '../../shared/middleware/validate.js';
+import { logAudit } from '../../shared/middleware/audit.js';
+import type { AuthRequest } from '../../shared/types/index.js';
+import {
+  createUserGroupDto,
+  updateUserGroupDto,
+  addMembersDto,
+  grantProjectRoleDto,
+} from './user-groups.dto.js';
+import * as service from './user-groups.service.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+
+/**
+ * TTSEC-2 Phase 2 router. Mounted at /api/admin/user-groups.
+ *
+ * TODO Phase 4: migrate gate from `requireRole('ADMIN')` (system ADMIN) to a proper
+ * system-level permission check (`USER_GROUP_VIEW` / `USER_GROUP_MANAGE`) once the helper is
+ * extracted. For now system ADMIN gets full access — same pattern as teams/*.
+ */
+
+const router = Router();
+router.use(authenticate);
+router.use(requireRole('ADMIN'));
+
+router.get('/', async (req, res, next) => {
+  try {
+    const search = typeof req.query.search === 'string' ? req.query.search : undefined;
+    res.json(await service.listGroups({ search }));
+  } catch (err) { next(err); }
+});
+
+router.post('/', validate(createUserGroupDto), async (req: AuthRequest, res, next) => {
+  try {
+    const group = await service.createGroup(req.body);
+    await logAudit(req, 'user_group.created', 'user_group', group.id, { name: group.name });
+    res.status(201).json(group);
+  } catch (err) { next(err); }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    res.json(await service.getGroup(req.params.id as string));
+  } catch (err) { next(err); }
+});
+
+router.patch('/:id', validate(updateUserGroupDto), async (req: AuthRequest, res, next) => {
+  try {
+    const groupId = req.params.id as string;
+    const before = await service.getGroup(groupId);
+    const updated = await service.updateGroup(groupId, req.body);
+    const action = req.body.name && req.body.name !== before.name
+      ? 'user_group.renamed'
+      : 'user_group.updated';
+    await logAudit(req, action, 'user_group', groupId, {
+      before: { name: before.name, description: before.description },
+      after: req.body,
+    });
+    res.json(updated);
+  } catch (err) { next(err); }
+});
+
+router.get('/:id/impact', async (req, res, next) => {
+  try {
+    res.json(await service.getGroupImpact(req.params.id as string));
+  } catch (err) { next(err); }
+});
+
+router.delete('/:id', async (req: AuthRequest, res, next) => {
+  try {
+    // confirm=true is mandatory for destructive group delete — without it return 412 + impact.
+    // This matches spec §5.6 / FR-A9: DELETE group requires confirm + list of affected.
+    if (req.query.confirm !== 'true') {
+      const impact = await service.getGroupImpact(req.params.id as string);
+      throw new AppError(412, 'CONFIRM_REQUIRED: добавьте ?confirm=true', { impact });
+    }
+    const result = await service.deleteGroup(req.params.id as string);
+    await logAudit(req, 'user_group.deleted', 'user_group', req.params.id as string, {
+      name: result.name,
+      removedMembers: result.removedMembers,
+      removedBindings: result.removedBindings,
+    });
+    res.json(result);
+  } catch (err) { next(err); }
+});
+
+router.post('/:id/members', validate(addMembersDto), async (req: AuthRequest, res, next) => {
+  try {
+    const groupId = req.params.id as string;
+    const result = await service.addMembers(groupId, req.body.userIds, req.user!.userId);
+    await logAudit(req, 'user_group.members_changed', 'user_group', groupId, {
+      added: req.body.userIds,
+      removed: [],
+    });
+    res.json(result);
+  } catch (err) { next(err); }
+});
+
+router.delete('/:id/members/:userId', async (req: AuthRequest, res, next) => {
+  try {
+    const groupId = req.params.id as string;
+    const userId = req.params.userId as string;
+    const result = await service.removeMember(groupId, userId);
+    await logAudit(req, 'user_group.members_changed', 'user_group', groupId, {
+      added: [],
+      removed: [userId],
+    });
+    res.json(result);
+  } catch (err) { next(err); }
+});
+
+router.post('/:id/project-roles', validate(grantProjectRoleDto), async (req: AuthRequest, res, next) => {
+  try {
+    const groupId = req.params.id as string;
+    const binding = await service.grantProjectRole(groupId, req.body);
+    await logAudit(req, 'project_group_role.granted', 'user_group', groupId, {
+      projectId: req.body.projectId,
+      roleId: req.body.roleId,
+    });
+    res.status(201).json(binding);
+  } catch (err) { next(err); }
+});
+
+router.delete('/:id/project-roles/:projectId', async (req: AuthRequest, res, next) => {
+  try {
+    const groupId = req.params.id as string;
+    const projectId = req.params.projectId as string;
+    const result = await service.revokeProjectRole(groupId, projectId);
+    await logAudit(req, 'project_group_role.revoked', 'user_group', groupId, { projectId });
+    res.json(result);
+  } catch (err) { next(err); }
+});
+
+export default router;

--- a/backend/src/modules/user-groups/user-groups.service.ts
+++ b/backend/src/modules/user-groups/user-groups.service.ts
@@ -87,7 +87,13 @@ export async function updateGroup(id: string, dto: UpdateUserGroupDto) {
 /**
  * Delete a group. Returns affected user-project pairs so the caller can audit exactly which
  * permissions were revoked. The DB cascades UserGroupMember/ProjectGroupRole via FK ON DELETE CASCADE.
- * We invalidate caches per-user before the delete so stale positive-permission reads don't linger.
+ *
+ * Cache invalidation order: we invalidate AFTER the delete so the DB row (source of truth) is
+ * gone before we drop the cache. Any concurrent request reading between delete and invalidation
+ * can still see a cached `true`, producing at most a ~ms-scale stale-allow window. Inverting the
+ * order (invalidate then delete) doesn't help — a read after invalidation but before delete would
+ * recompute and re-cache the still-granted state. Accept the short window; the delete call is
+ * synchronous and completes in milliseconds.
  */
 export async function deleteGroup(id: string) {
   const group = await prisma.userGroup.findUnique({

--- a/backend/src/modules/user-groups/user-groups.service.ts
+++ b/backend/src/modules/user-groups/user-groups.service.ts
@@ -1,14 +1,23 @@
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
-import {
-  invalidateUserEffectivePermissions,
-  invalidateProjectPermissionCache,
-} from '../../shared/middleware/rbac.js';
+import { invalidateProjectPermissionCache } from '../../shared/middleware/rbac.js';
 import type {
   CreateUserGroupDto,
   UpdateUserGroupDto,
   GrantProjectRoleDto,
 } from './user-groups.dto.js';
+
+/**
+ * Invalidate both the new group-aware effective cache AND the legacy per-permission cache for
+ * every (user, project) pair that a group change touches. Pair-based is exact and kills legacy
+ * `rbac:perm:*` keys too (AI review #65 round 3 🟡). Used by add/remove member, grant/revoke
+ * binding, delete group.
+ */
+async function invalidatePairs(pairs: Iterable<{ userId: string; projectId: string }>): Promise<void> {
+  await Promise.all(
+    Array.from(pairs).map(p => invalidateProjectPermissionCache(p.projectId, p.userId)),
+  );
+}
 
 /**
  * TTSEC-2 Phase 2 user groups.
@@ -114,12 +123,7 @@ export async function deleteGroup(id: string) {
   }
 
   await prisma.userGroup.delete({ where: { id } });
-
-  await Promise.all(
-    Array.from(new Set(group.members.map(m => m.userId))).map(uid =>
-      invalidateUserEffectivePermissions(uid),
-    ),
-  );
+  await invalidatePairs(affectedPairs);
 
   return {
     name: group.name,
@@ -153,7 +157,10 @@ export async function getGroupImpact(id: string) {
 }
 
 export async function addMembers(groupId: string, userIds: string[], addedById: string) {
-  const group = await prisma.userGroup.findUnique({ where: { id: groupId }, select: { id: true } });
+  const group = await prisma.userGroup.findUnique({
+    where: { id: groupId },
+    include: { projectRoles: { select: { projectId: true } } },
+  });
   if (!group) throw new AppError(404, 'Группа не найдена');
 
   const users = await prisma.user.findMany({
@@ -172,7 +179,9 @@ export async function addMembers(groupId: string, userIds: string[], addedById: 
     skipDuplicates: true,
   });
 
-  await Promise.all(userIds.map(uid => invalidateUserEffectivePermissions(uid)));
+  // Only the projects this group is bound to are affected by the new members — exact invalidation.
+  const pairs = userIds.flatMap(uid => group.projectRoles.map(pr => ({ userId: uid, projectId: pr.projectId })));
+  await invalidatePairs(pairs);
   return { added: result.count };
 }
 
@@ -182,10 +191,19 @@ export async function removeMember(groupId: string, userId: string) {
     select: { groupId: true },
   });
   if (!existing) throw new AppError(404, 'Пользователь не является участником группы');
+
+  // Capture the projects bound to this group BEFORE deleting membership — those are the projects
+  // where the removed user is losing access.
+  const bindings = await prisma.projectGroupRole.findMany({
+    where: { groupId },
+    select: { projectId: true },
+  });
+
   await prisma.userGroupMember.delete({
     where: { groupId_userId: { groupId, userId } },
   });
-  await invalidateUserEffectivePermissions(userId);
+
+  await invalidatePairs(bindings.map(b => ({ userId, projectId: b.projectId })));
   return { ok: true };
 }
 

--- a/backend/src/modules/user-groups/user-groups.service.ts
+++ b/backend/src/modules/user-groups/user-groups.service.ts
@@ -1,0 +1,265 @@
+import { prisma } from '../../prisma/client.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import {
+  invalidateUserEffectivePermissions,
+  invalidateProjectPermissionCache,
+} from '../../shared/middleware/rbac.js';
+import type {
+  CreateUserGroupDto,
+  UpdateUserGroupDto,
+  GrantProjectRoleDto,
+} from './user-groups.dto.js';
+
+/**
+ * TTSEC-2 Phase 2 user groups.
+ *
+ * Invariants kept by this module:
+ *   - Every membership/binding change invalidates the affected users' effective-permission caches.
+ *   - Grouping a user in a project they already have DIRECT role in — both sources contribute
+ *     to computeEffectiveRole (max permissions wins). No deduplication at write time.
+ *   - DELETE (group / member / binding) returns the list of affected user×project pairs so the
+ *     router can log audit and the UI can warn.
+ */
+
+const listInclude = {
+  _count: { select: { members: true, projectRoles: true } },
+} as const;
+
+const detailInclude = {
+  members: {
+    include: {
+      user: { select: { id: true, name: true, email: true, isActive: true } },
+      addedBy: { select: { id: true, name: true } },
+    },
+    orderBy: { addedAt: 'desc' as const },
+  },
+  projectRoles: {
+    include: {
+      project: { select: { id: true, key: true, name: true } },
+      roleDefinition: { select: { id: true, name: true, key: true, color: true } },
+    },
+  },
+} as const;
+
+export async function listGroups(query?: { search?: string }) {
+  return prisma.userGroup.findMany({
+    where: query?.search
+      ? { name: { contains: query.search, mode: 'insensitive' } }
+      : undefined,
+    include: listInclude,
+    orderBy: { name: 'asc' },
+  });
+}
+
+export async function getGroup(id: string) {
+  const group = await prisma.userGroup.findUnique({
+    where: { id },
+    include: detailInclude,
+  });
+  if (!group) throw new AppError(404, 'Группа не найдена');
+  return group;
+}
+
+export async function createGroup(dto: CreateUserGroupDto) {
+  const existing = await prisma.userGroup.findUnique({ where: { name: dto.name }, select: { id: true } });
+  if (existing) throw new AppError(409, 'Группа с таким именем уже существует');
+  return prisma.userGroup.create({
+    data: { name: dto.name, description: dto.description ?? null },
+  });
+}
+
+export async function updateGroup(id: string, dto: UpdateUserGroupDto) {
+  const existing = await prisma.userGroup.findUnique({ where: { id }, select: { id: true, name: true } });
+  if (!existing) throw new AppError(404, 'Группа не найдена');
+  if (dto.name && dto.name !== existing.name) {
+    const clash = await prisma.userGroup.findUnique({ where: { name: dto.name }, select: { id: true } });
+    if (clash && clash.id !== id) throw new AppError(409, 'Группа с таким именем уже существует');
+  }
+  return prisma.userGroup.update({
+    where: { id },
+    data: {
+      ...(dto.name !== undefined && { name: dto.name }),
+      ...(dto.description !== undefined && { description: dto.description }),
+    },
+  });
+}
+
+/**
+ * Delete a group. Returns affected user-project pairs so the caller can audit exactly which
+ * permissions were revoked. The DB cascades UserGroupMember/ProjectGroupRole via FK ON DELETE CASCADE.
+ * We invalidate caches per-user before the delete so stale positive-permission reads don't linger.
+ */
+export async function deleteGroup(id: string) {
+  const group = await prisma.userGroup.findUnique({
+    where: { id },
+    include: {
+      members: { select: { userId: true } },
+      projectRoles: { select: { projectId: true, roleId: true } },
+    },
+  });
+  if (!group) throw new AppError(404, 'Группа не найдена');
+
+  // Affected pairs: every member × every project the group bound to.
+  const affectedPairs: { userId: string; projectId: string }[] = [];
+  for (const m of group.members) {
+    for (const pr of group.projectRoles) {
+      affectedPairs.push({ userId: m.userId, projectId: pr.projectId });
+    }
+  }
+
+  await prisma.userGroup.delete({ where: { id } });
+
+  await Promise.all(
+    Array.from(new Set(group.members.map(m => m.userId))).map(uid =>
+      invalidateUserEffectivePermissions(uid),
+    ),
+  );
+
+  return {
+    name: group.name,
+    affectedPairs,
+    removedMembers: group.members.map(m => m.userId),
+    removedBindings: group.projectRoles,
+  };
+}
+
+export async function getGroupImpact(id: string) {
+  const group = await prisma.userGroup.findUnique({
+    where: { id },
+    select: {
+      _count: { select: { members: true, projectRoles: true } },
+      members: { select: { user: { select: { id: true, name: true, email: true } } } },
+      projectRoles: {
+        select: {
+          project: { select: { id: true, key: true, name: true } },
+          roleDefinition: { select: { id: true, name: true, key: true } },
+        },
+      },
+    },
+  });
+  if (!group) throw new AppError(404, 'Группа не найдена');
+  return {
+    memberCount: group._count.members,
+    projectCount: group._count.projectRoles,
+    members: group.members.map(m => m.user),
+    projects: group.projectRoles,
+  };
+}
+
+export async function addMembers(groupId: string, userIds: string[], addedById: string) {
+  const group = await prisma.userGroup.findUnique({ where: { id: groupId }, select: { id: true } });
+  if (!group) throw new AppError(404, 'Группа не найдена');
+
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true },
+  });
+  const foundIds = new Set(users.map(u => u.id));
+  const missing = userIds.filter(id => !foundIds.has(id));
+  if (missing.length > 0) {
+    throw new AppError(400, `Некоторые пользователи не найдены: ${missing.length}`);
+  }
+
+  // Batch insert; skip duplicates via composite PK + createMany skipDuplicates.
+  const result = await prisma.userGroupMember.createMany({
+    data: userIds.map(userId => ({ groupId, userId, addedById })),
+    skipDuplicates: true,
+  });
+
+  await Promise.all(userIds.map(uid => invalidateUserEffectivePermissions(uid)));
+  return { added: result.count };
+}
+
+export async function removeMember(groupId: string, userId: string) {
+  const existing = await prisma.userGroupMember.findUnique({
+    where: { groupId_userId: { groupId, userId } },
+    select: { groupId: true },
+  });
+  if (!existing) throw new AppError(404, 'Пользователь не является участником группы');
+  await prisma.userGroupMember.delete({
+    where: { groupId_userId: { groupId, userId } },
+  });
+  await invalidateUserEffectivePermissions(userId);
+  return { ok: true };
+}
+
+/**
+ * Grant a project role to a group. The role must belong to the project's ACTIVE role scheme —
+ * otherwise the binding would be useless at permission-resolution time (see computeEffectiveRole
+ * active-scheme filter). We also persist `schemeId` for the composite FK.
+ */
+export async function grantProjectRole(groupId: string, dto: GrantProjectRoleDto) {
+  const group = await prisma.userGroup.findUnique({ where: { id: groupId }, select: { id: true } });
+  if (!group) throw new AppError(404, 'Группа не найдена');
+
+  const project = await prisma.project.findUnique({ where: { id: dto.projectId }, select: { id: true } });
+  if (!project) throw new AppError(404, 'Проект не найден');
+
+  const role = await prisma.projectRoleDefinition.findUnique({
+    where: { id: dto.roleId },
+    select: { id: true, schemeId: true },
+  });
+  if (!role) throw new AppError(404, 'Роль не найдена');
+
+  // Resolve the project's active scheme. Accept a role from this scheme OR from the default
+  // scheme when the project has no explicit binding. Reject roles from unrelated schemes —
+  // they would never resolve at runtime and only confuse admins.
+  const projectBinding = await prisma.projectRoleSchemeProject.findUnique({
+    where: { projectId: dto.projectId },
+    select: { schemeId: true },
+  });
+  const activeSchemeId = projectBinding?.schemeId
+    ?? (await prisma.projectRoleScheme.findFirst({ where: { isDefault: true }, select: { id: true } }))?.id;
+  if (!activeSchemeId) throw new AppError(500, 'Не настроена дефолтная схема ролей');
+  if (role.schemeId !== activeSchemeId) {
+    throw new AppError(400, 'Роль принадлежит другой схеме — выберите роль из схемы проекта');
+  }
+
+  const existing = await prisma.projectGroupRole.findUnique({
+    where: { groupId_projectId: { groupId, projectId: dto.projectId } },
+    select: { id: true, roleId: true },
+  });
+  if (existing && existing.roleId === dto.roleId) {
+    return existing; // idempotent
+  }
+
+  const result = existing
+    ? await prisma.projectGroupRole.update({
+        where: { id: existing.id },
+        data: { roleId: dto.roleId, schemeId: role.schemeId },
+      })
+    : await prisma.projectGroupRole.create({
+        data: {
+          groupId,
+          projectId: dto.projectId,
+          roleId: dto.roleId,
+          schemeId: role.schemeId,
+        },
+      });
+
+  const members = await prisma.userGroupMember.findMany({
+    where: { groupId },
+    select: { userId: true },
+  });
+  await Promise.all(members.map(m => invalidateProjectPermissionCache(dto.projectId, m.userId)));
+
+  return result;
+}
+
+export async function revokeProjectRole(groupId: string, projectId: string) {
+  const existing = await prisma.projectGroupRole.findUnique({
+    where: { groupId_projectId: { groupId, projectId } },
+    select: { id: true },
+  });
+  if (!existing) throw new AppError(404, 'Группа не привязана к этому проекту');
+
+  await prisma.projectGroupRole.delete({ where: { id: existing.id } });
+
+  const members = await prisma.userGroupMember.findMany({
+    where: { groupId },
+    select: { userId: true },
+  });
+  await Promise.all(members.map(m => invalidateProjectPermissionCache(projectId, m.userId)));
+
+  return { ok: true };
+}

--- a/backend/src/modules/user-security/user-security.router.ts
+++ b/backend/src/modules/user-security/user-security.router.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { authenticate } from '../../shared/middleware/auth.js';
+import { requireRole } from '../../shared/middleware/rbac.js';
+import type { AuthRequest } from '../../shared/types/index.js';
+import { getUserSecurity } from './user-security.service.js';
+
+/**
+ * TTSEC-2 Phase 2 security endpoints.
+ *
+ * GET /api/users/me/security — any authenticated user reads THEIR OWN payload (SEC-2).
+ * GET /api/admin/users/:id/security — system ADMIN reads any user's payload (SEC-6).
+ *
+ * Phase 4 cleanup: swap the admin check from `requireRole('ADMIN')` to a proper system-level
+ * `USER_GROUP_VIEW` permission once the helper lands.
+ */
+
+const router = Router();
+
+router.get('/users/me/security', authenticate, async (req: AuthRequest, res, next) => {
+  try {
+    res.json(await getUserSecurity(req.user!.userId));
+  } catch (err) { next(err); }
+});
+
+router.get(
+  '/admin/users/:id/security',
+  authenticate,
+  requireRole('ADMIN'),
+  async (req: AuthRequest, res, next) => {
+    try {
+      res.json(await getUserSecurity(req.params.id as string));
+    } catch (err) { next(err); }
+  },
+);
+
+export default router;

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -1,6 +1,32 @@
+import type { ProjectPermission } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { computeEffectiveRolesForProjects } from '../../shared/middleware/rbac.js';
+
+/**
+ * TTSEC-2 Phase 2 security payload (spec §5.6). Exported so Phase 3 UI and tests can import
+ * the exact shape instead of inferring it.
+ */
+export interface SecurityProjectRole {
+  project: { id: string; key: string; name: string };
+  role: { id: string; name: string; key: string; permissions: ProjectPermission[] };
+  source: 'DIRECT' | 'GROUP';
+  sourceGroups: { id: string; name: string }[];
+}
+
+export interface SecurityGroupMembership {
+  id: string;
+  name: string;
+  addedAt: Date;
+  memberCount: number;
+}
+
+export interface UserSecurityPayload {
+  user: { id: string; name: string; email: string };
+  groups: SecurityGroupMembership[];
+  projectRoles: SecurityProjectRole[];
+  updatedAt: string;
+}
 
 /**
  * Build the payload for a user's «Безопасность» view (spec §5.6):
@@ -13,7 +39,7 @@ import { computeEffectiveRolesForProjects } from '../../shared/middleware/rbac.j
  * A project appears in `projectRoles` iff the user has ANY role there (direct or via a group
  * bound to the project). `source` and `sourceGroups` come from computeEffectiveRole (§5.2).
  */
-export async function getUserSecurity(userId: string) {
+export async function getUserSecurity(userId: string): Promise<UserSecurityPayload> {
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: { id: true, name: true, email: true },
@@ -56,7 +82,7 @@ export async function getUserSecurity(userId: string) {
   // instead of 2N queries. See computeEffectiveRolesForProjects.
   const effectiveByProject = await computeEffectiveRolesForProjects(userId, Array.from(projectIds));
 
-  const projectRoles = [];
+  const projectRoles: SecurityProjectRole[] = [];
   for (const [projectId, eff] of effectiveByProject) {
     if (!eff) continue;
     const project = projectById.get(projectId);

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -10,7 +10,13 @@ import { computeEffectiveRolesForProjects } from '../../shared/middleware/rbac.j
 export interface SecurityProjectRole {
   project: { id: string; key: string; name: string };
   role: { id: string; name: string; key: string; permissions: ProjectPermission[] };
+  /**
+   * The PRIMARY grant path. DIRECT wins when the user has the role directly assigned.
+   * When both DIRECT and at least one group grant the same role, source='DIRECT' and
+   * sourceGroups lists every group that additionally grants it ("also via Team A").
+   */
   source: 'DIRECT' | 'GROUP';
+  /** Every group that grants this role, independent of `source`. Empty iff the role is not granted via any group. */
   sourceGroups: { id: string; name: string }[];
 }
 

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -1,0 +1,85 @@
+import { prisma } from '../../prisma/client.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import { computeEffectiveRole } from '../../shared/middleware/rbac.js';
+
+/**
+ * Build the payload for a user's «Безопасность» view (spec §5.6):
+ *   {
+ *     groups: [{ id, name, addedAt, memberCount }],
+ *     projectRoles: [{ project, role, source, sourceGroups }],
+ *     updatedAt,
+ *   }
+ *
+ * A project appears in `projectRoles` iff the user has ANY role there (direct or via a group
+ * bound to the project). `source` and `sourceGroups` come from computeEffectiveRole (§5.2).
+ */
+export async function getUserSecurity(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true, email: true },
+  });
+  if (!user) throw new AppError(404, 'Пользователь не найден');
+
+  const [groups, directProjects, groupProjects] = await Promise.all([
+    prisma.userGroupMember.findMany({
+      where: { userId },
+      include: {
+        group: {
+          include: { _count: { select: { members: true } } },
+        },
+      },
+      orderBy: { addedAt: 'desc' },
+    }),
+    prisma.userProjectRole.findMany({
+      where: { userId },
+      select: { projectId: true },
+    }),
+    prisma.projectGroupRole.findMany({
+      where: { group: { members: { some: { userId } } } },
+      select: { projectId: true },
+    }),
+  ]);
+
+  const projectIds = new Set<string>([
+    ...directProjects.map(r => r.projectId),
+    ...groupProjects.map(r => r.projectId),
+  ]);
+
+  // Fetch project metadata once.
+  const projects = await prisma.project.findMany({
+    where: { id: { in: Array.from(projectIds) } },
+    select: { id: true, key: true, name: true },
+  });
+  const projectById = new Map(projects.map(p => [p.id, p]));
+
+  const projectRoles = [];
+  for (const projectId of projectIds) {
+    const project = projectById.get(projectId);
+    if (!project) continue;
+    const eff = await computeEffectiveRole(userId, projectId);
+    if (!eff) continue;
+    projectRoles.push({
+      project,
+      role: {
+        id: eff.roleId,
+        name: eff.roleName,
+        key: eff.roleKey,
+        permissions: eff.permissions,
+      },
+      source: eff.source,
+      sourceGroups: eff.sourceGroups,
+    });
+  }
+
+  return {
+    user: { id: user.id, name: user.name, email: user.email },
+    groups: groups.map(m => ({
+      id: m.group.id,
+      name: m.group.name,
+      addedAt: m.addedAt,
+      memberCount: m.group._count.members,
+    })),
+    projectRoles,
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
-import { computeEffectiveRole } from '../../shared/middleware/rbac.js';
+import { computeEffectiveRolesForProjects } from '../../shared/middleware/rbac.js';
 
 /**
  * Build the payload for a user's «Безопасность» view (spec §5.6):
@@ -52,29 +52,27 @@ export async function getUserSecurity(userId: string) {
   });
   const projectById = new Map(projects.map(p => [p.id, p]));
 
-  // Parallelise effective-role computation across projects. True batched resolution (single
-  // scheme/role fetch for all projects) is TTSEC-16 territory — tracked in Phase 4 perf work.
-  // Until then Promise.all cuts wall-time from N sequential trips to `max(trip)`.
-  const effective = await Promise.all(
-    Array.from(projectIds).map(async (projectId) => {
-      const project = projectById.get(projectId);
-      if (!project) return null;
-      const eff = await computeEffectiveRole(userId, projectId);
-      if (!eff) return null;
-      return {
-        project,
-        role: {
-          id: eff.roleId,
-          name: eff.roleName,
-          key: eff.roleKey,
-          permissions: eff.permissions,
-        },
-        source: eff.source,
-        sourceGroups: eff.sourceGroups,
-      };
-    }),
-  );
-  const projectRoles = effective.filter((r): r is NonNullable<typeof r> => r !== null);
+  // Batched resolution: 2 DB queries total (direct + group) + N Redis-cached scheme reads,
+  // instead of 2N queries. See computeEffectiveRolesForProjects.
+  const effectiveByProject = await computeEffectiveRolesForProjects(userId, Array.from(projectIds));
+
+  const projectRoles = [];
+  for (const [projectId, eff] of effectiveByProject) {
+    if (!eff) continue;
+    const project = projectById.get(projectId);
+    if (!project) continue;
+    projectRoles.push({
+      project,
+      role: {
+        id: eff.roleId,
+        name: eff.roleName,
+        key: eff.roleKey,
+        permissions: eff.permissions,
+      },
+      source: eff.source,
+      sourceGroups: eff.sourceGroups,
+    });
+  }
 
   return {
     user: { id: user.id, name: user.name, email: user.email },

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -106,6 +106,9 @@ export async function getUserSecurity(userId: string): Promise<UserSecurityPaylo
     });
   }
 
+  // AI review #65 round 5 🟡 — deterministic ordering so UI / tests / snapshots get stable output.
+  projectRoles.sort((a, b) => a.project.key.localeCompare(b.project.key));
+
   return {
     user: { id: user.id, name: user.name, email: user.email },
     groups: groups.map(m => ({

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -52,24 +52,29 @@ export async function getUserSecurity(userId: string) {
   });
   const projectById = new Map(projects.map(p => [p.id, p]));
 
-  const projectRoles = [];
-  for (const projectId of projectIds) {
-    const project = projectById.get(projectId);
-    if (!project) continue;
-    const eff = await computeEffectiveRole(userId, projectId);
-    if (!eff) continue;
-    projectRoles.push({
-      project,
-      role: {
-        id: eff.roleId,
-        name: eff.roleName,
-        key: eff.roleKey,
-        permissions: eff.permissions,
-      },
-      source: eff.source,
-      sourceGroups: eff.sourceGroups,
-    });
-  }
+  // Parallelise effective-role computation across projects. True batched resolution (single
+  // scheme/role fetch for all projects) is TTSEC-16 territory — tracked in Phase 4 perf work.
+  // Until then Promise.all cuts wall-time from N sequential trips to `max(trip)`.
+  const effective = await Promise.all(
+    Array.from(projectIds).map(async (projectId) => {
+      const project = projectById.get(projectId);
+      if (!project) return null;
+      const eff = await computeEffectiveRole(userId, projectId);
+      if (!eff) return null;
+      return {
+        project,
+        role: {
+          id: eff.roleId,
+          name: eff.roleName,
+          key: eff.roleKey,
+          permissions: eff.permissions,
+        },
+        source: eff.source,
+        sourceGroups: eff.sourceGroups,
+      };
+    }),
+  );
+  const projectRoles = effective.filter((r): r is NonNullable<typeof r> => r !== null);
 
   return {
     user: { id: user.id, name: user.name, email: user.email },

--- a/backend/src/prisma/migrations/20260421000000_ttsec2_enum_values/migration.sql
+++ b/backend/src/prisma/migrations/20260421000000_ttsec2_enum_values/migration.sql
@@ -1,0 +1,25 @@
+-- TTSEC-2: расширение ProjectPermission enum гранулярными значениями.
+--
+-- ВАЖНО: PostgreSQL требует, чтобы ALTER TYPE ... ADD VALUE выполнялся вне транзакции
+-- (см. риск #6 в TTSEC-2.md). Prisma по умолчанию оборачивает каждый файл миграции в
+-- транзакцию; поэтому эти ADD VALUE-операторы вынесены в ОТДЕЛЬНУЮ миграцию — без
+-- DDL/DML-соседей, чтобы Prisma detect logic применил её без BEGIN/COMMIT.
+--
+-- Новые значения:
+--   * SPRINTS_{CREATE,EDIT,DELETE} / RELEASES_{CREATE,EDIT,DELETE} — гранулярный CRUD
+--   * COMMENTS_DELETE_OTHERS / TIME_LOGS_DELETE_OTHERS — модерация чужих записей
+--   * USER_GROUP_{VIEW,MANAGE} — system-level permissions для админки групп
+--
+-- Старые *_MANAGE остаются в enum (DROP VALUE не поддерживается PG), но удаляются
+-- из UI-матрицы в последующей миграции-seed и в PermissionMatrixDrawer.
+
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'SPRINTS_CREATE';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'SPRINTS_EDIT';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'SPRINTS_DELETE';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'RELEASES_CREATE';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'RELEASES_EDIT';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'RELEASES_DELETE';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'COMMENTS_DELETE_OTHERS';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'TIME_LOGS_DELETE_OTHERS';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'USER_GROUP_VIEW';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'USER_GROUP_MANAGE';

--- a/backend/src/prisma/migrations/20260421000001_ttsec2_groups_and_backfill/migration.sql
+++ b/backend/src/prisma/migrations/20260421000001_ttsec2_groups_and_backfill/migration.sql
@@ -1,0 +1,202 @@
+-- TTSEC-2: UserGroup / UserGroupMember / ProjectGroupRole + backfill гранулярных прав + Legacy-группы.
+--
+-- Должна применяться СТРОГО после 20260421000000_ttsec2_enum_values (ADD VALUE для ProjectPermission).
+-- Порядок шагов критичен (риск #11): backfill-пермишны ПЕРЕД Legacy-группами, иначе Legacy-группы
+-- унаследуют только *_MANAGE и новые гранулярные не раздадутся.
+--
+-- Идемпотентность (SEC-3): ON CONFLICT DO NOTHING на каждом INSERT, IF NOT EXISTS на DDL.
+
+-- ШАГ 0: enum RoleAssignmentSource.
+DO $$ BEGIN
+  CREATE TYPE "RoleAssignmentSource" AS ENUM ('DIRECT', 'GROUP');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- ШАГ 1: колонка source в user_project_roles (default DIRECT — существующие записи остаются DIRECT).
+ALTER TABLE "user_project_roles"
+  ADD COLUMN IF NOT EXISTS "source" "RoleAssignmentSource" NOT NULL DEFAULT 'DIRECT';
+
+-- ШАГ 2: таблицы групп.
+CREATE TABLE IF NOT EXISTS "user_groups" (
+  "id"          TEXT NOT NULL,
+  "name"        TEXT NOT NULL,
+  "description" TEXT,
+  "created_at"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"  TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "user_groups_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "user_group_members" (
+  "group_id"     TEXT NOT NULL,
+  "user_id"      TEXT NOT NULL,
+  "added_at"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "added_by_id"  TEXT,
+  CONSTRAINT "user_group_members_pkey" PRIMARY KEY ("group_id", "user_id")
+);
+
+CREATE TABLE IF NOT EXISTS "project_group_roles" (
+  "id"         TEXT NOT NULL,
+  "group_id"   TEXT NOT NULL,
+  "project_id" TEXT NOT NULL,
+  "role_id"    TEXT NOT NULL,
+  "scheme_id"  TEXT NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "project_group_roles_pkey" PRIMARY KEY ("id")
+);
+
+-- Indexes
+CREATE UNIQUE INDEX IF NOT EXISTS "user_groups_name_key" ON "user_groups"("name");
+CREATE INDEX        IF NOT EXISTS "user_groups_name_idx" ON "user_groups"("name");
+CREATE INDEX        IF NOT EXISTS "user_group_members_user_id_idx" ON "user_group_members"("user_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "project_group_roles_group_id_project_id_key" ON "project_group_roles"("group_id", "project_id");
+CREATE INDEX        IF NOT EXISTS "project_group_roles_project_id_idx"          ON "project_group_roles"("project_id");
+CREATE INDEX        IF NOT EXISTS "project_group_roles_group_id_idx"            ON "project_group_roles"("group_id");
+
+-- Foreign keys (idempotent via DO-block + lookup pg_constraint).
+DO $$ BEGIN
+  ALTER TABLE "user_group_members"
+    ADD CONSTRAINT "user_group_members_group_id_fkey"
+    FOREIGN KEY ("group_id") REFERENCES "user_groups"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "user_group_members"
+    ADD CONSTRAINT "user_group_members_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "user_group_members"
+    ADD CONSTRAINT "user_group_members_added_by_id_fkey"
+    FOREIGN KEY ("added_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "project_group_roles"
+    ADD CONSTRAINT "project_group_roles_group_id_fkey"
+    FOREIGN KEY ("group_id") REFERENCES "user_groups"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "project_group_roles"
+    ADD CONSTRAINT "project_group_roles_project_id_fkey"
+    FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- Composite FK: (role_id, scheme_id) → project_role_definitions(id, scheme_id).
+-- Restrict — нельзя удалять роль, на которой есть активные bindings (защита прав доступа).
+DO $$ BEGIN
+  ALTER TABLE "project_group_roles"
+    ADD CONSTRAINT "project_group_roles_role_id_scheme_id_fkey"
+    FOREIGN KEY ("role_id", "scheme_id")
+    REFERENCES "project_role_definitions"("id", "scheme_id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- ШАГ 3: BACKFILL гранулярных permissions. ВЫПОЛНЯЕТСЯ ПЕРЕД созданием Legacy-групп (риск #11).
+-- Все роли, у которых granted=true по *_MANAGE, получают соответствующие CRUD/DELETE_OTHERS.
+
+-- SPRINTS_MANAGE → SPRINTS_CREATE + SPRINTS_EDIT + SPRINTS_DELETE
+INSERT INTO "project_role_permissions" ("id", "role_id", "permission", "granted")
+SELECT gen_random_uuid(), src.role_id, new_perm, true
+FROM (
+  SELECT DISTINCT role_id FROM "project_role_permissions"
+  WHERE permission = 'SPRINTS_MANAGE' AND granted = true
+) src
+CROSS JOIN (VALUES
+  ('SPRINTS_CREATE'::"ProjectPermission"),
+  ('SPRINTS_EDIT'::"ProjectPermission"),
+  ('SPRINTS_DELETE'::"ProjectPermission")
+) AS new_permissions(new_perm)
+ON CONFLICT ("role_id", "permission") DO NOTHING;
+
+-- RELEASES_MANAGE → RELEASES_CREATE + RELEASES_EDIT + RELEASES_DELETE
+INSERT INTO "project_role_permissions" ("id", "role_id", "permission", "granted")
+SELECT gen_random_uuid(), src.role_id, new_perm, true
+FROM (
+  SELECT DISTINCT role_id FROM "project_role_permissions"
+  WHERE permission = 'RELEASES_MANAGE' AND granted = true
+) src
+CROSS JOIN (VALUES
+  ('RELEASES_CREATE'::"ProjectPermission"),
+  ('RELEASES_EDIT'::"ProjectPermission"),
+  ('RELEASES_DELETE'::"ProjectPermission")
+) AS new_permissions(new_perm)
+ON CONFLICT ("role_id", "permission") DO NOTHING;
+
+-- COMMENTS_MANAGE → + COMMENTS_DELETE_OTHERS
+INSERT INTO "project_role_permissions" ("id", "role_id", "permission", "granted")
+SELECT gen_random_uuid(), role_id, 'COMMENTS_DELETE_OTHERS'::"ProjectPermission", true
+FROM "project_role_permissions"
+WHERE permission = 'COMMENTS_MANAGE' AND granted = true
+ON CONFLICT ("role_id", "permission") DO NOTHING;
+
+-- TIME_LOGS_MANAGE → + TIME_LOGS_DELETE_OTHERS
+INSERT INTO "project_role_permissions" ("id", "role_id", "permission", "granted")
+SELECT gen_random_uuid(), role_id, 'TIME_LOGS_DELETE_OTHERS'::"ProjectPermission", true
+FROM "project_role_permissions"
+WHERE permission = 'TIME_LOGS_MANAGE' AND granted = true
+ON CONFLICT ("role_id", "permission") DO NOTHING;
+
+-- USER_GROUP_* — выдаём ADMIN-ролям всех схем (detect ADMIN по key='ADMIN' AND is_system=true).
+INSERT INTO "project_role_permissions" ("id", "role_id", "permission", "granted")
+SELECT gen_random_uuid(), rd.id, new_perm, true
+FROM "project_role_definitions" rd
+CROSS JOIN (VALUES
+  ('USER_GROUP_VIEW'::"ProjectPermission"),
+  ('USER_GROUP_MANAGE'::"ProjectPermission")
+) AS new_permissions(new_perm)
+WHERE rd.key = 'ADMIN' AND rd.is_system = true
+ON CONFLICT ("role_id", "permission") DO NOTHING;
+
+-- ШАГ 4: LEGACY-ГРУППЫ из существующих UserProjectRole.
+-- Для каждой уникальной (project_id, role_id) → UserGroup "Legacy: {project.key} — {role.name}".
+-- Только строки с role_id IS NOT NULL: в TTMP-159 роль могла быть nullable на переходный период.
+
+-- 4.1: создать группы.
+INSERT INTO "user_groups" (id, name, description, created_at, updated_at)
+SELECT
+  gen_random_uuid(),
+  'Legacy: ' || p.key || ' — ' || rd.name,
+  'Auto-created from direct UserProjectRole migration (TTSEC-2)',
+  NOW(), NOW()
+FROM (
+  SELECT DISTINCT upr.project_id, upr.role_id, upr.scheme_id
+  FROM "user_project_roles" upr
+  WHERE upr.role_id IS NOT NULL AND upr.scheme_id IS NOT NULL
+) distinct_roles
+JOIN "projects" p ON p.id = distinct_roles.project_id
+JOIN "project_role_definitions" rd ON rd.id = distinct_roles.role_id
+ON CONFLICT ("name") DO NOTHING;
+
+-- 4.2: связать каждую Legacy-группу с (project, role) через ProjectGroupRole.
+INSERT INTO "project_group_roles" (id, group_id, project_id, role_id, scheme_id, created_at)
+SELECT
+  gen_random_uuid(),
+  ug.id,
+  distinct_roles.project_id,
+  distinct_roles.role_id,
+  distinct_roles.scheme_id,
+  NOW()
+FROM (
+  SELECT DISTINCT upr.project_id, upr.role_id, upr.scheme_id
+  FROM "user_project_roles" upr
+  WHERE upr.role_id IS NOT NULL AND upr.scheme_id IS NOT NULL
+) distinct_roles
+JOIN "projects" p ON p.id = distinct_roles.project_id
+JOIN "project_role_definitions" rd ON rd.id = distinct_roles.role_id
+JOIN "user_groups" ug ON ug.name = 'Legacy: ' || p.key || ' — ' || rd.name
+ON CONFLICT ("group_id", "project_id") DO NOTHING;
+
+-- 4.3: перенести членство.
+INSERT INTO "user_group_members" (group_id, user_id, added_at)
+SELECT ug.id, upr.user_id, NOW()
+FROM "user_project_roles" upr
+JOIN "projects" p ON p.id = upr.project_id
+JOIN "project_role_definitions" rd ON rd.id = upr.role_id
+JOIN "user_groups" ug ON ug.name = 'Legacy: ' || p.key || ' — ' || rd.name
+WHERE upr.role_id IS NOT NULL AND upr.scheme_id IS NOT NULL
+ON CONFLICT ("group_id", "user_id") DO NOTHING;
+
+-- ШАГ 5: NB. DIRECT UserProjectRole остаются в таблице — удаление произойдёт в TTSEC-18
+-- (feature-flag DIRECT_ROLES_DISABLED + cutover). До этого прямые права работают параллельно с
+-- групповыми; эффективная роль = MAX(permissions) по обеим сторонам (см. §5.2).

--- a/backend/src/prisma/migrations/20260421000001_ttsec2_groups_and_backfill/rollback.sql
+++ b/backend/src/prisma/migrations/20260421000001_ttsec2_groups_and_backfill/rollback.sql
@@ -1,0 +1,37 @@
+-- TTSEC-2 ROLLBACK (manual — не применяется Prisma автоматически).
+--
+-- Применяется при критической ошибке после наката 20260421000001_ttsec2_groups_and_backfill.
+-- Последовательность обратная: сначала снять FK, потом удалить таблицы и колонку source.
+-- ВАЖНО: ProjectPermission enum values (SPRINTS_CREATE/...) и Legacy-данные в
+-- project_role_permissions остаются — PostgreSQL не поддерживает DROP VALUE у enum, а лишние
+-- гранулярные permissions безопасно игнорируются кодом (effective set = superset).
+--
+-- Чтобы полностью откатиться до 20260420, потребуется также:
+--   DELETE FROM project_role_permissions WHERE permission IN (...новые значения...);
+-- (опционально — не ломает работу).
+
+BEGIN;
+
+-- 1. Снять FK и удалить таблицы групп.
+DROP TABLE IF EXISTS "project_group_roles";
+DROP TABLE IF EXISTS "user_group_members";
+DROP TABLE IF EXISTS "user_groups";
+
+-- 2. Удалить колонку source (возвращаем UserProjectRole к TTMP-159 состоянию).
+ALTER TABLE "user_project_roles" DROP COLUMN IF EXISTS "source";
+
+-- 3. Удалить enum RoleAssignmentSource (если не осталось зависимых колонок).
+DROP TYPE IF EXISTS "RoleAssignmentSource";
+
+-- 4. (опционально) откатить backfill гранулярных permissions.
+-- DELETE FROM "project_role_permissions"
+-- WHERE permission IN (
+--   'SPRINTS_CREATE', 'SPRINTS_EDIT', 'SPRINTS_DELETE',
+--   'RELEASES_CREATE', 'RELEASES_EDIT', 'RELEASES_DELETE',
+--   'COMMENTS_DELETE_OTHERS', 'TIME_LOGS_DELETE_OTHERS',
+--   'USER_GROUP_VIEW', 'USER_GROUP_MANAGE'
+-- );
+-- NB: эти DELETE-операции не идемпотентны по factor "старые permissions, которые админ выдал
+-- вручную после миграции" — перед prod-запуском делать snapshot project_role_permissions.
+
+COMMIT;

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -35,6 +35,8 @@ model User {
   customFieldUpdates IssueCustomFieldValue[]
   createdReleases    Release[]               @relation("releaseCreator")
   addedReleaseItems  ReleaseItem[]           @relation("releaseItemAdder")
+  groupMemberships   UserGroupMember[]       @relation("GroupMemberUser")
+  addedGroupMembers  UserGroupMember[]       @relation("GroupMemberAddedBy")
 
   @@map("users")
 }
@@ -81,14 +83,21 @@ enum ProjectRole {
   VIEWER
 }
 
+// TTSEC-2: role source — DIRECT = legacy per-user assignment, GROUP = from UserGroup membership.
+enum RoleAssignmentSource {
+  DIRECT
+  GROUP
+}
+
 model UserProjectRole {
-  id        String      @id @default(uuid())
-  userId    String      @map("user_id")
-  projectId String      @map("project_id")
+  id        String               @id @default(uuid())
+  userId    String               @map("user_id")
+  projectId String               @map("project_id")
   role      ProjectRole
-  roleId    String?     @map("role_id")         // nullable на фазе 1
-  schemeId  String?     @map("scheme_id")       // must match the scheme of roleId (see migration 20260417000000_user_project_role_scheme_fk)
-  createdAt DateTime    @default(now()) @map("created_at")
+  roleId    String?              @map("role_id")         // nullable на фазе 1
+  schemeId  String?              @map("scheme_id")       // must match the scheme of roleId (see migration 20260417000000_user_project_role_scheme_fk)
+  source    RoleAssignmentSource @default(DIRECT)        // TTSEC-2
+  createdAt DateTime             @default(now()) @map("created_at")
 
   user           User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
   project        Project                @relation(fields: [projectId], references: [id], onDelete: Cascade)
@@ -137,6 +146,7 @@ model Project {
   releases Release[]
   issueTypeScheme     IssueTypeSchemeProject?
   userRoles           UserProjectRole[]
+  groupRoles          ProjectGroupRole[]
   fieldSchemaBindings FieldSchemaBinding[]
   workflowScheme      WorkflowSchemeProject?
   roleScheme          ProjectRoleSchemeProject?
@@ -957,21 +967,31 @@ enum ProjectPermission {
   ISSUES_CHANGE_STATUS
   ISSUES_CHANGE_TYPE
   SPRINTS_VIEW
-  SPRINTS_MANAGE
+  SPRINTS_CREATE            // TTSEC-2
+  SPRINTS_EDIT              // TTSEC-2
+  SPRINTS_DELETE            // TTSEC-2
+  SPRINTS_MANAGE            // deprecated: Postgres не поддерживает DROP VALUE, скрыто из UI-матрицы
   RELEASES_VIEW
-  RELEASES_MANAGE
+  RELEASES_CREATE           // TTSEC-2
+  RELEASES_EDIT             // TTSEC-2
+  RELEASES_DELETE           // TTSEC-2
+  RELEASES_MANAGE           // deprecated
   MEMBERS_VIEW
   MEMBERS_MANAGE
   TIME_LOGS_VIEW
   TIME_LOGS_CREATE
+  TIME_LOGS_DELETE_OTHERS   // TTSEC-2: модерация чужих time logs
   TIME_LOGS_MANAGE
   COMMENTS_VIEW
   COMMENTS_CREATE
+  COMMENTS_DELETE_OTHERS    // TTSEC-2: модерация чужих комментариев
   COMMENTS_MANAGE
   PROJECT_SETTINGS_VIEW
   PROJECT_SETTINGS_EDIT
   BOARDS_VIEW
   BOARDS_MANAGE
+  USER_GROUP_VIEW           // TTSEC-2: system-level
+  USER_GROUP_MANAGE         // TTSEC-2: system-level
 }
 
 model ProjectRoleScheme {
@@ -999,9 +1019,10 @@ model ProjectRoleDefinition {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt      @map("updated_at")
 
-  scheme           ProjectRoleScheme       @relation(fields: [schemeId], references: [id], onDelete: Cascade)
-  permissions      ProjectRolePermission[]
-  userProjectRoles UserProjectRole[]
+  scheme            ProjectRoleScheme       @relation(fields: [schemeId], references: [id], onDelete: Cascade)
+  permissions       ProjectRolePermission[]
+  userProjectRoles  UserProjectRole[]
+  projectGroupRoles ProjectGroupRole[]
 
   @@unique([schemeId, key])
   @@unique([id, schemeId]) // composite unique — target for UserProjectRole composite FK
@@ -1033,4 +1054,53 @@ model ProjectRoleSchemeProject {
 
   @@index([schemeId])
   @@map("project_role_scheme_projects")
+}
+
+// ===== USER GROUPS (TTSEC-2) =====
+
+model UserGroup {
+  id          String   @id @default(uuid())
+  name        String   @unique
+  description String?
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt      @map("updated_at")
+
+  members      UserGroupMember[]
+  projectRoles ProjectGroupRole[]
+
+  @@index([name])
+  @@map("user_groups")
+}
+
+model UserGroupMember {
+  groupId   String   @map("group_id")
+  userId    String   @map("user_id")
+  addedAt   DateTime @default(now()) @map("added_at")
+  addedById String?  @map("added_by_id")
+
+  group   UserGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  user    User      @relation("GroupMemberUser", fields: [userId], references: [id], onDelete: Cascade)
+  addedBy User?     @relation("GroupMemberAddedBy", fields: [addedById], references: [id], onDelete: SetNull)
+
+  @@id([groupId, userId])
+  @@index([userId])
+  @@map("user_group_members")
+}
+
+model ProjectGroupRole {
+  id        String   @id @default(uuid())
+  groupId   String   @map("group_id")
+  projectId String   @map("project_id")
+  roleId    String   @map("role_id")
+  schemeId  String   @map("scheme_id") // composite FK — roleId must belong to schemeId
+  createdAt DateTime @default(now()) @map("created_at")
+
+  group          UserGroup             @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  project        Project               @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  roleDefinition ProjectRoleDefinition @relation(fields: [roleId, schemeId], references: [id, schemeId], onDelete: Restrict)
+
+  @@unique([groupId, projectId])
+  @@index([projectId])
+  @@index([groupId])
+  @@map("project_group_roles")
 }

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -958,6 +958,10 @@ model WorkflowSchemeProject {
 
 // ===== PROJECT ROLE SCHEMES =====
 
+// TTSEC-2 note: USER_GROUP_* живут в этом enum как временный компромисс —
+// инфраструктура permissions пока одна. В Phase 2 планируется изолировать
+// system-level проверки в отдельном helper (`assertSystemPermission`), чтобы
+// проектный middleware их не принимал как project-scoped permission.
 enum ProjectPermission {
   ISSUES_VIEW
   ISSUES_CREATE
@@ -1059,7 +1063,12 @@ model ProjectRoleSchemeProject {
 // ===== USER GROUPS (TTSEC-2) =====
 
 model UserGroup {
-  id          String   @id @default(uuid())
+  id   String @id @default(uuid())
+  // TTSEC-2: `name` — глобально уникален. Система single-tenant, `Project.key`
+  // уже глобально уникален, поэтому Legacy-имя `Legacy: {project.key} — {role.name}`
+  // детерминировано, а `ON CONFLICT (name) DO NOTHING` делает Legacy-backfill идемпотентным.
+  // Если в будущем появится мульти-тенант или переименование проекта — ввести slug/legacyKey
+  // и ослабить уникальность до контекста (см. AI-review PR #64).
   name        String   @unique
   description String?
   createdAt   DateTime @default(now()) @map("created_at")
@@ -1099,6 +1108,10 @@ model ProjectGroupRole {
   project        Project               @relation(fields: [projectId], references: [id], onDelete: Cascade)
   roleDefinition ProjectRoleDefinition @relation(fields: [roleId, schemeId], references: [id, schemeId], onDelete: Restrict)
 
+  // TTSEC-2 intentional: одна группа → одна роль в проекте. Продиктовано спекой §2+§5.1.2:
+  // merge-priority (max permissions) разводит конфликты МЕЖДУ несколькими группами одного юзера,
+  // а не внутри одной группы. Комбинирование нескольких ролей одной группы в одном проекте —
+  // out of scope MVP; при появлении такого требования ослабить до @@unique([groupId, projectId, roleId]).
   @@unique([groupId, projectId])
   @@index([projectId])
   @@index([groupId])

--- a/backend/src/prisma/seed.ts
+++ b/backend/src/prisma/seed.ts
@@ -110,13 +110,18 @@ async function main(prismaClient?: PrismaClient, scope?: string) {
       permissions: [
         ProjectPermission.ISSUES_VIEW, ProjectPermission.ISSUES_CREATE, ProjectPermission.ISSUES_EDIT, ProjectPermission.ISSUES_DELETE,
         ProjectPermission.ISSUES_ASSIGN, ProjectPermission.ISSUES_CHANGE_STATUS, ProjectPermission.ISSUES_CHANGE_TYPE,
-        ProjectPermission.SPRINTS_VIEW, ProjectPermission.SPRINTS_MANAGE,
-        ProjectPermission.RELEASES_VIEW, ProjectPermission.RELEASES_MANAGE,
+        // TTSEC-2: гранулярные SPRINTS/RELEASES; *_MANAGE исключены из default-матрицы
+        // (enum их сохраняет как deprecated для backward-compat).
+        ProjectPermission.SPRINTS_VIEW, ProjectPermission.SPRINTS_CREATE, ProjectPermission.SPRINTS_EDIT, ProjectPermission.SPRINTS_DELETE,
+        ProjectPermission.RELEASES_VIEW, ProjectPermission.RELEASES_CREATE, ProjectPermission.RELEASES_EDIT, ProjectPermission.RELEASES_DELETE,
         ProjectPermission.MEMBERS_VIEW, ProjectPermission.MEMBERS_MANAGE,
-        ProjectPermission.TIME_LOGS_VIEW, ProjectPermission.TIME_LOGS_CREATE, ProjectPermission.TIME_LOGS_MANAGE,
-        ProjectPermission.COMMENTS_VIEW, ProjectPermission.COMMENTS_CREATE, ProjectPermission.COMMENTS_MANAGE,
+        // TTSEC-2: TIME_LOGS_MANAGE сохранён (включает настройки модуля); DELETE_OTHERS — отдельно.
+        ProjectPermission.TIME_LOGS_VIEW, ProjectPermission.TIME_LOGS_CREATE, ProjectPermission.TIME_LOGS_DELETE_OTHERS, ProjectPermission.TIME_LOGS_MANAGE,
+        ProjectPermission.COMMENTS_VIEW, ProjectPermission.COMMENTS_CREATE, ProjectPermission.COMMENTS_DELETE_OTHERS, ProjectPermission.COMMENTS_MANAGE,
         ProjectPermission.PROJECT_SETTINGS_VIEW, ProjectPermission.PROJECT_SETTINGS_EDIT,
         ProjectPermission.BOARDS_VIEW, ProjectPermission.BOARDS_MANAGE,
+        // TTSEC-2: system-level — только ADMIN по умолчанию.
+        ProjectPermission.USER_GROUP_VIEW, ProjectPermission.USER_GROUP_MANAGE,
       ],
     },
     [ProjectRole.MANAGER]: {
@@ -124,11 +129,12 @@ async function main(prismaClient?: PrismaClient, scope?: string) {
       permissions: [
         ProjectPermission.ISSUES_VIEW, ProjectPermission.ISSUES_CREATE, ProjectPermission.ISSUES_EDIT, ProjectPermission.ISSUES_DELETE,
         ProjectPermission.ISSUES_ASSIGN, ProjectPermission.ISSUES_CHANGE_STATUS, ProjectPermission.ISSUES_CHANGE_TYPE,
-        ProjectPermission.SPRINTS_VIEW, ProjectPermission.SPRINTS_MANAGE,
-        ProjectPermission.RELEASES_VIEW, ProjectPermission.RELEASES_MANAGE,
+        // TTSEC-2: гранулярные SPRINTS/RELEASES вместо *_MANAGE.
+        ProjectPermission.SPRINTS_VIEW, ProjectPermission.SPRINTS_CREATE, ProjectPermission.SPRINTS_EDIT, ProjectPermission.SPRINTS_DELETE,
+        ProjectPermission.RELEASES_VIEW, ProjectPermission.RELEASES_CREATE, ProjectPermission.RELEASES_EDIT, ProjectPermission.RELEASES_DELETE,
         ProjectPermission.MEMBERS_VIEW, ProjectPermission.MEMBERS_MANAGE,
-        ProjectPermission.TIME_LOGS_VIEW, ProjectPermission.TIME_LOGS_CREATE, ProjectPermission.TIME_LOGS_MANAGE,
-        ProjectPermission.COMMENTS_VIEW, ProjectPermission.COMMENTS_CREATE, ProjectPermission.COMMENTS_MANAGE,
+        ProjectPermission.TIME_LOGS_VIEW, ProjectPermission.TIME_LOGS_CREATE, ProjectPermission.TIME_LOGS_DELETE_OTHERS, ProjectPermission.TIME_LOGS_MANAGE,
+        ProjectPermission.COMMENTS_VIEW, ProjectPermission.COMMENTS_CREATE, ProjectPermission.COMMENTS_DELETE_OTHERS, ProjectPermission.COMMENTS_MANAGE,
         ProjectPermission.PROJECT_SETTINGS_VIEW,
         ProjectPermission.BOARDS_VIEW, ProjectPermission.BOARDS_MANAGE,
       ],

--- a/backend/src/prisma/seed.ts
+++ b/backend/src/prisma/seed.ts
@@ -139,6 +139,9 @@ async function main(prismaClient?: PrismaClient, scope?: string) {
         ProjectPermission.BOARDS_VIEW, ProjectPermission.BOARDS_MANAGE,
       ],
     },
+    // TTSEC-2: USER и VIEWER НЕ получают новых permissions по умолчанию — спека §5.4.
+    // Гранулярный CRUD SPRINTS/RELEASES, *_DELETE_OTHERS и USER_GROUP_* — привилегии ADMIN/MANAGER.
+    // У USER остаётся только VIEW на sprints/releases; у VIEWER — read-only. Пропуск намеренный.
     [ProjectRole.USER]: {
       key: ProjectRole.USER, name: 'Участник', color: '#52c41a',
       permissions: [

--- a/backend/src/shared/middleware/rbac.ts
+++ b/backend/src/shared/middleware/rbac.ts
@@ -1,29 +1,231 @@
 import type { Response, NextFunction } from 'express';
 import type { SystemRoleType, ProjectPermission } from '@prisma/client';
 import { AppError } from './error-handler.js';
-import type { AuthRequest } from '../types/index.js';
+import type { AuthRequest, AuthUser } from '../types/index.js';
 import { hasAnySystemRole, isSuperAdmin, hasGlobalProjectReadAccess } from '../auth/roles.js';
 import { prisma } from '../../prisma/client.js';
 import { getSchemeForProject } from '../../modules/project-role-schemes/project-role-schemes.service.js';
-import { getCachedJson, setCachedJson, delCacheByPrefix } from '../redis.js';
+import { getCachedJson, setCachedJson, delCachedJson, delCacheByPrefix } from '../redis.js';
 
 /**
- * Invalidate cached permission results for a user+project pair.
+ * TTSEC-2 Phase 2: group-aware effective permissions.
  *
- * INVARIANT: every write path that creates, updates, or deletes a UserProjectRole MUST call
- * this helper (or `delCacheByPrefix('rbac:perm:${projectId}:')` for bulk updates). Current
- * callers:
+ * We compute a single "effective role" per (user, project) by unioning:
+ *   - DIRECT UserProjectRole rows
+ *   - roles granted via UserGroupMember → ProjectGroupRole bindings
+ *
+ * Among all candidates we pick the ONE role with the most `granted=true` permissions;
+ * tiebreaker — roleId ascending (for determinism across replicas). This matches spec §5.2.
+ *
+ * Cache layout: `rbac:effective:{userId}:{projectId}` → string[] (granted perms), TTL 60s.
+ * Cache is prefixed by userId first so we can drop a user's entire set on membership change.
+ */
+
+const EFFECTIVE_KEY = (userId: string, projectId: string) =>
+  `rbac:effective:${userId}:${projectId}`;
+const EFFECTIVE_TTL = 60;
+
+/**
+ * Invalidate cached permissions for a single (user, project) pair.
+ *
+ * INVARIANT: every write path that affects which roles apply to a user in a project MUST call
+ * this helper (or one of the broader helpers below). Current callers:
  *   - admin.service.assignProjectRole / removeProjectRole — per-user invalidation
  *   - project-role-schemes.service.attachProject / detachProject — per-project prefix invalidation
- *     (covers all users through the composite-FK remap)
  *   - project-role-schemes.service.updatePermissions + create/update/deleteRole — per-scheme
  *     invalidation via `invalidatePermissionCacheForScheme`
+ *   - user-groups.service.* — per-user (members) or per-group (project-role bindings)
  *
- * Missing a call leaves `requireProjectPermission` serving stale allow/deny decisions for up
- * to the cache TTL (60s).
+ * Missing a call leaves `requireProjectPermission` serving stale allow decisions for up to TTL.
  */
 export async function invalidateProjectPermissionCache(projectId: string, userId: string): Promise<void> {
-  await delCacheByPrefix(`rbac:perm:${projectId}:${userId}:`);
+  await Promise.all([
+    // New group-aware effective cache (single composite key).
+    delCachedJson(EFFECTIVE_KEY(userId, projectId)),
+    // Legacy per-permission cache — some callers may still hit it during deploy window.
+    delCacheByPrefix(`rbac:perm:${projectId}:${userId}:`),
+  ]);
+}
+
+/**
+ * Drop every cached effective-permission set for a single user across ALL projects. Called when
+ * the user's group membership changes (added/removed from a group), since that affects every
+ * project that group is bound to.
+ */
+export async function invalidateUserEffectivePermissions(userId: string): Promise<void> {
+  await delCacheByPrefix(`rbac:effective:${userId}:`);
+}
+
+/**
+ * Drop every cached effective-permission set for a project. Scans and deletes only the minority
+ * of users who had their entry cached (most won't). Call when a project-level scheme/role binding
+ * changes and you want to avoid iterating all group members.
+ */
+export async function invalidateProjectEffectivePermissions(projectId: string): Promise<void> {
+  // Redis doesn't support suffix-scan efficiently; fall back to iterating direct members + group
+  // members. For unbounded projects we could add pg_notify later; MVP uses explicit user-scan.
+  const [directUsers, groupUsers] = await Promise.all([
+    prisma.userProjectRole.findMany({ where: { projectId }, select: { userId: true } }),
+    prisma.userGroupMember.findMany({
+      where: { group: { projectRoles: { some: { projectId } } } },
+      select: { userId: true },
+    }),
+  ]);
+  const userIds = new Set<string>([
+    ...directUsers.map(u => u.userId),
+    ...groupUsers.map(u => u.userId),
+  ]);
+  await Promise.all(
+    Array.from(userIds).map(uid => delCachedJson(EFFECTIVE_KEY(uid, projectId))),
+  );
+  // Also kill legacy prefix for safety during the Phase 2 deploy window.
+  await delCacheByPrefix(`rbac:perm:${projectId}:`);
+}
+
+type EffectiveRole = {
+  roleId: string;
+  roleName: string;
+  roleKey: string;
+  permissions: ProjectPermission[];
+  source: 'DIRECT' | 'GROUP';
+  sourceGroups: { id: string; name: string }[]; // populated when source=GROUP (may be multiple)
+};
+
+/**
+ * Compute the effective role for a (user, project). Returns `null` if the user has no direct role
+ * and is not a member of any group bound to the project.
+ *
+ * The returned role is the ONE with max granted-permissions count across candidates
+ * (tiebreaker: roleId asc). `sourceGroups` lists every group that supplied the chosen role —
+ * typically one, but can be several if two groups bind to the same role definition.
+ *
+ * This is NOT cached — cache the permission set via `getEffectiveProjectPermissions`. Routes that
+ * need the role object itself (SecurityTab, /users/me/security) read it uncached; they're rare.
+ */
+export async function computeEffectiveRole(
+  userId: string,
+  projectId: string,
+): Promise<EffectiveRole | null> {
+  // Resolve via the project's ACTIVE scheme — a binding whose roleId points to a stale
+  // (previously-active) scheme falls back to matching by role key in the active scheme. This
+  // mirrors the original requireProjectPermission contract and covers the transitional state
+  // where some UserProjectRole rows still carry roleId=NULL.
+  const scheme = await getSchemeForProject(projectId);
+  const rolesInScheme = scheme.roles; // [{ id, key, permissions: [{permission, granted}] }]
+
+  const [directRows, groupRows] = await Promise.all([
+    prisma.userProjectRole.findMany({
+      where: { userId, projectId },
+      select: { roleId: true, role: true },
+    }),
+    prisma.projectGroupRole.findMany({
+      where: { projectId, group: { members: { some: { userId } } } },
+      select: {
+        roleId: true,
+        group: { select: { id: true, name: true } },
+        // Need the binding role's `key` in case the binding's scheme doesn't match active scheme.
+        roleDefinition: { select: { key: true } },
+      },
+    }),
+  ]);
+
+  type CandidateRole = typeof rolesInScheme[number];
+  type Candidate = { role: CandidateRole; source: 'DIRECT' | 'GROUP'; groups: { id: string; name: string }[] };
+  const byRoleId = new Map<string, Candidate>();
+
+  const resolveInScheme = (roleId: string | null | undefined, legacyKey: string | undefined): CandidateRole | undefined => {
+    if (roleId) {
+      const byId = rolesInScheme.find(r => r.id === roleId);
+      if (byId) return byId;
+    }
+    if (legacyKey) {
+      return rolesInScheme.find(r => r.key === legacyKey);
+    }
+    return undefined;
+  };
+
+  for (const row of directRows) {
+    const role = resolveInScheme(row.roleId, row.role);
+    if (!role) continue;
+    if (!byRoleId.has(role.id)) {
+      byRoleId.set(role.id, { role, source: 'DIRECT', groups: [] });
+    }
+  }
+  for (const row of groupRows) {
+    const role = resolveInScheme(row.roleId, row.roleDefinition.key);
+    if (!role) continue;
+    const existing = byRoleId.get(role.id);
+    if (existing) {
+      existing.groups.push(row.group);
+    } else {
+      byRoleId.set(role.id, { role, source: 'GROUP', groups: [row.group] });
+    }
+  }
+
+  const candidates = Array.from(byRoleId.values());
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => {
+    const aGranted = a.role.permissions.filter(p => p.granted).length;
+    const bGranted = b.role.permissions.filter(p => p.granted).length;
+    const d = bGranted - aGranted;
+    return d !== 0 ? d : a.role.id.localeCompare(b.role.id);
+  });
+
+  const chosen = candidates[0]!;
+  return {
+    roleId: chosen.role.id,
+    roleName: chosen.role.name,
+    roleKey: chosen.role.key,
+    permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
+    source: chosen.source,
+    sourceGroups: chosen.groups,
+  };
+}
+
+/**
+ * Return the effective permission set (granted=true only) for a (user, project). Redis-cached.
+ *
+ * Returns an empty array if the user has no access. We cache empty arrays too — unlike deny-caches
+ * in permission-specific code, the "no role at all" state is stable and changes only via explicit
+ * writes that DO call invalidation helpers.
+ */
+export async function getEffectiveProjectPermissions(
+  userId: string,
+  projectId: string,
+): Promise<ProjectPermission[]> {
+  const key = EFFECTIVE_KEY(userId, projectId);
+  const cached = await getCachedJson<ProjectPermission[]>(key);
+  if (cached !== null) return cached;
+
+  const role = await computeEffectiveRole(userId, projectId);
+  const perms = role?.permissions ?? [];
+  await setCachedJson(key, perms, EFFECTIVE_TTL);
+  return perms;
+}
+
+/**
+ * Assert that the authenticated user has AT LEAST ONE of the listed permissions in the project.
+ * Used when multiple permissions can authorise an action — e.g. deleting a comment authored by
+ * someone else requires `COMMENTS_DELETE_OTHERS` OR `COMMENTS_MANAGE`.
+ *
+ * SUPER_ADMIN bypasses. Global project-read roles bypass only if EVERY permission in the list is
+ * a `_VIEW` permission (otherwise we'd let them perform writes via the view-access shortcut).
+ */
+export async function assertProjectPermission(
+  user: AuthUser,
+  projectId: string,
+  permissions: ProjectPermission[],
+): Promise<void> {
+  if (permissions.length === 0) throw new AppError(500, 'assertProjectPermission: empty list');
+  if (isSuperAdmin(user.systemRoles)) return;
+  if (permissions.every(p => p.endsWith('_VIEW')) && hasGlobalProjectReadAccess(user.systemRoles)) return;
+
+  const granted = await getEffectiveProjectPermissions(user.userId, projectId);
+  const grantedSet = new Set(granted);
+  if (!permissions.some(p => grantedSet.has(p))) {
+    throw new AppError(403, `Requires one of: ${permissions.join(', ')}`);
+  }
 }
 
 export function requireRole(...roles: SystemRoleType[]) {
@@ -74,43 +276,11 @@ export function requireProjectPermission(
     const projectId = getProjectId(req);
     if (!projectId) return next(new AppError(400, 'Project ID required'));
 
-    const cacheKey = `rbac:perm:${projectId}:${req.user.userId}:${permission}`;
-
     try {
-      // Cache holds only positive (granted) results — a cached `true` means "still allowed".
-      // We do not cache deny decisions: a missing cache entry means "recompute", so granting a
-      // new role via a write path that forgot to invalidate still takes effect on the next
-      // request instead of being masked by a stale `false` for the full TTL.
-      const cachedResult = await getCachedJson<boolean>(cacheKey);
-      if (cachedResult === true) return next();
-
-      const scheme = await getSchemeForProject(projectId);
-      // Read ALL roles the user has in this project (in the canonical one-role-per-project model
-      // this returns 0..1 rows; during the migration window or after legacy data import it may
-      // return more). Permission is granted if ANY of the user's roles grants it — most
-      // permissive wins. This also makes behavior deterministic if multiple rows ever coexist.
-      const userRoles = await prisma.userProjectRole.findMany({
-        where: { userId: req.user.userId, projectId },
-        select: { roleId: true, role: true },
-      });
-
-      let granted = false;
-      for (const ur of userRoles) {
-        // Prefer roleId. If it's missing OR points to a role outside the active scheme
-        // (e.g. the project was recently re-attached to a different scheme and the migration
-        // hasn't caught up yet), fall back to matching by the legacy `role` key.
-        let roleDef = ur.roleId ? scheme.roles.find(r => r.id === ur.roleId) : undefined;
-        if (!roleDef) {
-          roleDef = scheme.roles.find(r => r.key === ur.role);
-        }
-        if (roleDef?.permissions.find(p => p.permission === permission)?.granted) {
-          granted = true;
-          break;
-        }
-      }
-
-      if (granted) await setCachedJson(cacheKey, true, 60);
-      return granted ? next() : next(new AppError(403, 'Insufficient project permissions'));
+      // TTSEC-2 Phase 2: uses the unified group-aware effective-permissions cache.
+      const granted = await getEffectiveProjectPermissions(req.user.userId, projectId);
+      if (granted.includes(permission)) return next();
+      return next(new AppError(403, 'Insufficient project permissions'));
     } catch (err) {
       next(err);
     }

--- a/backend/src/shared/middleware/rbac.ts
+++ b/backend/src/shared/middleware/rbac.ts
@@ -156,7 +156,12 @@ export async function computeEffectiveRole(
     if (!role) continue;
     const existing = byRoleId.get(role.id);
     if (existing) {
-      existing.groups.push(row.group);
+      // Dedup by group id — defensive: two bindings of the same group to the same role should
+      // be prevented by `@@unique([groupId, projectId])`, but data migration / join anomalies
+      // could still produce duplicates and leak to /users/me/security.
+      if (!existing.groups.some(g => g.id === row.group.id)) {
+        existing.groups.push(row.group);
+      }
     } else {
       byRoleId.set(role.id, { role, source: 'GROUP', groups: [row.group] });
     }
@@ -181,6 +186,108 @@ export async function computeEffectiveRole(
     source: chosen.source,
     sourceGroups: chosen.groups,
   };
+}
+
+/**
+ * Batched variant of computeEffectiveRole for many projects at once. Used by
+ * /users/me/security (AI review #65 round 2 — avoid N+1 when a user is in many projects).
+ *
+ * Query plan: 1× direct-roles + 1× group-roles + N× getSchemeForProject (Redis-cached, 300s TTL).
+ * Total DB queries: 2 instead of 2N; scheme reads hit Redis unless cold.
+ */
+export async function computeEffectiveRolesForProjects(
+  userId: string,
+  projectIds: string[],
+): Promise<Map<string, EffectiveRole | null>> {
+  const result = new Map<string, EffectiveRole | null>();
+  if (projectIds.length === 0) return result;
+
+  const [directRows, groupRows, schemes] = await Promise.all([
+    prisma.userProjectRole.findMany({
+      where: { userId, projectId: { in: projectIds } },
+      select: { projectId: true, roleId: true, role: true },
+    }),
+    prisma.projectGroupRole.findMany({
+      where: { projectId: { in: projectIds }, group: { members: { some: { userId } } } },
+      select: {
+        projectId: true,
+        roleId: true,
+        group: { select: { id: true, name: true } },
+        roleDefinition: { select: { key: true } },
+      },
+    }),
+    Promise.all(projectIds.map(async pid => [pid, await getSchemeForProject(pid)] as const)),
+  ]);
+
+  const schemeByProject = new Map(schemes);
+  const directByProject = new Map<string, typeof directRows>();
+  const groupByProject = new Map<string, typeof groupRows>();
+  for (const row of directRows) {
+    const arr = directByProject.get(row.projectId) ?? [];
+    arr.push(row);
+    directByProject.set(row.projectId, arr);
+  }
+  for (const row of groupRows) {
+    const arr = groupByProject.get(row.projectId) ?? [];
+    arr.push(row);
+    groupByProject.set(row.projectId, arr);
+  }
+
+  for (const projectId of projectIds) {
+    const scheme = schemeByProject.get(projectId);
+    if (!scheme) { result.set(projectId, null); continue; }
+    const rolesInScheme = scheme.roles;
+    type CandidateRole = typeof rolesInScheme[number];
+    type Candidate = { role: CandidateRole; source: 'DIRECT' | 'GROUP'; groups: { id: string; name: string }[] };
+    const byRoleId = new Map<string, Candidate>();
+
+    const resolveInScheme = (roleId: string | null | undefined, legacyKey: string | undefined): CandidateRole | undefined => {
+      if (roleId) {
+        const byId = rolesInScheme.find(r => r.id === roleId);
+        if (byId) return byId;
+      }
+      if (legacyKey) return rolesInScheme.find(r => r.key === legacyKey);
+      return undefined;
+    };
+
+    for (const row of (directByProject.get(projectId) ?? [])) {
+      const role = resolveInScheme(row.roleId, row.role);
+      if (!role) continue;
+      if (!byRoleId.has(role.id)) byRoleId.set(role.id, { role, source: 'DIRECT', groups: [] });
+    }
+    for (const row of (groupByProject.get(projectId) ?? [])) {
+      const role = resolveInScheme(row.roleId, row.roleDefinition.key);
+      if (!role) continue;
+      const existing = byRoleId.get(role.id);
+      if (existing) {
+        if (!existing.groups.some(g => g.id === row.group.id)) existing.groups.push(row.group);
+      } else {
+        byRoleId.set(role.id, { role, source: 'GROUP', groups: [row.group] });
+      }
+    }
+
+    const candidates = Array.from(byRoleId.values());
+    if (candidates.length === 0) { result.set(projectId, null); continue; }
+
+    candidates.sort((a, b) => {
+      const aGranted = a.role.permissions.filter(p => p.granted).length;
+      const bGranted = b.role.permissions.filter(p => p.granted).length;
+      const d = bGranted - aGranted;
+      return d !== 0 ? d : a.role.id.localeCompare(b.role.id);
+    });
+
+    const chosen = candidates[0]!;
+    result.set(projectId, {
+      roleId: chosen.role.id,
+      roleName: chosen.role.name,
+      roleKey: chosen.role.key,
+      permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
+      source: chosen.source,
+      sourceGroups: chosen.groups,
+    });
+  }
+
+  return result;
 }
 
 /**

--- a/backend/src/shared/middleware/rbac.ts
+++ b/backend/src/shared/middleware/rbac.ts
@@ -199,11 +199,13 @@ export async function computeEffectiveRole(
     roleName: chosen.role.name,
     roleKey: chosen.role.key,
     permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
+    // `source` indicates the PRIMARY grant path; DIRECT wins if the user has the role directly.
     source: chosen.source,
-    // AI review #65 round 3 🟡 — when the chosen role is DIRECT, don't leak irrelevant group
-    // context. If the user also holds the same role via groups, that's informational only and
-    // unrelated to the effective grant path; keeping it would contradict `source: 'DIRECT'`.
-    sourceGroups: chosen.source === 'DIRECT' ? [] : chosen.groups,
+    // `sourceGroups` lists ALL groups that also grant this role — independent of `source`.
+    // AI review #65 round 4 🟡: restored; round 3 cleared this when source=DIRECT, but that
+    // lost information SecurityTab needs ("also via Team A, Team B"). Documented in
+    // user-security.service SecurityProjectRole interface.
+    sourceGroups: chosen.groups,
   };
 }
 
@@ -302,8 +304,8 @@ export async function computeEffectiveRolesForProjects(
       roleKey: chosen.role.key,
       permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
       source: chosen.source,
-      // AI review #65 round 3 🟡 — see single-project variant above.
-      sourceGroups: chosen.source === 'DIRECT' ? [] : chosen.groups,
+      // See single-project variant — sourceGroups lists all groups that also grant this role.
+      sourceGroups: chosen.groups,
     });
   }
 

--- a/backend/src/shared/middleware/rbac.ts
+++ b/backend/src/shared/middleware/rbac.ts
@@ -17,12 +17,18 @@ import { getCachedJson, setCachedJson, delCachedJson, delCacheByPrefix } from '.
  * Among all candidates we pick the ONE role with the most `granted=true` permissions;
  * tiebreaker — roleId ascending (for determinism across replicas). This matches spec §5.2.
  *
- * Cache layout: `rbac:effective:{userId}:{projectId}` → string[] (granted perms), TTL 60s.
- * Cache is prefixed by userId first so we can drop a user's entire set on membership change.
+ * Cache layout (AI review #65 round 3): `rbac:effective:{projectId}:{userId}` → string[] (granted
+ * perms), TTL 60s. Key is projectId-first so scheme-level changes (attach/detach project, delete
+ * role, update permission matrix) can do a single prefix SCAN + delete — covering ALL cached
+ * users for the project, including ones who just lost access and no longer appear in the current
+ * bindings query. For per-user wipes (group membership change) we iterate the user's affected
+ * projects and delete pair-by-pair — bounded by the user's actual project count, not the whole
+ * keyspace.
  */
 
-const EFFECTIVE_KEY = (userId: string, projectId: string) =>
-  `rbac:effective:${userId}:${projectId}`;
+const EFFECTIVE_KEY = (projectId: string, userId: string) =>
+  `rbac:effective:${projectId}:${userId}`;
+const EFFECTIVE_PROJECT_PREFIX = (projectId: string) => `rbac:effective:${projectId}:`;
 const EFFECTIVE_TTL = 60;
 
 /**
@@ -41,7 +47,7 @@ const EFFECTIVE_TTL = 60;
 export async function invalidateProjectPermissionCache(projectId: string, userId: string): Promise<void> {
   await Promise.all([
     // New group-aware effective cache (single composite key).
-    delCachedJson(EFFECTIVE_KEY(userId, projectId)),
+    delCachedJson(EFFECTIVE_KEY(projectId, userId)),
     // Legacy per-permission cache — some callers may still hit it during deploy window.
     delCacheByPrefix(`rbac:perm:${projectId}:${userId}:`),
   ]);
@@ -50,36 +56,46 @@ export async function invalidateProjectPermissionCache(projectId: string, userId
 /**
  * Drop every cached effective-permission set for a single user across ALL projects. Called when
  * the user's group membership changes (added/removed from a group), since that affects every
- * project that group is bound to.
+ * project the user could see through direct roles or group bindings.
+ *
+ * Implementation iterates the user's currently-known projects (direct roles + groups the user
+ * is in) and deletes pair-by-pair. If the caller knows the exact projectIds affected (e.g. the
+ * group just bound/unbound), they should call `invalidateProjectPermissionCache(pid, uid)` for
+ * each pair directly — cheaper and exact. This helper is for the general "something about this
+ * user changed, flush them" case.
  */
 export async function invalidateUserEffectivePermissions(userId: string): Promise<void> {
-  await delCacheByPrefix(`rbac:effective:${userId}:`);
+  const [directProjects, groupProjects] = await Promise.all([
+    prisma.userProjectRole.findMany({ where: { userId }, select: { projectId: true } }),
+    prisma.projectGroupRole.findMany({
+      where: { group: { members: { some: { userId } } } },
+      select: { projectId: true },
+    }),
+  ]);
+  const projectIds = new Set<string>([
+    ...directProjects.map(r => r.projectId),
+    ...groupProjects.map(r => r.projectId),
+  ]);
+  await Promise.all(
+    Array.from(projectIds).map(pid => invalidateProjectPermissionCache(pid, userId)),
+  );
 }
 
 /**
- * Drop every cached effective-permission set for a project. Scans and deletes only the minority
- * of users who had their entry cached (most won't). Call when a project-level scheme/role binding
- * changes and you want to avoid iterating all group members.
+ * Drop every cached effective-permission set for a project — regardless of whether a user still
+ * has a direct/group binding.
+ *
+ * AI review #65 round 3 🟠 — scheme changes may REMOVE bindings (detach project, delete role,
+ * update matrix), and those users' stale cache entries must be wiped too. Prefix SCAN + DELETE
+ * on `rbac:effective:{projectId}:*` handles exactly this: it hits every user whose entry was
+ * ever cached for the project, not just users currently visible in the bindings query.
  */
 export async function invalidateProjectEffectivePermissions(projectId: string): Promise<void> {
-  // Redis doesn't support suffix-scan efficiently; fall back to iterating direct members + group
-  // members. For unbounded projects we could add pg_notify later; MVP uses explicit user-scan.
-  const [directUsers, groupUsers] = await Promise.all([
-    prisma.userProjectRole.findMany({ where: { projectId }, select: { userId: true } }),
-    prisma.userGroupMember.findMany({
-      where: { group: { projectRoles: { some: { projectId } } } },
-      select: { userId: true },
-    }),
+  await Promise.all([
+    delCacheByPrefix(EFFECTIVE_PROJECT_PREFIX(projectId)),
+    // Legacy per-permission cache — same treatment for deploy-window safety.
+    delCacheByPrefix(`rbac:perm:${projectId}:`),
   ]);
-  const userIds = new Set<string>([
-    ...directUsers.map(u => u.userId),
-    ...groupUsers.map(u => u.userId),
-  ]);
-  await Promise.all(
-    Array.from(userIds).map(uid => delCachedJson(EFFECTIVE_KEY(uid, projectId))),
-  );
-  // Also kill legacy prefix for safety during the Phase 2 deploy window.
-  await delCacheByPrefix(`rbac:perm:${projectId}:`);
 }
 
 type EffectiveRole = {
@@ -184,7 +200,10 @@ export async function computeEffectiveRole(
     roleKey: chosen.role.key,
     permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
     source: chosen.source,
-    sourceGroups: chosen.groups,
+    // AI review #65 round 3 🟡 — when the chosen role is DIRECT, don't leak irrelevant group
+    // context. If the user also holds the same role via groups, that's informational only and
+    // unrelated to the effective grant path; keeping it would contradict `source: 'DIRECT'`.
+    sourceGroups: chosen.source === 'DIRECT' ? [] : chosen.groups,
   };
 }
 
@@ -283,7 +302,8 @@ export async function computeEffectiveRolesForProjects(
       roleKey: chosen.role.key,
       permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
       source: chosen.source,
-      sourceGroups: chosen.groups,
+      // AI review #65 round 3 🟡 — see single-project variant above.
+      sourceGroups: chosen.source === 'DIRECT' ? [] : chosen.groups,
     });
   }
 
@@ -301,7 +321,7 @@ export async function getEffectiveProjectPermissions(
   userId: string,
   projectId: string,
 ): Promise<ProjectPermission[]> {
-  const key = EFFECTIVE_KEY(userId, projectId);
+  const key = EFFECTIVE_KEY(projectId, userId);
   const cached = await getCachedJson<ProjectPermission[]>(key);
   if (cached !== null) return cached;
 

--- a/backend/src/shared/middleware/rbac.ts
+++ b/backend/src/shared/middleware/rbac.ts
@@ -224,7 +224,7 @@ export async function assertProjectPermission(
   const granted = await getEffectiveProjectPermissions(user.userId, projectId);
   const grantedSet = new Set(granted);
   if (!permissions.some(p => grantedSet.has(p))) {
-    throw new AppError(403, `Requires one of: ${permissions.join(', ')}`);
+    throw new AppError(403, `Требуется одно из прав: ${permissions.join(', ')}`);
   }
 }
 

--- a/backend/src/shared/types/index.ts
+++ b/backend/src/shared/types/index.ts
@@ -1,10 +1,12 @@
 import type { Request } from 'express';
 import type { SystemRoleType } from '@prisma/client';
 
+export interface AuthUser {
+  userId: string;
+  email: string;
+  systemRoles: SystemRoleType[];
+}
+
 export interface AuthRequest extends Request {
-  user?: {
-    userId: string;
-    email: string;
-    systemRoles: SystemRoleType[];
-  };
+  user?: AuthUser;
 }

--- a/backend/tests/rbac-effective.unit.test.ts
+++ b/backend/tests/rbac-effective.unit.test.ts
@@ -141,14 +141,14 @@ describe('computeEffectiveRole', () => {
     expect(eff?.roleId).toBe('aaaa'); // min id wins tiebreaker
   });
 
-  it('same role via both DIRECT and GROUP is listed once with sourceGroups populated', async () => {
+  it('when chosen role is DIRECT, sourceGroups is empty even if groups also grant it (round 3)', async () => {
     mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: ADMIN.id, role: 'ADMIN' }]);
     mockPrisma.projectGroupRole.findMany.mockResolvedValue([
       { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
     ]);
     const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
-    expect(eff?.source).toBe('DIRECT'); // direct was inserted first
-    expect(eff?.sourceGroups).toEqual([{ id: 'g-1', name: 'Admins' }]);
+    expect(eff?.source).toBe('DIRECT');
+    expect(eff?.sourceGroups).toEqual([]);
   });
 
   it('sourceGroups is deduplicated when the same group appears twice (AI review #65 round 2)', async () => {

--- a/backend/tests/rbac-effective.unit.test.ts
+++ b/backend/tests/rbac-effective.unit.test.ts
@@ -6,23 +6,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ProjectPermission } from '@prisma/client';
 
-const { mockPrisma } = vi.hoisted(() => {
+const { mockPrisma, mockRedis } = vi.hoisted(() => {
   const mockPrisma = {
     userProjectRole: { findMany: vi.fn() },
     projectGroupRole: { findMany: vi.fn() },
     userGroupMember: { findMany: vi.fn() },
   };
-  return { mockPrisma };
+  const mockRedis = {
+    getCachedJson: vi.fn().mockResolvedValue(null),
+    setCachedJson: vi.fn(),
+    delCachedJson: vi.fn(),
+    delCacheByPrefix: vi.fn(),
+  };
+  return { mockPrisma, mockRedis };
 });
 
 vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
-
-vi.mock('../src/shared/redis.js', () => ({
-  getCachedJson: vi.fn().mockResolvedValue(null), // always miss → exercise compute path
-  setCachedJson: vi.fn(),
-  delCachedJson: vi.fn(),
-  delCacheByPrefix: vi.fn(),
-}));
+vi.mock('../src/shared/redis.js', () => mockRedis);
 
 const mockGetScheme = vi.fn();
 vi.mock('../src/modules/project-role-schemes/project-role-schemes.service.js', () => ({
@@ -35,6 +35,8 @@ const {
   assertProjectPermission,
   getEffectiveProjectPermissions,
   computeEffectiveRolesForProjects,
+  invalidateProjectEffectivePermissions,
+  invalidateProjectPermissionCache,
 } = await import('../src/shared/middleware/rbac.js');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -257,5 +259,23 @@ describe('getEffectiveProjectPermissions', () => {
     const perms = await getEffectiveProjectPermissions(USER_ID, PROJECT_ID);
     expect(perms).toContain('SPRINTS_CREATE');
     expect(perms).toContain('SPRINTS_DELETE');
+  });
+});
+
+// ─── Cache invalidation (AI review #65 round 5 🟠) ───────────────────────────
+
+describe('cache invalidation key format', () => {
+  it('invalidateProjectEffectivePermissions uses project-prefix (covers stale users)', async () => {
+    await invalidateProjectEffectivePermissions('proj-X');
+    // Must kill both the new effective cache prefix AND the legacy per-permission prefix.
+    expect(mockRedis.delCacheByPrefix).toHaveBeenCalledWith('rbac:effective:proj-X:');
+    expect(mockRedis.delCacheByPrefix).toHaveBeenCalledWith('rbac:perm:proj-X:');
+  });
+
+  it('invalidateProjectPermissionCache uses projectId-first composite key', async () => {
+    await invalidateProjectPermissionCache('proj-X', 'user-Y');
+    // Single composite key, projectId first — the SCAN above hits this same namespace.
+    expect(mockRedis.delCachedJson).toHaveBeenCalledWith('rbac:effective:proj-X:user-Y');
+    expect(mockRedis.delCacheByPrefix).toHaveBeenCalledWith('rbac:perm:proj-X:user-Y:');
   });
 });

--- a/backend/tests/rbac-effective.unit.test.ts
+++ b/backend/tests/rbac-effective.unit.test.ts
@@ -141,14 +141,18 @@ describe('computeEffectiveRole', () => {
     expect(eff?.roleId).toBe('aaaa'); // min id wins tiebreaker
   });
 
-  it('when chosen role is DIRECT, sourceGroups is empty even if groups also grant it (round 3)', async () => {
+  it('source=DIRECT but sourceGroups lists every group that also grants the same role (round 4)', async () => {
     mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: ADMIN.id, role: 'ADMIN' }]);
     mockPrisma.projectGroupRole.findMany.mockResolvedValue([
       { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
+      { roleId: ADMIN.id, group: { id: 'g-2', name: 'Leads' }, roleDefinition: { key: 'ADMIN' } },
     ]);
     const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
     expect(eff?.source).toBe('DIRECT');
-    expect(eff?.sourceGroups).toEqual([]);
+    expect(eff?.sourceGroups).toEqual([
+      { id: 'g-1', name: 'Admins' },
+      { id: 'g-2', name: 'Leads' },
+    ]);
   });
 
   it('sourceGroups is deduplicated when the same group appears twice (AI review #65 round 2)', async () => {

--- a/backend/tests/rbac-effective.unit.test.ts
+++ b/backend/tests/rbac-effective.unit.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit-тесты для group-aware RBAC из rbac.ts.
+ * Проверяем computeEffectiveRole + assertProjectPermission: выбор max-permissions,
+ * детерминированный tiebreaker, fallback через active scheme, source=DIRECT/GROUP.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ProjectPermission } from '@prisma/client';
+
+const { mockPrisma } = vi.hoisted(() => {
+  const mockPrisma = {
+    userProjectRole: { findMany: vi.fn() },
+    projectGroupRole: { findMany: vi.fn() },
+    userGroupMember: { findMany: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
+
+vi.mock('../src/shared/redis.js', () => ({
+  getCachedJson: vi.fn().mockResolvedValue(null), // always miss → exercise compute path
+  setCachedJson: vi.fn(),
+  delCachedJson: vi.fn(),
+  delCacheByPrefix: vi.fn(),
+}));
+
+const mockGetScheme = vi.fn();
+vi.mock('../src/modules/project-role-schemes/project-role-schemes.service.js', () => ({
+  getSchemeForProject: (projectId: string) => mockGetScheme(projectId),
+}));
+
+// Import after mocks.
+const {
+  computeEffectiveRole,
+  assertProjectPermission,
+  getEffectiveProjectPermissions,
+} = await import('../src/shared/middleware/rbac.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function role(id: string, key: string, name: string, perms: ProjectPermission[]) {
+  return {
+    id, key, name,
+    permissions: perms.map(p => ({ permission: p, granted: true })),
+  };
+}
+
+const USER_ID = 'user-1';
+const PROJECT_ID = 'proj-1';
+const SCHEME_ID = 'scheme-1';
+
+const ADMIN = role('r-admin', 'ADMIN', 'Администратор', [
+  'ISSUES_VIEW', 'ISSUES_CREATE', 'ISSUES_EDIT', 'ISSUES_DELETE',
+  'SPRINTS_CREATE', 'SPRINTS_EDIT', 'SPRINTS_DELETE',
+  'COMMENTS_MANAGE', 'COMMENTS_DELETE_OTHERS',
+] as ProjectPermission[]);
+const USER = role('r-user', 'USER', 'Участник', [
+  'ISSUES_VIEW', 'ISSUES_CREATE',
+] as ProjectPermission[]);
+const VIEWER = role('r-viewer', 'VIEWER', 'Наблюдатель', ['ISSUES_VIEW'] as ProjectPermission[]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetScheme.mockResolvedValue({ id: SCHEME_ID, roles: [ADMIN, USER, VIEWER] });
+  mockPrisma.userProjectRole.findMany.mockResolvedValue([]);
+  mockPrisma.projectGroupRole.findMany.mockResolvedValue([]);
+});
+
+// ─── computeEffectiveRole ────────────────────────────────────────────────────
+
+describe('computeEffectiveRole', () => {
+  it('returns null when user has neither direct nor group role', async () => {
+    expect(await computeEffectiveRole(USER_ID, PROJECT_ID)).toBeNull();
+  });
+
+  it('resolves DIRECT-only user via roleId', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([
+      { roleId: USER.id, role: 'USER' },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff).not.toBeNull();
+    expect(eff!.source).toBe('DIRECT');
+    expect(eff!.roleKey).toBe('USER');
+    expect(eff!.permissions).toContain('ISSUES_VIEW');
+    expect(eff!.permissions).not.toContain('ISSUES_DELETE');
+  });
+
+  it('falls back to matching by legacy `role` key when roleId is NULL', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([
+      { roleId: null, role: 'USER' },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.roleKey).toBe('USER');
+  });
+
+  it('falls back to `role` key when roleId points outside active scheme', async () => {
+    // Stale roleId (scheme switched) — runtime falls back to legacy key match.
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([
+      { roleId: 'stale-role-id', role: 'ADMIN' },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.roleKey).toBe('ADMIN');
+    expect(eff?.permissions).toContain('ISSUES_DELETE');
+  });
+
+  it('resolves GROUP-only user and exposes sourceGroups', async () => {
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      {
+        roleId: ADMIN.id,
+        group: { id: 'g-1', name: 'Frontend Team' },
+        roleDefinition: { key: 'ADMIN' },
+      },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.source).toBe('GROUP');
+    expect(eff?.sourceGroups).toEqual([{ id: 'g-1', name: 'Frontend Team' }]);
+    expect(eff?.permissions).toContain('ISSUES_DELETE');
+  });
+
+  it('picks role with max permissions when user has DIRECT=USER and GROUP=ADMIN', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: USER.id, role: 'USER' }]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.roleKey).toBe('ADMIN');
+    expect(eff?.source).toBe('GROUP');
+    expect(eff?.sourceGroups[0]?.id).toBe('g-1');
+  });
+
+  it('tiebreaker by roleId asc when two roles grant equal permissions', async () => {
+    const roleA = role('zzzz', 'A', 'A', ['ISSUES_VIEW'] as ProjectPermission[]);
+    const roleB = role('aaaa', 'B', 'B', ['ISSUES_VIEW'] as ProjectPermission[]);
+    mockGetScheme.mockResolvedValue({ id: SCHEME_ID, roles: [roleA, roleB] });
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: roleA.id, role: 'A' }]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { roleId: roleB.id, group: { id: 'g', name: 'G' }, roleDefinition: { key: 'B' } },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.roleId).toBe('aaaa'); // min id wins tiebreaker
+  });
+
+  it('same role via both DIRECT and GROUP is listed once with sourceGroups populated', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: ADMIN.id, role: 'ADMIN' }]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.source).toBe('DIRECT'); // direct was inserted first
+    expect(eff?.sourceGroups).toEqual([{ id: 'g-1', name: 'Admins' }]);
+  });
+});
+
+// ─── assertProjectPermission (OR-list) ───────────────────────────────────────
+
+describe('assertProjectPermission', () => {
+  const authUser = { userId: USER_ID, email: 'u@ex.com', systemRoles: [] };
+
+  it('passes when the user has at least one of the listed permissions', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: ADMIN.id, role: 'ADMIN' }]);
+    await expect(
+      assertProjectPermission(authUser, PROJECT_ID, ['COMMENTS_DELETE_OTHERS', 'COMMENTS_MANAGE']),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws 403 when none of the listed permissions are granted', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: USER.id, role: 'USER' }]);
+    await expect(
+      assertProjectPermission(authUser, PROJECT_ID, ['COMMENTS_DELETE_OTHERS', 'COMMENTS_MANAGE']),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('SUPER_ADMIN bypasses regardless of granted permissions', async () => {
+    const superUser = { userId: USER_ID, email: 'u@ex.com', systemRoles: ['SUPER_ADMIN' as const] };
+    await expect(
+      assertProjectPermission(superUser, PROJECT_ID, ['SPRINTS_DELETE']),
+    ).resolves.toBeUndefined();
+    expect(mockPrisma.userProjectRole.findMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty permission list (programmer error)', async () => {
+    await expect(
+      assertProjectPermission(authUser, PROJECT_ID, []),
+    ).rejects.toMatchObject({ statusCode: 500 });
+  });
+});
+
+// ─── getEffectiveProjectPermissions ──────────────────────────────────────────
+
+describe('getEffectiveProjectPermissions', () => {
+  it('returns empty array when no role found', async () => {
+    const perms = await getEffectiveProjectPermissions(USER_ID, PROJECT_ID);
+    expect(perms).toEqual([]);
+  });
+
+  it('returns the granted permissions of the chosen role', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: ADMIN.id, role: 'ADMIN' }]);
+    const perms = await getEffectiveProjectPermissions(USER_ID, PROJECT_ID);
+    expect(perms).toContain('SPRINTS_CREATE');
+    expect(perms).toContain('SPRINTS_DELETE');
+  });
+});

--- a/backend/tests/rbac-effective.unit.test.ts
+++ b/backend/tests/rbac-effective.unit.test.ts
@@ -34,6 +34,7 @@ const {
   computeEffectiveRole,
   assertProjectPermission,
   getEffectiveProjectPermissions,
+  computeEffectiveRolesForProjects,
 } = await import('../src/shared/middleware/rbac.js');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -148,6 +149,60 @@ describe('computeEffectiveRole', () => {
     const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
     expect(eff?.source).toBe('DIRECT'); // direct was inserted first
     expect(eff?.sourceGroups).toEqual([{ id: 'g-1', name: 'Admins' }]);
+  });
+
+  it('sourceGroups is deduplicated when the same group appears twice (AI review #65 round 2)', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
+      { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
+      { roleId: ADMIN.id, group: { id: 'g-2', name: 'Leads' }, roleDefinition: { key: 'ADMIN' } },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.sourceGroups).toEqual([
+      { id: 'g-1', name: 'Admins' },
+      { id: 'g-2', name: 'Leads' },
+    ]);
+  });
+});
+
+// ─── computeEffectiveRolesForProjects (batched) ──────────────────────────────
+
+describe('computeEffectiveRolesForProjects', () => {
+  it('returns empty map on empty input without any DB call', async () => {
+    const res = await computeEffectiveRolesForProjects(USER_ID, []);
+    expect(res.size).toBe(0);
+    expect(mockPrisma.userProjectRole.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.projectGroupRole.findMany).not.toHaveBeenCalled();
+  });
+
+  it('makes exactly one direct query and one group query for N projects', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([
+      { projectId: 'p1', roleId: USER.id, role: 'USER' },
+      { projectId: 'p2', roleId: ADMIN.id, role: 'ADMIN' },
+    ]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([]);
+
+    const res = await computeEffectiveRolesForProjects(USER_ID, ['p1', 'p2', 'p3']);
+
+    expect(mockPrisma.userProjectRole.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.projectGroupRole.findMany).toHaveBeenCalledTimes(1);
+    expect(res.get('p1')?.roleKey).toBe('USER');
+    expect(res.get('p2')?.roleKey).toBe('ADMIN');
+    expect(res.get('p3')).toBeNull(); // no role in p3
+  });
+
+  it('merges DIRECT + GROUP per-project with max-permissions pick', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([
+      { projectId: 'p1', roleId: USER.id, role: 'USER' },
+    ]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { projectId: 'p1', roleId: ADMIN.id, group: { id: 'g-1', name: 'G' }, roleDefinition: { key: 'ADMIN' } },
+    ]);
+    const res = await computeEffectiveRolesForProjects(USER_ID, ['p1']);
+    const eff = res.get('p1');
+    expect(eff?.roleKey).toBe('ADMIN');
+    expect(eff?.source).toBe('GROUP');
   });
 });
 

--- a/backend/tests/sprints-move-issues.unit.test.ts
+++ b/backend/tests/sprints-move-issues.unit.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit-тесты для moveIssuesToSprint: cross-project защита.
+ * См. TTSEC-2 Phase 2, AI review #65 🟠 — роутер /projects/:projectId/backlog/issues
+ * раньше не валидировал, что issueIds принадлежат projectId, что позволяло пользователю
+ * с SPRINTS_EDIT в проекте A трогать задачи проекта B.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPrisma } = vi.hoisted(() => {
+  const mockPrisma = {
+    issue: {
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  };
+  return { mockPrisma };
+});
+
+vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
+vi.mock('../src/shared/redis.js', () => ({
+  getCachedJson: vi.fn(),
+  setCachedJson: vi.fn(),
+  delCachedJson: vi.fn(),
+  delCacheByPrefix: vi.fn(),
+  acquireLock: vi.fn(),
+  releaseLock: vi.fn(),
+}));
+vi.mock('../src/modules/ai/ai.service.js', () => ({}));
+
+const { moveIssuesToSprint } = await import('../src/modules/sprints/sprints.service.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.issue.updateMany.mockResolvedValue({ count: 0 });
+});
+
+describe('moveIssuesToSprint cross-project guard', () => {
+  it('allows move when every issue belongs to expectedProjectId', async () => {
+    mockPrisma.issue.findMany.mockResolvedValue([
+      { id: 'i1', projectId: 'p1' },
+      { id: 'i2', projectId: 'p1' },
+    ]);
+    await expect(
+      moveIssuesToSprint(null, ['i1', 'i2'], 'p1'),
+    ).resolves.toBeUndefined();
+    expect(mockPrisma.issue.updateMany).toHaveBeenCalled();
+  });
+
+  it('rejects (403) when any issue belongs to a different project', async () => {
+    mockPrisma.issue.findMany.mockResolvedValue([
+      { id: 'i1', projectId: 'p1' },
+      { id: 'i2', projectId: 'p2' }, // foreign
+    ]);
+    await expect(
+      moveIssuesToSprint(null, ['i1', 'i2'], 'p1'),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(mockPrisma.issue.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects (400) when some issue ids are not found', async () => {
+    mockPrisma.issue.findMany.mockResolvedValue([{ id: 'i1', projectId: 'p1' }]);
+    await expect(
+      moveIssuesToSprint(null, ['i1', 'missing'], 'p1'),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(mockPrisma.issue.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('skips cross-project check when expectedProjectId is omitted (legacy callers)', async () => {
+    mockPrisma.issue.findMany.mockResolvedValue([
+      { id: 'i1', projectId: 'p1' },
+      { id: 'i2', projectId: 'p2' },
+    ]);
+    await expect(
+      moveIssuesToSprint('sprint-1', ['i1', 'i2']),
+    ).resolves.toBeUndefined();
+    expect(mockPrisma.issue.updateMany).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/user-groups.unit.test.ts
+++ b/backend/tests/user-groups.unit.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit-тесты для user-groups сервиса. Фокус — инварианты cache-инвалидации
+ * и корректность CRUD/membership логики без реальной БД.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPrisma } = vi.hoisted(() => {
+  const mockPrisma = {
+    userGroup: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    userGroupMember: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      createMany: vi.fn(),
+      delete: vi.fn(),
+    },
+    projectGroupRole: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    projectRoleDefinition: { findUnique: vi.fn() },
+    projectRoleScheme: { findFirst: vi.fn() },
+    projectRoleSchemeProject: { findUnique: vi.fn() },
+    project: { findUnique: vi.fn() },
+    user: { findMany: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
+vi.mock('../src/shared/redis.js', () => ({
+  getCachedJson: vi.fn(),
+  setCachedJson: vi.fn(),
+  delCachedJson: vi.fn(),
+  delCacheByPrefix: vi.fn(),
+}));
+
+const invalidateUserEffective = vi.fn();
+const invalidatePerProject = vi.fn();
+vi.mock('../src/shared/middleware/rbac.js', () => ({
+  invalidateUserEffectivePermissions: invalidateUserEffective,
+  invalidateProjectPermissionCache: invalidatePerProject,
+}));
+
+const service = await import('../src/modules/user-groups/user-groups.service.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createGroup', () => {
+  it('creates a group when the name is free', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue(null);
+    mockPrisma.userGroup.create.mockResolvedValue({ id: 'g1', name: 'Team', description: null });
+    const result = await service.createGroup({ name: 'Team' });
+    expect(result.id).toBe('g1');
+    expect(mockPrisma.userGroup.create).toHaveBeenCalledWith({
+      data: { name: 'Team', description: null },
+    });
+  });
+
+  it('rejects duplicate group names with 409', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'existing' });
+    await expect(service.createGroup({ name: 'Team' })).rejects.toMatchObject({ statusCode: 409 });
+  });
+});
+
+describe('addMembers', () => {
+  it('invalidates effective-permission cache for every added user', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1' });
+    mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }, { id: 'u2' }]);
+    mockPrisma.userGroupMember.createMany.mockResolvedValue({ count: 2 });
+
+    const result = await service.addMembers('g1', ['u1', 'u2'], 'actor');
+    expect(result.added).toBe(2);
+    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
+    expect(invalidateUserEffective).toHaveBeenCalledWith('u2');
+  });
+
+  it('rejects when some user ids do not exist', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1' });
+    mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }]);
+    await expect(service.addMembers('g1', ['u1', 'missing'], 'actor')).rejects.toMatchObject({
+      statusCode: 400,
+    });
+    expect(invalidateUserEffective).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeMember', () => {
+  it('invalidates effective-permission cache for the removed user', async () => {
+    mockPrisma.userGroupMember.findUnique.mockResolvedValue({ groupId: 'g1' });
+    mockPrisma.userGroupMember.delete.mockResolvedValue({});
+    await service.removeMember('g1', 'u1');
+    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
+  });
+
+  it('returns 404 when the user is not a member', async () => {
+    mockPrisma.userGroupMember.findUnique.mockResolvedValue(null);
+    await expect(service.removeMember('g1', 'u1')).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe('grantProjectRole', () => {
+  beforeEach(() => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1' });
+    mockPrisma.project.findUnique.mockResolvedValue({ id: 'p1' });
+    mockPrisma.projectRoleDefinition.findUnique.mockResolvedValue({
+      id: 'r1', schemeId: 'scheme-active',
+    });
+    mockPrisma.projectRoleSchemeProject.findUnique.mockResolvedValue({ schemeId: 'scheme-active' });
+  });
+
+  it('creates a new binding when none exists', async () => {
+    mockPrisma.projectGroupRole.findUnique.mockResolvedValue(null);
+    mockPrisma.projectGroupRole.create.mockResolvedValue({ id: 'b1' });
+    mockPrisma.userGroupMember.findMany.mockResolvedValue([{ userId: 'u1' }, { userId: 'u2' }]);
+
+    await service.grantProjectRole('g1', { projectId: 'p1', roleId: 'r1' });
+
+    expect(mockPrisma.projectGroupRole.create).toHaveBeenCalled();
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u1');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u2');
+  });
+
+  it('rejects a role that belongs to another scheme', async () => {
+    mockPrisma.projectRoleDefinition.findUnique.mockResolvedValue({
+      id: 'r1', schemeId: 'scheme-other',
+    });
+    await expect(
+      service.grantProjectRole('g1', { projectId: 'p1', roleId: 'r1' }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('idempotent: re-granting the same roleId is a no-op returning the existing binding', async () => {
+    mockPrisma.projectGroupRole.findUnique.mockResolvedValue({ id: 'b-existing', roleId: 'r1' });
+    const result = await service.grantProjectRole('g1', { projectId: 'p1', roleId: 'r1' });
+    expect(result).toMatchObject({ id: 'b-existing' });
+    expect(mockPrisma.projectGroupRole.create).not.toHaveBeenCalled();
+    expect(mockPrisma.projectGroupRole.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteGroup', () => {
+  it('returns affected user×project pairs and invalidates each distinct user', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({
+      id: 'g1', name: 'Team',
+      members: [{ userId: 'u1' }, { userId: 'u2' }],
+      projectRoles: [
+        { projectId: 'p1', roleId: 'r1' },
+        { projectId: 'p2', roleId: 'r1' },
+      ],
+    });
+    mockPrisma.userGroup.delete.mockResolvedValue({});
+
+    const result = await service.deleteGroup('g1');
+
+    expect(result.affectedPairs).toHaveLength(4); // 2 users × 2 projects
+    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
+    expect(invalidateUserEffective).toHaveBeenCalledWith('u2');
+    expect(invalidateUserEffective).toHaveBeenCalledTimes(2); // dedup by user
+  });
+});

--- a/backend/tests/user-groups.unit.test.ts
+++ b/backend/tests/user-groups.unit.test.ts
@@ -44,10 +44,8 @@ vi.mock('../src/shared/redis.js', () => ({
   delCacheByPrefix: vi.fn(),
 }));
 
-const invalidateUserEffective = vi.fn();
 const invalidatePerProject = vi.fn();
 vi.mock('../src/shared/middleware/rbac.js', () => ({
-  invalidateUserEffectivePermissions: invalidateUserEffective,
   invalidateProjectPermissionCache: invalidatePerProject,
 }));
 
@@ -75,33 +73,58 @@ describe('createGroup', () => {
 });
 
 describe('addMembers', () => {
-  it('invalidates effective-permission cache for every added user', async () => {
-    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1' });
+  it('invalidates (userId × groupProjectIds) pairs — exact, kills legacy cache too', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({
+      id: 'g1',
+      projectRoles: [{ projectId: 'p1' }, { projectId: 'p2' }],
+    });
     mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }, { id: 'u2' }]);
     mockPrisma.userGroupMember.createMany.mockResolvedValue({ count: 2 });
 
     const result = await service.addMembers('g1', ['u1', 'u2'], 'actor');
+
     expect(result.added).toBe(2);
-    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
-    expect(invalidateUserEffective).toHaveBeenCalledWith('u2');
+    // 2 users × 2 projects = 4 exact pair invalidations
+    expect(invalidatePerProject).toHaveBeenCalledTimes(4);
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u1');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p2', 'u1');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u2');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p2', 'u2');
+  });
+
+  it('skips invalidation when the group has no project bindings', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1', projectRoles: [] });
+    mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }]);
+    mockPrisma.userGroupMember.createMany.mockResolvedValue({ count: 1 });
+
+    await service.addMembers('g1', ['u1'], 'actor');
+    expect(invalidatePerProject).not.toHaveBeenCalled();
   });
 
   it('rejects when some user ids do not exist', async () => {
-    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1' });
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1', projectRoles: [] });
     mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }]);
     await expect(service.addMembers('g1', ['u1', 'missing'], 'actor')).rejects.toMatchObject({
       statusCode: 400,
     });
-    expect(invalidateUserEffective).not.toHaveBeenCalled();
+    expect(invalidatePerProject).not.toHaveBeenCalled();
   });
 });
 
 describe('removeMember', () => {
-  it('invalidates effective-permission cache for the removed user', async () => {
+  it('invalidates every (removedUser × projectId) pair for the group', async () => {
     mockPrisma.userGroupMember.findUnique.mockResolvedValue({ groupId: 'g1' });
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { projectId: 'p1' },
+      { projectId: 'p2' },
+    ]);
     mockPrisma.userGroupMember.delete.mockResolvedValue({});
+
     await service.removeMember('g1', 'u1');
-    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
+
+    expect(invalidatePerProject).toHaveBeenCalledTimes(2);
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u1');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p2', 'u1');
   });
 
   it('returns 404 when the user is not a member', async () => {
@@ -151,7 +174,7 @@ describe('grantProjectRole', () => {
 });
 
 describe('deleteGroup', () => {
-  it('returns affected user×project pairs and invalidates each distinct user', async () => {
+  it('returns affected user×project pairs and invalidates each pair (kills legacy cache too)', async () => {
     mockPrisma.userGroup.findUnique.mockResolvedValue({
       id: 'g1', name: 'Team',
       members: [{ userId: 'u1' }, { userId: 'u2' }],
@@ -165,8 +188,8 @@ describe('deleteGroup', () => {
     const result = await service.deleteGroup('g1');
 
     expect(result.affectedPairs).toHaveLength(4); // 2 users × 2 projects
-    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
-    expect(invalidateUserEffective).toHaveBeenCalledWith('u2');
-    expect(invalidateUserEffective).toHaveBeenCalledTimes(2); // dedup by user
+    expect(invalidatePerProject).toHaveBeenCalledTimes(4);
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u1');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p2', 'u2');
   });
 });

--- a/docs/tz/INDEX.md
+++ b/docs/tz/INDEX.md
@@ -7,3 +7,4 @@
 | [TTADM-68](./TTADM-68.md) | [Workflow Editor] null в conditions/validators/postFunctions не проходит Zod | 2026-04-07 | DONE (не закрыта на проде) | ~1.5ч |
 | [TTMP-171](./TTMP-171.md) | Сессия пользователя (sliding session + настройка в Системе) | 2026-04-07 | IN_PROGRESS | 9ч |
 | [TTMP-223](./TTMP-223.md) | [Release Mgmt] Исправление несоответствий реализации спеке | 2026-04-12 | OPEN | 8.5ч |
+| [TTSEC-2](./TTSEC-2.md) | Группы пользователей, «Безопасность» в профиле и гранулярность permission-матрицы | 2026-04-17 | OPEN | 75ч |

--- a/docs/tz/TTSEC-2.json
+++ b/docs/tz/TTSEC-2.json
@@ -1,0 +1,247 @@
+{
+  "key": "TTSEC-2",
+  "title": "Группы пользователей, раздел «Безопасность» в профиле и гранулярность permission-матрицы",
+  "generatedAt": "2026-04-17T12:00:00.000Z",
+  "generatedBy": "claude-code",
+  "source": {
+    "apiUrl": "local",
+    "issueId": null,
+    "fetchedAt": "2026-04-17T12:00:00.000Z"
+  },
+  "issue": {
+    "type": "EPIC",
+    "status": "OPEN",
+    "priority": "HIGH",
+    "project": "TTSEC+TTMP",
+    "assignee": null,
+    "creator": "Claude Code",
+    "estimatedHours": 75,
+    "description": "Сводное ТЗ: (A) UserGroup как уровень абстракции между юзером и проектной ролью + вкладка «Безопасность» в профиле + миграция UserProjectRole → Legacy-группы; (B) гранулярность permission-matrix: SPRINTS/RELEASES_CREATE|EDIT|DELETE вместо *_MANAGE; COMMENTS_DELETE_OTHERS + TIME_LOGS_DELETE_OTHERS. Единая миграция во избежание двух проходов и рассинхрона.",
+    "acceptanceCriteria": "Группы CRUD; эффективная роль детерминированно; миграция сохраняет все права; профиль показывает группы и роли с источником; granular CRUD работает через middleware; DELETE_OTHERS — OR-проверка; performance регресс ≤ 10%; audit."
+  },
+  "dependencies": {
+    "backendModules": [
+      "user-groups (новый)",
+      "users",
+      "projects",
+      "project-role-schemes",
+      "sprints",
+      "releases",
+      "comments",
+      "time",
+      "shared/auth/rbac",
+      "prisma (migration)"
+    ],
+    "frontendComponents": [
+      "pages/admin/AdminGroupsPage.tsx (новый)",
+      "pages/admin/AdminGroupDetailPage.tsx (новый)",
+      "components/admin/GroupMembersTable.tsx (новый)",
+      "components/admin/GroupProjectRolesTable.tsx (новый)",
+      "components/admin/PermissionMatrixDrawer.tsx (правка — новые колонки)",
+      "components/profile/SecurityTab.tsx (новый)",
+      "pages/ProfilePage.tsx (tabs + Security)",
+      "components/layout/Sidebar.tsx (пункт Группы)",
+      "api/user-groups.ts (новый)",
+      "api/user-security.ts (новый)"
+    ],
+    "prismaModels": [
+      "UserGroup (новая)",
+      "UserGroupMember (новая)",
+      "ProjectGroupRole (новая)",
+      "UserProjectRole (+source enum)",
+      "RoleAssignmentSource enum (новый)",
+      "ProjectPermission enum (+8 новых values)"
+    ],
+    "externalPackages": [],
+    "blockers": [
+      "TTMP-159 — project role schemes"
+    ]
+  },
+  "risks": [
+    {
+      "id": 1,
+      "description": "Миграция UserProjectRole → Legacy-группы теряет права",
+      "probability": "MEDIUM",
+      "impact": "Потеря доступов",
+      "mitigation": "Dry-run с diff-отчётом; rollback SQL; staging; pre/post snapshot"
+    },
+    {
+      "id": 2,
+      "description": "Эффективные роли через группы — регресс latency",
+      "probability": "HIGH",
+      "impact": "Медленный UI",
+      "mitigation": "Материализованная effective_project_roles + Redis cache; бенчмарк"
+    },
+    {
+      "id": 3,
+      "description": "Конфликт ролей в 2+ группах",
+      "probability": "HIGH",
+      "impact": "Неожиданные права",
+      "mitigation": "Priority: max permissions count; tiebreaker roleId asc"
+    },
+    {
+      "id": 4,
+      "description": "Удаление большой группы каскадит права",
+      "probability": "MEDIUM",
+      "impact": "Потеря доступов",
+      "mitigation": "confirm=true + список затронутых"
+    },
+    {
+      "id": 5,
+      "description": "DIRECT UserProjectRole остаются — shadow permissions",
+      "probability": "MEDIUM",
+      "impact": "Security issue",
+      "mitigation": "Feature-flag DIRECT_ROLES_DISABLED"
+    },
+    {
+      "id": 6,
+      "description": "ALTER TYPE ADD VALUE внутри транзакции",
+      "probability": "HIGH",
+      "impact": "Миграция не накатится",
+      "mitigation": "-- no transaction как первой строкой; staging"
+    },
+    {
+      "id": 7,
+      "description": "SPRINTS_MANAGE/RELEASES_MANAGE остаются в БД как мёртвый код",
+      "probability": "MEDIUM",
+      "impact": "Тех-долг",
+      "mitigation": "Плановая очистка отдельным релизом"
+    },
+    {
+      "id": 8,
+      "description": "Custom-схемы клиентов — backfill раздаст права",
+      "probability": "MEDIUM",
+      "impact": "Ожидаемое расширение",
+      "mitigation": "Проверить список custom-схем после миграции"
+    },
+    {
+      "id": 9,
+      "description": "COMMENTS_MANAGE overlap с DELETE_OTHERS",
+      "probability": "LOW",
+      "impact": "Регрессия",
+      "mitigation": "OR-helper assertProjectPermission + integration-тест"
+    },
+    {
+      "id": 10,
+      "description": "Массовые audit-записи при изменении членства",
+      "probability": "LOW",
+      "impact": "Шум в логах",
+      "mitigation": "Batch-событие user_group.members_changed с diff"
+    },
+    {
+      "id": 11,
+      "description": "Порядок миграции: Legacy-группы до backfill → получают старые *_MANAGE",
+      "probability": "HIGH",
+      "impact": "Двойная работа",
+      "mitigation": "Строгий порядок SQL: backfill permissions сначала, группы потом"
+    }
+  ],
+  "requirements": {
+    "functional": [
+      "FR-A1: CRUD групп через /admin/user-groups",
+      "FR-A2: Batch add/remove участников",
+      "FR-A3: Выдача/отзыв проектной роли группе",
+      "FR-A4: Эффективная роль = max permissions(direct + group)",
+      "FR-A5: Кэш эффективных ролей инвалидируется при изменениях",
+      "FR-A6: Вкладка Безопасность в профиле с группами и ролями + источник",
+      "FR-A7: Миграция UserProjectRole → Legacy-группы без потери прав",
+      "FR-A8: Feature-flag DIRECT_ROLES_DISABLED",
+      "FR-A9: DELETE группы требует confirm=true + список затронутых",
+      "FR-B1: Матрица SPRINTS_CREATE/EDIT/DELETE вместо SPRINTS_MANAGE",
+      "FR-B2: Матрица RELEASES_CREATE/EDIT/DELETE вместо RELEASES_MANAGE",
+      "FR-B3: COMMENTS_DELETE_OTHERS рядом с COMMENTS_MANAGE",
+      "FR-B4: TIME_LOGS_DELETE_OTHERS рядом с TIME_LOGS_MANAGE",
+      "FR-B5: Endpoints sprints/releases используют гранулярные permissions",
+      "FR-B6: DELETE comment/time log: author OR *_DELETE_OTHERS OR *_MANAGE",
+      "FR-B7: Backfill сохраняет эффективный уровень доступа",
+      "FR-C1: Diff-тест: права до и после миграции идентичны",
+      "FR-C2: USER_GROUP_VIEW / USER_GROUP_MANAGE — system-level permissions",
+      "FR-C3: Audit по всем изменениям групп/bindings/миграции"
+    ],
+    "nonFunctional": [
+      "NFR-1: GET /issues p95 регресс ≤ 10%",
+      "NFR-2: Миграция 100 юзеров × 20 проектов × 5 ролей ≤ 60 сек",
+      "NFR-3: GET /users/me/security ≤ 300ms p95",
+      "NFR-4: UI списка групп виртуализирован на 500+"
+    ],
+    "security": [
+      "SEC-1: USER_GROUP_MANAGE для CRUD групп и bindings",
+      "SEC-2: Юзер без USER_GROUP_VIEW — только свои группы",
+      "SEC-3: Миграция идемпотентна",
+      "SEC-4: Каскад delete user→Member; project→ProjectGroupRole; RoleDefinition→Restrict",
+      "SEC-5: Все мутации в AuditLog с actorId",
+      "SEC-6: /admin/users/:id/security — только USER_GROUP_VIEW",
+      "SEC-7: COMMENTS_MANAGE overlap — OR-проверка не ломает права"
+    ]
+  },
+  "acceptanceCriteria": [
+    "Миграция на staging: отчёт = реальности",
+    "Diff-тест effective permissions до/после идентичен",
+    "Админ создаёт группу + 3 юзера + Developer → permissions у всех 3",
+    "Удаление юзера из группы → права пропадают ≤ 5 сек",
+    "DELETE группы с confirm → права снимаются, audit записан",
+    "Профиль Безопасность показывает группы + роли + source",
+    "Конфликт ролей → max permissions, детерминированно",
+    "DIRECT_ROLES_DISABLED=true → POST прямых возвращает 403",
+    "USER с SPRINTS_CREATE без SPRINTS_DELETE — может создать, но не удалить",
+    "MANAGER с COMMENTS_DELETE_OTHERS без COMMENTS_MANAGE — удаляет чужие, не открывает настройки",
+    "DELETE comment автором — 200; не автором без perms — 403; с DELETE_OTHERS — 200",
+    "PermissionMatrixDrawer показывает новые колонки",
+    "Performance регресс ≤ 10% на GET /issues",
+    "E2E полный сценарий зелёный",
+    "Lint / typecheck / unit / integration зелёные",
+    "Rollback-SQL проверен на staging",
+    "docs/user-manual/features/access-schemes.md обновлён"
+  ],
+  "estimation": {
+    "analysis": 3,
+    "backend": 37,
+    "frontend": 17,
+    "testing": 10,
+    "review": 3,
+    "docs_qa": 2,
+    "performance": 3,
+    "total": 75
+  },
+  "relatedIssues": {
+    "parent": "TTMP-159",
+    "children": [
+      "TTSEC-3: Prisma schema UserGroup/Member/ProjectGroupRole + source enum + расширение ProjectPermission",
+      "TTSEC-4: Prisma migration SQL (ALTER TYPE + backfill granular + Legacy-группы)",
+      "TTSEC-5: Seed + DEFAULT_ROLE_MATRIX с новыми permissions",
+      "TTSEC-6: Backend модуль user-groups (CRUD + members + bindings)",
+      "TTSEC-7: Backend эффективные роли + кэш + assertProjectPermission helper",
+      "TTSEC-8: Backend /users/me/security + /admin/users/:id/security",
+      "TTSEC-9: Backend middleware: sprints/releases granular + comments/time DELETE_OTHERS",
+      "TTSEC-10: Backend audit-события",
+      "TTSEC-11: FE AdminGroupsPage + AdminGroupDetailPage + api",
+      "TTSEC-12: FE PermissionMatrixDrawer новые колонки",
+      "TTSEC-13: FE ProfilePage Безопасность + SecurityTab",
+      "TTSEC-14: FE Sidebar Группы",
+      "TTSEC-15: Тесты unit + integration + e2e",
+      "TTSEC-16: Performance benchmark",
+      "TTSEC-17: Docs access-schemes.md + manual QA staging",
+      "TTSEC-18: Feature-flag DIRECT_ROLES_DISABLED + prod cutover"
+    ],
+    "blocks": [],
+    "dependsOn": ["TTMP-159"]
+  },
+  "implementationOrder": [
+    "TTSEC-3",
+    "TTSEC-4",
+    "TTSEC-5",
+    "TTSEC-6",
+    "TTSEC-7",
+    "TTSEC-8",
+    "TTSEC-9",
+    "TTSEC-10",
+    "TTSEC-11",
+    "TTSEC-12",
+    "TTSEC-13",
+    "TTSEC-14",
+    "TTSEC-15",
+    "TTSEC-16",
+    "TTSEC-17",
+    "TTSEC-18"
+  ]
+}

--- a/docs/tz/TTSEC-2.md
+++ b/docs/tz/TTSEC-2.md
@@ -1,0 +1,752 @@
+# ТЗ: TTSEC-2 — Группы пользователей, раздел «Безопасность» в профиле и гранулярность permission-матрицы
+
+**Дата:** 2026-04-17
+**Тип:** EPIC | **Приоритет:** HIGH | **Статус:** OPEN
+**Проект:** TaskTime MVP / RBAC (TTSEC + TTMP)
+**Родительская задача:** [TTMP-159](./TTMP-159.md) — Схемы доступа
+**Автор ТЗ:** Claude Code
+
+---
+
+## 1. Постановка задачи
+
+Одно сводное ТЗ объединяет две смежные доработки RBAC, чтобы избежать двух миграций подряд и рассинхрона permission-matrix:
+
+**Направление A — «Группы пользователей»:** ввести `UserGroup` как уровень абстракции между юзером и проектной ролью. Эффективная роль = объединение прямых + групповых. Вкладка «Безопасность» в профиле. Миграция существующих `UserProjectRole` в Legacy-группы.
+
+**Направление B — «Гранулярность permission-матрицы»:** разбить `SPRINTS_MANAGE` / `RELEASES_MANAGE` на `CREATE / EDIT / DELETE`; добавить `COMMENTS_DELETE_OTHERS` и `TIME_LOGS_DELETE_OTHERS` для модерации чужих записей.
+
+Направления объединены потому, что:
+1. Обе задачи правят Prisma schema и миграционный путь вокруг RBAC — одна координированная миграция избавляет от конфликтов.
+2. Backfill permissions (B) должен отработать **до** создания Legacy-групп (A), иначе Legacy-группы получат старые `*_MANAGE`, и потом придётся раздавать гранулярные двум раз — сначала ролям, потом группам.
+3. `AuditLog` / `ProjectRoleDefinition` задеваются обоими направлениями.
+
+### Пользовательские сценарии
+
+**HR-менеджер** создаёт группу `Frontend Team`, добавляет 12 пользователей, выдаёт группе роль `Developer` в 5 проектах — все 12 разом получают права. При увольнении — убирает из группы, доступы снимаются в одном месте.
+
+**Администратор** в `PermissionMatrixDrawer` ставит роли `USER` флажок `SPRINTS_CREATE` без `SPRINTS_DELETE` — пользователь может создавать, но не удалять спринты. Для комментариев даёт `MANAGER`-у `COMMENTS_DELETE_OTHERS` без `COMMENTS_MANAGE` — может удалять чужие, но не менять настройки модуля.
+
+**Пользователь** в своём профиле в разделе «Безопасность» видит: список групп и таблицу `Проект → Роль → Источник (группа / прямое)`.
+
+---
+
+## 2. Зафиксированные решения (approved by owner, 2026-04-17)
+
+### Гранулярность (направление B)
+
+| # | Сущность | Подход | Основание |
+|---|----------|--------|-----------|
+| 1 | **Спринты** | Разделить `SPRINTS_MANAGE` на `SPRINTS_CREATE` + `SPRINTS_EDIT` + `SPRINTS_DELETE`. `*_MANAGE` удаляется из матрицы UI, но остаётся в enum как deprecated (PostgreSQL не поддерживает `DROP VALUE`). | Симметрия с `ISSUES_*` CRUD |
+| 2 | **Релизы** | Аналогично спринтам | По аналогии |
+| 3 | **Комментарии** | Оставить `COMMENTS_MANAGE` + добавить `COMMENTS_DELETE_OTHERS`. Автор всегда может удалить/редактировать свой комментарий без отдельного permission | Модель: запись пользователя, owner имеет полный контроль; модерация чужих — отдельное право |
+| 4 | **Время** | Та же схема, что для комментариев: `TIME_LOGS_MANAGE` + `TIME_LOGS_DELETE_OTHERS` | Symmetry с comments |
+
+**Новых permissions (8):** `SPRINTS_CREATE`, `SPRINTS_EDIT`, `SPRINTS_DELETE`, `RELEASES_CREATE`, `RELEASES_EDIT`, `RELEASES_DELETE`, `COMMENTS_DELETE_OTHERS`, `TIME_LOGS_DELETE_OTHERS`.
+
+**Backfill:** если у роли был granted `SPRINTS_MANAGE` — раздать `SPRINTS_CREATE + EDIT + DELETE`; для `RELEASES_MANAGE` — аналогично; `COMMENTS_MANAGE` → `+ COMMENTS_DELETE_OTHERS`; `TIME_LOGS_MANAGE` → `+ TIME_LOGS_DELETE_OTHERS`. Эффективный уровень доступа сохраняется.
+
+### Группы (направление A)
+
+- Группы — плоские (без вложенности).
+- Права юзера в проекте = direct `UserProjectRole` ∪ roles-from-groups. При конфликте — роль с максимальным числом permissions (детерминированный tiebreaker по `roleId`).
+- Миграция: для каждой уникальной `(projectId, roleId)` в `UserProjectRole` создаётся `UserGroup` с именем `Legacy: {project.key} — {role.name}`; юзеры переносятся в соответствующие Legacy-группы.
+- Поле `UserProjectRole.source: RoleAssignmentSource { DIRECT, GROUP }`. Feature-flag `DIRECT_ROLES_DISABLED=true` после миграции блокирует создание `DIRECT`-assignments через API.
+
+---
+
+## 3. Текущее состояние
+
+### Модель
+| Модель | Состояние | Проблема |
+|--------|-----------|----------|
+| `UserProjectRole` | [schema.prisma:84](../../backend/src/prisma/schema.prisma#L84) | Прямая связь user ↔ project ↔ role; unique `(userId, projectId)`; нет `source` |
+| `ProjectRoleDefinition` | Создана в TTMP-159 | — |
+| `ProjectRoleScheme` | Создана в TTMP-159 | — |
+| `ProjectPermission` enum | Содержит `SPRINTS_MANAGE`, `RELEASES_MANAGE`, `COMMENTS_MANAGE`, `TIME_LOGS_MANAGE` | Слишком крупно-гранулярно |
+| **Нет** `UserGroup` / `UserGroupMember` / `ProjectGroupRole` | — | Ключевой gap |
+
+### Backend
+| Файл | Проблема |
+|------|----------|
+| [backend/src/shared/auth/rbac.ts](../../backend/src/shared/auth/) | Считает права только через `UserProjectRole` direct; `requireProjectPermission` — по одному permission, не по OR-списку |
+| `modules/user-groups/` | Не существует |
+| [sprints.router.ts](../../backend/src/modules/sprints/sprints.router.ts) / [releases.router.ts](../../backend/src/modules/releases/releases.router.ts) | `requireProjectPermission(..., 'SPRINTS_MANAGE')` / `'RELEASES_MANAGE'` на всех мутациях (CRUD-middleware не гранулярно) |
+| [comments.router.ts](../../backend/src/modules/comments/comments.router.ts) / [time.router.ts](../../backend/src/modules/time/time.router.ts) | `DELETE` разрешает только автору или `*_MANAGE`, нет промежуточного `DELETE_OTHERS` |
+
+### Frontend
+| Страница | Состояние |
+|----------|-----------|
+| [AdminRolesPage](../../frontend/src/pages/admin/AdminRolesPage.tsx) | Прямое назначение roleId на (user, project) |
+| [PermissionMatrixDrawer](../../frontend/src/components/admin/PermissionMatrixDrawer.tsx) | Неодинаковая гранулярность: задачи — 7 operations, спринты/релизы — 2, комментарии/время — 3 |
+| [ProfilePage](../../frontend/src/pages/ProfilePage.tsx) | Нет раздела «Безопасность» |
+| `AdminGroupsPage` / `AdminGroupDetailPage` | Не существуют |
+| [Sidebar](../../frontend/src/components/layout/Sidebar.tsx) | Нет пункта «Группы» |
+
+---
+
+## 4. Зависимости
+
+### Prisma (единая миграция)
+- [x] Модели `UserGroup`, `UserGroupMember`, `ProjectGroupRole`
+- [x] `UserProjectRole.source: RoleAssignmentSource` enum
+- [x] Расширение `ProjectPermission` enum: 8 новых значений (направление B)
+- [x] Миграция данных: backfill permissions → создание Legacy-групп (порядок важен, §5.4)
+
+### Backend
+- [x] Новый модуль `modules/user-groups/`: `service.ts`, `router.ts`, `dto.ts`
+- [x] `shared/auth/rbac.ts` — эффективные права с учётом групп + кэш
+- [x] `shared/auth/rbac.ts` — helper `assertProjectPermission(user, projectId, permissions: ProjectPermission[])` (OR-список)
+- [x] `users.service.ts` — `getUserSecurity(userId)`
+- [x] `sprints.router.ts`, `releases.router.ts` — заменить `*_MANAGE` на гранулярные permissions
+- [x] `comments.router.ts`, `time.router.ts` — `DELETE` с проверкой author OR `*_DELETE_OTHERS` OR `*_MANAGE`
+- [x] Инвалидация кэша прав при изменениях членства групп / bindings
+- [x] Новые audit-события (§5.11)
+
+### Frontend
+- [x] `pages/admin/AdminGroupsPage.tsx` — CRUD списка групп
+- [x] `pages/admin/AdminGroupDetailPage.tsx` — tabs `Members` / `Project Roles`
+- [x] `components/admin/GroupMembersTable.tsx` — новый
+- [x] `components/admin/GroupProjectRolesTable.tsx` — новый
+- [x] `pages/ProfilePage.tsx` — `Tabs` + вкладка «Безопасность»
+- [x] `components/profile/SecurityTab.tsx` — новый
+- [x] `components/admin/PermissionMatrixDrawer.tsx` — новые колонки для сущностей B
+- [x] `components/layout/Sidebar.tsx` — пункт «Группы»
+- [x] `api/user-groups.ts`, `api/user-security.ts` — новые
+
+### Внешние зависимости
+- Нет новых
+
+### Блокеры
+- **TTMP-159** (project role schemes) должен быть замержен — группы выдают `roleId` в рамках схем; гранулярные permissions живут в `ProjectRoleDefinition.permissions`
+
+---
+
+## 5. Подробное описание правок
+
+### 5.1. Prisma schema
+
+#### 5.1.1. Расширение `ProjectPermission` enum (направление B)
+
+```prisma
+enum ProjectPermission {
+  // ... existing ...
+
+  SPRINTS_VIEW
+  SPRINTS_CREATE            // NEW
+  SPRINTS_EDIT              // NEW
+  SPRINTS_DELETE            // NEW
+  SPRINTS_MANAGE            // deprecated, остаётся в enum (PG не поддерживает DROP VALUE)
+
+  RELEASES_VIEW
+  RELEASES_CREATE           // NEW
+  RELEASES_EDIT             // NEW
+  RELEASES_DELETE           // NEW
+  RELEASES_MANAGE           // deprecated
+
+  COMMENTS_VIEW
+  COMMENTS_CREATE
+  COMMENTS_DELETE_OTHERS    // NEW
+  COMMENTS_MANAGE           // kept (включает DELETE_OTHERS + настройки модуля)
+
+  TIME_LOGS_VIEW
+  TIME_LOGS_CREATE
+  TIME_LOGS_DELETE_OTHERS   // NEW
+  TIME_LOGS_MANAGE          // kept
+
+  USER_GROUP_VIEW           // NEW — system-level permission
+  USER_GROUP_MANAGE         // NEW — system-level permission
+}
+```
+
+#### 5.1.2. Группы (направление A)
+
+```prisma
+model UserGroup {
+  id          String   @id @default(uuid())
+  name        String   @unique
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  members      UserGroupMember[]
+  projectRoles ProjectGroupRole[]
+
+  @@map("user_groups")
+  @@index([name])
+}
+
+model UserGroupMember {
+  groupId   String
+  userId    String
+  addedAt   DateTime @default(now())
+  addedById String?
+
+  group   UserGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  user    User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  addedBy User?     @relation("GroupMemberAddedBy", fields: [addedById], references: [id])
+
+  @@id([groupId, userId])
+  @@index([userId])
+  @@map("user_group_members")
+}
+
+model ProjectGroupRole {
+  id        String   @id @default(uuid())
+  groupId   String
+  projectId String
+  roleId    String
+  schemeId  String
+  createdAt DateTime @default(now())
+
+  group          UserGroup             @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  project        Project               @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  roleDefinition ProjectRoleDefinition @relation(
+    fields: [roleId, schemeId], references: [id, schemeId], onDelete: Restrict
+  )
+
+  @@unique([groupId, projectId])
+  @@index([projectId])
+  @@index([groupId])
+  @@map("project_group_roles")
+}
+
+enum RoleAssignmentSource { DIRECT  GROUP }
+
+model UserProjectRole {
+  // ... existing fields ...
+  source RoleAssignmentSource @default(DIRECT)
+}
+```
+
+### 5.2. Эффективные права — алгоритм
+
+```ts
+// backend/src/shared/auth/rbac.ts
+
+async function computeEffectiveRole(userId: string, projectId: string) {
+  const direct = await getDirectRole(userId, projectId);   // source=DIRECT
+  const groupRoles = await prisma.projectGroupRole.findMany({
+    where: { projectId, group: { members: { some: { userId } } } },
+    include: { roleDefinition: { include: { permissions: true } } },
+  });
+  const candidates = [direct, ...groupRoles.map(r => r.roleDefinition)].filter(Boolean);
+  if (candidates.length === 0) return null;
+
+  // Priority: max permissions count; tiebreaker — roleId asc (детерминизм)
+  return candidates.sort((a, b) => {
+    const d = b.permissions.length - a.permissions.length;
+    return d !== 0 ? d : a.id.localeCompare(b.id);
+  })[0];
+}
+
+// Новый helper для OR-списка permissions (нужен для author OR *_DELETE_OTHERS OR *_MANAGE)
+async function assertProjectPermission(
+  user: AuthUser,
+  projectId: string,
+  permissions: ProjectPermission[],
+): Promise<void> {
+  const role = await computeEffectiveRole(user.userId, projectId);
+  if (!role) throw new AppError(403, 'No role in project');
+  const granted = new Set(role.permissions.map(p => p.permission));
+  if (!permissions.some(p => granted.has(p))) {
+    throw new AppError(403, `Requires one of: ${permissions.join(', ')}`);
+  }
+}
+```
+
+**Материализованный кэш** `effective_project_roles(userId, projectId, roleId, source)` — пересчитывается триггером на изменения `UserProjectRole`, `UserGroupMember`, `ProjectGroupRole`. Redis-кэш `rbac:perms:{userId}:{projectId}` сбрасывается через `invalidateProjectPermissionCache()`.
+
+### 5.3. Миграция — единый план
+
+Скрипт `backend/src/prisma/migrations/20260421000000_unified_groups_and_granular_perms/migration.sql` — два файла в правильном порядке:
+
+**Файл 1: `migration.sql` (no transaction, ALTER TYPE)**
+```sql
+-- no transaction
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'SPRINTS_CREATE';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'SPRINTS_EDIT';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'SPRINTS_DELETE';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'RELEASES_CREATE';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'RELEASES_EDIT';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'RELEASES_DELETE';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'COMMENTS_DELETE_OTHERS';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'TIME_LOGS_DELETE_OTHERS';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'USER_GROUP_VIEW';
+ALTER TYPE "ProjectPermission" ADD VALUE IF NOT EXISTS 'USER_GROUP_MANAGE';
+```
+
+**Файл 2: `20260421000001_backfill_and_legacy_groups/migration.sql` (транзакция)**
+```sql
+BEGIN;
+
+-- ШАГ 1: backfill гранулярных permissions (направление B)
+INSERT INTO "project_role_permissions" ("id", "role_id", "permission", "granted")
+SELECT gen_random_uuid(), role_id, new_perm, true
+FROM (
+  SELECT DISTINCT role_id FROM "project_role_permissions"
+  WHERE permission = 'SPRINTS_MANAGE' AND granted = true
+) src
+CROSS JOIN (VALUES
+  ('SPRINTS_CREATE'::"ProjectPermission"),
+  ('SPRINTS_EDIT'::"ProjectPermission"),
+  ('SPRINTS_DELETE'::"ProjectPermission")
+) AS new_permissions(new_perm)
+ON CONFLICT ("role_id", "permission") DO NOTHING;
+
+-- RELEASES — аналогично
+INSERT INTO "project_role_permissions" ("id", "role_id", "permission", "granted")
+SELECT gen_random_uuid(), role_id, new_perm, true
+FROM (
+  SELECT DISTINCT role_id FROM "project_role_permissions"
+  WHERE permission = 'RELEASES_MANAGE' AND granted = true
+) src
+CROSS JOIN (VALUES
+  ('RELEASES_CREATE'::"ProjectPermission"),
+  ('RELEASES_EDIT'::"ProjectPermission"),
+  ('RELEASES_DELETE'::"ProjectPermission")
+) AS new_permissions(new_perm)
+ON CONFLICT ("role_id", "permission") DO NOTHING;
+
+-- COMMENTS: MANAGE → + DELETE_OTHERS
+INSERT INTO "project_role_permissions" ("id", "role_id", "permission", "granted")
+SELECT gen_random_uuid(), role_id, 'COMMENTS_DELETE_OTHERS'::"ProjectPermission", true
+FROM "project_role_permissions"
+WHERE permission = 'COMMENTS_MANAGE' AND granted = true
+ON CONFLICT ("role_id", "permission") DO NOTHING;
+
+-- TIME_LOGS: MANAGE → + DELETE_OTHERS
+INSERT INTO "project_role_permissions" ("id", "role_id", "permission", "granted")
+SELECT gen_random_uuid(), role_id, 'TIME_LOGS_DELETE_OTHERS'::"ProjectPermission", true
+FROM "project_role_permissions"
+WHERE permission = 'TIME_LOGS_MANAGE' AND granted = true
+ON CONFLICT ("role_id", "permission") DO NOTHING;
+
+-- ШАГ 2: добавить поле source в UserProjectRole
+ALTER TABLE "user_project_roles"
+  ADD COLUMN "source" "RoleAssignmentSource" NOT NULL DEFAULT 'DIRECT';
+
+-- ШАГ 3: создать таблицы групп (DDL уже сгенерирован Prisma)
+-- CREATE TABLE "user_groups" ...
+-- CREATE TABLE "user_group_members" ...
+-- CREATE TABLE "project_group_roles" ...
+
+-- ШАГ 4: Legacy-группы из существующих UserProjectRole (направление A)
+-- 4.1: для каждой уникальной (projectId, roleId) создать UserGroup
+INSERT INTO "user_groups" (id, name, description)
+SELECT
+  gen_random_uuid(),
+  'Legacy: ' || p.key || ' — ' || rd.name,
+  'Auto-created from direct UserProjectRole migration'
+FROM (
+  SELECT DISTINCT upr.project_id, upr.role_id, upr.scheme_id
+  FROM "user_project_roles" upr
+  WHERE upr.role_id IS NOT NULL
+) distinct_roles
+JOIN "projects" p ON p.id = distinct_roles.project_id
+JOIN "project_role_definitions" rd ON rd.id = distinct_roles.role_id;
+
+-- 4.2: ProjectGroupRole — связать каждую Legacy-группу с (project, role)
+INSERT INTO "project_group_roles" (id, group_id, project_id, role_id, scheme_id)
+SELECT
+  gen_random_uuid(),
+  ug.id,
+  distinct_roles.project_id,
+  distinct_roles.role_id,
+  distinct_roles.scheme_id
+FROM (
+  SELECT DISTINCT upr.project_id, upr.role_id, upr.scheme_id
+  FROM "user_project_roles" upr
+  WHERE upr.role_id IS NOT NULL
+) distinct_roles
+JOIN "projects" p ON p.id = distinct_roles.project_id
+JOIN "project_role_definitions" rd ON rd.id = distinct_roles.role_id
+JOIN "user_groups" ug ON ug.name = 'Legacy: ' || p.key || ' — ' || rd.name;
+
+-- 4.3: UserGroupMember — перенести членство
+INSERT INTO "user_group_members" (group_id, user_id)
+SELECT ug.id, upr.user_id
+FROM "user_project_roles" upr
+JOIN "projects" p ON p.id = upr.project_id
+JOIN "project_role_definitions" rd ON rd.id = upr.role_id
+JOIN "user_groups" ug ON ug.name = 'Legacy: ' || p.key || ' — ' || rd.name
+ON CONFLICT (group_id, user_id) DO NOTHING;
+
+-- ШАГ 5: пересчитать effective_project_roles для всех юзеров (триггер или материализация)
+-- (выполняется отдельным job-ом после миграции либо через pg_notify)
+
+COMMIT;
+```
+
+**Dry-run режим** (`--dry-run` в TS-обвязке): выводит отчёт без записи.
+
+**Rollback-SQL** (`rollback.sql`, отдельный файл):
+- `DROP TABLE` user_groups / user_group_members / project_group_roles
+- `ALTER TABLE user_project_roles DROP COLUMN source`
+- `DELETE FROM project_role_permissions WHERE permission IN ('SPRINTS_CREATE', ...)`
+- (Новые enum values остаются — PG не поддерживает DROP VALUE; безопасно игнорируются.)
+
+### 5.4. Seed и дефолтная матрица
+
+**Файл:** `backend/src/prisma/seed.ts` — `DEFAULT_ROLE_MATRIX`:
+
+| Permission | ADMIN | MANAGER | USER | VIEWER |
+|------------|-------|---------|------|--------|
+| SPRINTS_CREATE | ✓ | ✓ | — | — |
+| SPRINTS_EDIT | ✓ | ✓ | — | — |
+| SPRINTS_DELETE | ✓ | ✓ | — | — |
+| RELEASES_CREATE | ✓ | ✓ | — | — |
+| RELEASES_EDIT | ✓ | ✓ | — | — |
+| RELEASES_DELETE | ✓ | ✓ | — | — |
+| COMMENTS_DELETE_OTHERS | ✓ | ✓ | — | — |
+| TIME_LOGS_DELETE_OTHERS | ✓ | ✓ | — | — |
+| USER_GROUP_VIEW | ✓ | — | — | — |
+| USER_GROUP_MANAGE | ✓ | — | — | — |
+
+Удалить из матрицы `SPRINTS_MANAGE` и `RELEASES_MANAGE` (заменены гранулярными).
+
+### 5.5. Middleware — замена проверок
+
+**`sprints.router.ts`:**
+```ts
+router.post('/',        requireProjectPermission(getProjectId, 'SPRINTS_CREATE'), ...);
+router.patch('/:id',    requireProjectPermission(getProjectId, 'SPRINTS_EDIT'),   ...);
+router.delete('/:id',   requireProjectPermission(getProjectId, 'SPRINTS_DELETE'), ...);
+```
+
+**`releases.router.ts`** — аналогично.
+
+**`comments.router.ts` — `DELETE /api/comments/:id`:**
+```ts
+router.delete('/:id', authenticate, async (req, res, next) => {
+  const comment = await prisma.comment.findUnique({
+    where: { id: req.params.id },
+    select: { authorId: true, issue: { select: { projectId: true } } },
+  });
+  if (!comment) return next(new AppError(404, 'Comment not found'));
+
+  const isAuthor = comment.authorId === req.user.userId;
+  if (!isAuthor) {
+    await assertProjectPermission(req.user, comment.issue.projectId,
+      ['COMMENTS_DELETE_OTHERS', 'COMMENTS_MANAGE']);
+  }
+  // ... delete
+});
+```
+
+**`time.router.ts` — `DELETE /api/time-logs/:id`** — аналогично с `['TIME_LOGS_DELETE_OTHERS', 'TIME_LOGS_MANAGE']`.
+
+### 5.6. Backend API — группы
+
+| Метод | Путь | Permission | Назначение |
+|-------|------|-----------|-----------|
+| `GET` | `/admin/user-groups` | `USER_GROUP_VIEW` | Список + `memberCount`, `projectCount` |
+| `POST` | `/admin/user-groups` | `USER_GROUP_MANAGE` | `{ name, description? }` |
+| `GET` | `/admin/user-groups/:id` | `USER_GROUP_VIEW` | Детали (members + projectRoles) |
+| `PATCH` | `/admin/user-groups/:id` | `USER_GROUP_MANAGE` | Rename / description |
+| `DELETE` | `/admin/user-groups/:id?confirm=true` | `USER_GROUP_MANAGE` | Удалить; возвращает список отозванных прав |
+| `POST` | `/admin/user-groups/:id/members` | `USER_GROUP_MANAGE` | `{ userIds: string[] }` batch |
+| `DELETE` | `/admin/user-groups/:id/members/:userId` | `USER_GROUP_MANAGE` | — |
+| `POST` | `/admin/user-groups/:id/project-roles` | `USER_GROUP_MANAGE` | `{ projectId, roleId }` |
+| `DELETE` | `/admin/user-groups/:id/project-roles/:projectId` | `USER_GROUP_MANAGE` | — |
+| `GET` | `/users/me/security` | (auth) | Мои группы + эффективные роли |
+| `GET` | `/admin/users/:id/security` | `USER_GROUP_VIEW` | Аналогично для любого user |
+
+Формат `GET /users/me/security`:
+```ts
+{
+  groups: [{ id, name, addedAt, memberCount }],
+  projectRoles: [{
+    project: { id, key, name },
+    role: { id, name, permissions: [...] },
+    source: 'GROUP' | 'DIRECT',
+    sourceGroups: [{ id, name }],  // если GROUP
+  }],
+  updatedAt: '2026-04-17T...',
+}
+```
+
+### 5.7. Frontend — админ-страницы
+
+**`AdminGroupsPage`** — таблица `Name / Description / Members / Projects / Created`; `+ New Group` модалка; поиск; клик → `/admin/groups/:id`.
+
+**`AdminGroupDetailPage`** — `Tabs: Members | Project Roles`:
+- Members: user-таблица + `Add users` мульти-select; `✕` на строке.
+- Project Roles: `Project → Role`; `+ Grant role` модалка (роль выбирается в рамках схемы проекта).
+- Header: inline-edit `Name`, `Description`, `Delete group` (confirm со списком затронутых).
+
+**`PermissionMatrixDrawer`** (направление B):
+
+```ts
+// Спринты
+{
+  category: 'Спринты',
+  permissions: [
+    { key: 'SPRINTS_VIEW',   label: 'Просмотр' },
+    { key: 'SPRINTS_CREATE', label: 'Создание' },
+    { key: 'SPRINTS_EDIT',   label: 'Редактирование' },
+    { key: 'SPRINTS_DELETE', label: 'Удаление' },
+  ],
+},
+// Релизы — аналогично
+// Комментарии
+{
+  category: 'Комментарии',
+  permissions: [
+    { key: 'COMMENTS_VIEW',          label: 'Просмотр' },
+    { key: 'COMMENTS_CREATE',        label: 'Создание' },
+    { key: 'COMMENTS_DELETE_OTHERS', label: 'Удаление чужих' },
+    { key: 'COMMENTS_MANAGE',        label: 'Управление' },
+  ],
+},
+// Время — добавить TIME_LOGS_DELETE_OTHERS
+```
+
+Удалить из UI: `SPRINTS_MANAGE`, `RELEASES_MANAGE` (из enum не удаляем, но скрыть из матрицы).
+
+### 5.8. Frontend — профиль «Безопасность»
+
+`ProfilePage` оборачивается в `Tabs: Основное | Безопасность`.
+
+`SecurityTab.tsx`:
+```
+┌─────────────────────────────────────────────┐
+│ Мои группы                                  │
+│ • Frontend Team (42 участника)              │
+│ • On-call rotation (8 участников)           │
+│                                             │
+│ Мои роли в проектах                         │
+│ ┌──────────┬──────────┬──────────────────┐  │
+│ │ Проект   │ Роль     │ Источник         │  │
+│ ├──────────┼──────────┼──────────────────┤  │
+│ │ TTMP     │ Developer│ Frontend Team    │  │
+│ │ TTUI     │ Lead     │ Прямое назначение│  │
+│ └──────────┴──────────┴──────────────────┘  │
+│ [Экспорт в CSV]  Обновлено 2 мин назад      │
+└─────────────────────────────────────────────┘
+```
+
+- Read-only. Клик на роль → tooltip со списком permissions. Клик на группу → popover.
+- Кнопка `Экспорт в CSV`.
+
+### 5.9. Sidebar
+
+В [Sidebar.tsx](../../frontend/src/components/layout/Sidebar.tsx) добавить пункт `Группы` в секцию «Админ» (видимость по `USER_GROUP_VIEW`).
+
+### 5.10. Документация
+
+`docs/user-manual/features/access-schemes.md`:
+- Обновить таблицу permissions (новые гранулярные + `DELETE_OTHERS`).
+- Описать семантику групп, эффективных прав, миграцию Legacy-групп.
+- Пример: как создать группу, выдать ей роль в проекте.
+
+### 5.11. Audit-события
+
+Новые:
+- Groups: `user_group.created`, `user_group.renamed`, `user_group.deleted`, `user_group.members_changed` (diff `{added[], removed[]}`), `project_group_role.granted`, `project_group_role.revoked`
+- Migration: `migration.legacy_groups_created`, `migration.granular_perms_backfilled`, `migration.direct_roles_disabled`
+- Security trail: `user_project_role.effective_changed` (авто-лог при пересчёте кэша)
+
+---
+
+## 6. Требования
+
+### Функциональные — направление A (группы)
+- **FR-A1**: CRUD групп через `/admin/user-groups`.
+- **FR-A2**: Batch add/remove участников.
+- **FR-A3**: Выдача / отзыв проектной роли группе.
+- **FR-A4**: Эффективная роль = max permissions(direct + group); детерминированный tiebreaker.
+- **FR-A5**: Кэш эффективных ролей инвалидируется при изменениях членства / bindings.
+- **FR-A6**: Вкладка «Безопасность» в профиле — группы + эффективные роли с указанием источника.
+- **FR-A7**: Миграция `UserProjectRole` → Legacy-группы без потери прав.
+- **FR-A8**: Feature-flag `DIRECT_ROLES_DISABLED` блокирует прямые assign-ы через API.
+- **FR-A9**: `DELETE` группы требует `confirm=true` + список затронутых.
+
+### Функциональные — направление B (гранулярность)
+- **FR-B1**: Матрица показывает `SPRINTS_CREATE/EDIT/DELETE` вместо `SPRINTS_MANAGE`.
+- **FR-B2**: Матрица показывает `RELEASES_CREATE/EDIT/DELETE` вместо `RELEASES_MANAGE`.
+- **FR-B3**: Матрица показывает `COMMENTS_DELETE_OTHERS` рядом с `COMMENTS_MANAGE`.
+- **FR-B4**: Матрица показывает `TIME_LOGS_DELETE_OTHERS` рядом с `TIME_LOGS_MANAGE`.
+- **FR-B5**: Endpoints `sprints/releases` используют гранулярные permissions на CRUD.
+- **FR-B6**: `DELETE` comment / time log — проверка `author OR *_DELETE_OTHERS OR *_MANAGE`.
+- **FR-B7**: Backfill: роли с `SPRINTS_MANAGE`/`RELEASES_MANAGE` получают `CREATE+EDIT+DELETE`; с `COMMENTS_MANAGE`/`TIME_LOGS_MANAGE` — добавляется `DELETE_OTHERS`.
+
+### Общее
+- **FR-C1**: Эффективный уровень доступа у всех юзеров staging/prod сохраняется после миграции (diff-тест).
+- **FR-C2**: `USER_GROUP_VIEW` / `USER_GROUP_MANAGE` добавлены в permission-матрицу как system-level.
+- **FR-C3**: Audit пишется по всем изменениям групп / bindings / миграции.
+
+### Нефункциональные
+- **NFR-1**: `GET /issues` p95 регресс ≤ 10% после включения групп.
+- **NFR-2**: Миграция 100 юзеров × 20 проектов × 5 ролей ≤ 60 сек.
+- **NFR-3**: `GET /users/me/security` ≤ 300ms p95.
+- **NFR-4**: UI списка групп виртуализирован на 500+ групп.
+
+### Безопасность
+- **SEC-1**: Только `USER_GROUP_MANAGE` — CRUD групп и bindings.
+- **SEC-2**: Юзер без `USER_GROUP_VIEW` видит только свои группы в `/users/me/security`.
+- **SEC-3**: Миграция идемпотентна (повторный запуск не создаёт дубликаты).
+- **SEC-4**: Каскад: delete user → `UserGroupMember`. Delete project → `ProjectGroupRole`. Delete `ProjectRoleDefinition` — `Restrict` при наличии bindings.
+- **SEC-5**: Все мутации в `AuditLog` с `actorId`.
+- **SEC-6**: `/admin/users/:id/security` — только с `USER_GROUP_VIEW`.
+- **SEC-7**: `COMMENTS_MANAGE` overlap с `DELETE_OTHERS` — middleware проверяет OR-список, не ломает ранее работавшие права.
+
+---
+
+## 7. Критерии приёмки
+
+### Направление A (группы)
+- [ ] Миграция на staging: отчёт = реальности.
+- [ ] Diff-тест effective permissions до / после миграции — идентичен для всех юзеров.
+- [ ] Админ создаёт группу + 3 юзера + выдаёт `Developer` в проект → все 3 имеют permissions.
+- [ ] Удаление юзера из группы → permissions пропадают ≤ 5 сек.
+- [ ] Удаление группы (`confirm=true`) → права снимаются, audit записан.
+- [ ] Профиль «Безопасность» показывает группы + эффективные роли + source.
+- [ ] Конфликт ролей (2 группы с разными ролями на один проект) → выбирается роль с max permissions, детерминированно.
+- [ ] `DIRECT_ROLES_DISABLED=true` → `POST /admin/user-project-roles` возвращает 403.
+
+### Направление B (гранулярность)
+- [ ] `SELECT * FROM project_role_permissions WHERE permission LIKE 'SPRINTS_%'` на staging — новые значения присутствуют.
+- [ ] USER с `SPRINTS_CREATE` + без `SPRINTS_DELETE` может создать, но не удалить спринт (manual QA).
+- [ ] MANAGER с `COMMENTS_DELETE_OTHERS` без `COMMENTS_MANAGE` — может удалить чужой комментарий, но не открывает настройки модуля.
+- [ ] `DELETE /api/comments/:id` автором своего — 200; не автором без permissions — 403; с `COMMENTS_DELETE_OTHERS` — 200.
+- [ ] `PermissionMatrixDrawer` показывает новые колонки; сохранение работает.
+- [ ] `docs/user-manual/features/access-schemes.md` обновлён.
+
+### Общее
+- [ ] Performance: `GET /issues` p95 регресс ≤ 10%.
+- [ ] E2E: полный сценарий (создать группу → выдать роль с гранулярными permissions → зайти юзером → проверить CRUD sprint → проверить DELETE чужого comment-а → проверить профиль «Безопасность») зелёный.
+- [ ] Lint / typecheck / unit / integration — зелёные.
+- [ ] Rollback-SQL проверен на staging.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Analysis / согласование permission-matrix + merge-priority | 3 |
+| **Prisma (единая миграция)** | |
+| — Schema: UserGroup/Member/ProjectGroupRole + source enum + расширение ProjectPermission | 4 |
+| — Migration SQL: ALTER TYPE + backfill granular + Legacy-группы + rollback.sql | 7 |
+| — Seed + `DEFAULT_ROLE_MATRIX` | 1 |
+| **Backend** | |
+| — Модуль `user-groups` (CRUD + members + bindings) | 8 |
+| — Эффективные роли + материализованный кэш + Redis invalidation | 8 |
+| — `assertProjectPermission` helper (OR-список) | 1 |
+| — `/users/me/security` + `/admin/users/:id/security` | 3 |
+| — Middleware: sprints CRUD | 1 |
+| — Middleware: releases CRUD | 1 |
+| — Middleware + service: comments DELETE (author OR delete_others OR manage) | 1 |
+| — Middleware + service: time logs DELETE | 1 |
+| — Audit-события | 2 |
+| **Frontend** | |
+| — AdminGroupsPage + AdminGroupDetailPage + api client | 10 |
+| — PermissionMatrixDrawer (новые колонки + убрать *_MANAGE) | 1 |
+| — ProfilePage «Безопасность» + SecurityTab | 5 |
+| — Sidebar «Группы» | 1 |
+| **Тесты** | |
+| — Unit: merge-priority, миграция, backfill | 3 |
+| — Integration: API groups / granular perms / OR-helper | 4 |
+| — E2E: полный сценарий | 3 |
+| **Performance benchmark + фиксы** | 3 |
+| **Docs + QA на staging** | 2 |
+| **Code review + исправления** | 3 |
+| **Итого** | **75** |
+
+Экономия vs сумма отдельных ТЗ (64 + 8.75 = 72.75ч): фактически добавили +2ч на координацию, но сэкономили бы 2× миграционный риск и одну общую QA-сессию, если делать раздельно.
+
+---
+
+## 8.1. Фазы реализации и чек-листы
+
+Эпик разбит на 4 фазы; каждая — отдельный PR. Переход к следующей только после мерджа предыдущей.
+
+### Фаза 1 — Foundations (Prisma + миграция + seed) — **done (2026-04-17)**
+- [x] TTSEC-3: `schema.prisma` — `UserGroup`, `UserGroupMember`, `ProjectGroupRole`, `RoleAssignmentSource` enum, расширение `ProjectPermission` (8 project-level + 2 system-level).
+- [x] TTSEC-4: SQL-миграции — две директории:
+  - `20260421000000_ttsec2_enum_values/migration.sql` — `ALTER TYPE ADD VALUE IF NOT EXISTS` × 10 (без соседних DDL/DML, чтобы Prisma не обернул в транзакцию — риск #6).
+  - `20260421000001_ttsec2_groups_and_backfill/migration.sql` — `RoleAssignmentSource` enum + `source` колонка + три таблицы + FK + backfill гранулярных прав (`SPRINTS_MANAGE` → CREATE/EDIT/DELETE, `RELEASES_MANAGE` → аналогично, `COMMENTS_MANAGE`/`TIME_LOGS_MANAGE` → `+_DELETE_OTHERS`, ADMIN → `USER_GROUP_*`) + создание Legacy-групп по формуле `Legacy: {project.key} — {role.name}`. Порядок: backfill прав **до** Legacy-групп (риск #11).
+  - `20260421000001_ttsec2_groups_and_backfill/rollback.sql` — manual rollback (DROP таблиц, DROP колонки source, DROP enum).
+- [x] TTSEC-5: `seed.ts` → `DEFAULT_ROLE_MATRIX` обновлена. ADMIN: гранулярные + `*_DELETE_OTHERS` + `USER_GROUP_*`; MANAGER: гранулярные + `*_DELETE_OTHERS`; `COMMENTS_MANAGE` / `TIME_LOGS_MANAGE` сохранены для модерации и настроек модуля; `SPRINTS_MANAGE` / `RELEASES_MANAGE` удалены из default-матрицы (enum сохраняет их как deprecated).
+- **DoD:** `npx prisma validate` зелёный ✅, `npx prisma generate` ✅, `npx tsc --noEmit` (backend) ✅. `prisma migrate deploy` на локальной БД не прогнан — Docker/PG локально недоступны; обязательно прогнать на staging CI перед мерджем (см. risk #1).
+
+### Фаза 2 — Backend — pending
+- [ ] TTSEC-6: модуль `modules/user-groups/` (CRUD + members + project-roles bindings).
+- [ ] TTSEC-7: `shared/auth/rbac.ts` — `computeEffectiveRole` с учётом групп, Redis-кэш + инвалидация, `assertProjectPermission(user, projectId, permissions[])`.
+- [ ] TTSEC-8: `/users/me/security` + `/admin/users/:id/security`.
+- [ ] TTSEC-9: middleware — `sprints`/`releases` гранулярные, `comments`/`time` DELETE (author OR `*_DELETE_OTHERS` OR `*_MANAGE`).
+- [ ] TTSEC-10: audit-события (§5.11).
+- **DoD:** все unit + integration тесты зелёные; `GET /issues` p95 регресс ≤ 10% (NFR-1).
+
+### Фаза 3 — Frontend — pending
+- [ ] TTSEC-11: `AdminGroupsPage` + `AdminGroupDetailPage` + `api/user-groups.ts`.
+- [ ] TTSEC-12: `PermissionMatrixDrawer` — новые колонки, убрать `*_MANAGE` для sprints/releases.
+- [ ] TTSEC-13: `ProfilePage` + `SecurityTab` + `api/user-security.ts`.
+- [ ] TTSEC-14: `Sidebar` — пункт «Группы» под `USER_GROUP_VIEW`.
+- **DoD:** `npm run typecheck` + `npm run lint` зелёные; Storybook билдится.
+
+### Фаза 4 — QA + rollout — pending
+- [ ] TTSEC-15: unit + integration + e2e.
+- [ ] TTSEC-16: performance benchmark + фиксы.
+- [ ] TTSEC-17: `docs/user-manual/features/access-schemes.md` + manual QA на staging.
+- [ ] TTSEC-18: feature-flag `DIRECT_ROLES_DISABLED` + prod cutover.
+- **DoD:** все критерии приёмки §7 закрыты; rollback-SQL проверен на staging.
+
+---
+
+## 9. План разбиения на подзадачи
+
+| Ключ | Название | Оценка | Зависит |
+|------|----------|--------|---------|
+| **Фаза 1 — foundations (sequential)** | | | |
+| TTSEC-3 | Prisma schema: UserGroup/Member/ProjectGroupRole + enum source + расширение ProjectPermission | 4ч | TTMP-159 |
+| TTSEC-4 | Prisma migration SQL: ALTER TYPE + backfill granular + Legacy-группы | 7ч | TTSEC-3 |
+| TTSEC-5 | Seed + `DEFAULT_ROLE_MATRIX` с новыми permissions | 1ч | TTSEC-3 |
+| **Фаза 2 — backend (параллельно)** | | | |
+| TTSEC-6 | Backend: модуль `user-groups` (CRUD + members + bindings) | 8ч | TTSEC-3 |
+| TTSEC-7 | Backend: эффективные роли + кэш + инвалидация + `assertProjectPermission` helper | 9ч | TTSEC-3 |
+| TTSEC-8 | Backend: `/users/me/security` + `/admin/users/:id/security` | 3ч | TTSEC-7 |
+| TTSEC-9 | Backend middleware: sprints/releases гранулярные + comments/time DELETE_OTHERS | 4ч | TTSEC-4, TTSEC-7 |
+| TTSEC-10 | Backend audit-события (все новые) | 2ч | TTSEC-6, TTSEC-9 |
+| **Фаза 3 — frontend (параллельно)** | | | |
+| TTSEC-11 | FE: AdminGroupsPage + AdminGroupDetailPage + api | 10ч | TTSEC-6 |
+| TTSEC-12 | FE: PermissionMatrixDrawer (новые колонки) | 1ч | TTSEC-5 |
+| TTSEC-13 | FE: ProfilePage «Безопасность» + SecurityTab | 5ч | TTSEC-8 |
+| TTSEC-14 | FE: Sidebar «Группы» | 1ч | TTSEC-11 |
+| **Фаза 4 — QA + rollout** | | | |
+| TTSEC-15 | Тесты: unit + integration + e2e | 10ч | TTSEC-11..14 |
+| TTSEC-16 | Performance benchmark + фиксы | 3ч | TTSEC-7 |
+| TTSEC-17 | Docs: access-schemes.md + manual QA на staging | 2ч | TTSEC-12 |
+| TTSEC-18 | Feature-flag `DIRECT_ROLES_DISABLED` + enforcement + prod cutover | 1ч | TTSEC-4, TTSEC-15 |
+
+**Критический путь:** TTSEC-3 → TTSEC-4 → TTSEC-7 → TTSEC-8 → TTSEC-13 → TTSEC-15 → TTSEC-18 ≈ 34ч (≈4 рабочих дня).
+
+---
+
+## 10. Риски
+
+| # | Риск | Вер. | Влияние | Митигация |
+|---|------|------|---------|-----------|
+| 1 | Миграция `UserProjectRole` → Legacy-группы теряет права у 100+ юзеров | Средняя | Потеря доступов | Dry-run с diff-отчётом; rollback SQL; обязательный прогон на staging; pre/post snapshot |
+| 2 | Эффективные роли через группы → регресс latency горячих путей | Высокая | Медленный UI | Материализованная таблица `effective_project_roles` + Redis cache; бенчмарк p95 |
+| 3 | Конфликт ролей (2+ групп разные роли на один проект) | Высокая | Неожиданные права | Priority: max permissions count; tiebreaker — `roleId` asc |
+| 4 | Удаление большой группы каскадит права без уведомления | Средняя | Массовая потеря доступа | `confirm=true` + список затронутых |
+| 5 | `DIRECT UserProjectRole` остаются — shadow permissions | Средняя | Security issue | Feature-flag `DIRECT_ROLES_DISABLED` после миграции |
+| 6 | `ALTER TYPE ADD VALUE` внутри транзакции (PostgreSQL) | Высокая | Миграция не накатится | Миграция помечена `-- no transaction` как первой строкой; проверить на staging |
+| 7 | Legacy `SPRINTS_MANAGE`/`RELEASES_MANAGE` остаются в БД как мёртвый код | Средняя | Тех-долг | Плановая очистка в отдельном релизе (drop enum через пересоздание типа) |
+| 8 | Custom-схемы клиентов: backfill раздаст новые права | Средняя | Ожидаемое расширение | Проверить список custom-схем после миграции |
+| 9 | `COMMENTS_MANAGE` overlap с `DELETE_OTHERS` | Низкая | Регрессия | OR-helper `assertProjectPermission(..., [A, B])`; integration-тест |
+| 10 | Массовые audit-записи при изменении членства группы | Низкая | Шум в логах | Batch-событие `user_group.members_changed` с diff |
+| 11 | Порядок миграции: Legacy-группы созданы до backfill → получают старые `*_MANAGE` | Высокая | Двойная работа после | SQL-файлы в строгом порядке: backfill permissions **сначала**, группы **потом** (§5.3) |
+
+---
+
+## 11. Открытые вопросы
+
+1. **Оставить ли прямые `UserProjectRole` после миграции?** Рекомендация: оставить через feature-flag `DIRECT_ROLES_DISABLED`, по умолчанию выключить. Позволяет экстренно дать роль в обход группы.
+2. **Merge-priority** — count permissions vs явное `weight`. Рекомендация: count, weight добавить при реальных жалобах.
+3. **Вложенные группы** — не в MVP.
+4. **Уведомление юзеру** при получении/потере доступа — не в MVP.
+5. **Наименование Legacy-групп:** префикс `Legacy:` — легко фильтровать/удалить после cleanup.
+6. **`SPRINTS_MANAGE` / `RELEASES_MANAGE` deprecation cleanup** — отдельный релиз; drop enum через пересоздание типа (если потребуется).

--- a/docs/tz/TTSEC-2.md
+++ b/docs/tz/TTSEC-2.md
@@ -671,13 +671,13 @@ router.delete('/:id', authenticate, async (req, res, next) => {
 - [x] TTSEC-5: `seed.ts` → `DEFAULT_ROLE_MATRIX` обновлена. ADMIN: гранулярные + `*_DELETE_OTHERS` + `USER_GROUP_*`; MANAGER: гранулярные + `*_DELETE_OTHERS`; `COMMENTS_MANAGE` / `TIME_LOGS_MANAGE` сохранены для модерации и настроек модуля; `SPRINTS_MANAGE` / `RELEASES_MANAGE` удалены из default-матрицы (enum сохраняет их как deprecated).
 - **DoD:** `npx prisma validate` зелёный ✅, `npx prisma generate` ✅, `npx tsc --noEmit` (backend) ✅. `prisma migrate deploy` на локальной БД не прогнан — Docker/PG локально недоступны; обязательно прогнать на staging CI перед мерджем (см. risk #1).
 
-### Фаза 2 — Backend — pending
-- [ ] TTSEC-6: модуль `modules/user-groups/` (CRUD + members + project-roles bindings).
-- [ ] TTSEC-7: `shared/auth/rbac.ts` — `computeEffectiveRole` с учётом групп, Redis-кэш + инвалидация, `assertProjectPermission(user, projectId, permissions[])`.
-- [ ] TTSEC-8: `/users/me/security` + `/admin/users/:id/security`.
-- [ ] TTSEC-9: middleware — `sprints`/`releases` гранулярные, `comments`/`time` DELETE (author OR `*_DELETE_OTHERS` OR `*_MANAGE`).
-- [ ] TTSEC-10: audit-события (§5.11).
-- **DoD:** все unit + integration тесты зелёные; `GET /issues` p95 регресс ≤ 10% (NFR-1).
+### Фаза 2 — Backend — **done (2026-04-17)**
+- [x] TTSEC-6: модуль `modules/user-groups/` (CRUD + members + project-roles bindings). 4 audit-события. DELETE требует `?confirm=true` + impact (FR-A9).
+- [x] TTSEC-7: `shared/middleware/rbac.ts` — `computeEffectiveRole` с учётом групп (max permissions, roleId tiebreaker), fallback на legacy-key если roleId stale/NULL, Redis-кэш `rbac:effective:{userId}:{projectId}` TTL 60s, `assertProjectPermission(user, projectId, permissions[])` OR-helper, `invalidateUserEffectivePermissions` / `invalidateProjectEffectivePermissions`.
+- [x] TTSEC-8: `modules/user-security/` — `GET /users/me/security` + `GET /admin/users/:id/security` (роли с источником, группы, обновлено).
+- [x] TTSEC-9: гранулярные permissions на всех CRUD/edit спринтов (SPRINTS_CREATE/EDIT) и релизов (RELEASES_CREATE/EDIT/DELETE, INTEGRATION-релизы — requireRole fallback); `DELETE /comments/:id` = author OR `COMMENTS_DELETE_OTHERS` OR `COMMENTS_MANAGE`; новый `DELETE /time-logs/:id` с той же схемой для time logs.
+- [x] TTSEC-10: audit — `user_group.{created,renamed,updated,deleted,members_changed}`, `project_group_role.{granted,revoked}`, `comment.{updated,deleted}`, `time_log.deleted`.
+- **DoD:** `npx tsc --noEmit` зелёный ✅. 24 unit-теста (rbac-effective + user-groups) ✅. Integration-тесты + perf-benchmark — в Phase 4 (требуют живой БД/Redis на CI).
 
 ### Фаза 3 — Frontend — pending
 - [ ] TTSEC-11: `AdminGroupsPage` + `AdminGroupDetailPage` + `api/user-groups.ts`.

--- a/docs/tz/TTSEC-2.md
+++ b/docs/tz/TTSEC-2.md
@@ -679,12 +679,12 @@ router.delete('/:id', authenticate, async (req, res, next) => {
 - [x] TTSEC-10: audit — `user_group.{created,renamed,updated,deleted,members_changed}`, `project_group_role.{granted,revoked}`, `comment.{updated,deleted}`, `time_log.deleted`.
 - **DoD:** `npx tsc --noEmit` зелёный ✅. 24 unit-теста (rbac-effective + user-groups) ✅. Integration-тесты + perf-benchmark — в Phase 4 (требуют живой БД/Redis на CI).
 
-### Фаза 3 — Frontend — pending
-- [ ] TTSEC-11: `AdminGroupsPage` + `AdminGroupDetailPage` + `api/user-groups.ts`.
-- [ ] TTSEC-12: `PermissionMatrixDrawer` — новые колонки, убрать `*_MANAGE` для sprints/releases.
-- [ ] TTSEC-13: `ProfilePage` + `SecurityTab` + `api/user-security.ts`.
-- [ ] TTSEC-14: `Sidebar` — пункт «Группы» под `USER_GROUP_VIEW`.
-- **DoD:** `npm run typecheck` + `npm run lint` зелёные; Storybook билдится.
+### Фаза 3 — Frontend — **done (2026-04-17)**
+- [x] TTSEC-11: `api/user-groups.ts` + `AdminGroupsPage` (список + CRUD + delete-with-impact модалка) + `AdminGroupDetailPage` (табы Участники / Проектные роли, добавление/удаление, grant/revoke с фильтрацией ролей по активной схеме проекта).
+- [x] TTSEC-12: `PermissionMatrixDrawer` — гранулярные колонки для спринтов и релизов (CREATE/EDIT/DELETE), `*_DELETE_OTHERS` для комментариев и времени, новая категория «Группы пользователей» (`USER_GROUP_VIEW`/`USER_GROUP_MANAGE`); старые `SPRINTS_MANAGE`/`RELEASES_MANAGE` убраны из UI.
+- [x] TTSEC-13: `api/user-security.ts` + `components/profile/SecurityTab.tsx` (группы, таблица проект/роль/источник с tooltip на permissions, CSV-экспорт); встроено в `SettingsPage` как карточку «Безопасность».
+- [x] TTSEC-14: `Sidebar` — пункт «Группы» в секции «Пользователи» (под тем же admin-guard, что и остальные); `/admin/user-groups` + `/admin/user-groups/:id` в `App.tsx`.
+- **DoD:** `npx tsc --noEmit` ✅, `npx eslint` ✅ для новых и изменённых файлов. Storybook не трогал — новые компоненты без stories (не требуется по спецификации; Phase 4 добавит при необходимости).
 
 ### Фаза 4 — QA + rollout — pending
 - [ ] TTSEC-15: unit + integration + e2e.

--- a/docs/tz/TTSEC-2.md
+++ b/docs/tz/TTSEC-2.md
@@ -686,12 +686,28 @@ router.delete('/:id', authenticate, async (req, res, next) => {
 - [x] TTSEC-14: `Sidebar` — пункт «Группы» в секции «Пользователи» (под тем же admin-guard, что и остальные); `/admin/user-groups` + `/admin/user-groups/:id` в `App.tsx`.
 - **DoD:** `npx tsc --noEmit` ✅, `npx eslint` ✅ для новых и изменённых файлов. Storybook не трогал — новые компоненты без stories (не требуется по спецификации; Phase 4 добавит при необходимости).
 
-### Фаза 4 — QA + rollout — pending
-- [ ] TTSEC-15: unit + integration + e2e.
-- [ ] TTSEC-16: performance benchmark + фиксы.
-- [ ] TTSEC-17: `docs/user-manual/features/access-schemes.md` + manual QA на staging.
-- [ ] TTSEC-18: feature-flag `DIRECT_ROLES_DISABLED` + prod cutover.
-- **DoD:** все критерии приёмки §7 закрыты; rollback-SQL проверен на staging.
+### Фаза 4 — QA + rollout — **in progress (started 2026-04-17, план: вариант A)**
+
+Решение по варианту A (подтверждено owner-ом 2026-04-17): Фазы 1-3 мерджатся в main без ожидания Фазы 4, чтобы быстрее поймать реальные реграссии на staging. Фаза 4 разбита на follow-up PR-ы после мерджа основной трилогии.
+
+- [x] **Pre-merge unit-тесты** (часть TTSEC-15): 24 backend-unit в Phase 2 (rbac-effective + user-groups + sprints-move-issues) + 4 дополнительных на cross-project guard. Frontend — tsc + eslint. Всё зелёное.
+- [ ] TTSEC-15.1: integration-тесты на backend (`user-groups.test.ts`, `rbac-effective.int.test.ts`) — требуют живой БД в CI. Отдельный PR.
+- [ ] TTSEC-15.2: e2e сценарий (создать группу → добавить юзеров → выдать роль → проверить permissions → профиль «Безопасность»). Отдельный PR, зависит от 15.1.
+- [ ] TTSEC-16: performance benchmark `GET /issues` p95 (NFR-1: регресс ≤ 10%). **Только после deploy на staging.** Отдельный PR с benchmarkcript-ом + репортом.
+- [ ] TTSEC-17.1: `docs/user-manual/features/access-schemes.md`. Отдельный PR.
+- [ ] TTSEC-17.2: manual QA checklist по acceptance criteria §7 на staging. **После deploy, owner-driven.**
+- [ ] TTSEC-18.1: feature-flag `DIRECT_ROLES_DISABLED` в backend (`features.ts` + enforcement в `admin.service.assignProjectRole`). Отдельный PR.
+- [ ] TTSEC-18.2: prod cutover — включение флага после успешной staging-валидации.
+
+**Post-merge staging verification (обязательно перед TTSEC-18):**
+- [ ] SQL: `SELECT unnest(enum_range(NULL::"ProjectPermission"))` содержит все 10 новых значений.
+- [ ] SQL: `SELECT COUNT(*) FROM user_groups WHERE name LIKE 'Legacy:%'` — Legacy-группы созданы для каждой уникальной `(project.key, role.name)` пары из `user_project_roles`.
+- [ ] Diff-test (acceptance §7 / risk #1): effective permissions каждого пользователя до миграции = после. Скрипт сравнивает `GET /admin/users/:id/security` для всех юзеров с зафиксированным snapshot-ом.
+- [ ] Smoke: создать группу → добавить 3 участников → выдать роль в проекте → permissions появились в `GET /users/me/security` ≤ 5 сек.
+- [ ] Smoke: удалить группу с `?confirm=true` → impact-модалка показала корректные members+projects, права отозваны.
+- [ ] Rollback-SQL (`rollback.sql`) прогнан на staging-snapshot — проходит без ошибок.
+
+**DoD Фазы 4:** все критерии приёмки §7 закрыты; rollback-SQL проверен; `DIRECT_ROLES_DISABLED` включён на prod; доки обновлены.
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom';
 import { ConfigProvider, theme as antdTheme } from 'antd';
 import { useAuthStore } from './store/auth.store';
 import { useThemeStore } from './store/theme.store';
@@ -183,47 +183,40 @@ export default function App() {
             <Route path="teams" element={<TeamsPage />} />
             <Route path="uat" element={<UatTestsPage />} />
             {/*
-              TTSEC-2 TODO — admin route protection migration.
-
-              Only /admin/user-groups/* routes are currently wrapped in <AdminGate>.
-              The remaining admin/* routes (dashboard, users, roles, role-schemes, projects,
-              categories, issue-type-configs, workflows, release-*, system, etc.) rely solely
-              on backend 403 — an unauthorised user can briefly see admin UI before the first
-              API call fails. Two ways forward:
-                (a) add <AdminGate> to each remaining element inline — trivial but 20+ edits,
-                (b) introduce a parent <Route element={<AdminGate><Outlet /></AdminGate>}> nested
-                    segment wrapping the whole admin/* group — one change, invariant for future
-                    admin pages. Preferred for a dedicated cleanup PR.
-              Tracking here as a visible anchor — see also components/auth/AdminGate.tsx.
+              TTSEC-2 round 15: every /admin/* route now passes through a single <AdminGate>
+              parent — unauthorised users get redirected before any admin page renders, and new
+              admin routes can be added to this nested segment without remembering to wrap them.
             */}
-            <Route path="admin" element={<Navigate to="/admin/dashboard" replace />} />
-            <Route path="admin/dashboard" element={<AdminDashboardPage />} />
-            <Route path="admin/monitoring" element={<AdminMonitoringPage />} />
-            <Route path="admin/projects" element={<AdminProjectsPage />} />
-            <Route path="admin/categories" element={<AdminCategoriesPage />} />
-            <Route path="admin/link-types" element={<AdminLinkTypesPage />} />
-            <Route path="admin/issue-type-configs" element={<AdminIssueTypeConfigsPage />} />
-            <Route path="admin/issue-type-schemes" element={<AdminIssueTypeSchemesPage />} />
-            <Route path="admin/users" element={<AdminUsersPage />} />
-            <Route path="admin/roles" element={<AdminRolesPage />} />
-            <Route path="admin/custom-fields" element={<AdminCustomFieldsPage />} />
-            <Route path="admin/field-schemas" element={<AdminFieldSchemasPage />} />
-            <Route path="admin/field-schemas/:id" element={<AdminFieldSchemaDetailPage />} />
-            <Route path="admin/workflow-statuses" element={<AdminWorkflowStatusesPage />} />
-            <Route path="admin/workflows" element={<AdminWorkflowsPage />} />
-            <Route path="admin/workflows/:id" element={<AdminWorkflowEditorPage />} />
-            <Route path="admin/workflow-schemes" element={<AdminWorkflowSchemesPage />} />
-            <Route path="admin/workflow-schemes/:id" element={<AdminWorkflowSchemeEditorPage />} />
-            <Route path="admin/role-schemes" element={<AdminRoleSchemesPage />} />
-            <Route path="admin/role-schemes/:id" element={<AdminRoleSchemeDetailPage />} />
-            <Route path="admin/user-groups" element={<AdminGate><AdminGroupsPage /></AdminGate>} />
-            <Route path="admin/user-groups/:id" element={<AdminGate><AdminGroupDetailPage /></AdminGate>} />
-            <Route path="admin/transition-screens" element={<AdminTransitionScreensPage />} />
-            <Route path="admin/transition-screens/:id" element={<AdminTransitionScreenEditorPage />} />
-            <Route path="admin/release-workflows" element={<AdminReleaseWorkflowsPage />} />
-            <Route path="admin/release-workflows/:id" element={<AdminReleaseWorkflowEditorPage />} />
-            <Route path="admin/release-statuses" element={<AdminReleaseStatusesPage />} />
-            <Route path="admin/system" element={<AdminSystemPage />} />
+            <Route path="admin" element={<AdminGate><Outlet /></AdminGate>}>
+              <Route index element={<Navigate to="dashboard" replace />} />
+              <Route path="dashboard" element={<AdminDashboardPage />} />
+              <Route path="monitoring" element={<AdminMonitoringPage />} />
+              <Route path="projects" element={<AdminProjectsPage />} />
+              <Route path="categories" element={<AdminCategoriesPage />} />
+              <Route path="link-types" element={<AdminLinkTypesPage />} />
+              <Route path="issue-type-configs" element={<AdminIssueTypeConfigsPage />} />
+              <Route path="issue-type-schemes" element={<AdminIssueTypeSchemesPage />} />
+              <Route path="users" element={<AdminUsersPage />} />
+              <Route path="roles" element={<AdminRolesPage />} />
+              <Route path="custom-fields" element={<AdminCustomFieldsPage />} />
+              <Route path="field-schemas" element={<AdminFieldSchemasPage />} />
+              <Route path="field-schemas/:id" element={<AdminFieldSchemaDetailPage />} />
+              <Route path="workflow-statuses" element={<AdminWorkflowStatusesPage />} />
+              <Route path="workflows" element={<AdminWorkflowsPage />} />
+              <Route path="workflows/:id" element={<AdminWorkflowEditorPage />} />
+              <Route path="workflow-schemes" element={<AdminWorkflowSchemesPage />} />
+              <Route path="workflow-schemes/:id" element={<AdminWorkflowSchemeEditorPage />} />
+              <Route path="role-schemes" element={<AdminRoleSchemesPage />} />
+              <Route path="role-schemes/:id" element={<AdminRoleSchemeDetailPage />} />
+              <Route path="user-groups" element={<AdminGroupsPage />} />
+              <Route path="user-groups/:id" element={<AdminGroupDetailPage />} />
+              <Route path="transition-screens" element={<AdminTransitionScreensPage />} />
+              <Route path="transition-screens/:id" element={<AdminTransitionScreenEditorPage />} />
+              <Route path="release-workflows" element={<AdminReleaseWorkflowsPage />} />
+              <Route path="release-workflows/:id" element={<AdminReleaseWorkflowEditorPage />} />
+              <Route path="release-statuses" element={<AdminReleaseStatusesPage />} />
+              <Route path="system" element={<AdminSystemPage />} />
+            </Route>
             <Route path="settings" element={<SettingsPage />} />
             <Route path="pipeline" element={<PipelineDashboardPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ import AdminRoleSchemeDetailPage from './pages/admin/AdminRoleSchemeDetailPage';
 import AdminGroupsPage from './pages/admin/AdminGroupsPage';
 import AdminGroupDetailPage from './pages/admin/AdminGroupDetailPage';
 import AdminGate from './components/auth/AdminGate';
+import { canViewUserGroups } from './lib/roles';
 import AdminTransitionScreensPage from './pages/admin/AdminTransitionScreensPage';
 import AdminTransitionScreenEditorPage from './pages/admin/AdminTransitionScreenEditorPage';
 import AdminReleaseWorkflowsPage from './pages/admin/AdminReleaseWorkflowsPage';
@@ -211,8 +212,8 @@ export default function App() {
             <Route path="admin/workflow-schemes/:id" element={<AdminWorkflowSchemeEditorPage />} />
             <Route path="admin/role-schemes" element={<AdminRoleSchemesPage />} />
             <Route path="admin/role-schemes/:id" element={<AdminRoleSchemeDetailPage />} />
-            <Route path="admin/user-groups" element={<AdminGate><AdminGroupsPage /></AdminGate>} />
-            <Route path="admin/user-groups/:id" element={<AdminGate><AdminGroupDetailPage /></AdminGate>} />
+            <Route path="admin/user-groups" element={<AdminGate allow={canViewUserGroups}><AdminGroupsPage /></AdminGate>} />
+            <Route path="admin/user-groups/:id" element={<AdminGate allow={canViewUserGroups}><AdminGroupDetailPage /></AdminGate>} />
             <Route path="admin/transition-screens" element={<AdminTransitionScreensPage />} />
             <Route path="admin/transition-screens/:id" element={<AdminTransitionScreenEditorPage />} />
             <Route path="admin/release-workflows" element={<AdminReleaseWorkflowsPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,8 @@ import AdminWorkflowSchemesPage from './pages/admin/AdminWorkflowSchemesPage';
 import AdminWorkflowSchemeEditorPage from './pages/admin/AdminWorkflowSchemeEditorPage';
 import AdminRoleSchemesPage from './pages/admin/AdminRoleSchemesPage';
 import AdminRoleSchemeDetailPage from './pages/admin/AdminRoleSchemeDetailPage';
+import AdminGroupsPage from './pages/admin/AdminGroupsPage';
+import AdminGroupDetailPage from './pages/admin/AdminGroupDetailPage';
 import AdminTransitionScreensPage from './pages/admin/AdminTransitionScreensPage';
 import AdminTransitionScreenEditorPage from './pages/admin/AdminTransitionScreenEditorPage';
 import AdminReleaseWorkflowsPage from './pages/admin/AdminReleaseWorkflowsPage';
@@ -199,6 +201,8 @@ export default function App() {
             <Route path="admin/workflow-schemes/:id" element={<AdminWorkflowSchemeEditorPage />} />
             <Route path="admin/role-schemes" element={<AdminRoleSchemesPage />} />
             <Route path="admin/role-schemes/:id" element={<AdminRoleSchemeDetailPage />} />
+            <Route path="admin/user-groups" element={<AdminGroupsPage />} />
+            <Route path="admin/user-groups/:id" element={<AdminGroupDetailPage />} />
             <Route path="admin/transition-screens" element={<AdminTransitionScreensPage />} />
             <Route path="admin/transition-screens/:id" element={<AdminTransitionScreenEditorPage />} />
             <Route path="admin/release-workflows" element={<AdminReleaseWorkflowsPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { BrowserRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { ConfigProvider, theme as antdTheme } from 'antd';
 import { useAuthStore } from './store/auth.store';
 import { useThemeStore } from './store/theme.store';
@@ -183,40 +183,42 @@ export default function App() {
             <Route path="teams" element={<TeamsPage />} />
             <Route path="uat" element={<UatTestsPage />} />
             {/*
-              TTSEC-2 round 15: every /admin/* route now passes through a single <AdminGate>
-              parent — unauthorised users get redirected before any admin page renders, and new
-              admin routes can be added to this nested segment without remembering to wrap them.
+              TTSEC-2 round 16 — partial revert of round 15's global AdminGate.
+              AI review flagged that enforcing `hasSystemRole('ADMIN')` on EVERY existing admin
+              route (monitoring, release-workflows, role-schemes, etc.) could regress access for
+              roles like RELEASE_MANAGER/AUDITOR that previously relied on backend-only 403. No
+              existing access-matrix audit accompanies this PR, so the guard stays scoped to the
+              NEW user-groups routes only. Consolidation into a parent <AdminGate> wrapper
+              deserves its own PR with an explicit per-page audit.
             */}
-            <Route path="admin" element={<AdminGate><Outlet /></AdminGate>}>
-              <Route index element={<Navigate to="dashboard" replace />} />
-              <Route path="dashboard" element={<AdminDashboardPage />} />
-              <Route path="monitoring" element={<AdminMonitoringPage />} />
-              <Route path="projects" element={<AdminProjectsPage />} />
-              <Route path="categories" element={<AdminCategoriesPage />} />
-              <Route path="link-types" element={<AdminLinkTypesPage />} />
-              <Route path="issue-type-configs" element={<AdminIssueTypeConfigsPage />} />
-              <Route path="issue-type-schemes" element={<AdminIssueTypeSchemesPage />} />
-              <Route path="users" element={<AdminUsersPage />} />
-              <Route path="roles" element={<AdminRolesPage />} />
-              <Route path="custom-fields" element={<AdminCustomFieldsPage />} />
-              <Route path="field-schemas" element={<AdminFieldSchemasPage />} />
-              <Route path="field-schemas/:id" element={<AdminFieldSchemaDetailPage />} />
-              <Route path="workflow-statuses" element={<AdminWorkflowStatusesPage />} />
-              <Route path="workflows" element={<AdminWorkflowsPage />} />
-              <Route path="workflows/:id" element={<AdminWorkflowEditorPage />} />
-              <Route path="workflow-schemes" element={<AdminWorkflowSchemesPage />} />
-              <Route path="workflow-schemes/:id" element={<AdminWorkflowSchemeEditorPage />} />
-              <Route path="role-schemes" element={<AdminRoleSchemesPage />} />
-              <Route path="role-schemes/:id" element={<AdminRoleSchemeDetailPage />} />
-              <Route path="user-groups" element={<AdminGroupsPage />} />
-              <Route path="user-groups/:id" element={<AdminGroupDetailPage />} />
-              <Route path="transition-screens" element={<AdminTransitionScreensPage />} />
-              <Route path="transition-screens/:id" element={<AdminTransitionScreenEditorPage />} />
-              <Route path="release-workflows" element={<AdminReleaseWorkflowsPage />} />
-              <Route path="release-workflows/:id" element={<AdminReleaseWorkflowEditorPage />} />
-              <Route path="release-statuses" element={<AdminReleaseStatusesPage />} />
-              <Route path="system" element={<AdminSystemPage />} />
-            </Route>
+            <Route path="admin" element={<Navigate to="/admin/dashboard" replace />} />
+            <Route path="admin/dashboard" element={<AdminDashboardPage />} />
+            <Route path="admin/monitoring" element={<AdminMonitoringPage />} />
+            <Route path="admin/projects" element={<AdminProjectsPage />} />
+            <Route path="admin/categories" element={<AdminCategoriesPage />} />
+            <Route path="admin/link-types" element={<AdminLinkTypesPage />} />
+            <Route path="admin/issue-type-configs" element={<AdminIssueTypeConfigsPage />} />
+            <Route path="admin/issue-type-schemes" element={<AdminIssueTypeSchemesPage />} />
+            <Route path="admin/users" element={<AdminUsersPage />} />
+            <Route path="admin/roles" element={<AdminRolesPage />} />
+            <Route path="admin/custom-fields" element={<AdminCustomFieldsPage />} />
+            <Route path="admin/field-schemas" element={<AdminFieldSchemasPage />} />
+            <Route path="admin/field-schemas/:id" element={<AdminFieldSchemaDetailPage />} />
+            <Route path="admin/workflow-statuses" element={<AdminWorkflowStatusesPage />} />
+            <Route path="admin/workflows" element={<AdminWorkflowsPage />} />
+            <Route path="admin/workflows/:id" element={<AdminWorkflowEditorPage />} />
+            <Route path="admin/workflow-schemes" element={<AdminWorkflowSchemesPage />} />
+            <Route path="admin/workflow-schemes/:id" element={<AdminWorkflowSchemeEditorPage />} />
+            <Route path="admin/role-schemes" element={<AdminRoleSchemesPage />} />
+            <Route path="admin/role-schemes/:id" element={<AdminRoleSchemeDetailPage />} />
+            <Route path="admin/user-groups" element={<AdminGate><AdminGroupsPage /></AdminGate>} />
+            <Route path="admin/user-groups/:id" element={<AdminGate><AdminGroupDetailPage /></AdminGate>} />
+            <Route path="admin/transition-screens" element={<AdminTransitionScreensPage />} />
+            <Route path="admin/transition-screens/:id" element={<AdminTransitionScreenEditorPage />} />
+            <Route path="admin/release-workflows" element={<AdminReleaseWorkflowsPage />} />
+            <Route path="admin/release-workflows/:id" element={<AdminReleaseWorkflowEditorPage />} />
+            <Route path="admin/release-statuses" element={<AdminReleaseStatusesPage />} />
+            <Route path="admin/system" element={<AdminSystemPage />} />
             <Route path="settings" element={<SettingsPage />} />
             <Route path="pipeline" element={<PipelineDashboardPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -182,6 +182,20 @@ export default function App() {
             <Route path="time" element={<TimePage />} />
             <Route path="teams" element={<TeamsPage />} />
             <Route path="uat" element={<UatTestsPage />} />
+            {/*
+              TTSEC-2 TODO — admin route protection migration.
+
+              Only /admin/user-groups/* routes are currently wrapped in <AdminGate>.
+              The remaining admin/* routes (dashboard, users, roles, role-schemes, projects,
+              categories, issue-type-configs, workflows, release-*, system, etc.) rely solely
+              on backend 403 — an unauthorised user can briefly see admin UI before the first
+              API call fails. Two ways forward:
+                (a) add <AdminGate> to each remaining element inline — trivial but 20+ edits,
+                (b) introduce a parent <Route element={<AdminGate><Outlet /></AdminGate>}> nested
+                    segment wrapping the whole admin/* group — one change, invariant for future
+                    admin pages. Preferred for a dedicated cleanup PR.
+              Tracking here as a visible anchor — see also components/auth/AdminGate.tsx.
+            */}
             <Route path="admin" element={<Navigate to="/admin/dashboard" replace />} />
             <Route path="admin/dashboard" element={<AdminDashboardPage />} />
             <Route path="admin/monitoring" element={<AdminMonitoringPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import AdminRoleSchemesPage from './pages/admin/AdminRoleSchemesPage';
 import AdminRoleSchemeDetailPage from './pages/admin/AdminRoleSchemeDetailPage';
 import AdminGroupsPage from './pages/admin/AdminGroupsPage';
 import AdminGroupDetailPage from './pages/admin/AdminGroupDetailPage';
+import AdminGate from './components/auth/AdminGate';
 import AdminTransitionScreensPage from './pages/admin/AdminTransitionScreensPage';
 import AdminTransitionScreenEditorPage from './pages/admin/AdminTransitionScreenEditorPage';
 import AdminReleaseWorkflowsPage from './pages/admin/AdminReleaseWorkflowsPage';
@@ -201,8 +202,8 @@ export default function App() {
             <Route path="admin/workflow-schemes/:id" element={<AdminWorkflowSchemeEditorPage />} />
             <Route path="admin/role-schemes" element={<AdminRoleSchemesPage />} />
             <Route path="admin/role-schemes/:id" element={<AdminRoleSchemeDetailPage />} />
-            <Route path="admin/user-groups" element={<AdminGroupsPage />} />
-            <Route path="admin/user-groups/:id" element={<AdminGroupDetailPage />} />
+            <Route path="admin/user-groups" element={<AdminGate><AdminGroupsPage /></AdminGate>} />
+            <Route path="admin/user-groups/:id" element={<AdminGate><AdminGroupDetailPage /></AdminGate>} />
             <Route path="admin/transition-screens" element={<AdminTransitionScreensPage />} />
             <Route path="admin/transition-screens/:id" element={<AdminTransitionScreenEditorPage />} />
             <Route path="admin/release-workflows" element={<AdminReleaseWorkflowsPage />} />

--- a/frontend/src/api/user-groups.ts
+++ b/frontend/src/api/user-groups.ts
@@ -63,6 +63,15 @@ export const userGroupsApi = {
     api.delete(`/admin/user-groups/${id}/members/${userId}`).then(r => r.data),
   grantProjectRole: (id: string, data: { projectId: string; roleId: string }) =>
     api.post<UserGroupProjectRole>(`/admin/user-groups/${id}/project-roles`, data).then(r => r.data),
+  /**
+   * Revoke the group's project-role binding. Keyed by `projectId` because the backend contract
+   * (Phase 2, spec §5.6) enforces `@@unique([groupId, projectId])` on `ProjectGroupRole` — a
+   * group can have at most one role per project, so (groupId, projectId) IS the natural key.
+   *
+   * `UserGroupProjectRole.id` exists as a surrogate for `@id @default(uuid())` but is NOT part
+   * of the URL contract. If a future requirement allows multiple bindings per project
+   * (@@unique relaxed), both the backend route AND this method should migrate to binding id.
+   */
   revokeProjectRole: (id: string, projectId: string) =>
     api.delete(`/admin/user-groups/${id}/project-roles/${projectId}`).then(r => r.data),
 };

--- a/frontend/src/api/user-groups.ts
+++ b/frontend/src/api/user-groups.ts
@@ -1,0 +1,68 @@
+import api from './client';
+
+export interface UserGroupMember {
+  groupId: string;
+  userId: string;
+  addedAt: string;
+  addedById: string | null;
+  user: { id: string; name: string; email: string; isActive: boolean };
+  addedBy: { id: string; name: string } | null;
+}
+
+export interface UserGroupProjectRole {
+  id: string;
+  groupId: string;
+  projectId: string;
+  roleId: string;
+  schemeId: string;
+  createdAt: string;
+  project: { id: string; key: string; name: string };
+  roleDefinition: { id: string; name: string; key: string; color: string | null };
+}
+
+export interface UserGroupListItem {
+  id: string;
+  name: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+  _count: { members: number; projectRoles: number };
+}
+
+export interface UserGroupDetail extends UserGroupListItem {
+  members: UserGroupMember[];
+  projectRoles: UserGroupProjectRole[];
+}
+
+export interface UserGroupImpact {
+  memberCount: number;
+  projectCount: number;
+  members: { id: string; name: string; email: string }[];
+  projects: {
+    project: { id: string; key: string; name: string };
+    roleDefinition: { id: string; name: string; key: string };
+  }[];
+}
+
+export const userGroupsApi = {
+  list: (search?: string) =>
+    api.get<UserGroupListItem[]>('/admin/user-groups', { params: search ? { search } : undefined }).then(r => r.data),
+  get: (id: string) =>
+    api.get<UserGroupDetail>(`/admin/user-groups/${id}`).then(r => r.data),
+  getImpact: (id: string) =>
+    api.get<UserGroupImpact>(`/admin/user-groups/${id}/impact`).then(r => r.data),
+  create: (data: { name: string; description?: string | null }) =>
+    api.post<UserGroupListItem>('/admin/user-groups', data).then(r => r.data),
+  update: (id: string, data: { name?: string; description?: string | null }) =>
+    api.patch<UserGroupListItem>(`/admin/user-groups/${id}`, data).then(r => r.data),
+  remove: (id: string) =>
+    api.delete(`/admin/user-groups/${id}`, { params: { confirm: 'true' } }).then(r => r.data),
+  addMembers: (id: string, userIds: string[]) =>
+    api.post<{ added: number }>(`/admin/user-groups/${id}/members`, { userIds }).then(r => r.data),
+  removeMember: (id: string, userId: string) =>
+    api.delete(`/admin/user-groups/${id}/members/${userId}`).then(r => r.data),
+  grantProjectRole: (id: string, data: { projectId: string; roleId: string }) =>
+    api.post<UserGroupProjectRole>(`/admin/user-groups/${id}/project-roles`, data).then(r => r.data),
+  revokeProjectRole: (id: string, projectId: string) =>
+    api.delete(`/admin/user-groups/${id}/project-roles/${projectId}`).then(r => r.data),
+};

--- a/frontend/src/api/user-security.ts
+++ b/frontend/src/api/user-security.ts
@@ -1,0 +1,28 @@
+import api from './client';
+
+export interface SecurityProjectRole {
+  project: { id: string; key: string; name: string };
+  role: { id: string; name: string; key: string; permissions: string[] };
+  source: 'DIRECT' | 'GROUP';
+  sourceGroups: { id: string; name: string }[];
+}
+
+export interface SecurityGroupMembership {
+  id: string;
+  name: string;
+  addedAt: string;
+  memberCount: number;
+}
+
+export interface UserSecurityPayload {
+  user: { id: string; name: string; email: string };
+  groups: SecurityGroupMembership[];
+  projectRoles: SecurityProjectRole[];
+  updatedAt: string;
+}
+
+export const userSecurityApi = {
+  getMine: () => api.get<UserSecurityPayload>('/users/me/security').then(r => r.data),
+  getByUser: (userId: string) =>
+    api.get<UserSecurityPayload>(`/admin/users/${userId}/security`).then(r => r.data),
+};

--- a/frontend/src/components/admin/PermissionMatrixDrawer.tsx
+++ b/frontend/src/components/admin/PermissionMatrixDrawer.tsx
@@ -3,6 +3,11 @@ import { Drawer, Table, Checkbox, Button, Space, message, Tag } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { roleSchemesApi, type ProjectRoleDefinition } from '../../api/role-schemes';
 
+// TTSEC-2 Phase 3: granular sprint/release CRUD + *_DELETE_OTHERS for moderation.
+// SPRINTS_MANAGE / RELEASES_MANAGE deliberately omitted — they remain in the enum (Postgres
+// has no DROP VALUE) but are no longer surfaced in the matrix. Backfill in Phase 1 migration
+// grants equivalent granular perms to every role that had `*_MANAGE`. Additional user-group
+// admin perms (USER_GROUP_VIEW / USER_GROUP_MANAGE) live in a separate system category.
 const PERMISSION_CATEGORIES = [
   {
     category: 'Задачи',
@@ -20,14 +25,18 @@ const PERMISSION_CATEGORIES = [
     category: 'Спринты',
     permissions: [
       { key: 'SPRINTS_VIEW',   label: 'Просмотр' },
-      { key: 'SPRINTS_MANAGE', label: 'Управление' },
+      { key: 'SPRINTS_CREATE', label: 'Создание' },
+      { key: 'SPRINTS_EDIT',   label: 'Редактирование' },
+      { key: 'SPRINTS_DELETE', label: 'Удаление' },
     ],
   },
   {
     category: 'Релизы',
     permissions: [
       { key: 'RELEASES_VIEW',   label: 'Просмотр' },
-      { key: 'RELEASES_MANAGE', label: 'Управление' },
+      { key: 'RELEASES_CREATE', label: 'Создание' },
+      { key: 'RELEASES_EDIT',   label: 'Редактирование' },
+      { key: 'RELEASES_DELETE', label: 'Удаление' },
     ],
   },
   {
@@ -40,17 +49,19 @@ const PERMISSION_CATEGORIES = [
   {
     category: 'Время',
     permissions: [
-      { key: 'TIME_LOGS_VIEW',   label: 'Просмотр' },
-      { key: 'TIME_LOGS_CREATE', label: 'Создание' },
-      { key: 'TIME_LOGS_MANAGE', label: 'Управление' },
+      { key: 'TIME_LOGS_VIEW',          label: 'Просмотр' },
+      { key: 'TIME_LOGS_CREATE',        label: 'Создание' },
+      { key: 'TIME_LOGS_DELETE_OTHERS', label: 'Удаление чужих' },
+      { key: 'TIME_LOGS_MANAGE',        label: 'Управление' },
     ],
   },
   {
     category: 'Комментарии',
     permissions: [
-      { key: 'COMMENTS_VIEW',   label: 'Просмотр' },
-      { key: 'COMMENTS_CREATE', label: 'Создание' },
-      { key: 'COMMENTS_MANAGE', label: 'Управление' },
+      { key: 'COMMENTS_VIEW',          label: 'Просмотр' },
+      { key: 'COMMENTS_CREATE',        label: 'Создание' },
+      { key: 'COMMENTS_DELETE_OTHERS', label: 'Удаление чужих' },
+      { key: 'COMMENTS_MANAGE',        label: 'Управление' },
     ],
   },
   {
@@ -65,6 +76,13 @@ const PERMISSION_CATEGORIES = [
     permissions: [
       { key: 'BOARDS_VIEW',   label: 'Просмотр' },
       { key: 'BOARDS_MANAGE', label: 'Управление' },
+    ],
+  },
+  {
+    category: 'Группы пользователей',
+    permissions: [
+      { key: 'USER_GROUP_VIEW',   label: 'Просмотр' },
+      { key: 'USER_GROUP_MANAGE', label: 'Управление' },
     ],
   },
 ] as const;

--- a/frontend/src/components/auth/AdminGate.tsx
+++ b/frontend/src/components/auth/AdminGate.tsx
@@ -8,9 +8,11 @@ import { hasSystemRole } from '../../lib/roles';
  *
  * Backend middleware already enforces 403 on the protected endpoints, so this is purely a UX
  * hardening: unauthorised URL access redirects to `/` instead of flashing admin UI before the
- * first API call fails. Current project has 26 admin routes registered without a central guard
- * (AI review #66 rounds 5-6 🟠); adopting `<AdminGate>` per route is the incremental migration
- * path — each PR touching an admin route can wrap its own element.
+ * first API call fails.
+ *
+ * Applied once as the parent element of the /admin/* nested route segment in App.tsx, so every
+ * admin route — existing and future — passes through this single guard. No need to wrap new
+ * pages inline (AI review #66 rounds 5-15 🟠 — consolidated in round 15).
  */
 export default function AdminGate({ children }: { children: ReactElement }) {
   const user = useAuthStore(s => s.user);

--- a/frontend/src/components/auth/AdminGate.tsx
+++ b/frontend/src/components/auth/AdminGate.tsx
@@ -10,9 +10,10 @@ import { hasSystemRole } from '../../lib/roles';
  * hardening: unauthorised URL access redirects to `/` instead of flashing admin UI before the
  * first API call fails.
  *
- * Applied once as the parent element of the /admin/* nested route segment in App.tsx, so every
- * admin route — existing and future — passes through this single guard. No need to wrap new
- * pages inline (AI review #66 rounds 5-15 🟠 — consolidated in round 15).
+ * Currently applied ONLY to the new /admin/user-groups routes (TTSEC-2 Phase 3). Extending the
+ * gate to other /admin/* routes needs an access-matrix audit per page first — some existing
+ * admin views may be reachable by RELEASE_MANAGER / AUDITOR system roles and rely on backend
+ * 403, not ADMIN-only client-side gating (AI review #66 round 16 🟠 — consolidation rolled back).
  */
 export default function AdminGate({ children }: { children: ReactElement }) {
   const user = useAuthStore(s => s.user);

--- a/frontend/src/components/auth/AdminGate.tsx
+++ b/frontend/src/components/auth/AdminGate.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import type { SystemRoleType } from '../../types';
 import { Navigate } from 'react-router-dom';
 import { useAuthStore } from '../../store/auth.store';
 import { hasSystemRole } from '../../lib/roles';
@@ -10,14 +11,27 @@ import { hasSystemRole } from '../../lib/roles';
  * hardening: unauthorised URL access redirects to `/` instead of flashing admin UI before the
  * first API call fails.
  *
- * Currently applied ONLY to the new /admin/user-groups routes (TTSEC-2 Phase 3). Extending the
- * gate to other /admin/* routes needs an access-matrix audit per page first — some existing
- * admin views may be reachable by RELEASE_MANAGER / AUDITOR system roles and rely on backend
- * 403, not ADMIN-only client-side gating (AI review #66 round 16 🟠 — consolidation rolled back).
+ * `allow` is an injectable predicate so each feature can bring its own rule. Default is
+ * "system ADMIN" to preserve prior behaviour, but features with a distinct access helper
+ * (e.g. `canViewUserGroups` in Phase 3, anticipating Phase 4's `USER_GROUP_VIEW` permission)
+ * pass their own predicate — no hardcoded ADMIN check bleeds into feature code. AI review
+ * #66 round 17 🟠 — abstract, don't hardcode.
+ *
+ * Applied ONLY to the new /admin/user-groups routes (TTSEC-2 Phase 3). Extending the gate to
+ * other /admin/* routes needs an access-matrix audit per page first — some existing admin
+ * views may be reachable by RELEASE_MANAGER / AUDITOR system roles and rely on backend 403,
+ * not ADMIN-only client-side gating (AI review #66 round 16 🟠).
  */
-export default function AdminGate({ children }: { children: ReactElement }) {
+export default function AdminGate({
+  children,
+  allow,
+}: {
+  children: ReactElement;
+  allow?: (roles: SystemRoleType[] | null | undefined) => boolean;
+}) {
   const user = useAuthStore(s => s.user);
+  const predicate = allow ?? ((roles: SystemRoleType[] | null | undefined) => hasSystemRole(roles, 'ADMIN'));
   if (!user) return <Navigate to="/login" replace />;
-  if (!hasSystemRole(user.systemRoles, 'ADMIN')) return <Navigate to="/" replace />;
+  if (!predicate(user.systemRoles)) return <Navigate to="/" replace />;
   return children;
 }

--- a/frontend/src/components/auth/AdminGate.tsx
+++ b/frontend/src/components/auth/AdminGate.tsx
@@ -1,0 +1,20 @@
+import type { ReactElement } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '../../store/auth.store';
+import { hasSystemRole } from '../../lib/roles';
+
+/**
+ * Client-side gate for admin-only route elements.
+ *
+ * Backend middleware already enforces 403 on the protected endpoints, so this is purely a UX
+ * hardening: unauthorised URL access redirects to `/` instead of flashing admin UI before the
+ * first API call fails. Current project has 26 admin routes registered without a central guard
+ * (AI review #66 rounds 5-6 🟠); adopting `<AdminGate>` per route is the incremental migration
+ * path — each PR touching an admin route can wrap its own element.
+ */
+export default function AdminGate({ children }: { children: ReactElement }) {
+  const user = useAuthStore(s => s.user);
+  if (!user) return <Navigate to="/login" replace />;
+  if (!hasSystemRole(user.systemRoles, 'ADMIN')) return <Navigate to="/" replace />;
+  return children;
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -194,6 +194,12 @@ export default function Sidebar({
     | { type: 'link'; path: string; label: string }
     | { type: 'divider'; label: string };
 
+  // TTSEC-2 Phase 3 — scoped visibility for the «Группы» entry. Phase 4 will introduce a
+  // system-level permission helper and backend will expose per-user permissions; until then
+  // `canViewUserGroups` is just an alias for the existing admin check. Keeping it named and
+  // localised here so Phase 4 only needs to update one place.
+  const canViewUserGroups = isAdmin;
+
   const adminNavItems: AdminNavItem[] = [
     { type: 'divider', label: 'Обзор' },
     { type: 'link', path: '/admin/dashboard',   label: 'Дашборд' },
@@ -201,7 +207,9 @@ export default function Sidebar({
 
     { type: 'divider', label: 'Пользователи' },
     { type: 'link', path: '/admin/users',        label: 'Пользователи' },
-    { type: 'link', path: '/admin/user-groups',  label: 'Группы' },
+    ...(canViewUserGroups
+      ? [{ type: 'link' as const, path: '/admin/user-groups', label: 'Группы' }]
+      : []),
     { type: 'link', path: '/admin/roles',        label: 'Назначение ролей' },
     { type: 'link', path: '/admin/role-schemes', label: 'Схемы доступа' },
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -200,8 +200,9 @@ export default function Sidebar({
     { type: 'link', path: '/admin/monitoring',  label: 'Мониторинг' },
 
     { type: 'divider', label: 'Пользователи' },
-    { type: 'link', path: '/admin/users',       label: 'Пользователи' },
-    { type: 'link', path: '/admin/roles',       label: 'Назначение ролей' },
+    { type: 'link', path: '/admin/users',        label: 'Пользователи' },
+    { type: 'link', path: '/admin/user-groups',  label: 'Группы' },
+    { type: 'link', path: '/admin/roles',        label: 'Назначение ролей' },
     { type: 'link', path: '/admin/role-schemes', label: 'Схемы доступа' },
 
     { type: 'divider', label: 'Проекты' },

--- a/frontend/src/components/profile/SecurityTab.tsx
+++ b/frontend/src/components/profile/SecurityTab.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react';
+import { Table, Tag, Tooltip, Button, Alert, Space, message } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { ReloadOutlined, DownloadOutlined } from '@ant-design/icons';
+import {
+  userSecurityApi,
+  type UserSecurityPayload,
+  type SecurityProjectRole,
+} from '../../api/user-security';
+
+/**
+ * TTSEC-2 Phase 3: "Безопасность" block for SettingsPage (spec §5.8).
+ *
+ * Read-only — the user cannot grant themselves a role here. Shows:
+ *   - groups the user is a member of
+ *   - effective roles per project with `source` (DIRECT / GROUP) + `sourceGroups` list
+ *   - per-role permissions tooltip on hover
+ *   - CSV export for offline review
+ *
+ * Shape is driven by the backend `UserSecurityPayload` type.
+ */
+
+function downloadCsv(payload: UserSecurityPayload): void {
+  const header = 'Проект;Ключ;Роль;Источник;Через группы\n';
+  const body = payload.projectRoles
+    .map(r => {
+      const via = r.sourceGroups.map(g => g.name).join(', ');
+      return [
+        JSON.stringify(r.project.name),
+        JSON.stringify(r.project.key),
+        JSON.stringify(r.role.name),
+        r.source === 'DIRECT' ? 'Прямое' : 'Группа',
+        JSON.stringify(via),
+      ].join(';');
+    })
+    .join('\n');
+  const blob = new Blob([header + body], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `security-${payload.user.email}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function SecurityTab() {
+  const [data, setData] = useState<UserSecurityPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      setData(await userSecurityApi.getMine());
+    } catch {
+      message.error('Не удалось загрузить данные безопасности');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const columns: ColumnsType<SecurityProjectRole> = [
+    {
+      title: 'Проект',
+      render: (_, r) => (
+        <Space>
+          <code>{r.project.key}</code>
+          <span>{r.project.name}</span>
+        </Space>
+      ),
+    },
+    {
+      title: 'Роль',
+      render: (_, r) => (
+        <Tooltip title={r.role.permissions.length > 0 ? r.role.permissions.join(', ') : 'Нет прав'}>
+          <Tag>{r.role.name}</Tag>
+        </Tooltip>
+      ),
+    },
+    {
+      title: 'Источник',
+      render: (_, r) => {
+        const direct = r.source === 'DIRECT';
+        const groups = r.sourceGroups;
+        return (
+          <Space wrap size={4}>
+            <Tag color={direct ? 'blue' : 'purple'}>{direct ? 'Прямое назначение' : 'Через группу'}</Tag>
+            {groups.length > 0 && (
+              <Tooltip title={groups.map(g => g.name).join(', ')}>
+                <Tag>{direct ? 'также через' : ''} {groups.length} {groups.length === 1 ? 'группу' : 'групп(ы)'}</Tag>
+              </Tooltip>
+            )}
+          </Space>
+        );
+      },
+    },
+  ];
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+        <h3 style={{ margin: 0 }}>Безопасность</h3>
+        <Space>
+          <Button icon={<ReloadOutlined />} onClick={load} loading={loading}>Обновить</Button>
+          <Button
+            icon={<DownloadOutlined />}
+            disabled={!data || data.projectRoles.length === 0}
+            onClick={() => data && downloadCsv(data)}
+          >
+            Экспорт CSV
+          </Button>
+        </Space>
+      </div>
+
+      {data && data.groups.length > 0 ? (
+        <Alert
+          type="info"
+          showIcon
+          message="Ваши группы"
+          description={
+            <Space wrap>
+              {data.groups.map(g => (
+                <Tooltip key={g.id} title={`В группе: ${g.memberCount} участник(а/ов)`}>
+                  <Tag color="purple">{g.name}</Tag>
+                </Tooltip>
+              ))}
+            </Space>
+          }
+          style={{ marginBottom: 16 }}
+        />
+      ) : (
+        !loading && <Alert type="info" message="Вы не состоите ни в одной группе" style={{ marginBottom: 16 }} />
+      )}
+
+      <Table
+        rowKey={(r) => `${r.project.id}:${r.role.id}`}
+        dataSource={data?.projectRoles ?? []}
+        columns={columns}
+        loading={loading}
+        pagination={false}
+        size="small"
+        locale={{ emptyText: 'Нет проектных ролей' }}
+      />
+
+      {data && (
+        <div style={{ marginTop: 12, color: '#888', fontSize: 12 }}>
+          Обновлено: {new Date(data.updatedAt).toLocaleString('ru-RU')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/SecurityTab.tsx
+++ b/frontend/src/components/profile/SecurityTab.tsx
@@ -51,7 +51,9 @@ function downloadCsv(payload: UserSecurityPayload): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `security-${payload.user.email}.csv`;
+  // AI review #66 round 5 🟡 — filename from email could contain @ / whitespace / stray
+  // characters. Use the stable user id instead; it's already a UUID, guaranteed filesystem-safe.
+  a.download = `security-${payload.user.id}.csv`;
   a.click();
   URL.revokeObjectURL(url);
 }

--- a/frontend/src/components/profile/SecurityTab.tsx
+++ b/frontend/src/components/profile/SecurityTab.tsx
@@ -30,6 +30,19 @@ function csvField(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
 }
 
+/**
+ * Russian noun pluralization: `pluralize(1, 'группа', 'группы', 'групп')` → "группа".
+ * Rule: 1 → one, 2-4 → few (except 12-14 → many), 0/5+ → many.
+ */
+function pluralize(n: number, one: string, few: string, many: string): string {
+  const mod100 = Math.abs(n) % 100;
+  const mod10 = mod100 % 10;
+  if (mod100 >= 11 && mod100 <= 14) return many;
+  if (mod10 === 1) return one;
+  if (mod10 >= 2 && mod10 <= 4) return few;
+  return many;
+}
+
 function downloadCsv(payload: UserSecurityPayload): void {
   const rows: string[] = [
     ['Проект', 'Ключ', 'Роль', 'Источник', 'Через группы']
@@ -107,7 +120,10 @@ export default function SecurityTab() {
             <Tag color={direct ? 'blue' : 'purple'}>{direct ? 'Прямое назначение' : 'Через группу'}</Tag>
             {groups.length > 0 && (
               <Tooltip title={groups.map(g => g.name).join(', ')}>
-                <Tag>{direct ? 'также через' : ''} {groups.length} {groups.length === 1 ? 'группу' : 'групп(ы)'}</Tag>
+                <Tag>
+                  {direct ? 'также через ' : ''}
+                  {groups.length} {pluralize(groups.length, 'группу', 'группы', 'групп')}
+                </Tag>
               </Tooltip>
             )}
           </Space>
@@ -140,7 +156,7 @@ export default function SecurityTab() {
           description={
             <Space wrap>
               {data.groups.map(g => (
-                <Tooltip key={g.id} title={`В группе: ${g.memberCount} участник(а/ов)`}>
+                <Tooltip key={g.id} title={`В группе: ${g.memberCount} ${pluralize(g.memberCount, 'участник', 'участника', 'участников')}`}>
                   <Tag color="purple">{g.name}</Tag>
                 </Tooltip>
               ))}

--- a/frontend/src/components/profile/SecurityTab.tsx
+++ b/frontend/src/components/profile/SecurityTab.tsx
@@ -51,11 +51,15 @@ function downloadCsv(payload: UserSecurityPayload): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  // AI review #66 round 5 🟡 — filename from email could contain @ / whitespace / stray
-  // characters. Use the stable user id instead; it's already a UUID, guaranteed filesystem-safe.
+  // AI review #66 round 5 🟡 — user.id (UUID) is filesystem-safe; email could contain @/spaces.
   a.download = `security-${payload.user.id}.csv`;
+  // AI review #66 round 6 🟠 — Firefox/Safari sometimes miss the click on a detached <a>, and
+  // revoking the blob URL synchronously right after click can race the download fetch. Attach
+  // to DOM, click, detach, then revoke on the next tick.
+  document.body.appendChild(a);
   a.click();
-  URL.revokeObjectURL(url);
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 export default function SecurityTab() {

--- a/frontend/src/components/profile/SecurityTab.tsx
+++ b/frontend/src/components/profile/SecurityTab.tsx
@@ -147,13 +147,13 @@ export default function SecurityTab() {
       )}
 
       <Table
-        // Defensive key: include source + sorted sourceGroup ids so two rows for the same
-        // (project, role) via different paths wouldn't collapse (AI review #66 🟠). Today
-        // the backend returns one row per project, but the guard keeps rendering correct
-        // if that invariant changes.
-        rowKey={(r) =>
-          `${r.project.id}:${r.role.id}:${r.source}:${r.sourceGroups.map(g => g.id).sort().join(',')}`
-        }
+        // AI review #66 round 4 🟠 — use the actual unique identifier from the API contract.
+        // `computeEffectiveRole` returns exactly one effective row per (userId, projectId), so
+        // `project.id` is the stable unique key. If the contract ever changes to support
+        // multiple rows per project, the `SecurityProjectRole` type in `api/user-security.ts`
+        // should gain an explicit `id` field and this key updated to match — a compile-time
+        // signal rather than a silent rendering bug.
+        rowKey={(r) => r.project.id}
         dataSource={data?.projectRoles ?? []}
         columns={columns}
         loading={loading}

--- a/frontend/src/components/profile/SecurityTab.tsx
+++ b/frontend/src/components/profile/SecurityTab.tsx
@@ -20,21 +20,34 @@ import {
  * Shape is driven by the backend `UserSecurityPayload` type.
  */
 
+/**
+ * Proper CSV escaping per RFC 4180: wrap in double quotes, double any embedded quote.
+ * AI review #66 🟡 — previous version used JSON.stringify, which is NOT CSV and broke on
+ * values containing `;`, newlines, or quotes. Excel-friendly BOM prefix so Cyrillic renders
+ * correctly on Windows out of the box.
+ */
+function csvField(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
 function downloadCsv(payload: UserSecurityPayload): void {
-  const header = 'Проект;Ключ;Роль;Источник;Через группы\n';
-  const body = payload.projectRoles
-    .map(r => {
+  const rows: string[] = [
+    ['Проект', 'Ключ', 'Роль', 'Источник', 'Через группы']
+      .map(csvField)
+      .join(';'),
+    ...payload.projectRoles.map(r => {
       const via = r.sourceGroups.map(g => g.name).join(', ');
       return [
-        JSON.stringify(r.project.name),
-        JSON.stringify(r.project.key),
-        JSON.stringify(r.role.name),
-        r.source === 'DIRECT' ? 'Прямое' : 'Группа',
-        JSON.stringify(via),
+        csvField(r.project.name),
+        csvField(r.project.key),
+        csvField(r.role.name),
+        csvField(r.source === 'DIRECT' ? 'Прямое' : 'Группа'),
+        csvField(via),
       ].join(';');
-    })
-    .join('\n');
-  const blob = new Blob([header + body], { type: 'text/csv;charset=utf-8' });
+    }),
+  ];
+  // `\uFEFF` = UTF-8 BOM — Excel needs it to auto-detect Cyrillic text.
+  const blob = new Blob(['\uFEFF' + rows.join('\n')], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
@@ -134,7 +147,13 @@ export default function SecurityTab() {
       )}
 
       <Table
-        rowKey={(r) => `${r.project.id}:${r.role.id}`}
+        // Defensive key: include source + sorted sourceGroup ids so two rows for the same
+        // (project, role) via different paths wouldn't collapse (AI review #66 🟠). Today
+        // the backend returns one row per project, but the guard keeps rendering correct
+        // if that invariant changes.
+        rowKey={(r) =>
+          `${r.project.id}:${r.role.id}:${r.source}:${r.sourceGroups.map(g => g.id).sort().join(',')}`
+        }
         dataSource={data?.projectRoles ?? []}
         columns={columns}
         loading={loading}

--- a/frontend/src/lib/roles.ts
+++ b/frontend/src/lib/roles.ts
@@ -28,3 +28,17 @@ export function hasAnyRequiredRole(
 ): boolean {
   return hasAnySystemRole(userRoles, requiredRoles);
 }
+
+/**
+ * TTSEC-2 Phase 3 access helper for the user-groups admin surface.
+ *
+ * Today this is just `ADMIN` system role (SUPER_ADMIN bypasses via `hasSystemRole`). Phase 4
+ * will swap the body for a real per-user permission check against `USER_GROUP_VIEW` /
+ * `USER_GROUP_MANAGE` once the backend exposes per-user permissions to the client.
+ *
+ * Keeping the call-site abstraction stable lets Phase 4 be a one-function change without
+ * hunting down inline role checks across the UI.
+ */
+export function canViewUserGroups(userRoles: SystemRoleType[] | null | undefined): boolean {
+  return hasSystemRole(userRoles, 'ADMIN');
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useThemeStore } from '../store/theme.store';
 import { useAuthStore } from '../store/auth.store';
+import SecurityTab from '../components/profile/SecurityTab';
 
 const LOGO_GRAD =
   'linear-gradient(in oklab 135deg, oklab(59.3% -0.002 -0.207) 0%, oklab(54.1% 0.096 -0.227) 100%)';
@@ -749,6 +750,19 @@ export default function SettingsPage() {
                 </div>
               ))}
             </div>
+          </div>
+
+          {/* TTSEC-2 Phase 3: Security card — groups + effective project roles with source. */}
+          <div
+            style={{
+              background: C.bgCard,
+              border: `1px solid ${C.border}`,
+              borderRadius: 12,
+              paddingBlock: 24,
+              paddingInline: 24,
+            }}
+          >
+            <SecurityTab />
           </div>
 
           {/* Notifications card */}

--- a/frontend/src/pages/admin/AdminGroupDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupDetailPage.tsx
@@ -48,6 +48,7 @@ export default function AdminGroupDetailPage() {
   const [allProjects, setAllProjects] = useState<Project[]>([]);
   const [grantProjectId, setGrantProjectId] = useState<string | undefined>();
   const [grantProjectScheme, setGrantProjectScheme] = useState<ProjectRoleScheme | null>(null);
+  const [grantSchemeLoading, setGrantSchemeLoading] = useState(false);
   const [grantRoleId, setGrantRoleId] = useState<string | undefined>();
   const [granting, setGranting] = useState(false);
 
@@ -107,15 +108,18 @@ export default function AdminGroupDetailPage() {
   useEffect(() => {
     setGrantProjectScheme(null);
     setGrantRoleId(undefined);
-    if (!grantProjectId) return;
+    if (!grantProjectId) { setGrantSchemeLoading(false); return; }
+    // AI review #66 round 9 🟡 — surface the scheme fetch as a loading state on the role select
+    // so the user doesn't see an unexplained empty dropdown during the request.
+    setGrantSchemeLoading(true);
     let cancelled = false;
     roleSchemesApi.getForProject(grantProjectId)
       .then(s => { if (!cancelled) setGrantProjectScheme(s); })
       .catch(() => {
         if (cancelled) return;
         message.error('Не удалось загрузить схему проекта');
-        // State already cleared above — nothing to roll back.
-      });
+      })
+      .finally(() => { if (!cancelled) setGrantSchemeLoading(false); });
     return () => { cancelled = true; };
   }, [grantProjectId]);
 
@@ -409,11 +413,18 @@ export default function AdminGroupDetailPage() {
             options={availableProjectsForGrant.map(p => ({ value: p.id, label: `${p.key}: ${p.name}` }))}
           />
           <Select
-            placeholder={grantProjectScheme ? 'Роль' : 'Сначала выберите проект'}
+            placeholder={
+              grantSchemeLoading
+                ? 'Загрузка ролей…'
+                : grantProjectScheme
+                  ? 'Роль'
+                  : 'Сначала выберите проект'
+            }
             style={{ width: '100%' }}
             value={grantRoleId}
             onChange={setGrantRoleId}
-            disabled={!grantProjectScheme}
+            disabled={!grantProjectScheme || grantSchemeLoading}
+            loading={grantSchemeLoading}
             options={(grantProjectScheme?.roles ?? []).map(r => ({
               value: r.id,
               label: r.name,

--- a/frontend/src/pages/admin/AdminGroupDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupDetailPage.tsx
@@ -53,20 +53,34 @@ export default function AdminGroupDetailPage() {
   const load = useCallback(async () => {
     if (!id) return;
     setLoading(true);
+    // AI review #66 round 3 🟠 — group is critical; projects/users are reference lists for
+    // modals. Failing to load the reference lists should NOT hide the group page. Use
+    // allSettled to keep partial degradation: group fails → fall back to error state; ref
+    // lists fail → the page still renders, only the relevant modal shows an error on open.
     try {
-      const [g, projects, usersResp] = await Promise.all([
-        userGroupsApi.get(id),
-        listProjects(),
-        adminApi.listUsers({ isActive: true, pageSize: 500 }),
-      ]);
+      const g = await userGroupsApi.get(id);
       setGroup(g);
-      setAllProjects(projects);
-      setAllUsers(usersResp.users);
     } catch {
       message.error('Не удалось загрузить группу');
-    } finally {
       setLoading(false);
+      return;
     }
+
+    const [projectsResult, usersResult] = await Promise.allSettled([
+      listProjects(),
+      adminApi.listUsers({ isActive: true, pageSize: 500 }),
+    ]);
+    if (projectsResult.status === 'fulfilled') {
+      setAllProjects(projectsResult.value);
+    } else {
+      message.warning('Не удалось загрузить список проектов');
+    }
+    if (usersResult.status === 'fulfilled') {
+      setAllUsers(usersResult.value.users);
+    } else {
+      message.warning('Не удалось загрузить список пользователей');
+    }
+    setLoading(false);
   }, [id]);
 
   useEffect(() => { load(); }, [load]);

--- a/frontend/src/pages/admin/AdminGroupDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupDetailPage.tsx
@@ -59,6 +59,10 @@ export default function AdminGroupDetailPage() {
     // allSettled to keep partial degradation: group fails → fall back to error state; ref
     // lists fail → the page still renders, only the relevant modal shows an error on open.
     setLoadError(null);
+    // AI review #66 round 8 🟡 — clear reference lists upfront so a subsequent partial-failure
+    // cannot leave stale data from a previous group visible in modal dropdowns.
+    setAllProjects([]);
+    setAllUsers([]);
     try {
       const g = await userGroupsApi.get(id);
       setGroup(g);

--- a/frontend/src/pages/admin/AdminGroupDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupDetailPage.tsx
@@ -409,13 +409,26 @@ export default function AdminGroupDetailPage() {
           onChange={setSelectedUserIds}
           style={{ width: '100%' }}
           showSearch
-          // Switch to server-driven search: client-side filtering returns false so the Select
-          // trusts the options we pass (already filtered by server search + existing members).
-          filterOption={false}
+          // AI review #66 round 13 🟠 — dual-mode filter:
+          //   - No server search active → client-side filter by label over the initial bulk list
+          //     so the dropdown is snappy and works without typing triggering a roundtrip.
+          //   - Server search active (memberCandidates populated) → options are already filtered
+          //     by the backend; disable client-side filter to trust them as-is.
+          filterOption={
+            memberCandidates === null
+              ? (input, opt) => (opt?.label as string)?.toLowerCase().includes(input.toLowerCase())
+              : false
+          }
           onSearch={setMemberSearch}
           onBlur={() => setMemberSearch('')}
           loading={memberSearchLoading}
-          notFoundContent={memberSearchLoading ? 'Поиск…' : memberSearch ? 'Ничего не найдено' : 'Введите запрос для поиска большего числа пользователей'}
+          notFoundContent={
+            memberSearchLoading
+              ? 'Поиск…'
+              : memberSearch
+                ? 'Ничего не найдено'
+                : 'Нет доступных пользователей'
+          }
           options={availableUsersForAdd.map(u => ({
             value: u.id,
             label: `${u.name} · ${u.email}`,

--- a/frontend/src/pages/admin/AdminGroupDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupDetailPage.tsx
@@ -73,12 +73,22 @@ export default function AdminGroupDetailPage() {
 
   // When the admin picks a project, fetch its active scheme so the role-select only lists roles
   // that backend will actually accept (grantProjectRole rejects cross-scheme roles with 400).
+  //
+  // AI review #66 round 2 🟠 — clear scheme state at the START of a new request and on ERROR,
+  // so the previously-selected project's roles don't linger in the dropdown. Otherwise a failed
+  // fetch would leave stale options that produce a 400 on submit.
   useEffect(() => {
-    if (!grantProjectId) { setGrantProjectScheme(null); setGrantRoleId(undefined); return; }
+    setGrantProjectScheme(null);
+    setGrantRoleId(undefined);
+    if (!grantProjectId) return;
     let cancelled = false;
     roleSchemesApi.getForProject(grantProjectId)
-      .then(s => { if (!cancelled) { setGrantProjectScheme(s); setGrantRoleId(undefined); } })
-      .catch(() => { if (!cancelled) message.error('Не удалось загрузить схему проекта'); });
+      .then(s => { if (!cancelled) setGrantProjectScheme(s); })
+      .catch(() => {
+        if (cancelled) return;
+        message.error('Не удалось загрузить схему проекта');
+        // State already cleared above — nothing to roll back.
+      });
     return () => { cancelled = true; };
   }, [grantProjectId]);
 

--- a/frontend/src/pages/admin/AdminGroupDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupDetailPage.tsx
@@ -48,6 +48,12 @@ export default function AdminGroupDetailPage() {
   const [memberSearch, setMemberSearch] = useState('');
   const [memberSearchLoading, setMemberSearchLoading] = useState(false);
   const [memberCandidates, setMemberCandidates] = useState<AdminUser[] | null>(null);
+  // AI review #66 round 14 🟠 — keep a stable cache of user metadata (id → {name, email})
+  // for everyone we've ever seen in this session: initial bulk list, server-search results,
+  // and already-selected ids. Without this, toggling the server search off (via onBlur or
+  // similar) would lose option labels for selections that came from server results, causing
+  // Ant Select to render raw UUIDs.
+  const [selectedUserCache, setSelectedUserCache] = useState<Map<string, AdminUser>>(new Map());
 
   // Grant project role
   const [grantOpen, setGrantOpen] = useState(false);
@@ -201,8 +207,19 @@ export default function AdminGroupDetailPage() {
     // Source precedence: active server search results > initial bulk list. Both get the
     // existing-members filter so we never offer someone who's already in.
     const source = memberCandidates ?? allUsers;
-    return source.filter(u => !existing.has(u.id));
-  }, [allUsers, memberCandidates, group]);
+    const sourceFiltered = source.filter(u => !existing.has(u.id));
+    // AI review #66 round 14 🟠 — always keep already-selected users visible so Ant Select
+    // can show their proper labels even when source list switches. We union the source with
+    // the cached metadata for currently-selected ids, de-duped by id.
+    const byId = new Map<string, AdminUser>(sourceFiltered.map(u => [u.id, u]));
+    for (const id of selectedUserIds) {
+      if (byId.has(id)) continue;
+      if (existing.has(id)) continue;
+      const cached = selectedUserCache.get(id);
+      if (cached) byId.set(id, cached);
+    }
+    return Array.from(byId.values());
+  }, [allUsers, memberCandidates, group, selectedUserIds, selectedUserCache]);
 
   const availableProjectsForGrant = useMemo(() => {
     if (!group) return allProjects;
@@ -236,6 +253,7 @@ export default function AdminGroupDetailPage() {
       setSelectedUserIds([]);
       setMemberSearch('');
       setMemberCandidates(null);
+      setSelectedUserCache(new Map());
       load();
     } catch {
       message.error('Не удалось добавить участников');
@@ -393,7 +411,14 @@ export default function AdminGroupDetailPage() {
       <Modal
         title="Добавить участников"
         open={addMembersOpen}
-        onCancel={() => { setAddMembersOpen(false); setSelectedUserIds([]); setMemberSearch(''); setMemberCandidates(null); void load(); }}
+        onCancel={() => {
+          setAddMembersOpen(false);
+          setSelectedUserIds([]);
+          setMemberSearch('');
+          setMemberCandidates(null);
+          setSelectedUserCache(new Map());
+          void load();
+        }}
         onOk={handleAddMembers}
         okText="Добавить"
         cancelText="Отмена"
@@ -406,7 +431,23 @@ export default function AdminGroupDetailPage() {
           mode="multiple"
           placeholder="Начните вводить имя или email"
           value={selectedUserIds}
-          onChange={setSelectedUserIds}
+          onChange={(ids: string[]) => {
+            // Snapshot the metadata for every newly-added id so the option can always render
+            // a proper label — even if we later switch source lists (AI review #66 round 14).
+            const pool = memberCandidates ?? allUsers;
+            const byId = new Map<string, AdminUser>(pool.map(u => [u.id, u]));
+            setSelectedUserCache(prev => {
+              const next = new Map(prev);
+              for (const id of ids) {
+                if (!next.has(id)) {
+                  const hit = byId.get(id);
+                  if (hit) next.set(id, hit);
+                }
+              }
+              return next;
+            });
+            setSelectedUserIds(ids);
+          }}
           style={{ width: '100%' }}
           showSearch
           // AI review #66 round 13 🟠 — dual-mode filter:
@@ -420,7 +461,6 @@ export default function AdminGroupDetailPage() {
               : false
           }
           onSearch={setMemberSearch}
-          onBlur={() => setMemberSearch('')}
           loading={memberSearchLoading}
           notFoundContent={
             memberSearchLoading

--- a/frontend/src/pages/admin/AdminGroupDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupDetailPage.tsx
@@ -240,6 +240,8 @@ export default function AdminGroupDetailPage() {
     }
   };
 
+  // Takes projectId (not binding.id) — backend keys by (groupId, projectId) per @@unique.
+  // See api/user-groups.ts revokeProjectRole for full contract note.
   const handleRevokeProjectRole = async (projectId: string) => {
     if (!group) return;
     try {

--- a/frontend/src/pages/admin/AdminGroupDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   Table, Button, Modal, Form, Input, Space, Tag, message,
-  Popconfirm, Tabs, Select, Tooltip,
+  Popconfirm, Tabs, Select, Tooltip, Result,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { ArrowLeftOutlined, PlusOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons';
@@ -30,6 +30,7 @@ export default function AdminGroupDetailPage() {
 
   const [group, setGroup] = useState<UserGroupDetail | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // Edit header
   const [editOpen, setEditOpen] = useState(false);
@@ -57,11 +58,19 @@ export default function AdminGroupDetailPage() {
     // modals. Failing to load the reference lists should NOT hide the group page. Use
     // allSettled to keep partial degradation: group fails → fall back to error state; ref
     // lists fail → the page still renders, only the relevant modal shows an error on open.
+    setLoadError(null);
     try {
       const g = await userGroupsApi.get(id);
       setGroup(g);
-    } catch {
-      message.error('Не удалось загрузить группу');
+    } catch (e: unknown) {
+      // AI review #66 round 6 🟡 — keep error state separate from loading so the UI can show
+      // a real "group not available" screen instead of an eternal «Загрузка...».
+      const err = e as { response?: { status?: number; data?: { error?: string } } };
+      const msg = err?.response?.status === 404
+        ? 'Группа не найдена'
+        : err?.response?.data?.error ?? 'Не удалось загрузить группу';
+      message.error(msg);
+      setLoadError(msg);
       setLoading(false);
       return;
     }
@@ -234,8 +243,23 @@ export default function AdminGroupDetailPage() {
     }
   };
 
-  if (loading || !group) {
+  if (loading) {
     return <div className="tt-page"><div>Загрузка...</div></div>;
+  }
+  if (loadError || !group) {
+    return (
+      <div className="tt-page">
+        <Result
+          status="warning"
+          title={loadError ?? 'Группа недоступна'}
+          extra={
+            <Button type="primary" onClick={() => navigate('/admin/user-groups')}>
+              К списку групп
+            </Button>
+          }
+        />
+      </div>
+    );
   }
 
   return (

--- a/frontend/src/pages/admin/AdminGroupDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupDetailPage.tsx
@@ -1,0 +1,374 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  Table, Button, Modal, Form, Input, Space, Tag, message,
+  Popconfirm, Tabs, Select, Tooltip,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { ArrowLeftOutlined, PlusOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons';
+import {
+  userGroupsApi,
+  type UserGroupDetail,
+  type UserGroupMember,
+  type UserGroupProjectRole,
+} from '../../api/user-groups';
+import { adminApi, type AdminUser } from '../../api/admin';
+import { listProjects } from '../../api/projects';
+import { roleSchemesApi, type ProjectRoleScheme } from '../../api/role-schemes';
+import type { Project } from '../../types';
+
+/**
+ * TTSEC-2 Phase 3: group detail with Members + Project Roles tabs.
+ *
+ * Grant project role UX: user picks a project → frontend fetches that project's active role
+ * scheme via `/projects/:id/role-scheme` → role select populates with roles from THAT scheme.
+ * Matches backend validation in grantProjectRole (role must belong to active scheme).
+ */
+export default function AdminGroupDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [group, setGroup] = useState<UserGroupDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Edit header
+  const [editOpen, setEditOpen] = useState(false);
+  const [editForm] = Form.useForm();
+  const [savingEdit, setSavingEdit] = useState(false);
+
+  // Add members
+  const [addMembersOpen, setAddMembersOpen] = useState(false);
+  const [allUsers, setAllUsers] = useState<AdminUser[]>([]);
+  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
+  const [addingMembers, setAddingMembers] = useState(false);
+
+  // Grant project role
+  const [grantOpen, setGrantOpen] = useState(false);
+  const [allProjects, setAllProjects] = useState<Project[]>([]);
+  const [grantProjectId, setGrantProjectId] = useState<string | undefined>();
+  const [grantProjectScheme, setGrantProjectScheme] = useState<ProjectRoleScheme | null>(null);
+  const [grantRoleId, setGrantRoleId] = useState<string | undefined>();
+  const [granting, setGranting] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    try {
+      const [g, projects, usersResp] = await Promise.all([
+        userGroupsApi.get(id),
+        listProjects(),
+        adminApi.listUsers({ isActive: true, pageSize: 500 }),
+      ]);
+      setGroup(g);
+      setAllProjects(projects);
+      setAllUsers(usersResp.users);
+    } catch {
+      message.error('Не удалось загрузить группу');
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  // When the admin picks a project, fetch its active scheme so the role-select only lists roles
+  // that backend will actually accept (grantProjectRole rejects cross-scheme roles with 400).
+  useEffect(() => {
+    if (!grantProjectId) { setGrantProjectScheme(null); setGrantRoleId(undefined); return; }
+    let cancelled = false;
+    roleSchemesApi.getForProject(grantProjectId)
+      .then(s => { if (!cancelled) { setGrantProjectScheme(s); setGrantRoleId(undefined); } })
+      .catch(() => { if (!cancelled) message.error('Не удалось загрузить схему проекта'); });
+    return () => { cancelled = true; };
+  }, [grantProjectId]);
+
+  const memberColumns: ColumnsType<UserGroupMember> = [
+    { title: 'Имя', dataIndex: ['user', 'name'] },
+    { title: 'Email', dataIndex: ['user', 'email'] },
+    { title: 'Добавлен', dataIndex: 'addedAt', render: (v: string) => new Date(v).toLocaleString('ru-RU') },
+    { title: 'Добавил', dataIndex: ['addedBy', 'name'], render: (v: string | null) => v || '—' },
+    {
+      title: '', width: 80,
+      render: (_, m) => (
+        <Popconfirm
+          title="Убрать пользователя из группы?"
+          onConfirm={() => handleRemoveMember(m.userId)}
+          okText="Убрать"
+          okButtonProps={{ danger: true }}
+        >
+          <Button size="small" danger icon={<DeleteOutlined />} />
+        </Popconfirm>
+      ),
+    },
+  ];
+
+  const projectRoleColumns: ColumnsType<UserGroupProjectRole> = [
+    { title: 'Ключ', dataIndex: ['project', 'key'], render: (v: string) => <code>{v}</code> },
+    { title: 'Проект', dataIndex: ['project', 'name'] },
+    {
+      title: 'Роль',
+      render: (_, r) => (
+        <Tag color={r.roleDefinition.color ?? 'default'}>{r.roleDefinition.name}</Tag>
+      ),
+    },
+    {
+      title: '', width: 100,
+      render: (_, r) => (
+        <Popconfirm
+          title="Отозвать роль?"
+          onConfirm={() => handleRevokeProjectRole(r.projectId)}
+          okText="Отозвать"
+          okButtonProps={{ danger: true }}
+        >
+          <Button size="small" danger>Отозвать</Button>
+        </Popconfirm>
+      ),
+    },
+  ];
+
+  const availableUsersForAdd = useMemo(() => {
+    if (!group) return [];
+    const existing = new Set(group.members.map(m => m.userId));
+    return allUsers.filter(u => !existing.has(u.id));
+  }, [allUsers, group]);
+
+  const availableProjectsForGrant = useMemo(() => {
+    if (!group) return allProjects;
+    const bound = new Set(group.projectRoles.map(r => r.projectId));
+    return allProjects.filter(p => !bound.has(p.id));
+  }, [allProjects, group]);
+
+  const handleSaveEdit = async (vals: { name: string; description?: string }) => {
+    if (!group) return;
+    setSavingEdit(true);
+    try {
+      await userGroupsApi.update(group.id, { name: vals.name, description: vals.description || null });
+      message.success('Группа обновлена');
+      setEditOpen(false);
+      load();
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { error?: string } } };
+      message.error(err?.response?.data?.error || 'Не удалось сохранить');
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
+  const handleAddMembers = async () => {
+    if (!group || selectedUserIds.length === 0) return;
+    setAddingMembers(true);
+    try {
+      await userGroupsApi.addMembers(group.id, selectedUserIds);
+      message.success(`Добавлено: ${selectedUserIds.length}`);
+      setAddMembersOpen(false);
+      setSelectedUserIds([]);
+      load();
+    } catch {
+      message.error('Не удалось добавить участников');
+    } finally {
+      setAddingMembers(false);
+    }
+  };
+
+  const handleRemoveMember = async (userId: string) => {
+    if (!group) return;
+    try {
+      await userGroupsApi.removeMember(group.id, userId);
+      message.success('Участник удалён');
+      load();
+    } catch {
+      message.error('Не удалось удалить участника');
+    }
+  };
+
+  const handleGrant = async () => {
+    if (!group || !grantProjectId || !grantRoleId) return;
+    setGranting(true);
+    try {
+      await userGroupsApi.grantProjectRole(group.id, { projectId: grantProjectId, roleId: grantRoleId });
+      message.success('Роль выдана');
+      setGrantOpen(false);
+      setGrantProjectId(undefined);
+      setGrantRoleId(undefined);
+      load();
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { error?: string } } };
+      message.error(err?.response?.data?.error || 'Не удалось выдать роль');
+    } finally {
+      setGranting(false);
+    }
+  };
+
+  const handleRevokeProjectRole = async (projectId: string) => {
+    if (!group) return;
+    try {
+      await userGroupsApi.revokeProjectRole(group.id, projectId);
+      message.success('Роль отозвана');
+      load();
+    } catch {
+      message.error('Не удалось отозвать роль');
+    }
+  };
+
+  if (loading || !group) {
+    return <div className="tt-page"><div>Загрузка...</div></div>;
+  }
+
+  return (
+    <div className="tt-page">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+        <Button icon={<ArrowLeftOutlined />} onClick={() => navigate('/admin/user-groups')}>Назад</Button>
+        <h2 className="tt-page-title" style={{ margin: 0 }}>{group.name}</h2>
+        <Tooltip title="Переименовать">
+          <Button
+            icon={<EditOutlined />}
+            onClick={() => {
+              editForm.setFieldsValue({ name: group.name, description: group.description ?? '' });
+              setEditOpen(true);
+            }}
+          />
+        </Tooltip>
+      </div>
+
+      {group.description && (
+        <p style={{ color: '#888', marginBottom: 16 }}>{group.description}</p>
+      )}
+
+      <Tabs
+        items={[
+          {
+            key: 'members',
+            label: `Участники (${group.members.length})`,
+            children: (
+              <>
+                <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 12 }}>
+                  <Button type="primary" icon={<PlusOutlined />} onClick={() => setAddMembersOpen(true)}>
+                    Добавить участников
+                  </Button>
+                </div>
+                <Table
+                  rowKey="userId"
+                  dataSource={group.members}
+                  columns={memberColumns}
+                  pagination={{ pageSize: 20 }}
+                  size="small"
+                />
+              </>
+            ),
+          },
+          {
+            key: 'projectRoles',
+            label: `Проектные роли (${group.projectRoles.length})`,
+            children: (
+              <>
+                <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 12 }}>
+                  <Button type="primary" icon={<PlusOutlined />} onClick={() => setGrantOpen(true)}>
+                    Выдать роль в проекте
+                  </Button>
+                </div>
+                <Table
+                  rowKey="id"
+                  dataSource={group.projectRoles}
+                  columns={projectRoleColumns}
+                  pagination={false}
+                  size="small"
+                />
+              </>
+            ),
+          },
+        ]}
+      />
+
+      <Modal
+        title="Редактировать группу"
+        open={editOpen}
+        onCancel={() => { setEditOpen(false); void load(); }}
+        onOk={() => editForm.submit()}
+        okText="Сохранить"
+        cancelText="Отмена"
+        confirmLoading={savingEdit}
+        destroyOnClose
+      >
+        <Form form={editForm} layout="vertical" onFinish={handleSaveEdit}>
+          <Form.Item name="name" label="Название" rules={[{ required: true, message: 'Введите название' }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="description" label="Описание">
+            <Input.TextArea rows={2} />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal
+        title="Добавить участников"
+        open={addMembersOpen}
+        onCancel={() => { setAddMembersOpen(false); setSelectedUserIds([]); void load(); }}
+        onOk={handleAddMembers}
+        okText="Добавить"
+        cancelText="Отмена"
+        confirmLoading={addingMembers}
+        okButtonProps={{ disabled: selectedUserIds.length === 0 }}
+        destroyOnClose
+        width={560}
+      >
+        <Select
+          mode="multiple"
+          placeholder="Выберите пользователей"
+          value={selectedUserIds}
+          onChange={setSelectedUserIds}
+          style={{ width: '100%' }}
+          showSearch
+          filterOption={(input, opt) =>
+            (opt?.label as string)?.toLowerCase().includes(input.toLowerCase())
+          }
+          options={availableUsersForAdd.map(u => ({
+            value: u.id,
+            label: `${u.name} · ${u.email}`,
+          }))}
+        />
+      </Modal>
+
+      <Modal
+        title="Выдать роль в проекте"
+        open={grantOpen}
+        onCancel={() => {
+          setGrantOpen(false);
+          setGrantProjectId(undefined);
+          setGrantRoleId(undefined);
+          void load();
+        }}
+        onOk={handleGrant}
+        okText="Выдать"
+        cancelText="Отмена"
+        confirmLoading={granting}
+        okButtonProps={{ disabled: !grantProjectId || !grantRoleId }}
+        destroyOnClose
+      >
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Select
+            placeholder="Проект"
+            style={{ width: '100%' }}
+            value={grantProjectId}
+            onChange={setGrantProjectId}
+            showSearch
+            filterOption={(input, opt) =>
+              (opt?.label as string)?.toLowerCase().includes(input.toLowerCase())
+            }
+            options={availableProjectsForGrant.map(p => ({ value: p.id, label: `${p.key}: ${p.name}` }))}
+          />
+          <Select
+            placeholder={grantProjectScheme ? 'Роль' : 'Сначала выберите проект'}
+            style={{ width: '100%' }}
+            value={grantRoleId}
+            onChange={setGrantRoleId}
+            disabled={!grantProjectScheme}
+            options={(grantProjectScheme?.roles ?? []).map(r => ({
+              value: r.id,
+              label: r.name,
+            }))}
+          />
+        </Space>
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminGroupDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupDetailPage.tsx
@@ -42,6 +42,12 @@ export default function AdminGroupDetailPage() {
   const [allUsers, setAllUsers] = useState<AdminUser[]>([]);
   const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
   const [addingMembers, setAddingMembers] = useState(false);
+  // AI review #66 round 12 🟡 — initial bulk load is capped at 500 for UX (virtualisation
+  // becomes ugly beyond that). On installations with more users, admins type a search in the
+  // multi-select; we run a debounced server-side search and swap the candidate list.
+  const [memberSearch, setMemberSearch] = useState('');
+  const [memberSearchLoading, setMemberSearchLoading] = useState(false);
+  const [memberCandidates, setMemberCandidates] = useState<AdminUser[] | null>(null);
 
   // Grant project role
   const [grantOpen, setGrantOpen] = useState(false);
@@ -98,6 +104,28 @@ export default function AdminGroupDetailPage() {
   }, [id]);
 
   useEffect(() => { load(); }, [load]);
+
+  // Debounced server-side user search for the add-members select. Null `memberCandidates` means
+  // "no active search" and the UI falls back to the initial 500-user bulk load; populated array
+  // means "show these server results". Empty search clears the override.
+  useEffect(() => {
+    if (!addMembersOpen) return;
+    const q = memberSearch.trim();
+    if (q.length === 0) { setMemberCandidates(null); setMemberSearchLoading(false); return; }
+    setMemberSearchLoading(true);
+    let cancelled = false;
+    const t = setTimeout(async () => {
+      try {
+        const resp = await adminApi.listUsers({ search: q, isActive: true, pageSize: 100 });
+        if (!cancelled) setMemberCandidates(resp.users);
+      } catch {
+        if (!cancelled) setMemberCandidates([]);
+      } finally {
+        if (!cancelled) setMemberSearchLoading(false);
+      }
+    }, 250);
+    return () => { cancelled = true; clearTimeout(t); };
+  }, [memberSearch, addMembersOpen]);
 
   // When the admin picks a project, fetch its active scheme so the role-select only lists roles
   // that backend will actually accept (grantProjectRole rejects cross-scheme roles with 400).
@@ -170,8 +198,11 @@ export default function AdminGroupDetailPage() {
   const availableUsersForAdd = useMemo(() => {
     if (!group) return [];
     const existing = new Set(group.members.map(m => m.userId));
-    return allUsers.filter(u => !existing.has(u.id));
-  }, [allUsers, group]);
+    // Source precedence: active server search results > initial bulk list. Both get the
+    // existing-members filter so we never offer someone who's already in.
+    const source = memberCandidates ?? allUsers;
+    return source.filter(u => !existing.has(u.id));
+  }, [allUsers, memberCandidates, group]);
 
   const availableProjectsForGrant = useMemo(() => {
     if (!group) return allProjects;
@@ -203,6 +234,8 @@ export default function AdminGroupDetailPage() {
       message.success(`Добавлено: ${selectedUserIds.length}`);
       setAddMembersOpen(false);
       setSelectedUserIds([]);
+      setMemberSearch('');
+      setMemberCandidates(null);
       load();
     } catch {
       message.error('Не удалось добавить участников');
@@ -360,7 +393,7 @@ export default function AdminGroupDetailPage() {
       <Modal
         title="Добавить участников"
         open={addMembersOpen}
-        onCancel={() => { setAddMembersOpen(false); setSelectedUserIds([]); void load(); }}
+        onCancel={() => { setAddMembersOpen(false); setSelectedUserIds([]); setMemberSearch(''); setMemberCandidates(null); void load(); }}
         onOk={handleAddMembers}
         okText="Добавить"
         cancelText="Отмена"
@@ -371,14 +404,18 @@ export default function AdminGroupDetailPage() {
       >
         <Select
           mode="multiple"
-          placeholder="Выберите пользователей"
+          placeholder="Начните вводить имя или email"
           value={selectedUserIds}
           onChange={setSelectedUserIds}
           style={{ width: '100%' }}
           showSearch
-          filterOption={(input, opt) =>
-            (opt?.label as string)?.toLowerCase().includes(input.toLowerCase())
-          }
+          // Switch to server-driven search: client-side filtering returns false so the Select
+          // trusts the options we pass (already filtered by server search + existing members).
+          filterOption={false}
+          onSearch={setMemberSearch}
+          onBlur={() => setMemberSearch('')}
+          loading={memberSearchLoading}
+          notFoundContent={memberSearchLoading ? 'Поиск…' : memberSearch ? 'Ничего не найдено' : 'Введите запрос для поиска большего числа пользователей'}
           options={availableUsersForAdd.map(u => ({
             value: u.id,
             label: `${u.name} · ${u.email}`,

--- a/frontend/src/pages/admin/AdminGroupsPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Table, Button, Modal, Form, Input, Space, message, Tooltip } from 'antd';
+import { Table, Button, Modal, Form, Input, Space, message, Tooltip, Alert } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { PlusOutlined, EditOutlined, DeleteOutlined, TeamOutlined, SearchOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
@@ -24,6 +24,7 @@ export default function AdminGroupsPage() {
 
   const [impact, setImpact] = useState<UserGroupImpact | null>(null);
   const [impactFor, setImpactFor] = useState<UserGroupListItem | null>(null);
+  const [impactError, setImpactError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
 
   // Debounce the user-typed search so we don't fire a request per keystroke
@@ -74,12 +75,12 @@ export default function AdminGroupsPage() {
     }
   };
 
-  const openDelete = async (g: UserGroupListItem) => {
+  const loadImpact = async (g: UserGroupListItem) => {
     // Race guard (AI review #66 round 3 🟠) — if the admin quickly switches between groups,
     // a slower in-flight response must NOT overwrite the impact for the currently-open group.
     // We re-read `impactFor` inside the settled handlers and apply only when it's still `g`.
-    setImpactFor(g);
-    setImpact(null); // clear whatever was there for the previous group while the new one loads
+    setImpact(null);
+    setImpactError(null);
     try {
       const result = await userGroupsApi.getImpact(g.id);
       setImpactFor(current => {
@@ -87,14 +88,19 @@ export default function AdminGroupsPage() {
         return current;
       });
     } catch {
+      // AI review #66 round 8 🟠 — keep the modal open on error so the user sees what went
+      // wrong and can retry; previously we closed it silently, which hid the delete-with-impact
+      // UX contract.
       setImpactFor(current => {
-        if (current?.id === g.id) {
-          message.error('Не удалось получить impact группы');
-          return null;
-        }
+        if (current?.id === g.id) setImpactError('Не удалось получить impact группы');
         return current;
       });
     }
+  };
+
+  const openDelete = async (g: UserGroupListItem) => {
+    setImpactFor(g);
+    await loadImpact(g);
   };
 
   const confirmDelete = async () => {
@@ -189,14 +195,19 @@ export default function AdminGroupsPage() {
       <Modal
         title={`Удалить группу «${impactFor?.name ?? ''}»?`}
         open={!!impactFor}
-        onCancel={() => { setImpactFor(null); setImpact(null); }}
+        onCancel={() => { setImpactFor(null); setImpact(null); setImpactError(null); }}
         onOk={confirmDelete}
         okText="Удалить"
         okButtonProps={{ danger: true, disabled: !impact }}
         cancelText="Отмена"
         confirmLoading={deleting}
       >
-        {impact ? (
+        {impactError ? (
+          <Space direction="vertical" style={{ width: '100%' }}>
+            <Alert type="error" message={impactError} showIcon />
+            <Button onClick={() => impactFor && loadImpact(impactFor)}>Повторить</Button>
+          </Space>
+        ) : impact ? (
           <>
             <p>Будут отозваны следующие доступы:</p>
             <ul>

--- a/frontend/src/pages/admin/AdminGroupsPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupsPage.tsx
@@ -22,10 +22,16 @@ export default function AdminGroupsPage() {
   const [saving, setSaving] = useState(false);
   const [form] = Form.useForm();
 
-  const [impact, setImpact] = useState<UserGroupImpact | null>(null);
+  // AI review #66 round 10 🟠 — bundle impact with the group id it was loaded for, so render
+  // code can only use impact when it genuinely belongs to the currently-open group. Prevents a
+  // stale impact from a previous group from enabling delete before the new fetch settles.
+  const [impact, setImpact] = useState<{ forGroupId: string; data: UserGroupImpact } | null>(null);
   const [impactFor, setImpactFor] = useState<UserGroupListItem | null>(null);
   const [impactError, setImpactError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+
+  // Impact is "ready" only when it was loaded for the currently-open group and no error is set.
+  const impactReady = !!impact && !!impactFor && impact.forGroupId === impactFor.id && !impactError;
 
   // Debounce the user-typed search so we don't fire a request per keystroke
   // (AI review #66 🟡). 300ms is the usual sweet spot — feels instant, batches fast typists.
@@ -84,7 +90,7 @@ export default function AdminGroupsPage() {
     try {
       const result = await userGroupsApi.getImpact(g.id);
       setImpactFor(current => {
-        if (current?.id === g.id) setImpact(result);
+        if (current?.id === g.id) setImpact({ forGroupId: g.id, data: result });
         return current;
       });
     } catch {
@@ -200,7 +206,7 @@ export default function AdminGroupsPage() {
         onCancel={() => { setImpactFor(null); setImpact(null); setImpactError(null); }}
         onOk={confirmDelete}
         okText="Удалить"
-        okButtonProps={{ danger: true, disabled: !impact }}
+        okButtonProps={{ danger: true, disabled: !impactReady || deleting }}
         cancelText="Отмена"
         confirmLoading={deleting}
       >
@@ -209,15 +215,15 @@ export default function AdminGroupsPage() {
             <Alert type="error" message={impactError} showIcon />
             <Button onClick={() => impactFor && loadImpact(impactFor)}>Повторить</Button>
           </Space>
-        ) : impact ? (
+        ) : impactReady && impact ? (
           <>
             <p>Будут отозваны следующие доступы:</p>
             <ul>
               <li>
-                <b>{impact.memberCount}</b> участников потеряют членство
-                {impact.members.length > 0 && (
+                <b>{impact.data.memberCount}</b> участников потеряют членство
+                {impact.data.members.length > 0 && (
                   <ul style={{ maxHeight: 160, overflowY: 'auto', marginTop: 4 }}>
-                    {impact.members.map(m => (
+                    {impact.data.members.map(m => (
                       <li key={m.id}>
                         {m.name} <span style={{ color: '#888' }}>· {m.email}</span>
                       </li>
@@ -226,10 +232,10 @@ export default function AdminGroupsPage() {
                 )}
               </li>
               <li>
-                <b>{impact.projectCount}</b> проектных биндингов будут удалены
-                {impact.projects.length > 0 && (
+                <b>{impact.data.projectCount}</b> проектных биндингов будут удалены
+                {impact.data.projects.length > 0 && (
                   <ul>
-                    {impact.projects.map(p => (
+                    {impact.data.projects.map(p => (
                       // Composite key: backend currently guarantees one binding per project
                       // in a group (@@unique([groupId, projectId])), but defensive against
                       // contract extension or duplicate rows sneaking in via data migration.

--- a/frontend/src/pages/admin/AdminGroupsPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Table, Button, Modal, Form, Input, Space, message, Popconfirm, Tooltip } from 'antd';
+import { Table, Button, Modal, Form, Input, Space, message, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { PlusOutlined, EditOutlined, DeleteOutlined, TeamOutlined, SearchOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
@@ -16,6 +16,7 @@ export default function AdminGroupsPage() {
   const [groups, setGroups] = useState<UserGroupListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<UserGroupListItem | null>(null);
   const [saving, setSaving] = useState(false);
@@ -25,16 +26,23 @@ export default function AdminGroupsPage() {
   const [impactFor, setImpactFor] = useState<UserGroupListItem | null>(null);
   const [deleting, setDeleting] = useState(false);
 
+  // Debounce the user-typed search so we don't fire a request per keystroke
+  // (AI review #66 🟡). 300ms is the usual sweet spot — feels instant, batches fast typists.
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(t);
+  }, [search]);
+
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      setGroups(await userGroupsApi.list(search.trim() || undefined));
+      setGroups(await userGroupsApi.list(debouncedSearch.trim() || undefined));
     } catch {
       message.error('Не удалось загрузить группы');
     } finally {
       setLoading(false);
     }
-  }, [search]);
+  }, [debouncedSearch]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -192,14 +200,9 @@ export default function AdminGroupsPage() {
                 )}
               </li>
             </ul>
-            <Popconfirm
-              title="Операция необратима"
-              description="Убедитесь, что участникам предоставлен альтернативный доступ"
-              okText="Понятно"
-              showCancel={false}
-            >
-              <span />
-            </Popconfirm>
+            <p style={{ color: '#d46b08', marginBottom: 0 }}>
+              Операция необратима. Убедитесь, что участникам предоставлен альтернативный доступ.
+            </p>
           </>
         ) : (
           <p>Загрузка…</p>

--- a/frontend/src/pages/admin/AdminGroupsPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupsPage.tsx
@@ -1,0 +1,210 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Table, Button, Modal, Form, Input, Space, message, Popconfirm, Tooltip } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { PlusOutlined, EditOutlined, DeleteOutlined, TeamOutlined, SearchOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
+import { userGroupsApi, type UserGroupListItem, type UserGroupImpact } from '../../api/user-groups';
+
+/**
+ * TTSEC-2 Phase 3: list of user groups with CRUD.
+ * DELETE requires a confirmation modal that shows impact (members + project bindings) —
+ * matches spec §5.7 / FR-A9. Backend responds 412 without `?confirm=true`, but the API
+ * client already sets the flag; the UX here still surfaces the impact before firing.
+ */
+export default function AdminGroupsPage() {
+  const navigate = useNavigate();
+  const [groups, setGroups] = useState<UserGroupListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<UserGroupListItem | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [form] = Form.useForm();
+
+  const [impact, setImpact] = useState<UserGroupImpact | null>(null);
+  const [impactFor, setImpactFor] = useState<UserGroupListItem | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setGroups(await userGroupsApi.list(search.trim() || undefined));
+    } catch {
+      message.error('Не удалось загрузить группы');
+    } finally {
+      setLoading(false);
+    }
+  }, [search]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const openCreate = () => { setEditing(null); form.resetFields(); setModalOpen(true); };
+  const openEdit = (g: UserGroupListItem) => {
+    setEditing(g);
+    form.setFieldsValue({ name: g.name, description: g.description ?? '' });
+    setModalOpen(true);
+  };
+
+  const handleSave = async (vals: { name: string; description?: string }) => {
+    setSaving(true);
+    try {
+      const dto = { name: vals.name, description: vals.description || null };
+      if (editing) {
+        await userGroupsApi.update(editing.id, dto);
+        message.success('Группа обновлена');
+      } else {
+        await userGroupsApi.create(dto);
+        message.success('Группа создана');
+      }
+      setModalOpen(false);
+      load();
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { error?: string } } };
+      message.error(err?.response?.data?.error || 'Не удалось сохранить');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const openDelete = async (g: UserGroupListItem) => {
+    setImpactFor(g);
+    try {
+      setImpact(await userGroupsApi.getImpact(g.id));
+    } catch {
+      message.error('Не удалось получить impact группы');
+      setImpactFor(null);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!impactFor) return;
+    setDeleting(true);
+    try {
+      await userGroupsApi.remove(impactFor.id);
+      message.success('Группа удалена');
+      setImpactFor(null);
+      setImpact(null);
+      load();
+    } catch {
+      message.error('Не удалось удалить группу');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const columns: ColumnsType<UserGroupListItem> = [
+    {
+      title: 'Название',
+      dataIndex: 'name',
+      render: (name: string, g) => (
+        <Button type="link" style={{ padding: 0 }} onClick={() => navigate(`/admin/user-groups/${g.id}`)}>
+          {name}
+        </Button>
+      ),
+    },
+    { title: 'Описание', dataIndex: 'description', render: (v: string | null) => v || '—' },
+    { title: 'Участников', dataIndex: ['_count', 'members'], render: (v: number) => v ?? 0 },
+    { title: 'Проектов', dataIndex: ['_count', 'projectRoles'], render: (v: number) => v ?? 0 },
+    {
+      title: '',
+      width: 140,
+      render: (_, g) => (
+        <Space>
+          <Tooltip title="Настроить">
+            <Button size="small" icon={<TeamOutlined />} onClick={() => navigate(`/admin/user-groups/${g.id}`)} />
+          </Tooltip>
+          <Tooltip title="Переименовать">
+            <Button size="small" icon={<EditOutlined />} onClick={() => openEdit(g)} />
+          </Tooltip>
+          <Tooltip title="Удалить">
+            <Button size="small" danger icon={<DeleteOutlined />} onClick={() => openDelete(g)} />
+          </Tooltip>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div className="tt-page">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+        <h2 className="tt-page-title">Группы пользователей</h2>
+        <Space>
+          <Input
+            placeholder="Поиск"
+            prefix={<SearchOutlined />}
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            allowClear
+            style={{ width: 240 }}
+          />
+          <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>Создать</Button>
+        </Space>
+      </div>
+
+      <Table rowKey="id" dataSource={groups} columns={columns} loading={loading} pagination={false} />
+
+      <Modal
+        title={editing ? 'Редактировать группу' : 'Новая группа'}
+        open={modalOpen}
+        onCancel={() => { setModalOpen(false); void load(); }}
+        onOk={() => form.submit()}
+        okText="Сохранить"
+        cancelText="Отмена"
+        confirmLoading={saving}
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical" onFinish={handleSave}>
+          <Form.Item name="name" label="Название" rules={[{ required: true, message: 'Введите название' }]}>
+            <Input autoFocus />
+          </Form.Item>
+          <Form.Item name="description" label="Описание">
+            <Input.TextArea rows={2} />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      {/* Delete-with-impact modal */}
+      <Modal
+        title={`Удалить группу «${impactFor?.name ?? ''}»?`}
+        open={!!impactFor}
+        onCancel={() => { setImpactFor(null); setImpact(null); }}
+        onOk={confirmDelete}
+        okText="Удалить"
+        okButtonProps={{ danger: true }}
+        cancelText="Отмена"
+        confirmLoading={deleting}
+      >
+        {impact ? (
+          <>
+            <p>Будут отозваны следующие доступы:</p>
+            <ul>
+              <li><b>{impact.memberCount}</b> участников потеряют членство</li>
+              <li>
+                <b>{impact.projectCount}</b> проектных биндингов будут удалены
+                {impact.projects.length > 0 && (
+                  <ul>
+                    {impact.projects.map(p => (
+                      <li key={p.project.id}>
+                        <code>{p.project.key}</code> · роль <b>{p.roleDefinition.name}</b>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            </ul>
+            <Popconfirm
+              title="Операция необратима"
+              description="Убедитесь, что участникам предоставлен альтернативный доступ"
+              okText="Понятно"
+              showCancel={false}
+            >
+              <span />
+            </Popconfirm>
+          </>
+        ) : (
+          <p>Загрузка…</p>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminGroupsPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupsPage.tsx
@@ -171,14 +171,15 @@ export default function AdminGroupsPage() {
         </Form>
       </Modal>
 
-      {/* Delete-with-impact modal */}
+      {/* Delete-with-impact modal. OK is disabled until the impact payload loads so the admin
+          cannot confirm blindly before seeing consequences (AI review #66 round 2 🟠). */}
       <Modal
         title={`Удалить группу «${impactFor?.name ?? ''}»?`}
         open={!!impactFor}
         onCancel={() => { setImpactFor(null); setImpact(null); }}
         onOk={confirmDelete}
         okText="Удалить"
-        okButtonProps={{ danger: true }}
+        okButtonProps={{ danger: true, disabled: !impact }}
         cancelText="Отмена"
         confirmLoading={deleting}
       >
@@ -186,7 +187,18 @@ export default function AdminGroupsPage() {
           <>
             <p>Будут отозваны следующие доступы:</p>
             <ul>
-              <li><b>{impact.memberCount}</b> участников потеряют членство</li>
+              <li>
+                <b>{impact.memberCount}</b> участников потеряют членство
+                {impact.members.length > 0 && (
+                  <ul style={{ maxHeight: 160, overflowY: 'auto', marginTop: 4 }}>
+                    {impact.members.map(m => (
+                      <li key={m.id}>
+                        {m.name} <span style={{ color: '#888' }}>· {m.email}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
               <li>
                 <b>{impact.projectCount}</b> проектных биндингов будут удалены
                 {impact.projects.length > 0 && (

--- a/frontend/src/pages/admin/AdminGroupsPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupsPage.tsx
@@ -217,7 +217,10 @@ export default function AdminGroupsPage() {
                 {impact.projects.length > 0 && (
                   <ul>
                     {impact.projects.map(p => (
-                      <li key={p.project.id}>
+                      // Composite key: backend currently guarantees one binding per project
+                      // in a group (@@unique([groupId, projectId])), but defensive against
+                      // contract extension or duplicate rows sneaking in via data migration.
+                      <li key={`${p.project.id}-${p.roleDefinition.id}`}>
                         <code>{p.project.key}</code> · роль <b>{p.roleDefinition.name}</b>
                       </li>
                     ))}

--- a/frontend/src/pages/admin/AdminGroupsPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupsPage.tsx
@@ -109,8 +109,10 @@ export default function AdminGroupsPage() {
     try {
       await userGroupsApi.remove(impactFor.id);
       message.success('Группа удалена');
+      // AI review #66 round 9 🔵 — reset full delete-modal state symmetrically.
       setImpactFor(null);
       setImpact(null);
+      setImpactError(null);
       load();
     } catch {
       message.error('Не удалось удалить группу');

--- a/frontend/src/pages/admin/AdminGroupsPage.tsx
+++ b/frontend/src/pages/admin/AdminGroupsPage.tsx
@@ -75,12 +75,25 @@ export default function AdminGroupsPage() {
   };
 
   const openDelete = async (g: UserGroupListItem) => {
+    // Race guard (AI review #66 round 3 🟠) — if the admin quickly switches between groups,
+    // a slower in-flight response must NOT overwrite the impact for the currently-open group.
+    // We re-read `impactFor` inside the settled handlers and apply only when it's still `g`.
     setImpactFor(g);
+    setImpact(null); // clear whatever was there for the previous group while the new one loads
     try {
-      setImpact(await userGroupsApi.getImpact(g.id));
+      const result = await userGroupsApi.getImpact(g.id);
+      setImpactFor(current => {
+        if (current?.id === g.id) setImpact(result);
+        return current;
+      });
     } catch {
-      message.error('Не удалось получить impact группы');
-      setImpactFor(null);
+      setImpactFor(current => {
+        if (current?.id === g.id) {
+          message.error('Не удалось получить impact группы');
+          return null;
+        }
+        return current;
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- **Phase 3 / 4** of TTSEC-2 — frontend surface for everything Phase 2 shipped. **Stacked on Phase 2 (#65)** — base against that branch once it's merged.
- Ships: `api/user-groups.ts` + `api/user-security.ts`, `AdminGroupsPage` + `AdminGroupDetailPage`, granular columns in `PermissionMatrixDrawer`, `SecurityTab` card in `SettingsPage`, Sidebar «Группы» entry + routes.

## Key UX decisions
- **Delete-with-impact modal** on AdminGroupsPage fetches `/admin/user-groups/:id/impact` and shows `<members> участников` + each `<project.key> · роль <roleName>` before the destructive confirm. Backend requires `?confirm=true`, which the API client always passes — the UI responsibility is to surface consequences.
- **Scheme-aware role select** in the Grant Project Role modal — when the admin picks a project, the frontend fetches its active role scheme via `/projects/:id/role-scheme` and populates the role dropdown with only those roles. Matches backend validation in `grantProjectRole` (cross-scheme roles are rejected 400).
- **SecurityTab** is read-only — `source` tag + `sourceGroups` "also via" list preserve the full truth from `computeEffectiveRole`. Permissions hover tooltip on the role tag avoids a long column. CSV export for offline review.
- **PermissionMatrixDrawer** — dropped `SPRINTS_MANAGE`/`RELEASES_MANAGE` (deprecated enum values stay in backend but are no longer offered as checkboxes), added `*_DELETE_OTHERS` and a new "Группы пользователей" category for `USER_GROUP_*` system perms. Dynamic column generation automatically picks up new labels.
- **Sidebar** — new «Группы» entry in the Пользователи admin section, gated by the same admin-guard that protects the rest of the admin menu. Proper per-permission gating (`USER_GROUP_VIEW`) will land in Phase 4 when the system-level helper is extracted.

## What's NOT in this PR (Phase 4)
- Integration, e2e, perf benchmark on staging.
- `DIRECT_ROLES_DISABLED` feature flag + prod cutover.
- Storybook stories for the new components (not required by the spec).
- System-level permission helper — user-groups endpoints are still gated by system ADMIN; `USER_GROUP_VIEW` in the matrix is informational at the project-role level.

See [docs/tz/TTSEC-2.md §8.1](docs/tz/TTSEC-2.md) — phase checklist updated, Phase 3 marked done.

## Test plan
- [x] `npx tsc --noEmit` (frontend) — green
- [x] `npx eslint` on new + modified files — green
- [ ] **Manual UI walkthrough** (Phase 4 staging QA will automate):
  - [ ] Create group → add 3 users → grant role in project → users see new permissions in /users/me/security
  - [ ] Delete group with confirm — impact modal shows correct member/project counts
  - [ ] PermissionMatrixDrawer — open for a role, toggle `SPRINTS_CREATE`, save, re-open — persisted
  - [ ] SettingsPage → Security card: groups list + project roles, role tooltip shows permissions
  - [ ] Export CSV from SecurityTab → opens in spreadsheet with proper columns
  - [ ] Sidebar «Группы» entry visible to ADMIN, hidden to USER
  - [ ] Grant modal disables role select until project chosen; only scheme roles appear
- [ ] Smoke test with dev server: backend Phase 2 + frontend Phase 3 running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
