### PR TITLE
feat(rbac): TTSEC-2 Phase 2 — group-aware RBAC + granular middleware

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -39,6 +39,8 @@ import workflowEngineRouter from './modules/workflow-engine/workflow-engine.rout
 import releaseStatusesRouter from './modules/releases/release-statuses.router.js';
 import releaseWorkflowsAdminRouter from './modules/releases/release-workflows-admin.router.js';
 import roleSchemesRouter from './modules/project-role-schemes/project-role-schemes.router.js';
+import userGroupsRouter from './modules/user-groups/user-groups.router.js';
+import userSecurityRouter from './modules/user-security/user-security.router.js';
 import { getSchemeForProject } from './modules/workflow-schemes/workflow-schemes.service.js';
 import { getSchemeForProject as getRoleSchemeForProject } from './modules/project-role-schemes/project-role-schemes.service.js';
 import { authenticate } from './shared/middleware/auth.js';
@@ -137,6 +139,8 @@ export function createApp() {
   app.use('/api/admin/release-statuses', releaseStatusesRouter);
   app.use('/api/admin/release-workflows', releaseWorkflowsAdminRouter);
   app.use('/api/admin/role-schemes', roleSchemesRouter);
+  app.use('/api/admin/user-groups', userGroupsRouter);
+  app.use('/api', userSecurityRouter);
   app.use('/api', workflowEngineRouter);
 
   // Public: project workflow scheme

--- a/backend/src/modules/comments/comments.router.ts
+++ b/backend/src/modules/comments/comments.router.ts
@@ -26,14 +26,16 @@ router.post('/issues/:issueId/comments', validate(createCommentDto), async (req:
 
 router.patch('/comments/:id', validate(updateCommentDto), async (req: AuthRequest, res, next) => {
   try {
-    const comment = await commentsService.updateComment(req.params.id as string, req.user!.userId, req.user!.systemRoles, req.body);
+    const comment = await commentsService.updateComment(req.params.id as string, req.user!, req.body);
+    await logAudit(req, 'comment.updated', 'comment', comment.id);
     res.json(comment);
   } catch (err) { next(err); }
 });
 
 router.delete('/comments/:id', async (req: AuthRequest, res, next) => {
   try {
-    await commentsService.deleteComment(req.params.id as string, req.user!.userId, req.user!.systemRoles);
+    await commentsService.deleteComment(req.params.id as string, req.user!);
+    await logAudit(req, 'comment.deleted', 'comment', req.params.id as string);
     res.status(204).send();
   } catch (err) { next(err); }
 });

--- a/backend/src/modules/comments/comments.service.ts
+++ b/backend/src/modules/comments/comments.service.ts
@@ -1,6 +1,7 @@
-import type { SystemRoleType } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
+import type { AuthUser } from '../../shared/types/index.js';
+import { assertProjectPermission } from '../../shared/middleware/rbac.js';
 import type { CreateCommentDto, UpdateCommentDto } from './comments.dto.js';
 
 export async function listComments(issueId: string) {
@@ -21,11 +22,27 @@ export async function createComment(issueId: string, authorId: string, dto: Crea
   });
 }
 
-export async function updateComment(id: string, userId: string, userRoles: SystemRoleType[], dto: UpdateCommentDto) {
-  const comment = await prisma.comment.findUnique({ where: { id } });
+/**
+ * TTSEC-2 Phase 2 authorisation:
+ *   - Author always may edit/delete their own comment (spec §2 — owner control).
+ *   - Otherwise require `COMMENTS_MANAGE` (edit + full admin) for edit.
+ *   - For delete of someone else's: `COMMENTS_DELETE_OTHERS` OR `COMMENTS_MANAGE`.
+ *
+ * SUPER_ADMIN bypass and global project-read bypass are handled inside assertProjectPermission.
+ */
+export async function updateComment(id: string, user: AuthUser, dto: UpdateCommentDto) {
+  const comment = await prisma.comment.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      authorId: true,
+      issue: { select: { projectId: true } },
+    },
+  });
   if (!comment) throw new AppError(404, 'Comment not found');
-  if (comment.authorId !== userId && !userRoles.includes('ADMIN') && !userRoles.includes('SUPER_ADMIN')) {
-    throw new AppError(403, 'Not allowed');
+
+  if (comment.authorId !== user.userId) {
+    await assertProjectPermission(user, comment.issue.projectId, ['COMMENTS_MANAGE']);
   }
 
   return prisma.comment.update({
@@ -35,11 +52,22 @@ export async function updateComment(id: string, userId: string, userRoles: Syste
   });
 }
 
-export async function deleteComment(id: string, userId: string, userRoles: SystemRoleType[]) {
-  const comment = await prisma.comment.findUnique({ where: { id } });
+export async function deleteComment(id: string, user: AuthUser) {
+  const comment = await prisma.comment.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      authorId: true,
+      issue: { select: { projectId: true } },
+    },
+  });
   if (!comment) throw new AppError(404, 'Comment not found');
-  if (comment.authorId !== userId && !userRoles.includes('ADMIN') && !userRoles.includes('SUPER_ADMIN')) {
-    throw new AppError(403, 'Not allowed');
+
+  if (comment.authorId !== user.userId) {
+    await assertProjectPermission(user, comment.issue.projectId, [
+      'COMMENTS_DELETE_OTHERS',
+      'COMMENTS_MANAGE',
+    ]);
   }
 
   await prisma.comment.delete({ where: { id } });

--- a/backend/src/modules/project-role-schemes/project-role-schemes.service.ts
+++ b/backend/src/modules/project-role-schemes/project-role-schemes.service.ts
@@ -3,6 +3,7 @@ import { ProjectRole } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { getCachedJson, setCachedJson, delCachedJson, delCacheByPrefix } from '../../shared/redis.js';
+import { invalidateProjectEffectivePermissions } from '../../shared/middleware/rbac.js';
 import type {
   CreateSchemeDto,
   UpdateSchemeDto,
@@ -24,42 +25,17 @@ async function invalidateSchemeCache(schemeId: string) {
 /** Invalidate per-user permission cache for all projects bound to a scheme.
  * Call after any change that affects permission resolution (permissions matrix, role membership).
  *
- * TTSEC-2 Phase 2: kills both legacy (`rbac:perm:{projectId}:*`) and new group-aware
- * (`rbac:effective:{userId}:{projectId}`) caches for every user who could be affected by the
- * scheme — direct role holders PLUS members of any group bound to a project in this scheme.
- * Per-user scan is necessary because the new key is userId-prefixed, not projectId-prefixed. */
+ * AI review #65 round 4 🟠 — delegates to the exported `invalidateProjectEffectivePermissions`
+ * helper which does a prefix SCAN+DELETE over `rbac:effective:{projectId}:*`. This covers every
+ * cached user for the project, including ones who just lost access via this scheme change. Using
+ * the shared helper also guarantees key-format parity with the rest of rbac.ts — no more
+ * hand-built keys drifting out of sync. */
 async function invalidatePermissionCacheForScheme(schemeId: string) {
   const bindings = await prisma.projectRoleSchemeProject.findMany({
     where: { schemeId },
     select: { projectId: true },
   });
-  const projectIds = bindings.map(b => b.projectId);
-  if (projectIds.length === 0) return;
-
-  const [directUsers, groupUsers] = await Promise.all([
-    prisma.userProjectRole.findMany({
-      where: { projectId: { in: projectIds } },
-      select: { userId: true, projectId: true },
-    }),
-    prisma.userGroupMember.findMany({
-      where: { group: { projectRoles: { some: { projectId: { in: projectIds } } } } },
-      select: { userId: true, group: { select: { projectRoles: { where: { projectId: { in: projectIds } }, select: { projectId: true } } } } },
-    }),
-  ]);
-
-  const pairs = new Set<string>();
-  for (const row of directUsers) pairs.add(`${row.userId}::${row.projectId}`);
-  for (const row of groupUsers) {
-    for (const pr of row.group.projectRoles) pairs.add(`${row.userId}::${pr.projectId}`);
-  }
-
-  await Promise.all([
-    ...projectIds.map(pid => delCacheByPrefix(`rbac:perm:${pid}:`)),
-    ...Array.from(pairs).map(p => {
-      const [uid, pid] = p.split('::');
-      return delCachedJson(`rbac:effective:${uid}:${pid}`);
-    }),
-  ]);
+  await Promise.all(bindings.map(b => invalidateProjectEffectivePermissions(b.projectId)));
 }
 
 const schemeInclude = {

--- a/backend/src/modules/project-role-schemes/project-role-schemes.service.ts
+++ b/backend/src/modules/project-role-schemes/project-role-schemes.service.ts
@@ -22,13 +22,44 @@ async function invalidateSchemeCache(schemeId: string) {
 }
 
 /** Invalidate per-user permission cache for all projects bound to a scheme.
- * Call after any change that affects permission resolution (permissions matrix, role membership). */
+ * Call after any change that affects permission resolution (permissions matrix, role membership).
+ *
+ * TTSEC-2 Phase 2: kills both legacy (`rbac:perm:{projectId}:*`) and new group-aware
+ * (`rbac:effective:{userId}:{projectId}`) caches for every user who could be affected by the
+ * scheme — direct role holders PLUS members of any group bound to a project in this scheme.
+ * Per-user scan is necessary because the new key is userId-prefixed, not projectId-prefixed. */
 async function invalidatePermissionCacheForScheme(schemeId: string) {
   const bindings = await prisma.projectRoleSchemeProject.findMany({
     where: { schemeId },
     select: { projectId: true },
   });
-  await Promise.all(bindings.map(b => delCacheByPrefix(`rbac:perm:${b.projectId}:`)));
+  const projectIds = bindings.map(b => b.projectId);
+  if (projectIds.length === 0) return;
+
+  const [directUsers, groupUsers] = await Promise.all([
+    prisma.userProjectRole.findMany({
+      where: { projectId: { in: projectIds } },
+      select: { userId: true, projectId: true },
+    }),
+    prisma.userGroupMember.findMany({
+      where: { group: { projectRoles: { some: { projectId: { in: projectIds } } } } },
+      select: { userId: true, group: { select: { projectRoles: { where: { projectId: { in: projectIds } }, select: { projectId: true } } } } },
+    }),
+  ]);
+
+  const pairs = new Set<string>();
+  for (const row of directUsers) pairs.add(`${row.userId}::${row.projectId}`);
+  for (const row of groupUsers) {
+    for (const pr of row.group.projectRoles) pairs.add(`${row.userId}::${pr.projectId}`);
+  }
+
+  await Promise.all([
+    ...projectIds.map(pid => delCacheByPrefix(`rbac:perm:${pid}:`)),
+    ...Array.from(pairs).map(p => {
+      const [uid, pid] = p.split('::');
+      return delCachedJson(`rbac:effective:${uid}:${pid}`);
+    }),
+  ]);
 }
 
 const schemeInclude = {

--- a/backend/src/modules/releases/releases.router.ts
+++ b/backend/src/modules/releases/releases.router.ts
@@ -54,7 +54,7 @@ async function assertReleasePermission(
   // INTEGRATION release — no single project; keep system-role gate until a multi-project perm
   // model is designed. ADMIN and RELEASE_MANAGER correspond to the existing requireRole set.
   if (!hasAnySystemRole(req.user!.systemRoles, ['ADMIN', 'RELEASE_MANAGER', 'SUPER_ADMIN'])) {
-    throw new AppError(403, 'Insufficient permissions for integration release');
+    throw new AppError(403, 'Недостаточно прав для межпроектного релиза');
   }
 }
 

--- a/backend/src/modules/releases/releases.router.ts
+++ b/backend/src/modules/releases/releases.router.ts
@@ -2,7 +2,6 @@ import { Router } from 'express';
 import type { ProjectPermission } from '@prisma/client';
 import { authenticate } from '../../shared/middleware/auth.js';
 import {
-  requireRole,
   requireProjectPermission,
   assertProjectPermission,
 } from '../../shared/middleware/rbac.js';
@@ -70,17 +69,23 @@ router.get('/releases', async (req: AuthRequest, res, next) => {
   }
 });
 
-// ─── RM-03.2: POST /releases — create (INTEGRATION spans projects) ──────────
-// Global create retains requireRole — INTEGRATION releases may have no projectId to gate on.
-// ATOMIC releases with projectId additionally pass through the granular check below.
+// ─── RM-03.2: POST /releases — create (ATOMIC | INTEGRATION) ────────────────
+// TTSEC-2 Phase 2 (AI review #65 round 2): gate by context, not by one-size-fits-all role.
+//   - projectId in body  → ATOMIC release, project-scoped → `RELEASES_CREATE` granular check.
+//   - projectId omitted  → INTEGRATION release (multi-project), no single project to gate on →
+//     fall back to system-role `requireRole` equivalent until a multi-project perm model exists.
+// Combining both (requireRole AND granular) used to narrow access for users who had RELEASES_CREATE
+// in a project but no system ADMIN/RELEASE_MANAGER — they could not create project-scoped releases
+// through this endpoint, which contradicts the whole premise of granular permissions.
 router.post(
   '/releases',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(createReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
       if (req.body.projectId) {
         await assertProjectPermission(req.user!, req.body.projectId, ['RELEASES_CREATE']);
+      } else if (!hasAnySystemRole(req.user!.systemRoles, ['ADMIN', 'RELEASE_MANAGER', 'SUPER_ADMIN'])) {
+        throw new AppError(403, 'Недостаточно прав для межпроектного релиза');
       }
       const release = await releasesService.createReleaseGlobal(req.body, req.user!.userId);
       await logAudit(req, 'release.created', 'release', release.id, {

--- a/backend/src/modules/releases/releases.router.ts
+++ b/backend/src/modules/releases/releases.router.ts
@@ -1,6 +1,11 @@
 import { Router } from 'express';
+import type { ProjectPermission } from '@prisma/client';
 import { authenticate } from '../../shared/middleware/auth.js';
-import { requireRole } from '../../shared/middleware/rbac.js';
+import {
+  requireRole,
+  requireProjectPermission,
+  assertProjectPermission,
+} from '../../shared/middleware/rbac.js';
 import { validate } from '../../shared/middleware/validate.js';
 import {
   createReleaseDto,
@@ -16,10 +21,42 @@ import {
 import * as releasesService from './releases.service.js';
 import * as releaseWorkflowEngine from './release-workflow-engine.service.js';
 import { logAudit } from '../../shared/middleware/audit.js';
+import { hasAnySystemRole } from '../../shared/auth/roles.js';
 import type { AuthRequest } from '../../shared/types/index.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import { prisma } from '../../prisma/client.js';
 
 const router = Router();
 router.use(authenticate);
+
+/**
+ * TTSEC-2 Phase 2: gate release mutations on granular `RELEASES_*` permissions.
+ *
+ * Releases may be project-scoped (ATOMIC) or multi-project (INTEGRATION). When projectId is
+ * known, we use `assertProjectPermission`; for INTEGRATION releases (projectId=null) we fall
+ * back to the legacy system-role gate (ADMIN / RELEASE_MANAGER).
+ */
+async function assertReleasePermission(
+  req: AuthRequest,
+  releaseId: string,
+  perms: ProjectPermission[],
+): Promise<void> {
+  const release = await prisma.release.findUnique({
+    where: { id: releaseId },
+    select: { projectId: true },
+  });
+  if (!release) throw new AppError(404, 'Релиз не найден');
+
+  if (release.projectId) {
+    await assertProjectPermission(req.user!, release.projectId, perms);
+    return;
+  }
+  // INTEGRATION release — no single project; keep system-role gate until a multi-project perm
+  // model is designed. ADMIN and RELEASE_MANAGER correspond to the existing requireRole set.
+  if (!hasAnySystemRole(req.user!.systemRoles, ['ADMIN', 'RELEASE_MANAGER', 'SUPER_ADMIN'])) {
+    throw new AppError(403, 'Insufficient permissions for integration release');
+  }
+}
 
 // ─── RM-03.1: GET /releases — global list with filtering ────────────────────
 
@@ -33,14 +70,18 @@ router.get('/releases', async (req: AuthRequest, res, next) => {
   }
 });
 
-// ─── RM-03.2: POST /releases — create with type ATOMIC/INTEGRATION ──────────
-
+// ─── RM-03.2: POST /releases — create (INTEGRATION spans projects) ──────────
+// Global create retains requireRole — INTEGRATION releases may have no projectId to gate on.
+// ATOMIC releases with projectId additionally pass through the granular check below.
 router.post(
   '/releases',
   requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(createReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
+      if (req.body.projectId) {
+        await assertProjectPermission(req.user!, req.body.projectId, ['RELEASES_CREATE']);
+      }
       const release = await releasesService.createReleaseGlobal(req.body, req.user!.userId);
       await logAudit(req, 'release.created', 'release', release.id, {
         name: release.name,
@@ -54,8 +95,6 @@ router.post(
   },
 );
 
-// ─── GET /releases/:id — single release ──────────────────────────────────────
-
 router.get('/releases/:id', async (req: AuthRequest, res, next) => {
   try {
     const release = await releasesService.getRelease(req.params.id as string);
@@ -64,8 +103,6 @@ router.get('/releases/:id', async (req: AuthRequest, res, next) => {
     next(err);
   }
 });
-
-// ─── GET /releases/:id/history — audit log ───────────────────────────────────
 
 router.get('/releases/:id/history', async (req: AuthRequest, res, next) => {
   try {
@@ -76,40 +113,27 @@ router.get('/releases/:id/history', async (req: AuthRequest, res, next) => {
   }
 });
 
-// ─── RM-03.3: PATCH /releases/:id — update (immutable: type, projectId) ─────
+router.patch('/releases/:id', validate(updateReleaseDto), async (req: AuthRequest, res, next) => {
+  try {
+    await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
+    const release = await releasesService.updateRelease(req.params.id as string, req.body);
+    await logAudit(req, 'release.updated', 'release', release.id, req.body);
+    res.json(release);
+  } catch (err) {
+    next(err);
+  }
+});
 
-router.patch(
-  '/releases/:id',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
-  validate(updateReleaseDto),
-  async (req: AuthRequest, res, next) => {
-    try {
-      const release = await releasesService.updateRelease(req.params.id as string, req.body);
-      await logAudit(req, 'release.updated', 'release', release.id, req.body);
-      res.json(release);
-    } catch (err) {
-      next(err);
-    }
-  },
-);
-
-// ─── RM-03.4: DELETE /releases/:id ───────────────────────────────────────────
-
-router.delete(
-  '/releases/:id',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
-  async (req: AuthRequest, res, next) => {
-    try {
-      await releasesService.deleteRelease(req.params.id as string);
-      await logAudit(req, 'release.deleted', 'release', req.params.id as string);
-      res.status(204).send();
-    } catch (err) {
-      next(err);
-    }
-  },
-);
-
-// ─── RM-03.5: ReleaseItem CRUD ────────────────────────────────────────────────
+router.delete('/releases/:id', async (req: AuthRequest, res, next) => {
+  try {
+    await assertReleasePermission(req, req.params.id as string, ['RELEASES_DELETE']);
+    await releasesService.deleteRelease(req.params.id as string);
+    await logAudit(req, 'release.deleted', 'release', req.params.id as string);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.get('/releases/:id/items', async (req: AuthRequest, res, next) => {
   try {
@@ -123,15 +147,11 @@ router.get('/releases/:id/items', async (req: AuthRequest, res, next) => {
 
 router.post(
   '/releases/:id/items',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(releaseItemsAddDto),
   async (req: AuthRequest, res, next) => {
     try {
-      await releasesService.addReleaseItems(
-        req.params.id as string,
-        req.body,
-        req.user!.userId,
-      );
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
+      await releasesService.addReleaseItems(req.params.id as string, req.body, req.user!.userId);
       await logAudit(req, 'release.items_added', 'release', req.params.id as string, {
         issueIds: req.body.issueIds,
       });
@@ -144,14 +164,11 @@ router.post(
 
 router.post(
   '/releases/:id/items/remove',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(releaseItemsRemoveDto),
   async (req: AuthRequest, res, next) => {
     try {
-      await releasesService.removeReleaseItems(
-        req.params.id as string,
-        req.body.issueIds,
-      );
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
+      await releasesService.removeReleaseItems(req.params.id as string, req.body.issueIds);
       await logAudit(req, 'release.items_removed', 'release', req.params.id as string, {
         issueIds: req.body.issueIds,
       });
@@ -162,30 +179,25 @@ router.post(
   },
 );
 
-// ─── RM-03.6: Transitions ────────────────────────────────────────────────────
-
-router.get(
-  '/releases/:id/transitions',
-  async (req: AuthRequest, res, next) => {
-    try {
-      const result = await releaseWorkflowEngine.getAvailableTransitions(
-        req.params.id as string,
-        req.user!.userId,
-        req.user!.systemRoles,
-      );
-      res.json(result);
-    } catch (err) {
-      next(err);
-    }
-  },
-);
+router.get('/releases/:id/transitions', async (req: AuthRequest, res, next) => {
+  try {
+    const result = await releaseWorkflowEngine.getAvailableTransitions(
+      req.params.id as string,
+      req.user!.userId,
+      req.user!.systemRoles,
+    );
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.post(
   '/releases/:id/transitions/:transitionId',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(executeTransitionDto),
   async (req: AuthRequest, res, next) => {
     try {
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
       await releaseWorkflowEngine.executeTransition(
         req.params.id as string,
         req.params.transitionId as string,
@@ -193,15 +205,12 @@ router.post(
         req.user!.systemRoles,
         (req.body as { comment?: string }).comment,
       );
-      // audit is written inside executeTransition via prisma.$transaction
       res.json({ ok: true });
     } catch (err) {
       next(err);
     }
   },
 );
-
-// ─── RM-03.7: GET /releases/:id/readiness — extended ─────────────────────────
 
 router.get('/releases/:id/readiness', async (req: AuthRequest, res, next) => {
   try {
@@ -216,14 +225,13 @@ router.get('/releases/:id/readiness', async (req: AuthRequest, res, next) => {
   }
 });
 
-// ─── RM-03.8: POST /releases/:id/clone ───────────────────────────────────────
-
 router.post(
   '/releases/:id/clone',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(cloneReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
+      // Cloning produces a NEW release; gate on CREATE at the source project boundary.
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_CREATE']);
       const cloned = await releasesService.cloneRelease(
         req.params.id as string,
         req.body,
@@ -235,8 +243,6 @@ router.post(
     }
   },
 );
-
-// ─── RM-03.9: Deprecated endpoints → 410 Gone ────────────────────────────────
 
 router.post('/releases/:id/ready', (_req, res) => {
   res.status(410).json({
@@ -265,7 +271,7 @@ router.get('/projects/:projectId/releases', async (req, res, next) => {
 
 router.post(
   '/projects/:projectId/releases',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
+  requireProjectPermission((req) => req.params.projectId as string, 'RELEASES_CREATE'),
   validate(createReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
@@ -304,10 +310,10 @@ router.get('/releases/:id/sprints', async (req, res, next) => {
 
 router.post(
   '/releases/:id/sprints',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(manageSprintsInReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
       await releasesService.addSprintsToRelease(req.params.id as string, req.body.sprintIds);
       await logAudit(req, 'release.sprints_added', 'release', req.params.id as string, {
         sprintIds: req.body.sprintIds,
@@ -321,10 +327,10 @@ router.post(
 
 router.post(
   '/releases/:id/sprints/remove',
-  requireRole('ADMIN', 'RELEASE_MANAGER'),
   validate(manageSprintsInReleaseDto),
   async (req: AuthRequest, res, next) => {
     try {
+      await assertReleasePermission(req, req.params.id as string, ['RELEASES_EDIT']);
       await releasesService.removeSprintsFromRelease(req.params.id as string, req.body.sprintIds);
       await logAudit(req, 'release.sprints_removed', 'release', req.params.id as string, {
         sprintIds: req.body.sprintIds,

--- a/backend/src/modules/sprints/sprints.router.ts
+++ b/backend/src/modules/sprints/sprints.router.ts
@@ -117,25 +117,28 @@ router.post('/sprints/:id/close', async (req: AuthRequest, res, next) => {
 });
 
 // Move issues to a sprint — edit-level change on the target sprint.
+// Pass expectedProjectId = sprint.projectId so the service rejects foreign-project ids.
 router.post('/sprints/:id/issues', validate(moveIssuesToSprintDto), async (req: AuthRequest, res, next) => {
   try {
     const projectId = await projectIdFromSprint(req.params.id as string);
     await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
-    await sprintsService.moveIssuesToSprint(req.params.id as string, req.body.issueIds);
+    await sprintsService.moveIssuesToSprint(req.params.id as string, req.body.issueIds, projectId);
     await logAudit(req, 'sprint.issues_moved', 'sprint', req.params.id as string, { issueIds: req.body.issueIds });
     res.json({ ok: true });
   } catch (err) { next(err); }
 });
 
 // Move issues to backlog — affects sprint membership in a project.
+// Pass expectedProjectId = req.params.projectId so issueIds from other projects are rejected.
 router.post(
   '/projects/:projectId/backlog/issues',
   requireProjectPermission((req) => req.params.projectId as string, 'SPRINTS_EDIT'),
   validate(moveIssuesToSprintDto),
   async (req: AuthRequest, res, next) => {
     try {
-      await sprintsService.moveIssuesToSprint(null, req.body.issueIds);
-      await logAudit(req, 'sprint.issues_moved_to_backlog', 'project', req.params.projectId as string, { issueIds: req.body.issueIds });
+      const projectId = req.params.projectId as string;
+      await sprintsService.moveIssuesToSprint(null, req.body.issueIds, projectId);
+      await logAudit(req, 'sprint.issues_moved_to_backlog', 'project', projectId, { issueIds: req.body.issueIds });
       res.json({ ok: true });
     } catch (err) { next(err); }
   },

--- a/backend/src/modules/sprints/sprints.router.ts
+++ b/backend/src/modules/sprints/sprints.router.ts
@@ -1,15 +1,23 @@
 import { Router } from 'express';
 import { authenticate } from '../../shared/middleware/auth.js';
-import { requireRole } from '../../shared/middleware/rbac.js';
+import { requireProjectPermission, assertProjectPermission } from '../../shared/middleware/rbac.js';
 import { validate } from '../../shared/middleware/validate.js';
 import { createSprintDto, updateSprintDto, moveIssuesToSprintDto } from './sprints.dto.js';
 import * as sprintsService from './sprints.service.js';
 import { logAudit } from '../../shared/middleware/audit.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 import { parsePagination } from '../../shared/utils/params.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import { prisma } from '../../prisma/client.js';
 
 const router = Router();
 router.use(authenticate);
+
+async function projectIdFromSprint(sprintId: string): Promise<string> {
+  const sprint = await prisma.sprint.findUnique({ where: { id: sprintId }, select: { projectId: true } });
+  if (!sprint) throw new AppError(404, 'Sprint not found');
+  return sprint.projectId;
+}
 
 // Global list of sprints with optional filters
 router.get('/sprints', async (req, res, next) => {
@@ -63,64 +71,81 @@ router.get('/projects/:projectId/backlog', async (req, res, next) => {
   } catch (err) { next(err); }
 });
 
-// Create sprint
-router.post('/projects/:projectId/sprints', requireRole('ADMIN'), validate(createSprintDto), async (req: AuthRequest, res, next) => {
-  try {
-    const sprint = await sprintsService.createSprint(req.params.projectId as string, req.body);
-    await logAudit(req, 'sprint.created', 'sprint', sprint.id, { name: sprint.name });
-    res.status(201).json(sprint);
-  } catch (err) { next(err); }
-});
+// Create sprint — TTSEC-2: SPRINTS_CREATE
+router.post(
+  '/projects/:projectId/sprints',
+  requireProjectPermission((req) => req.params.projectId as string, 'SPRINTS_CREATE'),
+  validate(createSprintDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const sprint = await sprintsService.createSprint(req.params.projectId as string, req.body);
+      await logAudit(req, 'sprint.created', 'sprint', sprint.id, { name: sprint.name });
+      res.status(201).json(sprint);
+    } catch (err) { next(err); }
+  },
+);
 
-// Update sprint
-router.patch('/sprints/:id', requireRole('ADMIN'), validate(updateSprintDto), async (req: AuthRequest, res, next) => {
+// Update sprint — TTSEC-2: SPRINTS_EDIT (projectId looked up from sprint)
+router.patch('/sprints/:id', validate(updateSprintDto), async (req: AuthRequest, res, next) => {
   try {
+    const projectId = await projectIdFromSprint(req.params.id as string);
+    await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
     const sprint = await sprintsService.updateSprint(req.params.id as string, req.body);
     await logAudit(req, 'sprint.updated', 'sprint', sprint.id, req.body);
     res.json(sprint);
   } catch (err) { next(err); }
 });
 
-// Start sprint
-router.post('/sprints/:id/start', requireRole('ADMIN'), async (req: AuthRequest, res, next) => {
+router.post('/sprints/:id/start', async (req: AuthRequest, res, next) => {
   try {
+    const projectId = await projectIdFromSprint(req.params.id as string);
+    await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
     const sprint = await sprintsService.startSprint(req.params.id as string);
     await logAudit(req, 'sprint.started', 'sprint', sprint.id);
     res.json(sprint);
   } catch (err) { next(err); }
 });
 
-// Close sprint
-router.post('/sprints/:id/close', requireRole('ADMIN'), async (req: AuthRequest, res, next) => {
+router.post('/sprints/:id/close', async (req: AuthRequest, res, next) => {
   try {
+    const projectId = await projectIdFromSprint(req.params.id as string);
+    await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
     const sprint = await sprintsService.closeSprint(req.params.id as string);
     await logAudit(req, 'sprint.closed', 'sprint', sprint.id);
     res.json(sprint);
   } catch (err) { next(err); }
 });
 
-// Move issues to sprint (or backlog if sprintId=null in body)
-router.post('/sprints/:id/issues', requireRole('ADMIN'), validate(moveIssuesToSprintDto), async (req: AuthRequest, res, next) => {
+// Move issues to a sprint — edit-level change on the target sprint.
+router.post('/sprints/:id/issues', validate(moveIssuesToSprintDto), async (req: AuthRequest, res, next) => {
   try {
+    const projectId = await projectIdFromSprint(req.params.id as string);
+    await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
     await sprintsService.moveIssuesToSprint(req.params.id as string, req.body.issueIds);
     await logAudit(req, 'sprint.issues_moved', 'sprint', req.params.id as string, { issueIds: req.body.issueIds });
     res.json({ ok: true });
   } catch (err) { next(err); }
 });
 
-// Move issues to backlog
-router.post('/projects/:projectId/backlog/issues', requireRole('ADMIN'), validate(moveIssuesToSprintDto), async (req: AuthRequest, res, next) => {
-  try {
-    await sprintsService.moveIssuesToSprint(null, req.body.issueIds);
-    await logAudit(req, 'sprint.issues_moved_to_backlog', 'project', req.params.projectId as string, { issueIds: req.body.issueIds });
-    res.json({ ok: true });
-  } catch (err) { next(err); }
-});
+// Move issues to backlog — affects sprint membership in a project.
+router.post(
+  '/projects/:projectId/backlog/issues',
+  requireProjectPermission((req) => req.params.projectId as string, 'SPRINTS_EDIT'),
+  validate(moveIssuesToSprintDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      await sprintsService.moveIssuesToSprint(null, req.body.issueIds);
+      await logAudit(req, 'sprint.issues_moved_to_backlog', 'project', req.params.projectId as string, { issueIds: req.body.issueIds });
+      res.json({ ok: true });
+    } catch (err) { next(err); }
+  },
+);
 
-// Bulk AI estimate all issues in a sprint
-router.post('/sprints/:id/ai/estimate-all', requireRole('ADMIN'), async (req: AuthRequest, res, next) => {
+router.post('/sprints/:id/ai/estimate-all', async (req: AuthRequest, res, next) => {
   try {
     const sprintId = req.params.id as string;
+    const projectId = await projectIdFromSprint(sprintId);
+    await assertProjectPermission(req.user!, projectId, ['SPRINTS_EDIT']);
     const result = await sprintsService.bulkEstimateIssues(sprintId);
     await logAudit(req, 'sprint.ai_estimate_all', 'sprint', sprintId, {
       total: result.total,

--- a/backend/src/modules/sprints/sprints.service.ts
+++ b/backend/src/modules/sprints/sprints.service.ts
@@ -243,11 +243,33 @@ export async function closeSprint(id: string) {
   return updated;
 }
 
-export async function moveIssuesToSprint(sprintId: string | null, issueIds: string[]) {
-  // Fetch all unique projectIds for correct cache invalidation across projects
+/**
+ * Move a batch of issues to a sprint (or to backlog when sprintId is null).
+ *
+ * TTSEC-2 hardening (AI review #65): `expectedProjectId` forces all issue ids to belong to the
+ * caller-approved project. Without it a user authorised to edit sprints in project A could pass
+ * issueIds from project B and touch them. Routes that have a clear "target project" — the sprint
+ * owner, or the backlog's projectId — MUST supply it.
+ */
+export async function moveIssuesToSprint(
+  sprintId: string | null,
+  issueIds: string[],
+  expectedProjectId?: string,
+) {
   const affectedIssues = issueIds.length > 0
-    ? await prisma.issue.findMany({ where: { id: { in: issueIds } }, select: { projectId: true } })
+    ? await prisma.issue.findMany({ where: { id: { in: issueIds } }, select: { id: true, projectId: true } })
     : [];
+
+  if (expectedProjectId) {
+    if (affectedIssues.length !== issueIds.length) {
+      throw new AppError(400, 'Некоторые задачи не найдены');
+    }
+    const foreign = affectedIssues.filter(i => i.projectId !== expectedProjectId);
+    if (foreign.length > 0) {
+      throw new AppError(403, 'Задачи принадлежат другому проекту');
+    }
+  }
+
   const projectIds = [...new Set(affectedIssues.map((i) => i.projectId))];
 
   await prisma.issue.updateMany({

--- a/backend/src/modules/time/time.router.ts
+++ b/backend/src/modules/time/time.router.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { authenticate } from '../../shared/middleware/auth.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { validate } from '../../shared/middleware/validate.js';
+import { logAudit } from '../../shared/middleware/audit.js';
 import { manualTimeDto } from './time.dto.js';
 import * as timeService from './time.service.js';
 import type { AuthRequest } from '../../shared/types/index.js';
@@ -71,6 +72,15 @@ router.get('/time/active', async (req: AuthRequest, res, next) => {
   try {
     const timer = await timeService.getActiveTimer(req.user!.userId);
     res.json(timer);
+  } catch (err) { next(err); }
+});
+
+// TTSEC-2: DELETE time log (owner OR TIME_LOGS_DELETE_OTHERS OR TIME_LOGS_MANAGE)
+router.delete('/time-logs/:id', async (req: AuthRequest, res, next) => {
+  try {
+    await timeService.deleteTimeLog(req.params.id as string, req.user!);
+    await logAudit(req, 'time_log.deleted', 'time_log', req.params.id as string);
+    res.status(204).send();
   } catch (err) { next(err); }
 });
 

--- a/backend/src/modules/time/time.service.ts
+++ b/backend/src/modules/time/time.service.ts
@@ -1,6 +1,8 @@
 import { Decimal } from '@prisma/client/runtime/library';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
+import type { AuthUser } from '../../shared/types/index.js';
+import { assertProjectPermission } from '../../shared/middleware/rbac.js';
 import type { ManualTimeDto } from './time.dto.js';
 import { buildUserTimeSummary } from './time.domain.js';
 import { getCachedJson, setCachedJson, delCachedJson } from '../../shared/redis.js';
@@ -93,6 +95,32 @@ export async function getUserLogs(userId: string) {
     orderBy: { createdAt: 'desc' },
     take: 100,
   });
+}
+
+/**
+ * TTSEC-2 Phase 2: delete a time log. Owner always may delete their own. Otherwise require
+ * `TIME_LOGS_DELETE_OTHERS` OR `TIME_LOGS_MANAGE` in the log's project.
+ */
+export async function deleteTimeLog(id: string, user: AuthUser) {
+  const log = await prisma.timeLog.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      userId: true,
+      issue: { select: { projectId: true } },
+    },
+  });
+  if (!log) throw new AppError(404, 'Time log not found');
+
+  if (log.userId !== user.userId) {
+    await assertProjectPermission(user, log.issue.projectId, [
+      'TIME_LOGS_DELETE_OTHERS',
+      'TIME_LOGS_MANAGE',
+    ]);
+  }
+
+  await prisma.timeLog.delete({ where: { id } });
+  await delCachedJson(`time:summary:${log.userId}`);
 }
 
 export async function getUserTimeSummary(userId: string) {

--- a/backend/src/modules/user-groups/user-groups.dto.ts
+++ b/backend/src/modules/user-groups/user-groups.dto.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const createUserGroupDto = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).nullable().optional(),
+});
+
+export const updateUserGroupDto = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(2000).nullable().optional(),
+});
+
+export const addMembersDto = z.object({
+  userIds: z.array(z.string().uuid()).min(1).max(500),
+});
+
+export const grantProjectRoleDto = z.object({
+  projectId: z.string().uuid(),
+  roleId: z.string().uuid(),
+});
+
+export type CreateUserGroupDto = z.infer<typeof createUserGroupDto>;
+export type UpdateUserGroupDto = z.infer<typeof updateUserGroupDto>;
+export type AddMembersDto = z.infer<typeof addMembersDto>;
+export type GrantProjectRoleDto = z.infer<typeof grantProjectRoleDto>;

--- a/backend/src/modules/user-groups/user-groups.router.ts
+++ b/backend/src/modules/user-groups/user-groups.router.ts
@@ -1,0 +1,136 @@
+import { Router } from 'express';
+import { authenticate } from '../../shared/middleware/auth.js';
+import { requireRole } from '../../shared/middleware/rbac.js';
+import { validate } from '../../shared/middleware/validate.js';
+import { logAudit } from '../../shared/middleware/audit.js';
+import type { AuthRequest } from '../../shared/types/index.js';
+import {
+  createUserGroupDto,
+  updateUserGroupDto,
+  addMembersDto,
+  grantProjectRoleDto,
+} from './user-groups.dto.js';
+import * as service from './user-groups.service.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+
+/**
+ * TTSEC-2 Phase 2 router. Mounted at /api/admin/user-groups.
+ *
+ * TODO Phase 4: migrate gate from `requireRole('ADMIN')` (system ADMIN) to a proper
+ * system-level permission check (`USER_GROUP_VIEW` / `USER_GROUP_MANAGE`) once the helper is
+ * extracted. For now system ADMIN gets full access — same pattern as teams/*.
+ */
+
+const router = Router();
+router.use(authenticate);
+router.use(requireRole('ADMIN'));
+
+router.get('/', async (req, res, next) => {
+  try {
+    const search = typeof req.query.search === 'string' ? req.query.search : undefined;
+    res.json(await service.listGroups({ search }));
+  } catch (err) { next(err); }
+});
+
+router.post('/', validate(createUserGroupDto), async (req: AuthRequest, res, next) => {
+  try {
+    const group = await service.createGroup(req.body);
+    await logAudit(req, 'user_group.created', 'user_group', group.id, { name: group.name });
+    res.status(201).json(group);
+  } catch (err) { next(err); }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    res.json(await service.getGroup(req.params.id as string));
+  } catch (err) { next(err); }
+});
+
+router.patch('/:id', validate(updateUserGroupDto), async (req: AuthRequest, res, next) => {
+  try {
+    const groupId = req.params.id as string;
+    const before = await service.getGroup(groupId);
+    const updated = await service.updateGroup(groupId, req.body);
+    const action = req.body.name && req.body.name !== before.name
+      ? 'user_group.renamed'
+      : 'user_group.updated';
+    await logAudit(req, action, 'user_group', groupId, {
+      before: { name: before.name, description: before.description },
+      after: req.body,
+    });
+    res.json(updated);
+  } catch (err) { next(err); }
+});
+
+router.get('/:id/impact', async (req, res, next) => {
+  try {
+    res.json(await service.getGroupImpact(req.params.id as string));
+  } catch (err) { next(err); }
+});
+
+router.delete('/:id', async (req: AuthRequest, res, next) => {
+  try {
+    // confirm=true is mandatory for destructive group delete — without it return 412 + impact.
+    // This matches spec §5.6 / FR-A9: DELETE group requires confirm + list of affected.
+    if (req.query.confirm !== 'true') {
+      const impact = await service.getGroupImpact(req.params.id as string);
+      throw new AppError(412, 'CONFIRM_REQUIRED: добавьте ?confirm=true', { impact });
+    }
+    const result = await service.deleteGroup(req.params.id as string);
+    await logAudit(req, 'user_group.deleted', 'user_group', req.params.id as string, {
+      name: result.name,
+      removedMembers: result.removedMembers,
+      removedBindings: result.removedBindings,
+    });
+    res.json(result);
+  } catch (err) { next(err); }
+});
+
+router.post('/:id/members', validate(addMembersDto), async (req: AuthRequest, res, next) => {
+  try {
+    const groupId = req.params.id as string;
+    const result = await service.addMembers(groupId, req.body.userIds, req.user!.userId);
+    await logAudit(req, 'user_group.members_changed', 'user_group', groupId, {
+      added: req.body.userIds,
+      removed: [],
+    });
+    res.json(result);
+  } catch (err) { next(err); }
+});
+
+router.delete('/:id/members/:userId', async (req: AuthRequest, res, next) => {
+  try {
+    const groupId = req.params.id as string;
+    const userId = req.params.userId as string;
+    const result = await service.removeMember(groupId, userId);
+    await logAudit(req, 'user_group.members_changed', 'user_group', groupId, {
+      added: [],
+      removed: [userId],
+    });
+    res.json(result);
+  } catch (err) { next(err); }
+});
+
+router.post('/:id/project-roles', validate(grantProjectRoleDto), async (req: AuthRequest, res, next) => {
+  try {
+    const groupId = req.params.id as string;
+    const binding = await service.grantProjectRole(groupId, req.body);
+    await logAudit(req, 'project_group_role.granted', 'user_group', groupId, {
+      projectId: req.body.projectId,
+      roleId: req.body.roleId,
+    });
+    res.status(201).json(binding);
+  } catch (err) { next(err); }
+});
+
+router.delete('/:id/project-roles/:projectId', async (req: AuthRequest, res, next) => {
+  try {
+    const groupId = req.params.id as string;
+    const projectId = req.params.projectId as string;
+    const result = await service.revokeProjectRole(groupId, projectId);
+    await logAudit(req, 'project_group_role.revoked', 'user_group', groupId, { projectId });
+    res.json(result);
+  } catch (err) { next(err); }
+});
+
+export default router;

--- a/backend/src/modules/user-groups/user-groups.service.ts
+++ b/backend/src/modules/user-groups/user-groups.service.ts
@@ -87,7 +87,13 @@ export async function updateGroup(id: string, dto: UpdateUserGroupDto) {
 /**
  * Delete a group. Returns affected user-project pairs so the caller can audit exactly which
  * permissions were revoked. The DB cascades UserGroupMember/ProjectGroupRole via FK ON DELETE CASCADE.
- * We invalidate caches per-user before the delete so stale positive-permission reads don't linger.
+ *
+ * Cache invalidation order: we invalidate AFTER the delete so the DB row (source of truth) is
+ * gone before we drop the cache. Any concurrent request reading between delete and invalidation
+ * can still see a cached `true`, producing at most a ~ms-scale stale-allow window. Inverting the
+ * order (invalidate then delete) doesn't help — a read after invalidation but before delete would
+ * recompute and re-cache the still-granted state. Accept the short window; the delete call is
+ * synchronous and completes in milliseconds.
  */
 export async function deleteGroup(id: string) {
   const group = await prisma.userGroup.findUnique({

--- a/backend/src/modules/user-groups/user-groups.service.ts
+++ b/backend/src/modules/user-groups/user-groups.service.ts
@@ -1,14 +1,23 @@
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
-import {
-  invalidateUserEffectivePermissions,
-  invalidateProjectPermissionCache,
-} from '../../shared/middleware/rbac.js';
+import { invalidateProjectPermissionCache } from '../../shared/middleware/rbac.js';
 import type {
   CreateUserGroupDto,
   UpdateUserGroupDto,
   GrantProjectRoleDto,
 } from './user-groups.dto.js';
+
+/**
+ * Invalidate both the new group-aware effective cache AND the legacy per-permission cache for
+ * every (user, project) pair that a group change touches. Pair-based is exact and kills legacy
+ * `rbac:perm:*` keys too (AI review #65 round 3 🟡). Used by add/remove member, grant/revoke
+ * binding, delete group.
+ */
+async function invalidatePairs(pairs: Iterable<{ userId: string; projectId: string }>): Promise<void> {
+  await Promise.all(
+    Array.from(pairs).map(p => invalidateProjectPermissionCache(p.projectId, p.userId)),
+  );
+}
 
 /**
  * TTSEC-2 Phase 2 user groups.
@@ -114,12 +123,7 @@ export async function deleteGroup(id: string) {
   }
 
   await prisma.userGroup.delete({ where: { id } });
-
-  await Promise.all(
-    Array.from(new Set(group.members.map(m => m.userId))).map(uid =>
-      invalidateUserEffectivePermissions(uid),
-    ),
-  );
+  await invalidatePairs(affectedPairs);
 
   return {
     name: group.name,
@@ -153,7 +157,10 @@ export async function getGroupImpact(id: string) {
 }
 
 export async function addMembers(groupId: string, userIds: string[], addedById: string) {
-  const group = await prisma.userGroup.findUnique({ where: { id: groupId }, select: { id: true } });
+  const group = await prisma.userGroup.findUnique({
+    where: { id: groupId },
+    include: { projectRoles: { select: { projectId: true } } },
+  });
   if (!group) throw new AppError(404, 'Группа не найдена');
 
   const users = await prisma.user.findMany({
@@ -172,7 +179,9 @@ export async function addMembers(groupId: string, userIds: string[], addedById: 
     skipDuplicates: true,
   });
 
-  await Promise.all(userIds.map(uid => invalidateUserEffectivePermissions(uid)));
+  // Only the projects this group is bound to are affected by the new members — exact invalidation.
+  const pairs = userIds.flatMap(uid => group.projectRoles.map(pr => ({ userId: uid, projectId: pr.projectId })));
+  await invalidatePairs(pairs);
   return { added: result.count };
 }
 
@@ -182,10 +191,19 @@ export async function removeMember(groupId: string, userId: string) {
     select: { groupId: true },
   });
   if (!existing) throw new AppError(404, 'Пользователь не является участником группы');
+
+  // Capture the projects bound to this group BEFORE deleting membership — those are the projects
+  // where the removed user is losing access.
+  const bindings = await prisma.projectGroupRole.findMany({
+    where: { groupId },
+    select: { projectId: true },
+  });
+
   await prisma.userGroupMember.delete({
     where: { groupId_userId: { groupId, userId } },
   });
-  await invalidateUserEffectivePermissions(userId);
+
+  await invalidatePairs(bindings.map(b => ({ userId, projectId: b.projectId })));
   return { ok: true };
 }
 

--- a/backend/src/modules/user-groups/user-groups.service.ts
+++ b/backend/src/modules/user-groups/user-groups.service.ts
@@ -1,0 +1,265 @@
+import { prisma } from '../../prisma/client.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import {
+  invalidateUserEffectivePermissions,
+  invalidateProjectPermissionCache,
+} from '../../shared/middleware/rbac.js';
+import type {
+  CreateUserGroupDto,
+  UpdateUserGroupDto,
+  GrantProjectRoleDto,
+} from './user-groups.dto.js';
+
+/**
+ * TTSEC-2 Phase 2 user groups.
+ *
+ * Invariants kept by this module:
+ *   - Every membership/binding change invalidates the affected users' effective-permission caches.
+ *   - Grouping a user in a project they already have DIRECT role in — both sources contribute
+ *     to computeEffectiveRole (max permissions wins). No deduplication at write time.
+ *   - DELETE (group / member / binding) returns the list of affected user×project pairs so the
+ *     router can log audit and the UI can warn.
+ */
+
+const listInclude = {
+  _count: { select: { members: true, projectRoles: true } },
+} as const;
+
+const detailInclude = {
+  members: {
+    include: {
+      user: { select: { id: true, name: true, email: true, isActive: true } },
+      addedBy: { select: { id: true, name: true } },
+    },
+    orderBy: { addedAt: 'desc' as const },
+  },
+  projectRoles: {
+    include: {
+      project: { select: { id: true, key: true, name: true } },
+      roleDefinition: { select: { id: true, name: true, key: true, color: true } },
+    },
+  },
+} as const;
+
+export async function listGroups(query?: { search?: string }) {
+  return prisma.userGroup.findMany({
+    where: query?.search
+      ? { name: { contains: query.search, mode: 'insensitive' } }
+      : undefined,
+    include: listInclude,
+    orderBy: { name: 'asc' },
+  });
+}
+
+export async function getGroup(id: string) {
+  const group = await prisma.userGroup.findUnique({
+    where: { id },
+    include: detailInclude,
+  });
+  if (!group) throw new AppError(404, 'Группа не найдена');
+  return group;
+}
+
+export async function createGroup(dto: CreateUserGroupDto) {
+  const existing = await prisma.userGroup.findUnique({ where: { name: dto.name }, select: { id: true } });
+  if (existing) throw new AppError(409, 'Группа с таким именем уже существует');
+  return prisma.userGroup.create({
+    data: { name: dto.name, description: dto.description ?? null },
+  });
+}
+
+export async function updateGroup(id: string, dto: UpdateUserGroupDto) {
+  const existing = await prisma.userGroup.findUnique({ where: { id }, select: { id: true, name: true } });
+  if (!existing) throw new AppError(404, 'Группа не найдена');
+  if (dto.name && dto.name !== existing.name) {
+    const clash = await prisma.userGroup.findUnique({ where: { name: dto.name }, select: { id: true } });
+    if (clash && clash.id !== id) throw new AppError(409, 'Группа с таким именем уже существует');
+  }
+  return prisma.userGroup.update({
+    where: { id },
+    data: {
+      ...(dto.name !== undefined && { name: dto.name }),
+      ...(dto.description !== undefined && { description: dto.description }),
+    },
+  });
+}
+
+/**
+ * Delete a group. Returns affected user-project pairs so the caller can audit exactly which
+ * permissions were revoked. The DB cascades UserGroupMember/ProjectGroupRole via FK ON DELETE CASCADE.
+ * We invalidate caches per-user before the delete so stale positive-permission reads don't linger.
+ */
+export async function deleteGroup(id: string) {
+  const group = await prisma.userGroup.findUnique({
+    where: { id },
+    include: {
+      members: { select: { userId: true } },
+      projectRoles: { select: { projectId: true, roleId: true } },
+    },
+  });
+  if (!group) throw new AppError(404, 'Группа не найдена');
+
+  // Affected pairs: every member × every project the group bound to.
+  const affectedPairs: { userId: string; projectId: string }[] = [];
+  for (const m of group.members) {
+    for (const pr of group.projectRoles) {
+      affectedPairs.push({ userId: m.userId, projectId: pr.projectId });
+    }
+  }
+
+  await prisma.userGroup.delete({ where: { id } });
+
+  await Promise.all(
+    Array.from(new Set(group.members.map(m => m.userId))).map(uid =>
+      invalidateUserEffectivePermissions(uid),
+    ),
+  );
+
+  return {
+    name: group.name,
+    affectedPairs,
+    removedMembers: group.members.map(m => m.userId),
+    removedBindings: group.projectRoles,
+  };
+}
+
+export async function getGroupImpact(id: string) {
+  const group = await prisma.userGroup.findUnique({
+    where: { id },
+    select: {
+      _count: { select: { members: true, projectRoles: true } },
+      members: { select: { user: { select: { id: true, name: true, email: true } } } },
+      projectRoles: {
+        select: {
+          project: { select: { id: true, key: true, name: true } },
+          roleDefinition: { select: { id: true, name: true, key: true } },
+        },
+      },
+    },
+  });
+  if (!group) throw new AppError(404, 'Группа не найдена');
+  return {
+    memberCount: group._count.members,
+    projectCount: group._count.projectRoles,
+    members: group.members.map(m => m.user),
+    projects: group.projectRoles,
+  };
+}
+
+export async function addMembers(groupId: string, userIds: string[], addedById: string) {
+  const group = await prisma.userGroup.findUnique({ where: { id: groupId }, select: { id: true } });
+  if (!group) throw new AppError(404, 'Группа не найдена');
+
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true },
+  });
+  const foundIds = new Set(users.map(u => u.id));
+  const missing = userIds.filter(id => !foundIds.has(id));
+  if (missing.length > 0) {
+    throw new AppError(400, `Некоторые пользователи не найдены: ${missing.length}`);
+  }
+
+  // Batch insert; skip duplicates via composite PK + createMany skipDuplicates.
+  const result = await prisma.userGroupMember.createMany({
+    data: userIds.map(userId => ({ groupId, userId, addedById })),
+    skipDuplicates: true,
+  });
+
+  await Promise.all(userIds.map(uid => invalidateUserEffectivePermissions(uid)));
+  return { added: result.count };
+}
+
+export async function removeMember(groupId: string, userId: string) {
+  const existing = await prisma.userGroupMember.findUnique({
+    where: { groupId_userId: { groupId, userId } },
+    select: { groupId: true },
+  });
+  if (!existing) throw new AppError(404, 'Пользователь не является участником группы');
+  await prisma.userGroupMember.delete({
+    where: { groupId_userId: { groupId, userId } },
+  });
+  await invalidateUserEffectivePermissions(userId);
+  return { ok: true };
+}
+
+/**
+ * Grant a project role to a group. The role must belong to the project's ACTIVE role scheme —
+ * otherwise the binding would be useless at permission-resolution time (see computeEffectiveRole
+ * active-scheme filter). We also persist `schemeId` for the composite FK.
+ */
+export async function grantProjectRole(groupId: string, dto: GrantProjectRoleDto) {
+  const group = await prisma.userGroup.findUnique({ where: { id: groupId }, select: { id: true } });
+  if (!group) throw new AppError(404, 'Группа не найдена');
+
+  const project = await prisma.project.findUnique({ where: { id: dto.projectId }, select: { id: true } });
+  if (!project) throw new AppError(404, 'Проект не найден');
+
+  const role = await prisma.projectRoleDefinition.findUnique({
+    where: { id: dto.roleId },
+    select: { id: true, schemeId: true },
+  });
+  if (!role) throw new AppError(404, 'Роль не найдена');
+
+  // Resolve the project's active scheme. Accept a role from this scheme OR from the default
+  // scheme when the project has no explicit binding. Reject roles from unrelated schemes —
+  // they would never resolve at runtime and only confuse admins.
+  const projectBinding = await prisma.projectRoleSchemeProject.findUnique({
+    where: { projectId: dto.projectId },
+    select: { schemeId: true },
+  });
+  const activeSchemeId = projectBinding?.schemeId
+    ?? (await prisma.projectRoleScheme.findFirst({ where: { isDefault: true }, select: { id: true } }))?.id;
+  if (!activeSchemeId) throw new AppError(500, 'Не настроена дефолтная схема ролей');
+  if (role.schemeId !== activeSchemeId) {
+    throw new AppError(400, 'Роль принадлежит другой схеме — выберите роль из схемы проекта');
+  }
+
+  const existing = await prisma.projectGroupRole.findUnique({
+    where: { groupId_projectId: { groupId, projectId: dto.projectId } },
+    select: { id: true, roleId: true },
+  });
+  if (existing && existing.roleId === dto.roleId) {
+    return existing; // idempotent
+  }
+
+  const result = existing
+    ? await prisma.projectGroupRole.update({
+        where: { id: existing.id },
+        data: { roleId: dto.roleId, schemeId: role.schemeId },
+      })
+    : await prisma.projectGroupRole.create({
+        data: {
+          groupId,
+          projectId: dto.projectId,
+          roleId: dto.roleId,
+          schemeId: role.schemeId,
+        },
+      });
+
+  const members = await prisma.userGroupMember.findMany({
+    where: { groupId },
+    select: { userId: true },
+  });
+  await Promise.all(members.map(m => invalidateProjectPermissionCache(dto.projectId, m.userId)));
+
+  return result;
+}
+
+export async function revokeProjectRole(groupId: string, projectId: string) {
+  const existing = await prisma.projectGroupRole.findUnique({
+    where: { groupId_projectId: { groupId, projectId } },
+    select: { id: true },
+  });
+  if (!existing) throw new AppError(404, 'Группа не привязана к этому проекту');
+
+  await prisma.projectGroupRole.delete({ where: { id: existing.id } });
+
+  const members = await prisma.userGroupMember.findMany({
+    where: { groupId },
+    select: { userId: true },
+  });
+  await Promise.all(members.map(m => invalidateProjectPermissionCache(projectId, m.userId)));
+
+  return { ok: true };
+}

--- a/backend/src/modules/user-security/user-security.router.ts
+++ b/backend/src/modules/user-security/user-security.router.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { authenticate } from '../../shared/middleware/auth.js';
+import { requireRole } from '../../shared/middleware/rbac.js';
+import type { AuthRequest } from '../../shared/types/index.js';
+import { getUserSecurity } from './user-security.service.js';
+
+/**
+ * TTSEC-2 Phase 2 security endpoints.
+ *
+ * GET /api/users/me/security — any authenticated user reads THEIR OWN payload (SEC-2).
+ * GET /api/admin/users/:id/security — system ADMIN reads any user's payload (SEC-6).
+ *
+ * Phase 4 cleanup: swap the admin check from `requireRole('ADMIN')` to a proper system-level
+ * `USER_GROUP_VIEW` permission once the helper lands.
+ */
+
+const router = Router();
+
+router.get('/users/me/security', authenticate, async (req: AuthRequest, res, next) => {
+  try {
+    res.json(await getUserSecurity(req.user!.userId));
+  } catch (err) { next(err); }
+});
+
+router.get(
+  '/admin/users/:id/security',
+  authenticate,
+  requireRole('ADMIN'),
+  async (req: AuthRequest, res, next) => {
+    try {
+      res.json(await getUserSecurity(req.params.id as string));
+    } catch (err) { next(err); }
+  },
+);
+
+export default router;

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -1,6 +1,32 @@
+import type { ProjectPermission } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { computeEffectiveRolesForProjects } from '../../shared/middleware/rbac.js';
+
+/**
+ * TTSEC-2 Phase 2 security payload (spec §5.6). Exported so Phase 3 UI and tests can import
+ * the exact shape instead of inferring it.
+ */
+export interface SecurityProjectRole {
+  project: { id: string; key: string; name: string };
+  role: { id: string; name: string; key: string; permissions: ProjectPermission[] };
+  source: 'DIRECT' | 'GROUP';
+  sourceGroups: { id: string; name: string }[];
+}
+
+export interface SecurityGroupMembership {
+  id: string;
+  name: string;
+  addedAt: Date;
+  memberCount: number;
+}
+
+export interface UserSecurityPayload {
+  user: { id: string; name: string; email: string };
+  groups: SecurityGroupMembership[];
+  projectRoles: SecurityProjectRole[];
+  updatedAt: string;
+}
 
 /**
  * Build the payload for a user's «Безопасность» view (spec §5.6):
@@ -13,7 +39,7 @@ import { computeEffectiveRolesForProjects } from '../../shared/middleware/rbac.j
  * A project appears in `projectRoles` iff the user has ANY role there (direct or via a group
  * bound to the project). `source` and `sourceGroups` come from computeEffectiveRole (§5.2).
  */
-export async function getUserSecurity(userId: string) {
+export async function getUserSecurity(userId: string): Promise<UserSecurityPayload> {
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: { id: true, name: true, email: true },
@@ -56,7 +82,7 @@ export async function getUserSecurity(userId: string) {
   // instead of 2N queries. See computeEffectiveRolesForProjects.
   const effectiveByProject = await computeEffectiveRolesForProjects(userId, Array.from(projectIds));
 
-  const projectRoles = [];
+  const projectRoles: SecurityProjectRole[] = [];
   for (const [projectId, eff] of effectiveByProject) {
     if (!eff) continue;
     const project = projectById.get(projectId);

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -10,7 +10,13 @@ import { computeEffectiveRolesForProjects } from '../../shared/middleware/rbac.j
 export interface SecurityProjectRole {
   project: { id: string; key: string; name: string };
   role: { id: string; name: string; key: string; permissions: ProjectPermission[] };
+  /**
+   * The PRIMARY grant path. DIRECT wins when the user has the role directly assigned.
+   * When both DIRECT and at least one group grant the same role, source='DIRECT' and
+   * sourceGroups lists every group that additionally grants it ("also via Team A").
+   */
   source: 'DIRECT' | 'GROUP';
+  /** Every group that grants this role, independent of `source`. Empty iff the role is not granted via any group. */
   sourceGroups: { id: string; name: string }[];
 }
 

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -1,0 +1,85 @@
+import { prisma } from '../../prisma/client.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import { computeEffectiveRole } from '../../shared/middleware/rbac.js';
+
+/**
+ * Build the payload for a user's «Безопасность» view (spec §5.6):
+ *   {
+ *     groups: [{ id, name, addedAt, memberCount }],
+ *     projectRoles: [{ project, role, source, sourceGroups }],
+ *     updatedAt,
+ *   }
+ *
+ * A project appears in `projectRoles` iff the user has ANY role there (direct or via a group
+ * bound to the project). `source` and `sourceGroups` come from computeEffectiveRole (§5.2).
+ */
+export async function getUserSecurity(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true, email: true },
+  });
+  if (!user) throw new AppError(404, 'Пользователь не найден');
+
+  const [groups, directProjects, groupProjects] = await Promise.all([
+    prisma.userGroupMember.findMany({
+      where: { userId },
+      include: {
+        group: {
+          include: { _count: { select: { members: true } } },
+        },
+      },
+      orderBy: { addedAt: 'desc' },
+    }),
+    prisma.userProjectRole.findMany({
+      where: { userId },
+      select: { projectId: true },
+    }),
+    prisma.projectGroupRole.findMany({
+      where: { group: { members: { some: { userId } } } },
+      select: { projectId: true },
+    }),
+  ]);
+
+  const projectIds = new Set<string>([
+    ...directProjects.map(r => r.projectId),
+    ...groupProjects.map(r => r.projectId),
+  ]);
+
+  // Fetch project metadata once.
+  const projects = await prisma.project.findMany({
+    where: { id: { in: Array.from(projectIds) } },
+    select: { id: true, key: true, name: true },
+  });
+  const projectById = new Map(projects.map(p => [p.id, p]));
+
+  const projectRoles = [];
+  for (const projectId of projectIds) {
+    const project = projectById.get(projectId);
+    if (!project) continue;
+    const eff = await computeEffectiveRole(userId, projectId);
+    if (!eff) continue;
+    projectRoles.push({
+      project,
+      role: {
+        id: eff.roleId,
+        name: eff.roleName,
+        key: eff.roleKey,
+        permissions: eff.permissions,
+      },
+      source: eff.source,
+      sourceGroups: eff.sourceGroups,
+    });
+  }
+
+  return {
+    user: { id: user.id, name: user.name, email: user.email },
+    groups: groups.map(m => ({
+      id: m.group.id,
+      name: m.group.name,
+      addedAt: m.addedAt,
+      memberCount: m.group._count.members,
+    })),
+    projectRoles,
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
-import { computeEffectiveRole } from '../../shared/middleware/rbac.js';
+import { computeEffectiveRolesForProjects } from '../../shared/middleware/rbac.js';
 
 /**
  * Build the payload for a user's «Безопасность» view (spec §5.6):
@@ -52,29 +52,27 @@ export async function getUserSecurity(userId: string) {
   });
   const projectById = new Map(projects.map(p => [p.id, p]));
 
-  // Parallelise effective-role computation across projects. True batched resolution (single
-  // scheme/role fetch for all projects) is TTSEC-16 territory — tracked in Phase 4 perf work.
-  // Until then Promise.all cuts wall-time from N sequential trips to `max(trip)`.
-  const effective = await Promise.all(
-    Array.from(projectIds).map(async (projectId) => {
-      const project = projectById.get(projectId);
-      if (!project) return null;
-      const eff = await computeEffectiveRole(userId, projectId);
-      if (!eff) return null;
-      return {
-        project,
-        role: {
-          id: eff.roleId,
-          name: eff.roleName,
-          key: eff.roleKey,
-          permissions: eff.permissions,
-        },
-        source: eff.source,
-        sourceGroups: eff.sourceGroups,
-      };
-    }),
-  );
-  const projectRoles = effective.filter((r): r is NonNullable<typeof r> => r !== null);
+  // Batched resolution: 2 DB queries total (direct + group) + N Redis-cached scheme reads,
+  // instead of 2N queries. See computeEffectiveRolesForProjects.
+  const effectiveByProject = await computeEffectiveRolesForProjects(userId, Array.from(projectIds));
+
+  const projectRoles = [];
+  for (const [projectId, eff] of effectiveByProject) {
+    if (!eff) continue;
+    const project = projectById.get(projectId);
+    if (!project) continue;
+    projectRoles.push({
+      project,
+      role: {
+        id: eff.roleId,
+        name: eff.roleName,
+        key: eff.roleKey,
+        permissions: eff.permissions,
+      },
+      source: eff.source,
+      sourceGroups: eff.sourceGroups,
+    });
+  }
 
   return {
     user: { id: user.id, name: user.name, email: user.email },

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -106,6 +106,9 @@ export async function getUserSecurity(userId: string): Promise<UserSecurityPaylo
     });
   }
 
+  // AI review #65 round 5 🟡 — deterministic ordering so UI / tests / snapshots get stable output.
+  projectRoles.sort((a, b) => a.project.key.localeCompare(b.project.key));
+
   return {
     user: { id: user.id, name: user.name, email: user.email },
     groups: groups.map(m => ({

--- a/backend/src/modules/user-security/user-security.service.ts
+++ b/backend/src/modules/user-security/user-security.service.ts
@@ -52,24 +52,29 @@ export async function getUserSecurity(userId: string) {
   });
   const projectById = new Map(projects.map(p => [p.id, p]));
 
-  const projectRoles = [];
-  for (const projectId of projectIds) {
-    const project = projectById.get(projectId);
-    if (!project) continue;
-    const eff = await computeEffectiveRole(userId, projectId);
-    if (!eff) continue;
-    projectRoles.push({
-      project,
-      role: {
-        id: eff.roleId,
-        name: eff.roleName,
-        key: eff.roleKey,
-        permissions: eff.permissions,
-      },
-      source: eff.source,
-      sourceGroups: eff.sourceGroups,
-    });
-  }
+  // Parallelise effective-role computation across projects. True batched resolution (single
+  // scheme/role fetch for all projects) is TTSEC-16 territory — tracked in Phase 4 perf work.
+  // Until then Promise.all cuts wall-time from N sequential trips to `max(trip)`.
+  const effective = await Promise.all(
+    Array.from(projectIds).map(async (projectId) => {
+      const project = projectById.get(projectId);
+      if (!project) return null;
+      const eff = await computeEffectiveRole(userId, projectId);
+      if (!eff) return null;
+      return {
+        project,
+        role: {
+          id: eff.roleId,
+          name: eff.roleName,
+          key: eff.roleKey,
+          permissions: eff.permissions,
+        },
+        source: eff.source,
+        sourceGroups: eff.sourceGroups,
+      };
+    }),
+  );
+  const projectRoles = effective.filter((r): r is NonNullable<typeof r> => r !== null);
 
   return {
     user: { id: user.id, name: user.name, email: user.email },

--- a/backend/src/shared/middleware/rbac.ts
+++ b/backend/src/shared/middleware/rbac.ts
@@ -1,29 +1,231 @@
 import type { Response, NextFunction } from 'express';
 import type { SystemRoleType, ProjectPermission } from '@prisma/client';
 import { AppError } from './error-handler.js';
-import type { AuthRequest } from '../types/index.js';
+import type { AuthRequest, AuthUser } from '../types/index.js';
 import { hasAnySystemRole, isSuperAdmin, hasGlobalProjectReadAccess } from '../auth/roles.js';
 import { prisma } from '../../prisma/client.js';
 import { getSchemeForProject } from '../../modules/project-role-schemes/project-role-schemes.service.js';
-import { getCachedJson, setCachedJson, delCacheByPrefix } from '../redis.js';
+import { getCachedJson, setCachedJson, delCachedJson, delCacheByPrefix } from '../redis.js';
 
 /**
- * Invalidate cached permission results for a user+project pair.
+ * TTSEC-2 Phase 2: group-aware effective permissions.
  *
- * INVARIANT: every write path that creates, updates, or deletes a UserProjectRole MUST call
- * this helper (or `delCacheByPrefix('rbac:perm:${projectId}:')` for bulk updates). Current
- * callers:
+ * We compute a single "effective role" per (user, project) by unioning:
+ *   - DIRECT UserProjectRole rows
+ *   - roles granted via UserGroupMember → ProjectGroupRole bindings
+ *
+ * Among all candidates we pick the ONE role with the most `granted=true` permissions;
+ * tiebreaker — roleId ascending (for determinism across replicas). This matches spec §5.2.
+ *
+ * Cache layout: `rbac:effective:{userId}:{projectId}` → string[] (granted perms), TTL 60s.
+ * Cache is prefixed by userId first so we can drop a user's entire set on membership change.
+ */
+
+const EFFECTIVE_KEY = (userId: string, projectId: string) =>
+  `rbac:effective:${userId}:${projectId}`;
+const EFFECTIVE_TTL = 60;
+
+/**
+ * Invalidate cached permissions for a single (user, project) pair.
+ *
+ * INVARIANT: every write path that affects which roles apply to a user in a project MUST call
+ * this helper (or one of the broader helpers below). Current callers:
  *   - admin.service.assignProjectRole / removeProjectRole — per-user invalidation
  *   - project-role-schemes.service.attachProject / detachProject — per-project prefix invalidation
- *     (covers all users through the composite-FK remap)
  *   - project-role-schemes.service.updatePermissions + create/update/deleteRole — per-scheme
  *     invalidation via `invalidatePermissionCacheForScheme`
+ *   - user-groups.service.* — per-user (members) or per-group (project-role bindings)
  *
- * Missing a call leaves `requireProjectPermission` serving stale allow/deny decisions for up
- * to the cache TTL (60s).
+ * Missing a call leaves `requireProjectPermission` serving stale allow decisions for up to TTL.
  */
 export async function invalidateProjectPermissionCache(projectId: string, userId: string): Promise<void> {
-  await delCacheByPrefix(`rbac:perm:${projectId}:${userId}:`);
+  await Promise.all([
+    // New group-aware effective cache (single composite key).
+    delCachedJson(EFFECTIVE_KEY(userId, projectId)),
+    // Legacy per-permission cache — some callers may still hit it during deploy window.
+    delCacheByPrefix(`rbac:perm:${projectId}:${userId}:`),
+  ]);
+}
+
+/**
+ * Drop every cached effective-permission set for a single user across ALL projects. Called when
+ * the user's group membership changes (added/removed from a group), since that affects every
+ * project that group is bound to.
+ */
+export async function invalidateUserEffectivePermissions(userId: string): Promise<void> {
+  await delCacheByPrefix(`rbac:effective:${userId}:`);
+}
+
+/**
+ * Drop every cached effective-permission set for a project. Scans and deletes only the minority
+ * of users who had their entry cached (most won't). Call when a project-level scheme/role binding
+ * changes and you want to avoid iterating all group members.
+ */
+export async function invalidateProjectEffectivePermissions(projectId: string): Promise<void> {
+  // Redis doesn't support suffix-scan efficiently; fall back to iterating direct members + group
+  // members. For unbounded projects we could add pg_notify later; MVP uses explicit user-scan.
+  const [directUsers, groupUsers] = await Promise.all([
+    prisma.userProjectRole.findMany({ where: { projectId }, select: { userId: true } }),
+    prisma.userGroupMember.findMany({
+      where: { group: { projectRoles: { some: { projectId } } } },
+      select: { userId: true },
+    }),
+  ]);
+  const userIds = new Set<string>([
+    ...directUsers.map(u => u.userId),
+    ...groupUsers.map(u => u.userId),
+  ]);
+  await Promise.all(
+    Array.from(userIds).map(uid => delCachedJson(EFFECTIVE_KEY(uid, projectId))),
+  );
+  // Also kill legacy prefix for safety during the Phase 2 deploy window.
+  await delCacheByPrefix(`rbac:perm:${projectId}:`);
+}
+
+type EffectiveRole = {
+  roleId: string;
+  roleName: string;
+  roleKey: string;
+  permissions: ProjectPermission[];
+  source: 'DIRECT' | 'GROUP';
+  sourceGroups: { id: string; name: string }[]; // populated when source=GROUP (may be multiple)
+};
+
+/**
+ * Compute the effective role for a (user, project). Returns `null` if the user has no direct role
+ * and is not a member of any group bound to the project.
+ *
+ * The returned role is the ONE with max granted-permissions count across candidates
+ * (tiebreaker: roleId asc). `sourceGroups` lists every group that supplied the chosen role —
+ * typically one, but can be several if two groups bind to the same role definition.
+ *
+ * This is NOT cached — cache the permission set via `getEffectiveProjectPermissions`. Routes that
+ * need the role object itself (SecurityTab, /users/me/security) read it uncached; they're rare.
+ */
+export async function computeEffectiveRole(
+  userId: string,
+  projectId: string,
+): Promise<EffectiveRole | null> {
+  // Resolve via the project's ACTIVE scheme — a binding whose roleId points to a stale
+  // (previously-active) scheme falls back to matching by role key in the active scheme. This
+  // mirrors the original requireProjectPermission contract and covers the transitional state
+  // where some UserProjectRole rows still carry roleId=NULL.
+  const scheme = await getSchemeForProject(projectId);
+  const rolesInScheme = scheme.roles; // [{ id, key, permissions: [{permission, granted}] }]
+
+  const [directRows, groupRows] = await Promise.all([
+    prisma.userProjectRole.findMany({
+      where: { userId, projectId },
+      select: { roleId: true, role: true },
+    }),
+    prisma.projectGroupRole.findMany({
+      where: { projectId, group: { members: { some: { userId } } } },
+      select: {
+        roleId: true,
+        group: { select: { id: true, name: true } },
+        // Need the binding role's `key` in case the binding's scheme doesn't match active scheme.
+        roleDefinition: { select: { key: true } },
+      },
+    }),
+  ]);
+
+  type CandidateRole = typeof rolesInScheme[number];
+  type Candidate = { role: CandidateRole; source: 'DIRECT' | 'GROUP'; groups: { id: string; name: string }[] };
+  const byRoleId = new Map<string, Candidate>();
+
+  const resolveInScheme = (roleId: string | null | undefined, legacyKey: string | undefined): CandidateRole | undefined => {
+    if (roleId) {
+      const byId = rolesInScheme.find(r => r.id === roleId);
+      if (byId) return byId;
+    }
+    if (legacyKey) {
+      return rolesInScheme.find(r => r.key === legacyKey);
+    }
+    return undefined;
+  };
+
+  for (const row of directRows) {
+    const role = resolveInScheme(row.roleId, row.role);
+    if (!role) continue;
+    if (!byRoleId.has(role.id)) {
+      byRoleId.set(role.id, { role, source: 'DIRECT', groups: [] });
+    }
+  }
+  for (const row of groupRows) {
+    const role = resolveInScheme(row.roleId, row.roleDefinition.key);
+    if (!role) continue;
+    const existing = byRoleId.get(role.id);
+    if (existing) {
+      existing.groups.push(row.group);
+    } else {
+      byRoleId.set(role.id, { role, source: 'GROUP', groups: [row.group] });
+    }
+  }
+
+  const candidates = Array.from(byRoleId.values());
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => {
+    const aGranted = a.role.permissions.filter(p => p.granted).length;
+    const bGranted = b.role.permissions.filter(p => p.granted).length;
+    const d = bGranted - aGranted;
+    return d !== 0 ? d : a.role.id.localeCompare(b.role.id);
+  });
+
+  const chosen = candidates[0]!;
+  return {
+    roleId: chosen.role.id,
+    roleName: chosen.role.name,
+    roleKey: chosen.role.key,
+    permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
+    source: chosen.source,
+    sourceGroups: chosen.groups,
+  };
+}
+
+/**
+ * Return the effective permission set (granted=true only) for a (user, project). Redis-cached.
+ *
+ * Returns an empty array if the user has no access. We cache empty arrays too — unlike deny-caches
+ * in permission-specific code, the "no role at all" state is stable and changes only via explicit
+ * writes that DO call invalidation helpers.
+ */
+export async function getEffectiveProjectPermissions(
+  userId: string,
+  projectId: string,
+): Promise<ProjectPermission[]> {
+  const key = EFFECTIVE_KEY(userId, projectId);
+  const cached = await getCachedJson<ProjectPermission[]>(key);
+  if (cached !== null) return cached;
+
+  const role = await computeEffectiveRole(userId, projectId);
+  const perms = role?.permissions ?? [];
+  await setCachedJson(key, perms, EFFECTIVE_TTL);
+  return perms;
+}
+
+/**
+ * Assert that the authenticated user has AT LEAST ONE of the listed permissions in the project.
+ * Used when multiple permissions can authorise an action — e.g. deleting a comment authored by
+ * someone else requires `COMMENTS_DELETE_OTHERS` OR `COMMENTS_MANAGE`.
+ *
+ * SUPER_ADMIN bypasses. Global project-read roles bypass only if EVERY permission in the list is
+ * a `_VIEW` permission (otherwise we'd let them perform writes via the view-access shortcut).
+ */
+export async function assertProjectPermission(
+  user: AuthUser,
+  projectId: string,
+  permissions: ProjectPermission[],
+): Promise<void> {
+  if (permissions.length === 0) throw new AppError(500, 'assertProjectPermission: empty list');
+  if (isSuperAdmin(user.systemRoles)) return;
+  if (permissions.every(p => p.endsWith('_VIEW')) && hasGlobalProjectReadAccess(user.systemRoles)) return;
+
+  const granted = await getEffectiveProjectPermissions(user.userId, projectId);
+  const grantedSet = new Set(granted);
+  if (!permissions.some(p => grantedSet.has(p))) {
+    throw new AppError(403, `Requires one of: ${permissions.join(', ')}`);
+  }
 }
 
 export function requireRole(...roles: SystemRoleType[]) {
@@ -74,43 +276,11 @@ export function requireProjectPermission(
     const projectId = getProjectId(req);
     if (!projectId) return next(new AppError(400, 'Project ID required'));
 
-    const cacheKey = `rbac:perm:${projectId}:${req.user.userId}:${permission}`;
-
     try {
-      // Cache holds only positive (granted) results — a cached `true` means "still allowed".
-      // We do not cache deny decisions: a missing cache entry means "recompute", so granting a
-      // new role via a write path that forgot to invalidate still takes effect on the next
-      // request instead of being masked by a stale `false` for the full TTL.
-      const cachedResult = await getCachedJson<boolean>(cacheKey);
-      if (cachedResult === true) return next();
-
-      const scheme = await getSchemeForProject(projectId);
-      // Read ALL roles the user has in this project (in the canonical one-role-per-project model
-      // this returns 0..1 rows; during the migration window or after legacy data import it may
-      // return more). Permission is granted if ANY of the user's roles grants it — most
-      // permissive wins. This also makes behavior deterministic if multiple rows ever coexist.
-      const userRoles = await prisma.userProjectRole.findMany({
-        where: { userId: req.user.userId, projectId },
-        select: { roleId: true, role: true },
-      });
-
-      let granted = false;
-      for (const ur of userRoles) {
-        // Prefer roleId. If it's missing OR points to a role outside the active scheme
-        // (e.g. the project was recently re-attached to a different scheme and the migration
-        // hasn't caught up yet), fall back to matching by the legacy `role` key.
-        let roleDef = ur.roleId ? scheme.roles.find(r => r.id === ur.roleId) : undefined;
-        if (!roleDef) {
-          roleDef = scheme.roles.find(r => r.key === ur.role);
-        }
-        if (roleDef?.permissions.find(p => p.permission === permission)?.granted) {
-          granted = true;
-          break;
-        }
-      }
-
-      if (granted) await setCachedJson(cacheKey, true, 60);
-      return granted ? next() : next(new AppError(403, 'Insufficient project permissions'));
+      // TTSEC-2 Phase 2: uses the unified group-aware effective-permissions cache.
+      const granted = await getEffectiveProjectPermissions(req.user.userId, projectId);
+      if (granted.includes(permission)) return next();
+      return next(new AppError(403, 'Insufficient project permissions'));
     } catch (err) {
       next(err);
     }

--- a/backend/src/shared/middleware/rbac.ts
+++ b/backend/src/shared/middleware/rbac.ts
@@ -156,7 +156,12 @@ export async function computeEffectiveRole(
     if (!role) continue;
     const existing = byRoleId.get(role.id);
     if (existing) {
-      existing.groups.push(row.group);
+      // Dedup by group id — defensive: two bindings of the same group to the same role should
+      // be prevented by `@@unique([groupId, projectId])`, but data migration / join anomalies
+      // could still produce duplicates and leak to /users/me/security.
+      if (!existing.groups.some(g => g.id === row.group.id)) {
+        existing.groups.push(row.group);
+      }
     } else {
       byRoleId.set(role.id, { role, source: 'GROUP', groups: [row.group] });
     }
@@ -181,6 +186,108 @@ export async function computeEffectiveRole(
     source: chosen.source,
     sourceGroups: chosen.groups,
   };
+}
+
+/**
+ * Batched variant of computeEffectiveRole for many projects at once. Used by
+ * /users/me/security (AI review #65 round 2 — avoid N+1 when a user is in many projects).
+ *
+ * Query plan: 1× direct-roles + 1× group-roles + N× getSchemeForProject (Redis-cached, 300s TTL).
+ * Total DB queries: 2 instead of 2N; scheme reads hit Redis unless cold.
+ */
+export async function computeEffectiveRolesForProjects(
+  userId: string,
+  projectIds: string[],
+): Promise<Map<string, EffectiveRole | null>> {
+  const result = new Map<string, EffectiveRole | null>();
+  if (projectIds.length === 0) return result;
+
+  const [directRows, groupRows, schemes] = await Promise.all([
+    prisma.userProjectRole.findMany({
+      where: { userId, projectId: { in: projectIds } },
+      select: { projectId: true, roleId: true, role: true },
+    }),
+    prisma.projectGroupRole.findMany({
+      where: { projectId: { in: projectIds }, group: { members: { some: { userId } } } },
+      select: {
+        projectId: true,
+        roleId: true,
+        group: { select: { id: true, name: true } },
+        roleDefinition: { select: { key: true } },
+      },
+    }),
+    Promise.all(projectIds.map(async pid => [pid, await getSchemeForProject(pid)] as const)),
+  ]);
+
+  const schemeByProject = new Map(schemes);
+  const directByProject = new Map<string, typeof directRows>();
+  const groupByProject = new Map<string, typeof groupRows>();
+  for (const row of directRows) {
+    const arr = directByProject.get(row.projectId) ?? [];
+    arr.push(row);
+    directByProject.set(row.projectId, arr);
+  }
+  for (const row of groupRows) {
+    const arr = groupByProject.get(row.projectId) ?? [];
+    arr.push(row);
+    groupByProject.set(row.projectId, arr);
+  }
+
+  for (const projectId of projectIds) {
+    const scheme = schemeByProject.get(projectId);
+    if (!scheme) { result.set(projectId, null); continue; }
+    const rolesInScheme = scheme.roles;
+    type CandidateRole = typeof rolesInScheme[number];
+    type Candidate = { role: CandidateRole; source: 'DIRECT' | 'GROUP'; groups: { id: string; name: string }[] };
+    const byRoleId = new Map<string, Candidate>();
+
+    const resolveInScheme = (roleId: string | null | undefined, legacyKey: string | undefined): CandidateRole | undefined => {
+      if (roleId) {
+        const byId = rolesInScheme.find(r => r.id === roleId);
+        if (byId) return byId;
+      }
+      if (legacyKey) return rolesInScheme.find(r => r.key === legacyKey);
+      return undefined;
+    };
+
+    for (const row of (directByProject.get(projectId) ?? [])) {
+      const role = resolveInScheme(row.roleId, row.role);
+      if (!role) continue;
+      if (!byRoleId.has(role.id)) byRoleId.set(role.id, { role, source: 'DIRECT', groups: [] });
+    }
+    for (const row of (groupByProject.get(projectId) ?? [])) {
+      const role = resolveInScheme(row.roleId, row.roleDefinition.key);
+      if (!role) continue;
+      const existing = byRoleId.get(role.id);
+      if (existing) {
+        if (!existing.groups.some(g => g.id === row.group.id)) existing.groups.push(row.group);
+      } else {
+        byRoleId.set(role.id, { role, source: 'GROUP', groups: [row.group] });
+      }
+    }
+
+    const candidates = Array.from(byRoleId.values());
+    if (candidates.length === 0) { result.set(projectId, null); continue; }
+
+    candidates.sort((a, b) => {
+      const aGranted = a.role.permissions.filter(p => p.granted).length;
+      const bGranted = b.role.permissions.filter(p => p.granted).length;
+      const d = bGranted - aGranted;
+      return d !== 0 ? d : a.role.id.localeCompare(b.role.id);
+    });
+
+    const chosen = candidates[0]!;
+    result.set(projectId, {
+      roleId: chosen.role.id,
+      roleName: chosen.role.name,
+      roleKey: chosen.role.key,
+      permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
+      source: chosen.source,
+      sourceGroups: chosen.groups,
+    });
+  }
+
+  return result;
 }
 
 /**

--- a/backend/src/shared/middleware/rbac.ts
+++ b/backend/src/shared/middleware/rbac.ts
@@ -199,11 +199,13 @@ export async function computeEffectiveRole(
     roleName: chosen.role.name,
     roleKey: chosen.role.key,
     permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
+    // `source` indicates the PRIMARY grant path; DIRECT wins if the user has the role directly.
     source: chosen.source,
-    // AI review #65 round 3 🟡 — when the chosen role is DIRECT, don't leak irrelevant group
-    // context. If the user also holds the same role via groups, that's informational only and
-    // unrelated to the effective grant path; keeping it would contradict `source: 'DIRECT'`.
-    sourceGroups: chosen.source === 'DIRECT' ? [] : chosen.groups,
+    // `sourceGroups` lists ALL groups that also grant this role — independent of `source`.
+    // AI review #65 round 4 🟡: restored; round 3 cleared this when source=DIRECT, but that
+    // lost information SecurityTab needs ("also via Team A, Team B"). Documented in
+    // user-security.service SecurityProjectRole interface.
+    sourceGroups: chosen.groups,
   };
 }
 
@@ -302,8 +304,8 @@ export async function computeEffectiveRolesForProjects(
       roleKey: chosen.role.key,
       permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
       source: chosen.source,
-      // AI review #65 round 3 🟡 — see single-project variant above.
-      sourceGroups: chosen.source === 'DIRECT' ? [] : chosen.groups,
+      // See single-project variant — sourceGroups lists all groups that also grant this role.
+      sourceGroups: chosen.groups,
     });
   }
 

--- a/backend/src/shared/middleware/rbac.ts
+++ b/backend/src/shared/middleware/rbac.ts
@@ -17,12 +17,18 @@ import { getCachedJson, setCachedJson, delCachedJson, delCacheByPrefix } from '.
  * Among all candidates we pick the ONE role with the most `granted=true` permissions;
  * tiebreaker — roleId ascending (for determinism across replicas). This matches spec §5.2.
  *
- * Cache layout: `rbac:effective:{userId}:{projectId}` → string[] (granted perms), TTL 60s.
- * Cache is prefixed by userId first so we can drop a user's entire set on membership change.
+ * Cache layout (AI review #65 round 3): `rbac:effective:{projectId}:{userId}` → string[] (granted
+ * perms), TTL 60s. Key is projectId-first so scheme-level changes (attach/detach project, delete
+ * role, update permission matrix) can do a single prefix SCAN + delete — covering ALL cached
+ * users for the project, including ones who just lost access and no longer appear in the current
+ * bindings query. For per-user wipes (group membership change) we iterate the user's affected
+ * projects and delete pair-by-pair — bounded by the user's actual project count, not the whole
+ * keyspace.
  */
 
-const EFFECTIVE_KEY = (userId: string, projectId: string) =>
-  `rbac:effective:${userId}:${projectId}`;
+const EFFECTIVE_KEY = (projectId: string, userId: string) =>
+  `rbac:effective:${projectId}:${userId}`;
+const EFFECTIVE_PROJECT_PREFIX = (projectId: string) => `rbac:effective:${projectId}:`;
 const EFFECTIVE_TTL = 60;
 
 /**
@@ -41,7 +47,7 @@ const EFFECTIVE_TTL = 60;
 export async function invalidateProjectPermissionCache(projectId: string, userId: string): Promise<void> {
   await Promise.all([
     // New group-aware effective cache (single composite key).
-    delCachedJson(EFFECTIVE_KEY(userId, projectId)),
+    delCachedJson(EFFECTIVE_KEY(projectId, userId)),
     // Legacy per-permission cache — some callers may still hit it during deploy window.
     delCacheByPrefix(`rbac:perm:${projectId}:${userId}:`),
   ]);
@@ -50,36 +56,46 @@ export async function invalidateProjectPermissionCache(projectId: string, userId
 /**
  * Drop every cached effective-permission set for a single user across ALL projects. Called when
  * the user's group membership changes (added/removed from a group), since that affects every
- * project that group is bound to.
+ * project the user could see through direct roles or group bindings.
+ *
+ * Implementation iterates the user's currently-known projects (direct roles + groups the user
+ * is in) and deletes pair-by-pair. If the caller knows the exact projectIds affected (e.g. the
+ * group just bound/unbound), they should call `invalidateProjectPermissionCache(pid, uid)` for
+ * each pair directly — cheaper and exact. This helper is for the general "something about this
+ * user changed, flush them" case.
  */
 export async function invalidateUserEffectivePermissions(userId: string): Promise<void> {
-  await delCacheByPrefix(`rbac:effective:${userId}:`);
+  const [directProjects, groupProjects] = await Promise.all([
+    prisma.userProjectRole.findMany({ where: { userId }, select: { projectId: true } }),
+    prisma.projectGroupRole.findMany({
+      where: { group: { members: { some: { userId } } } },
+      select: { projectId: true },
+    }),
+  ]);
+  const projectIds = new Set<string>([
+    ...directProjects.map(r => r.projectId),
+    ...groupProjects.map(r => r.projectId),
+  ]);
+  await Promise.all(
+    Array.from(projectIds).map(pid => invalidateProjectPermissionCache(pid, userId)),
+  );
 }
 
 /**
- * Drop every cached effective-permission set for a project. Scans and deletes only the minority
- * of users who had their entry cached (most won't). Call when a project-level scheme/role binding
- * changes and you want to avoid iterating all group members.
+ * Drop every cached effective-permission set for a project — regardless of whether a user still
+ * has a direct/group binding.
+ *
+ * AI review #65 round 3 🟠 — scheme changes may REMOVE bindings (detach project, delete role,
+ * update matrix), and those users' stale cache entries must be wiped too. Prefix SCAN + DELETE
+ * on `rbac:effective:{projectId}:*` handles exactly this: it hits every user whose entry was
+ * ever cached for the project, not just users currently visible in the bindings query.
  */
 export async function invalidateProjectEffectivePermissions(projectId: string): Promise<void> {
-  // Redis doesn't support suffix-scan efficiently; fall back to iterating direct members + group
-  // members. For unbounded projects we could add pg_notify later; MVP uses explicit user-scan.
-  const [directUsers, groupUsers] = await Promise.all([
-    prisma.userProjectRole.findMany({ where: { projectId }, select: { userId: true } }),
-    prisma.userGroupMember.findMany({
-      where: { group: { projectRoles: { some: { projectId } } } },
-      select: { userId: true },
-    }),
+  await Promise.all([
+    delCacheByPrefix(EFFECTIVE_PROJECT_PREFIX(projectId)),
+    // Legacy per-permission cache — same treatment for deploy-window safety.
+    delCacheByPrefix(`rbac:perm:${projectId}:`),
   ]);
-  const userIds = new Set<string>([
-    ...directUsers.map(u => u.userId),
-    ...groupUsers.map(u => u.userId),
-  ]);
-  await Promise.all(
-    Array.from(userIds).map(uid => delCachedJson(EFFECTIVE_KEY(uid, projectId))),
-  );
-  // Also kill legacy prefix for safety during the Phase 2 deploy window.
-  await delCacheByPrefix(`rbac:perm:${projectId}:`);
 }
 
 type EffectiveRole = {
@@ -184,7 +200,10 @@ export async function computeEffectiveRole(
     roleKey: chosen.role.key,
     permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
     source: chosen.source,
-    sourceGroups: chosen.groups,
+    // AI review #65 round 3 🟡 — when the chosen role is DIRECT, don't leak irrelevant group
+    // context. If the user also holds the same role via groups, that's informational only and
+    // unrelated to the effective grant path; keeping it would contradict `source: 'DIRECT'`.
+    sourceGroups: chosen.source === 'DIRECT' ? [] : chosen.groups,
   };
 }
 
@@ -283,7 +302,8 @@ export async function computeEffectiveRolesForProjects(
       roleKey: chosen.role.key,
       permissions: chosen.role.permissions.filter(p => p.granted).map(p => p.permission),
       source: chosen.source,
-      sourceGroups: chosen.groups,
+      // AI review #65 round 3 🟡 — see single-project variant above.
+      sourceGroups: chosen.source === 'DIRECT' ? [] : chosen.groups,
     });
   }
 
@@ -301,7 +321,7 @@ export async function getEffectiveProjectPermissions(
   userId: string,
   projectId: string,
 ): Promise<ProjectPermission[]> {
-  const key = EFFECTIVE_KEY(userId, projectId);
+  const key = EFFECTIVE_KEY(projectId, userId);
   const cached = await getCachedJson<ProjectPermission[]>(key);
   if (cached !== null) return cached;
 

--- a/backend/src/shared/middleware/rbac.ts
+++ b/backend/src/shared/middleware/rbac.ts
@@ -224,7 +224,7 @@ export async function assertProjectPermission(
   const granted = await getEffectiveProjectPermissions(user.userId, projectId);
   const grantedSet = new Set(granted);
   if (!permissions.some(p => grantedSet.has(p))) {
-    throw new AppError(403, `Requires one of: ${permissions.join(', ')}`);
+    throw new AppError(403, `Требуется одно из прав: ${permissions.join(', ')}`);
   }
 }
 

--- a/backend/src/shared/middleware/rbac.ts
+++ b/backend/src/shared/middleware/rbac.ts
@@ -347,7 +347,8 @@ export async function assertProjectPermission(
   permissions: ProjectPermission[],
 ): Promise<void> {
   if (permissions.length === 0) throw new AppError(500, 'assertProjectPermission: empty list');
-  if (isSuperAdmin(user.systemRoles)) return;
+  // SUPER_ADMIN and system ADMIN bypass — symmetric with requireProjectPermission.
+  if (hasAnySystemRole(user.systemRoles, ['SUPER_ADMIN', 'ADMIN'])) return;
   if (permissions.every(p => p.endsWith('_VIEW')) && hasGlobalProjectReadAccess(user.systemRoles)) return;
 
   const granted = await getEffectiveProjectPermissions(user.userId, projectId);
@@ -399,7 +400,10 @@ export function requireProjectPermission(
   const { allowGlobalRead = true } = options;
   return async (req: AuthRequest, _res: Response, next: NextFunction) => {
     if (!req.user) return next(new AppError(401, 'Authentication required'));
-    if (isSuperAdmin(req.user.systemRoles)) return next();
+    // SUPER_ADMIN and system ADMIN bypass project-scoped checks — matches the pre-Phase-2
+    // semantics of `requireRole('ADMIN')` and keeps existing integration tests / admin tooling
+    // working without having to seed a project role for every tenant admin.
+    if (hasAnySystemRole(req.user.systemRoles, ['SUPER_ADMIN', 'ADMIN'])) return next();
     if (allowGlobalRead && permission.endsWith('_VIEW') && hasGlobalProjectReadAccess(req.user.systemRoles)) return next();
 
     const projectId = getProjectId(req);

--- a/backend/src/shared/types/index.ts
+++ b/backend/src/shared/types/index.ts
@@ -1,10 +1,12 @@
 import type { Request } from 'express';
 import type { SystemRoleType } from '@prisma/client';
 
+export interface AuthUser {
+  userId: string;
+  email: string;
+  systemRoles: SystemRoleType[];
+}
+
 export interface AuthRequest extends Request {
-  user?: {
-    userId: string;
-    email: string;
-    systemRoles: SystemRoleType[];
-  };
+  user?: AuthUser;
 }

--- a/backend/tests/rbac-effective.unit.test.ts
+++ b/backend/tests/rbac-effective.unit.test.ts
@@ -141,14 +141,14 @@ describe('computeEffectiveRole', () => {
     expect(eff?.roleId).toBe('aaaa'); // min id wins tiebreaker
   });
 
-  it('same role via both DIRECT and GROUP is listed once with sourceGroups populated', async () => {
+  it('when chosen role is DIRECT, sourceGroups is empty even if groups also grant it (round 3)', async () => {
     mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: ADMIN.id, role: 'ADMIN' }]);
     mockPrisma.projectGroupRole.findMany.mockResolvedValue([
       { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
     ]);
     const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
-    expect(eff?.source).toBe('DIRECT'); // direct was inserted first
-    expect(eff?.sourceGroups).toEqual([{ id: 'g-1', name: 'Admins' }]);
+    expect(eff?.source).toBe('DIRECT');
+    expect(eff?.sourceGroups).toEqual([]);
   });
 
   it('sourceGroups is deduplicated when the same group appears twice (AI review #65 round 2)', async () => {

--- a/backend/tests/rbac-effective.unit.test.ts
+++ b/backend/tests/rbac-effective.unit.test.ts
@@ -6,23 +6,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ProjectPermission } from '@prisma/client';
 
-const { mockPrisma } = vi.hoisted(() => {
+const { mockPrisma, mockRedis } = vi.hoisted(() => {
   const mockPrisma = {
     userProjectRole: { findMany: vi.fn() },
     projectGroupRole: { findMany: vi.fn() },
     userGroupMember: { findMany: vi.fn() },
   };
-  return { mockPrisma };
+  const mockRedis = {
+    getCachedJson: vi.fn().mockResolvedValue(null),
+    setCachedJson: vi.fn(),
+    delCachedJson: vi.fn(),
+    delCacheByPrefix: vi.fn(),
+  };
+  return { mockPrisma, mockRedis };
 });
 
 vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
-
-vi.mock('../src/shared/redis.js', () => ({
-  getCachedJson: vi.fn().mockResolvedValue(null), // always miss → exercise compute path
-  setCachedJson: vi.fn(),
-  delCachedJson: vi.fn(),
-  delCacheByPrefix: vi.fn(),
-}));
+vi.mock('../src/shared/redis.js', () => mockRedis);
 
 const mockGetScheme = vi.fn();
 vi.mock('../src/modules/project-role-schemes/project-role-schemes.service.js', () => ({
@@ -35,6 +35,8 @@ const {
   assertProjectPermission,
   getEffectiveProjectPermissions,
   computeEffectiveRolesForProjects,
+  invalidateProjectEffectivePermissions,
+  invalidateProjectPermissionCache,
 } = await import('../src/shared/middleware/rbac.js');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -257,5 +259,23 @@ describe('getEffectiveProjectPermissions', () => {
     const perms = await getEffectiveProjectPermissions(USER_ID, PROJECT_ID);
     expect(perms).toContain('SPRINTS_CREATE');
     expect(perms).toContain('SPRINTS_DELETE');
+  });
+});
+
+// ─── Cache invalidation (AI review #65 round 5 🟠) ───────────────────────────
+
+describe('cache invalidation key format', () => {
+  it('invalidateProjectEffectivePermissions uses project-prefix (covers stale users)', async () => {
+    await invalidateProjectEffectivePermissions('proj-X');
+    // Must kill both the new effective cache prefix AND the legacy per-permission prefix.
+    expect(mockRedis.delCacheByPrefix).toHaveBeenCalledWith('rbac:effective:proj-X:');
+    expect(mockRedis.delCacheByPrefix).toHaveBeenCalledWith('rbac:perm:proj-X:');
+  });
+
+  it('invalidateProjectPermissionCache uses projectId-first composite key', async () => {
+    await invalidateProjectPermissionCache('proj-X', 'user-Y');
+    // Single composite key, projectId first — the SCAN above hits this same namespace.
+    expect(mockRedis.delCachedJson).toHaveBeenCalledWith('rbac:effective:proj-X:user-Y');
+    expect(mockRedis.delCacheByPrefix).toHaveBeenCalledWith('rbac:perm:proj-X:user-Y:');
   });
 });

--- a/backend/tests/rbac-effective.unit.test.ts
+++ b/backend/tests/rbac-effective.unit.test.ts
@@ -141,14 +141,18 @@ describe('computeEffectiveRole', () => {
     expect(eff?.roleId).toBe('aaaa'); // min id wins tiebreaker
   });
 
-  it('when chosen role is DIRECT, sourceGroups is empty even if groups also grant it (round 3)', async () => {
+  it('source=DIRECT but sourceGroups lists every group that also grants the same role (round 4)', async () => {
     mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: ADMIN.id, role: 'ADMIN' }]);
     mockPrisma.projectGroupRole.findMany.mockResolvedValue([
       { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
+      { roleId: ADMIN.id, group: { id: 'g-2', name: 'Leads' }, roleDefinition: { key: 'ADMIN' } },
     ]);
     const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
     expect(eff?.source).toBe('DIRECT');
-    expect(eff?.sourceGroups).toEqual([]);
+    expect(eff?.sourceGroups).toEqual([
+      { id: 'g-1', name: 'Admins' },
+      { id: 'g-2', name: 'Leads' },
+    ]);
   });
 
   it('sourceGroups is deduplicated when the same group appears twice (AI review #65 round 2)', async () => {

--- a/backend/tests/rbac-effective.unit.test.ts
+++ b/backend/tests/rbac-effective.unit.test.ts
@@ -239,6 +239,14 @@ describe('assertProjectPermission', () => {
     expect(mockPrisma.userProjectRole.findMany).not.toHaveBeenCalled();
   });
 
+  it('system ADMIN bypasses non-VIEW permissions (matches pre-Phase-2 requireRole ADMIN)', async () => {
+    const admin = { userId: USER_ID, email: 'a@ex.com', systemRoles: ['ADMIN' as const] };
+    await expect(
+      assertProjectPermission(admin, PROJECT_ID, ['SPRINTS_CREATE']),
+    ).resolves.toBeUndefined();
+    expect(mockPrisma.userProjectRole.findMany).not.toHaveBeenCalled();
+  });
+
   it('rejects empty permission list (programmer error)', async () => {
     await expect(
       assertProjectPermission(authUser, PROJECT_ID, []),

--- a/backend/tests/rbac-effective.unit.test.ts
+++ b/backend/tests/rbac-effective.unit.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit-тесты для group-aware RBAC из rbac.ts.
+ * Проверяем computeEffectiveRole + assertProjectPermission: выбор max-permissions,
+ * детерминированный tiebreaker, fallback через active scheme, source=DIRECT/GROUP.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ProjectPermission } from '@prisma/client';
+
+const { mockPrisma } = vi.hoisted(() => {
+  const mockPrisma = {
+    userProjectRole: { findMany: vi.fn() },
+    projectGroupRole: { findMany: vi.fn() },
+    userGroupMember: { findMany: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
+
+vi.mock('../src/shared/redis.js', () => ({
+  getCachedJson: vi.fn().mockResolvedValue(null), // always miss → exercise compute path
+  setCachedJson: vi.fn(),
+  delCachedJson: vi.fn(),
+  delCacheByPrefix: vi.fn(),
+}));
+
+const mockGetScheme = vi.fn();
+vi.mock('../src/modules/project-role-schemes/project-role-schemes.service.js', () => ({
+  getSchemeForProject: (projectId: string) => mockGetScheme(projectId),
+}));
+
+// Import after mocks.
+const {
+  computeEffectiveRole,
+  assertProjectPermission,
+  getEffectiveProjectPermissions,
+} = await import('../src/shared/middleware/rbac.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function role(id: string, key: string, name: string, perms: ProjectPermission[]) {
+  return {
+    id, key, name,
+    permissions: perms.map(p => ({ permission: p, granted: true })),
+  };
+}
+
+const USER_ID = 'user-1';
+const PROJECT_ID = 'proj-1';
+const SCHEME_ID = 'scheme-1';
+
+const ADMIN = role('r-admin', 'ADMIN', 'Администратор', [
+  'ISSUES_VIEW', 'ISSUES_CREATE', 'ISSUES_EDIT', 'ISSUES_DELETE',
+  'SPRINTS_CREATE', 'SPRINTS_EDIT', 'SPRINTS_DELETE',
+  'COMMENTS_MANAGE', 'COMMENTS_DELETE_OTHERS',
+] as ProjectPermission[]);
+const USER = role('r-user', 'USER', 'Участник', [
+  'ISSUES_VIEW', 'ISSUES_CREATE',
+] as ProjectPermission[]);
+const VIEWER = role('r-viewer', 'VIEWER', 'Наблюдатель', ['ISSUES_VIEW'] as ProjectPermission[]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetScheme.mockResolvedValue({ id: SCHEME_ID, roles: [ADMIN, USER, VIEWER] });
+  mockPrisma.userProjectRole.findMany.mockResolvedValue([]);
+  mockPrisma.projectGroupRole.findMany.mockResolvedValue([]);
+});
+
+// ─── computeEffectiveRole ────────────────────────────────────────────────────
+
+describe('computeEffectiveRole', () => {
+  it('returns null when user has neither direct nor group role', async () => {
+    expect(await computeEffectiveRole(USER_ID, PROJECT_ID)).toBeNull();
+  });
+
+  it('resolves DIRECT-only user via roleId', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([
+      { roleId: USER.id, role: 'USER' },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff).not.toBeNull();
+    expect(eff!.source).toBe('DIRECT');
+    expect(eff!.roleKey).toBe('USER');
+    expect(eff!.permissions).toContain('ISSUES_VIEW');
+    expect(eff!.permissions).not.toContain('ISSUES_DELETE');
+  });
+
+  it('falls back to matching by legacy `role` key when roleId is NULL', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([
+      { roleId: null, role: 'USER' },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.roleKey).toBe('USER');
+  });
+
+  it('falls back to `role` key when roleId points outside active scheme', async () => {
+    // Stale roleId (scheme switched) — runtime falls back to legacy key match.
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([
+      { roleId: 'stale-role-id', role: 'ADMIN' },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.roleKey).toBe('ADMIN');
+    expect(eff?.permissions).toContain('ISSUES_DELETE');
+  });
+
+  it('resolves GROUP-only user and exposes sourceGroups', async () => {
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      {
+        roleId: ADMIN.id,
+        group: { id: 'g-1', name: 'Frontend Team' },
+        roleDefinition: { key: 'ADMIN' },
+      },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.source).toBe('GROUP');
+    expect(eff?.sourceGroups).toEqual([{ id: 'g-1', name: 'Frontend Team' }]);
+    expect(eff?.permissions).toContain('ISSUES_DELETE');
+  });
+
+  it('picks role with max permissions when user has DIRECT=USER and GROUP=ADMIN', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: USER.id, role: 'USER' }]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.roleKey).toBe('ADMIN');
+    expect(eff?.source).toBe('GROUP');
+    expect(eff?.sourceGroups[0]?.id).toBe('g-1');
+  });
+
+  it('tiebreaker by roleId asc when two roles grant equal permissions', async () => {
+    const roleA = role('zzzz', 'A', 'A', ['ISSUES_VIEW'] as ProjectPermission[]);
+    const roleB = role('aaaa', 'B', 'B', ['ISSUES_VIEW'] as ProjectPermission[]);
+    mockGetScheme.mockResolvedValue({ id: SCHEME_ID, roles: [roleA, roleB] });
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: roleA.id, role: 'A' }]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { roleId: roleB.id, group: { id: 'g', name: 'G' }, roleDefinition: { key: 'B' } },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.roleId).toBe('aaaa'); // min id wins tiebreaker
+  });
+
+  it('same role via both DIRECT and GROUP is listed once with sourceGroups populated', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: ADMIN.id, role: 'ADMIN' }]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.source).toBe('DIRECT'); // direct was inserted first
+    expect(eff?.sourceGroups).toEqual([{ id: 'g-1', name: 'Admins' }]);
+  });
+});
+
+// ─── assertProjectPermission (OR-list) ───────────────────────────────────────
+
+describe('assertProjectPermission', () => {
+  const authUser = { userId: USER_ID, email: 'u@ex.com', systemRoles: [] };
+
+  it('passes when the user has at least one of the listed permissions', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: ADMIN.id, role: 'ADMIN' }]);
+    await expect(
+      assertProjectPermission(authUser, PROJECT_ID, ['COMMENTS_DELETE_OTHERS', 'COMMENTS_MANAGE']),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws 403 when none of the listed permissions are granted', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: USER.id, role: 'USER' }]);
+    await expect(
+      assertProjectPermission(authUser, PROJECT_ID, ['COMMENTS_DELETE_OTHERS', 'COMMENTS_MANAGE']),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('SUPER_ADMIN bypasses regardless of granted permissions', async () => {
+    const superUser = { userId: USER_ID, email: 'u@ex.com', systemRoles: ['SUPER_ADMIN' as const] };
+    await expect(
+      assertProjectPermission(superUser, PROJECT_ID, ['SPRINTS_DELETE']),
+    ).resolves.toBeUndefined();
+    expect(mockPrisma.userProjectRole.findMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty permission list (programmer error)', async () => {
+    await expect(
+      assertProjectPermission(authUser, PROJECT_ID, []),
+    ).rejects.toMatchObject({ statusCode: 500 });
+  });
+});
+
+// ─── getEffectiveProjectPermissions ──────────────────────────────────────────
+
+describe('getEffectiveProjectPermissions', () => {
+  it('returns empty array when no role found', async () => {
+    const perms = await getEffectiveProjectPermissions(USER_ID, PROJECT_ID);
+    expect(perms).toEqual([]);
+  });
+
+  it('returns the granted permissions of the chosen role', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([{ roleId: ADMIN.id, role: 'ADMIN' }]);
+    const perms = await getEffectiveProjectPermissions(USER_ID, PROJECT_ID);
+    expect(perms).toContain('SPRINTS_CREATE');
+    expect(perms).toContain('SPRINTS_DELETE');
+  });
+});

--- a/backend/tests/rbac-effective.unit.test.ts
+++ b/backend/tests/rbac-effective.unit.test.ts
@@ -34,6 +34,7 @@ const {
   computeEffectiveRole,
   assertProjectPermission,
   getEffectiveProjectPermissions,
+  computeEffectiveRolesForProjects,
 } = await import('../src/shared/middleware/rbac.js');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -148,6 +149,60 @@ describe('computeEffectiveRole', () => {
     const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
     expect(eff?.source).toBe('DIRECT'); // direct was inserted first
     expect(eff?.sourceGroups).toEqual([{ id: 'g-1', name: 'Admins' }]);
+  });
+
+  it('sourceGroups is deduplicated when the same group appears twice (AI review #65 round 2)', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
+      { roleId: ADMIN.id, group: { id: 'g-1', name: 'Admins' }, roleDefinition: { key: 'ADMIN' } },
+      { roleId: ADMIN.id, group: { id: 'g-2', name: 'Leads' }, roleDefinition: { key: 'ADMIN' } },
+    ]);
+    const eff = await computeEffectiveRole(USER_ID, PROJECT_ID);
+    expect(eff?.sourceGroups).toEqual([
+      { id: 'g-1', name: 'Admins' },
+      { id: 'g-2', name: 'Leads' },
+    ]);
+  });
+});
+
+// ─── computeEffectiveRolesForProjects (batched) ──────────────────────────────
+
+describe('computeEffectiveRolesForProjects', () => {
+  it('returns empty map on empty input without any DB call', async () => {
+    const res = await computeEffectiveRolesForProjects(USER_ID, []);
+    expect(res.size).toBe(0);
+    expect(mockPrisma.userProjectRole.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.projectGroupRole.findMany).not.toHaveBeenCalled();
+  });
+
+  it('makes exactly one direct query and one group query for N projects', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([
+      { projectId: 'p1', roleId: USER.id, role: 'USER' },
+      { projectId: 'p2', roleId: ADMIN.id, role: 'ADMIN' },
+    ]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([]);
+
+    const res = await computeEffectiveRolesForProjects(USER_ID, ['p1', 'p2', 'p3']);
+
+    expect(mockPrisma.userProjectRole.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.projectGroupRole.findMany).toHaveBeenCalledTimes(1);
+    expect(res.get('p1')?.roleKey).toBe('USER');
+    expect(res.get('p2')?.roleKey).toBe('ADMIN');
+    expect(res.get('p3')).toBeNull(); // no role in p3
+  });
+
+  it('merges DIRECT + GROUP per-project with max-permissions pick', async () => {
+    mockPrisma.userProjectRole.findMany.mockResolvedValue([
+      { projectId: 'p1', roleId: USER.id, role: 'USER' },
+    ]);
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { projectId: 'p1', roleId: ADMIN.id, group: { id: 'g-1', name: 'G' }, roleDefinition: { key: 'ADMIN' } },
+    ]);
+    const res = await computeEffectiveRolesForProjects(USER_ID, ['p1']);
+    const eff = res.get('p1');
+    expect(eff?.roleKey).toBe('ADMIN');
+    expect(eff?.source).toBe('GROUP');
   });
 });
 

--- a/backend/tests/sprints-move-issues.unit.test.ts
+++ b/backend/tests/sprints-move-issues.unit.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit-тесты для moveIssuesToSprint: cross-project защита.
+ * См. TTSEC-2 Phase 2, AI review #65 🟠 — роутер /projects/:projectId/backlog/issues
+ * раньше не валидировал, что issueIds принадлежат projectId, что позволяло пользователю
+ * с SPRINTS_EDIT в проекте A трогать задачи проекта B.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPrisma } = vi.hoisted(() => {
+  const mockPrisma = {
+    issue: {
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  };
+  return { mockPrisma };
+});
+
+vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
+vi.mock('../src/shared/redis.js', () => ({
+  getCachedJson: vi.fn(),
+  setCachedJson: vi.fn(),
+  delCachedJson: vi.fn(),
+  delCacheByPrefix: vi.fn(),
+  acquireLock: vi.fn(),
+  releaseLock: vi.fn(),
+}));
+vi.mock('../src/modules/ai/ai.service.js', () => ({}));
+
+const { moveIssuesToSprint } = await import('../src/modules/sprints/sprints.service.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.issue.updateMany.mockResolvedValue({ count: 0 });
+});
+
+describe('moveIssuesToSprint cross-project guard', () => {
+  it('allows move when every issue belongs to expectedProjectId', async () => {
+    mockPrisma.issue.findMany.mockResolvedValue([
+      { id: 'i1', projectId: 'p1' },
+      { id: 'i2', projectId: 'p1' },
+    ]);
+    await expect(
+      moveIssuesToSprint(null, ['i1', 'i2'], 'p1'),
+    ).resolves.toBeUndefined();
+    expect(mockPrisma.issue.updateMany).toHaveBeenCalled();
+  });
+
+  it('rejects (403) when any issue belongs to a different project', async () => {
+    mockPrisma.issue.findMany.mockResolvedValue([
+      { id: 'i1', projectId: 'p1' },
+      { id: 'i2', projectId: 'p2' }, // foreign
+    ]);
+    await expect(
+      moveIssuesToSprint(null, ['i1', 'i2'], 'p1'),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(mockPrisma.issue.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects (400) when some issue ids are not found', async () => {
+    mockPrisma.issue.findMany.mockResolvedValue([{ id: 'i1', projectId: 'p1' }]);
+    await expect(
+      moveIssuesToSprint(null, ['i1', 'missing'], 'p1'),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(mockPrisma.issue.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('skips cross-project check when expectedProjectId is omitted (legacy callers)', async () => {
+    mockPrisma.issue.findMany.mockResolvedValue([
+      { id: 'i1', projectId: 'p1' },
+      { id: 'i2', projectId: 'p2' },
+    ]);
+    await expect(
+      moveIssuesToSprint('sprint-1', ['i1', 'i2']),
+    ).resolves.toBeUndefined();
+    expect(mockPrisma.issue.updateMany).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/user-groups.unit.test.ts
+++ b/backend/tests/user-groups.unit.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit-тесты для user-groups сервиса. Фокус — инварианты cache-инвалидации
+ * и корректность CRUD/membership логики без реальной БД.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPrisma } = vi.hoisted(() => {
+  const mockPrisma = {
+    userGroup: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    userGroupMember: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      createMany: vi.fn(),
+      delete: vi.fn(),
+    },
+    projectGroupRole: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    projectRoleDefinition: { findUnique: vi.fn() },
+    projectRoleScheme: { findFirst: vi.fn() },
+    projectRoleSchemeProject: { findUnique: vi.fn() },
+    project: { findUnique: vi.fn() },
+    user: { findMany: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
+vi.mock('../src/shared/redis.js', () => ({
+  getCachedJson: vi.fn(),
+  setCachedJson: vi.fn(),
+  delCachedJson: vi.fn(),
+  delCacheByPrefix: vi.fn(),
+}));
+
+const invalidateUserEffective = vi.fn();
+const invalidatePerProject = vi.fn();
+vi.mock('../src/shared/middleware/rbac.js', () => ({
+  invalidateUserEffectivePermissions: invalidateUserEffective,
+  invalidateProjectPermissionCache: invalidatePerProject,
+}));
+
+const service = await import('../src/modules/user-groups/user-groups.service.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createGroup', () => {
+  it('creates a group when the name is free', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue(null);
+    mockPrisma.userGroup.create.mockResolvedValue({ id: 'g1', name: 'Team', description: null });
+    const result = await service.createGroup({ name: 'Team' });
+    expect(result.id).toBe('g1');
+    expect(mockPrisma.userGroup.create).toHaveBeenCalledWith({
+      data: { name: 'Team', description: null },
+    });
+  });
+
+  it('rejects duplicate group names with 409', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'existing' });
+    await expect(service.createGroup({ name: 'Team' })).rejects.toMatchObject({ statusCode: 409 });
+  });
+});
+
+describe('addMembers', () => {
+  it('invalidates effective-permission cache for every added user', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1' });
+    mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }, { id: 'u2' }]);
+    mockPrisma.userGroupMember.createMany.mockResolvedValue({ count: 2 });
+
+    const result = await service.addMembers('g1', ['u1', 'u2'], 'actor');
+    expect(result.added).toBe(2);
+    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
+    expect(invalidateUserEffective).toHaveBeenCalledWith('u2');
+  });
+
+  it('rejects when some user ids do not exist', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1' });
+    mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }]);
+    await expect(service.addMembers('g1', ['u1', 'missing'], 'actor')).rejects.toMatchObject({
+      statusCode: 400,
+    });
+    expect(invalidateUserEffective).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeMember', () => {
+  it('invalidates effective-permission cache for the removed user', async () => {
+    mockPrisma.userGroupMember.findUnique.mockResolvedValue({ groupId: 'g1' });
+    mockPrisma.userGroupMember.delete.mockResolvedValue({});
+    await service.removeMember('g1', 'u1');
+    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
+  });
+
+  it('returns 404 when the user is not a member', async () => {
+    mockPrisma.userGroupMember.findUnique.mockResolvedValue(null);
+    await expect(service.removeMember('g1', 'u1')).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe('grantProjectRole', () => {
+  beforeEach(() => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1' });
+    mockPrisma.project.findUnique.mockResolvedValue({ id: 'p1' });
+    mockPrisma.projectRoleDefinition.findUnique.mockResolvedValue({
+      id: 'r1', schemeId: 'scheme-active',
+    });
+    mockPrisma.projectRoleSchemeProject.findUnique.mockResolvedValue({ schemeId: 'scheme-active' });
+  });
+
+  it('creates a new binding when none exists', async () => {
+    mockPrisma.projectGroupRole.findUnique.mockResolvedValue(null);
+    mockPrisma.projectGroupRole.create.mockResolvedValue({ id: 'b1' });
+    mockPrisma.userGroupMember.findMany.mockResolvedValue([{ userId: 'u1' }, { userId: 'u2' }]);
+
+    await service.grantProjectRole('g1', { projectId: 'p1', roleId: 'r1' });
+
+    expect(mockPrisma.projectGroupRole.create).toHaveBeenCalled();
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u1');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u2');
+  });
+
+  it('rejects a role that belongs to another scheme', async () => {
+    mockPrisma.projectRoleDefinition.findUnique.mockResolvedValue({
+      id: 'r1', schemeId: 'scheme-other',
+    });
+    await expect(
+      service.grantProjectRole('g1', { projectId: 'p1', roleId: 'r1' }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('idempotent: re-granting the same roleId is a no-op returning the existing binding', async () => {
+    mockPrisma.projectGroupRole.findUnique.mockResolvedValue({ id: 'b-existing', roleId: 'r1' });
+    const result = await service.grantProjectRole('g1', { projectId: 'p1', roleId: 'r1' });
+    expect(result).toMatchObject({ id: 'b-existing' });
+    expect(mockPrisma.projectGroupRole.create).not.toHaveBeenCalled();
+    expect(mockPrisma.projectGroupRole.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteGroup', () => {
+  it('returns affected user×project pairs and invalidates each distinct user', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({
+      id: 'g1', name: 'Team',
+      members: [{ userId: 'u1' }, { userId: 'u2' }],
+      projectRoles: [
+        { projectId: 'p1', roleId: 'r1' },
+        { projectId: 'p2', roleId: 'r1' },
+      ],
+    });
+    mockPrisma.userGroup.delete.mockResolvedValue({});
+
+    const result = await service.deleteGroup('g1');
+
+    expect(result.affectedPairs).toHaveLength(4); // 2 users × 2 projects
+    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
+    expect(invalidateUserEffective).toHaveBeenCalledWith('u2');
+    expect(invalidateUserEffective).toHaveBeenCalledTimes(2); // dedup by user
+  });
+});

--- a/backend/tests/user-groups.unit.test.ts
+++ b/backend/tests/user-groups.unit.test.ts
@@ -44,10 +44,8 @@ vi.mock('../src/shared/redis.js', () => ({
   delCacheByPrefix: vi.fn(),
 }));
 
-const invalidateUserEffective = vi.fn();
 const invalidatePerProject = vi.fn();
 vi.mock('../src/shared/middleware/rbac.js', () => ({
-  invalidateUserEffectivePermissions: invalidateUserEffective,
   invalidateProjectPermissionCache: invalidatePerProject,
 }));
 
@@ -75,33 +73,58 @@ describe('createGroup', () => {
 });
 
 describe('addMembers', () => {
-  it('invalidates effective-permission cache for every added user', async () => {
-    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1' });
+  it('invalidates (userId × groupProjectIds) pairs — exact, kills legacy cache too', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({
+      id: 'g1',
+      projectRoles: [{ projectId: 'p1' }, { projectId: 'p2' }],
+    });
     mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }, { id: 'u2' }]);
     mockPrisma.userGroupMember.createMany.mockResolvedValue({ count: 2 });
 
     const result = await service.addMembers('g1', ['u1', 'u2'], 'actor');
+
     expect(result.added).toBe(2);
-    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
-    expect(invalidateUserEffective).toHaveBeenCalledWith('u2');
+    // 2 users × 2 projects = 4 exact pair invalidations
+    expect(invalidatePerProject).toHaveBeenCalledTimes(4);
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u1');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p2', 'u1');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u2');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p2', 'u2');
+  });
+
+  it('skips invalidation when the group has no project bindings', async () => {
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1', projectRoles: [] });
+    mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }]);
+    mockPrisma.userGroupMember.createMany.mockResolvedValue({ count: 1 });
+
+    await service.addMembers('g1', ['u1'], 'actor');
+    expect(invalidatePerProject).not.toHaveBeenCalled();
   });
 
   it('rejects when some user ids do not exist', async () => {
-    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1' });
+    mockPrisma.userGroup.findUnique.mockResolvedValue({ id: 'g1', projectRoles: [] });
     mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }]);
     await expect(service.addMembers('g1', ['u1', 'missing'], 'actor')).rejects.toMatchObject({
       statusCode: 400,
     });
-    expect(invalidateUserEffective).not.toHaveBeenCalled();
+    expect(invalidatePerProject).not.toHaveBeenCalled();
   });
 });
 
 describe('removeMember', () => {
-  it('invalidates effective-permission cache for the removed user', async () => {
+  it('invalidates every (removedUser × projectId) pair for the group', async () => {
     mockPrisma.userGroupMember.findUnique.mockResolvedValue({ groupId: 'g1' });
+    mockPrisma.projectGroupRole.findMany.mockResolvedValue([
+      { projectId: 'p1' },
+      { projectId: 'p2' },
+    ]);
     mockPrisma.userGroupMember.delete.mockResolvedValue({});
+
     await service.removeMember('g1', 'u1');
-    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
+
+    expect(invalidatePerProject).toHaveBeenCalledTimes(2);
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u1');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p2', 'u1');
   });
 
   it('returns 404 when the user is not a member', async () => {
@@ -151,7 +174,7 @@ describe('grantProjectRole', () => {
 });
 
 describe('deleteGroup', () => {
-  it('returns affected user×project pairs and invalidates each distinct user', async () => {
+  it('returns affected user×project pairs and invalidates each pair (kills legacy cache too)', async () => {
     mockPrisma.userGroup.findUnique.mockResolvedValue({
       id: 'g1', name: 'Team',
       members: [{ userId: 'u1' }, { userId: 'u2' }],
@@ -165,8 +188,8 @@ describe('deleteGroup', () => {
     const result = await service.deleteGroup('g1');
 
     expect(result.affectedPairs).toHaveLength(4); // 2 users × 2 projects
-    expect(invalidateUserEffective).toHaveBeenCalledWith('u1');
-    expect(invalidateUserEffective).toHaveBeenCalledWith('u2');
-    expect(invalidateUserEffective).toHaveBeenCalledTimes(2); // dedup by user
+    expect(invalidatePerProject).toHaveBeenCalledTimes(4);
+    expect(invalidatePerProject).toHaveBeenCalledWith('p1', 'u1');
+    expect(invalidatePerProject).toHaveBeenCalledWith('p2', 'u2');
   });
 });

--- a/docs/tz/TTSEC-2.md
+++ b/docs/tz/TTSEC-2.md
@@ -671,13 +671,13 @@ router.delete('/:id', authenticate, async (req, res, next) => {
 - [x] TTSEC-5: `seed.ts` → `DEFAULT_ROLE_MATRIX` обновлена. ADMIN: гранулярные + `*_DELETE_OTHERS` + `USER_GROUP_*`; MANAGER: гранулярные + `*_DELETE_OTHERS`; `COMMENTS_MANAGE` / `TIME_LOGS_MANAGE` сохранены для модерации и настроек модуля; `SPRINTS_MANAGE` / `RELEASES_MANAGE` удалены из default-матрицы (enum сохраняет их как deprecated).
 - **DoD:** `npx prisma validate` зелёный ✅, `npx prisma generate` ✅, `npx tsc --noEmit` (backend) ✅. `prisma migrate deploy` на локальной БД не прогнан — Docker/PG локально недоступны; обязательно прогнать на staging CI перед мерджем (см. risk #1).
 
-### Фаза 2 — Backend — pending
-- [ ] TTSEC-6: модуль `modules/user-groups/` (CRUD + members + project-roles bindings).
-- [ ] TTSEC-7: `shared/auth/rbac.ts` — `computeEffectiveRole` с учётом групп, Redis-кэш + инвалидация, `assertProjectPermission(user, projectId, permissions[])`.
-- [ ] TTSEC-8: `/users/me/security` + `/admin/users/:id/security`.
-- [ ] TTSEC-9: middleware — `sprints`/`releases` гранулярные, `comments`/`time` DELETE (author OR `*_DELETE_OTHERS` OR `*_MANAGE`).
-- [ ] TTSEC-10: audit-события (§5.11).
-- **DoD:** все unit + integration тесты зелёные; `GET /issues` p95 регресс ≤ 10% (NFR-1).
+### Фаза 2 — Backend — **done (2026-04-17)**
+- [x] TTSEC-6: модуль `modules/user-groups/` (CRUD + members + project-roles bindings). 4 audit-события. DELETE требует `?confirm=true` + impact (FR-A9).
+- [x] TTSEC-7: `shared/middleware/rbac.ts` — `computeEffectiveRole` с учётом групп (max permissions, roleId tiebreaker), fallback на legacy-key если roleId stale/NULL, Redis-кэш `rbac:effective:{userId}:{projectId}` TTL 60s, `assertProjectPermission(user, projectId, permissions[])` OR-helper, `invalidateUserEffectivePermissions` / `invalidateProjectEffectivePermissions`.
+- [x] TTSEC-8: `modules/user-security/` — `GET /users/me/security` + `GET /admin/users/:id/security` (роли с источником, группы, обновлено).
+- [x] TTSEC-9: гранулярные permissions на всех CRUD/edit спринтов (SPRINTS_CREATE/EDIT) и релизов (RELEASES_CREATE/EDIT/DELETE, INTEGRATION-релизы — requireRole fallback); `DELETE /comments/:id` = author OR `COMMENTS_DELETE_OTHERS` OR `COMMENTS_MANAGE`; новый `DELETE /time-logs/:id` с той же схемой для time logs.
+- [x] TTSEC-10: audit — `user_group.{created,renamed,updated,deleted,members_changed}`, `project_group_role.{granted,revoked}`, `comment.{updated,deleted}`, `time_log.deleted`.
+- **DoD:** `npx tsc --noEmit` зелёный ✅. 24 unit-теста (rbac-effective + user-groups) ✅. Integration-тесты + perf-benchmark — в Phase 4 (требуют живой БД/Redis на CI).
 
 ### Фаза 3 — Frontend — pending
 - [ ] TTSEC-11: `AdminGroupsPage` + `AdminGroupDetailPage` + `api/user-groups.ts`.


### PR DESCRIPTION
## Summary
- **Phase 2 / 4** of TTSEC-2 — backend for user groups + group-aware RBAC + granular permissions. Rebased onto main after Phase 1 (#64) merged.
- Ships: `modules/user-groups/` (CRUD + members + bindings), `modules/user-security/` (/users/me/security + /admin/users/:id/security), group-aware `computeEffectiveRole` + `assertProjectPermission` OR-helper in `shared/middleware/rbac.ts`, granular permissions on sprints/releases/comments/time, 11 new audit events, 33 unit tests.

## Review rounds addressed (from closed #65)
- Round 1: 🟠 move-issues cross-project authZ bypass; 🟡 N+1 in /users/me/security; 🟡 deleteGroup comment; 🔵 mixed RU/EN errors.
- Round 2: 🟠 POST /releases widened auth; 🟡 sourceGroups dedup; 🟡 full batching.
- Round 3: 🟠 cache key flipped to projectId-first; 🟡 source=DIRECT attribution; 🟡 user-groups pair-based invalidation; 🔵 explicit security payload types.
- Round 4: 🟠 scheme invalidation delegated to shared helper; 🟡 sourceGroups preserved when source=DIRECT.
- Round 5: 🟠 stale PR-body (false positive); 🟡 deterministic projectRoles ordering; 🟡 SUPER_ADMIN false positive.

## Key design decisions
- **projectId-first cache key** `rbac:effective:{projectId}:{userId}` — scheme changes wipe every cached user for the project via a single prefix SCAN.
- **max-permissions tiebreaker** via `roleId` ASC. `sourceGroups` lists every group that also grants the chosen role, independent of `source`.
- **INTEGRATION releases (projectId=null)** use system-role fallback; ATOMIC use granular `RELEASES_CREATE/EDIT/DELETE`.
- **Fallback preserved**: stale roleId / NULL falls back to legacy `role` key in active scheme.
- **Cross-project guard** in `moveIssuesToSprint(sprintId, issueIds, expectedProjectId?)`.
- **Batched getUserSecurity**: 2 DB queries + N Redis-cached scheme reads regardless of project count.

## Test plan
- [x] `npx tsc --noEmit` green
- [x] 33 unit tests green: rbac-effective, user-groups, sprints-move-issues
- [ ] Full CI on main base
- [ ] Post-merge staging verification (see docs/tz/TTSEC-2.md §8.1 Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
