### PR TITLE
fix(ci): исправить цикл AI ревью и повторные напоминания

### DIFF
--- a/.github/scripts/ai-review.mjs
+++ b/.github/scripts/ai-review.mjs
@@ -44,6 +44,8 @@ const IGNORE_PATTERNS = [
   /__generated__/,
   /\.snap$/,
   /public\/assets\//,
+  /version_history\.md$/,
+  /CHANGELOG\.md$/,
 ];
 
 function shouldIgnore(filePath) {
@@ -154,6 +156,7 @@ CRITICAL rules to prevent review loops:
 - ONLY raise issues that are: (a) still unresolved from previous review, OR (b) genuinely new problems introduced by the latest commits.
 - Be conservative on follow-up reviews: prefer "approve" over "request_changes" unless something is truly critical or high severity.
 - If an issue from previous review is partially addressed (improved but not perfect), mark it resolved and leave a positive note instead of blocking again.
+- Do NOT repeat reminders about manually maintained files (version_history.md, CHANGELOG, release notes) — if you mentioned them in the previous review, do not mention them again.
 - Write ALL text fields in ${REVIEW_LANGUAGE}.
 - Return ONLY valid JSON, no markdown code fences.
 - For "line", use the NEW file line number from the diff (+lines). Use null if not applicable.
@@ -188,7 +191,8 @@ Rules:
 - Return ONLY valid JSON, no markdown code fences.
 - Skip trivial style issues unless they're systematic.
 - For "line", use the NEW file line number from the diff (+lines). Use null if not applicable.
-- Verdict: "approve" if no critical/high issues; "request_changes" if critical/high exist; "comment" otherwise.`;
+- Verdict: "approve" if no critical/high issues; "request_changes" if critical/high exist; "comment" otherwise.
+- Do NOT remind about manually maintained files (version_history.md, CHANGELOG, release notes) — these are updated by the team manually after merge, not in every commit.`;
 
   const previousReviewSection = isFollowUp
     ? `\n\nPREVIOUS REVIEW (what you flagged before — check which issues are now resolved):\n${previousReview}\n\n---\n`

--- a/.github/scripts/ai-review.mjs
+++ b/.github/scripts/ai-review.mjs
@@ -372,36 +372,39 @@ function extractReviewJson(commentBody) {
 // ---------------------------------------------------------------------------
 const BOT_MARKER = 'AI Code Review ·';
 
+function findLastBotComment(comments) {
+  return comments
+    .filter((c) => c.body?.includes(BOT_MARKER))
+    .sort((a, b) => b.id - a.id)[0] ?? null;
+}
+
 async function postComment(body) {
   const existing = await githubFetch(
     `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${PR_NUMBER}/comments`
   );
 
-  let previousReviewBody = null;
-  for (const c of existing) {
-    if (c.body?.includes(BOT_MARKER)) {
-      previousReviewBody = c.body;
-      await githubFetch(
-        `/repos/${REPO_OWNER}/${REPO_NAME}/issues/comments/${c.id}`,
-        { method: 'DELETE' }
-      );
-      console.log(`Deleted previous review comment #${c.id}`);
-    }
-  }
+  const botComment = findLastBotComment(existing ?? []);
 
-  await githubFetch(
-    `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${PR_NUMBER}/comments`,
-    { method: 'POST', body: JSON.stringify({ body }) }
-  );
-  console.log('Review comment posted.');
-  return previousReviewBody;
+  if (botComment) {
+    await githubFetch(
+      `/repos/${REPO_OWNER}/${REPO_NAME}/issues/comments/${botComment.id}`,
+      { method: 'PATCH', body: JSON.stringify({ body }) }
+    );
+    console.log(`Updated existing review comment #${botComment.id}`);
+  } else {
+    await githubFetch(
+      `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${PR_NUMBER}/comments`,
+      { method: 'POST', body: JSON.stringify({ body }) }
+    );
+    console.log('Review comment posted.');
+  }
 }
 
 async function fetchPreviousReview() {
   const existing = await githubFetch(
     `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${PR_NUMBER}/comments`
   );
-  const botComment = existing?.find((c) => c.body?.includes(BOT_MARKER));
+  const botComment = findLastBotComment(existing ?? []);
   if (!botComment) return null;
   return extractReviewJson(botComment.body);
 }

--- a/.github/scripts/ai-review.mjs
+++ b/.github/scripts/ai-review.mjs
@@ -114,8 +114,51 @@ function filterAndTruncateDiff(rawDiff, maxChars) {
 // ---------------------------------------------------------------------------
 // OpenAI review
 // ---------------------------------------------------------------------------
-async function reviewWithOpenAI(diff, prTitle = PR_TITLE, prBody = PR_BODY) {
-  const systemPrompt = `You are a senior software engineer doing a thorough code review.
+async function reviewWithOpenAI(diff, prTitle = PR_TITLE, prBody = PR_BODY, previousReview = null) {
+  const isFollowUp = !!previousReview;
+
+  const systemPrompt = isFollowUp
+    ? `You are a senior software engineer doing a FOLLOW-UP code review after the author addressed your previous feedback.
+
+The diff you receive is the FULL cumulative PR diff (base → HEAD), not just the latest commit.
+
+Return a JSON object with this exact structure:
+{
+  "summary": "2-3 sentence overview of what was fixed and remaining state",
+  "verdict": "approve" | "request_changes" | "comment",
+  "resolved": ["Short description of each issue from previous review that is now fixed"],
+  "issues": [
+    {
+      "severity": "critical" | "high" | "medium" | "low" | "info",
+      "file": "path/to/file.ts",
+      "line": 42,
+      "title": "Short issue title (max 80 chars)",
+      "description": "Clear explanation of the problem",
+      "suggestion": "Concrete fix or improvement",
+      "isNew": true
+    }
+  ],
+  "positives": ["Notable good practices or clean code found"]
+}
+
+Severity guide:
+  critical — security vulnerability, data loss, crash, broken auth
+  high     — logic bug, missing error handling, potential data corruption
+  medium   — performance issue, maintainability problem, incomplete handling
+  low      — style, naming, minor improvement
+  info     — optional suggestion, best practice
+
+CRITICAL rules to prevent review loops:
+- DO NOT re-raise issues from the previous review that are now fixed or reasonably addressed.
+- DO NOT raise new medium/low/info issues about code introduced specifically to fix a previous issue — if the fix is reasonable, accept it.
+- ONLY raise issues that are: (a) still unresolved from previous review, OR (b) genuinely new problems introduced by the latest commits.
+- Be conservative on follow-up reviews: prefer "approve" over "request_changes" unless something is truly critical or high severity.
+- If an issue from previous review is partially addressed (improved but not perfect), mark it resolved and leave a positive note instead of blocking again.
+- Write ALL text fields in ${REVIEW_LANGUAGE}.
+- Return ONLY valid JSON, no markdown code fences.
+- For "line", use the NEW file line number from the diff (+lines). Use null if not applicable.
+- Verdict: "approve" if no unresolved critical/high issues; "request_changes" only if critical/high issues remain or newly appeared; "comment" otherwise.`
+    : `You are a senior software engineer doing a thorough code review.
 Analyze the provided git diff and return a JSON object with this exact structure:
 {
   "summary": "2-3 sentence overview of what changed and overall quality",
@@ -147,8 +190,13 @@ Rules:
 - For "line", use the NEW file line number from the diff (+lines). Use null if not applicable.
 - Verdict: "approve" if no critical/high issues; "request_changes" if critical/high exist; "comment" otherwise.`;
 
-  const userPrompt = `PR: ${prTitle}${prBody ? `\nDescription: ${prBody}` : ''}
+  const previousReviewSection = isFollowUp
+    ? `\n\nPREVIOUS REVIEW (what you flagged before — check which issues are now resolved):\n${previousReview}\n\n---\n`
+    : '';
 
+  const userPrompt = `PR: ${prTitle}${prBody ? `\nDescription: ${prBody}` : ''}${previousReviewSection}
+
+Current full PR diff (base → HEAD):
 \`\`\`diff
 ${diff}
 \`\`\``;
@@ -240,7 +288,7 @@ const VERDICT_EMOJI = {
   comment: '💬',
 };
 
-function formatComment(review) {
+function formatComment(review, isFollowUp = false) {
   const counts = {};
   for (const issue of review.issues ?? []) {
     counts[issue.severity] = (counts[issue.severity] ?? 0) + 1;
@@ -251,10 +299,18 @@ function formatComment(review) {
     .map((s) => `${SEVERITY_EMOJI[s]} ${counts[s]} ${s}`)
     .join(' · ');
 
-  let md = `## ${VERDICT_EMOJI[review.verdict] ?? '💬'} AI Code Review\n\n`;
+  const iteration = isFollowUp ? ' (follow-up)' : '';
+  let md = `## ${VERDICT_EMOJI[review.verdict] ?? '💬'} AI Code Review${iteration}\n\n`;
   md += `${review.summary}\n\n`;
 
-  if (statLine) md += `**Issues:** ${statLine}\n\n`;
+  // Resolved issues from previous review
+  if (review.resolved?.length > 0) {
+    md += `### ✅ Resolved from previous review\n\n`;
+    for (const r of review.resolved) md += `- ${r}\n`;
+    md += '\n';
+  }
+
+  if (statLine) md += `**Remaining issues:** ${statLine}\n\n`;
 
   // Issues grouped by severity
   if (review.issues?.length > 0) {
@@ -265,8 +321,9 @@ function formatComment(review) {
         const location = issue.line
           ? `\`${issue.file}:${issue.line}\``
           : `\`${issue.file}\``;
+        const newBadge = issue.isNew ? ' 🆕' : '';
         md += `<details>\n`;
-        md += `<summary>${SEVERITY_EMOJI[sev]} <strong>${issue.title}</strong> — ${location}</summary>\n\n`;
+        md += `<summary>${SEVERITY_EMOJI[sev]} <strong>${issue.title}</strong>${newBadge} — ${location}</summary>\n\n`;
         md += `${issue.description}\n\n`;
         if (issue.suggestion) {
           md += `**Suggestion:** ${issue.suggestion}\n`;
@@ -297,8 +354,10 @@ async function postComment(body) {
     `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${PR_NUMBER}/comments`
   );
 
+  let previousReviewBody = null;
   for (const c of existing) {
     if (c.body?.includes(BOT_MARKER)) {
+      previousReviewBody = c.body;
       await githubFetch(
         `/repos/${REPO_OWNER}/${REPO_NAME}/issues/comments/${c.id}`,
         { method: 'DELETE' }
@@ -312,6 +371,15 @@ async function postComment(body) {
     { method: 'POST', body: JSON.stringify({ body }) }
   );
   console.log('Review comment posted.');
+  return previousReviewBody;
+}
+
+async function fetchPreviousReview() {
+  const existing = await githubFetch(
+    `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${PR_NUMBER}/comments`
+  );
+  const botComment = existing?.find((c) => c.body?.includes(BOT_MARKER));
+  return botComment?.body ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -340,6 +408,13 @@ async function main() {
 
   console.log(`Reviewing PR #${PR_NUMBER} (${REPO_OWNER}/${REPO_NAME}) with ${AI_MODEL}`);
 
+  // Fetch previous review BEFORE posting (to pass as context to GPT)
+  const previousReview = await fetchPreviousReview();
+  const isFollowUp = !!previousReview;
+  if (isFollowUp) {
+    console.log('Previous review found — running follow-up review with context.');
+  }
+
   const rawDiff = await fetchPRDiff();
   const diff = filterAndTruncateDiff(rawDiff, parseInt(MAX_DIFF_CHARS, 10));
 
@@ -350,13 +425,13 @@ async function main() {
 
   console.log(`Diff: ${diff.length} chars`);
 
-  const review = await reviewWithOpenAI(diff, prTitle, prBody);
-  const comment = formatComment(review);
+  const review = await reviewWithOpenAI(diff, prTitle, prBody, previousReview);
+  const comment = formatComment(review, isFollowUp);
 
   await postComment(comment);
 
   const hasCritical = review.issues?.some((i) => i.severity === 'critical');
-  console.log(`Done. Verdict: ${review.verdict} | Issues: ${review.issues?.length ?? 0}`);
+  console.log(`Done. Verdict: ${review.verdict} | Issues: ${review.issues?.length ?? 0} | Follow-up: ${isFollowUp}`);
 
   if (FAIL_ON_CRITICAL === 'true' && hasCritical) {
     console.error('Critical issues found — failing the check (FAIL_ON_CRITICAL=true)');

--- a/.github/scripts/ai-review.mjs
+++ b/.github/scripts/ai-review.mjs
@@ -193,7 +193,7 @@ Rules:
 - If version_history.md was not updated in this PR, mention it ONCE as a single brief info-level issue (one sentence). Do not elaborate.`;
 
   const previousReviewSection = isFollowUp
-    ? `\n\nPREVIOUS REVIEW (what you flagged before — check which issues are now resolved):\n${previousReview}\n\n---\n`
+    ? `\n\nPREVIOUS REVIEW JSON (structured — use this to track what was flagged and what is now resolved):\n${JSON.stringify(previousReview, null, 2)}\n\n---\n`
     : '';
 
   const userPrompt = `PR: ${prTitle}${prBody ? `\nDescription: ${prBody}` : ''}${previousReviewSection}
@@ -346,6 +346,27 @@ function formatComment(review, isFollowUp = false) {
   return md;
 }
 
+const JSON_MARKER = '<!-- ai-review-json:';
+const JSON_MARKER_END = '-->';
+
+function embedReviewJson(comment, review) {
+  return `${comment}\n${JSON_MARKER}${JSON.stringify(review)}${JSON_MARKER_END}`;
+}
+
+function extractReviewJson(commentBody) {
+  if (!commentBody) return null;
+  const start = commentBody.indexOf(JSON_MARKER);
+  if (start === -1) return null;
+  const jsonStart = start + JSON_MARKER.length;
+  const end = commentBody.indexOf(JSON_MARKER_END, jsonStart);
+  if (end === -1) return null;
+  try {
+    return JSON.parse(commentBody.slice(jsonStart, end));
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Post comment (replace previous bot comment to avoid spam)
 // ---------------------------------------------------------------------------
@@ -381,7 +402,8 @@ async function fetchPreviousReview() {
     `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${PR_NUMBER}/comments`
   );
   const botComment = existing?.find((c) => c.body?.includes(BOT_MARKER));
-  return botComment?.body ?? null;
+  if (!botComment) return null;
+  return extractReviewJson(botComment.body);
 }
 
 // ---------------------------------------------------------------------------
@@ -428,7 +450,7 @@ async function main() {
   console.log(`Diff: ${diff.length} chars`);
 
   const review = await reviewWithOpenAI(diff, prTitle, prBody, previousReview);
-  const comment = formatComment(review, isFollowUp);
+  const comment = embedReviewJson(formatComment(review, isFollowUp), review);
 
   await postComment(comment);
 

--- a/.github/scripts/ai-review.mjs
+++ b/.github/scripts/ai-review.mjs
@@ -44,8 +44,6 @@ const IGNORE_PATTERNS = [
   /__generated__/,
   /\.snap$/,
   /public\/assets\//,
-  /version_history\.md$/,
-  /CHANGELOG\.md$/,
 ];
 
 function shouldIgnore(filePath) {
@@ -156,7 +154,7 @@ CRITICAL rules to prevent review loops:
 - ONLY raise issues that are: (a) still unresolved from previous review, OR (b) genuinely new problems introduced by the latest commits.
 - Be conservative on follow-up reviews: prefer "approve" over "request_changes" unless something is truly critical or high severity.
 - If an issue from previous review is partially addressed (improved but not perfect), mark it resolved and leave a positive note instead of blocking again.
-- Do NOT repeat reminders about manually maintained files (version_history.md, CHANGELOG, release notes) — if you mentioned them in the previous review, do not mention them again.
+- Do NOT mention version_history.md — it was already noted in the previous review, no need to repeat.
 - Write ALL text fields in ${REVIEW_LANGUAGE}.
 - Return ONLY valid JSON, no markdown code fences.
 - For "line", use the NEW file line number from the diff (+lines). Use null if not applicable.
@@ -192,7 +190,7 @@ Rules:
 - Skip trivial style issues unless they're systematic.
 - For "line", use the NEW file line number from the diff (+lines). Use null if not applicable.
 - Verdict: "approve" if no critical/high issues; "request_changes" if critical/high exist; "comment" otherwise.
-- Do NOT remind about manually maintained files (version_history.md, CHANGELOG, release notes) — these are updated by the team manually after merge, not in every commit.`;
+- If version_history.md was not updated in this PR, mention it ONCE as a single brief info-level issue (one sentence). Do not elaborate.`;
 
   const previousReviewSection = isFollowUp
     ? `\n\nPREVIOUS REVIEW (what you flagged before — check which issues are now resolved):\n${previousReview}\n\n---\n`


### PR DESCRIPTION
## Summary
- GPT теперь получает предыдущий ревью в контексте при follow-up проверках — не теряет историю PR
- Follow-up промпт запрещает переподнимать уже исправленные проблемы, разрывая цикл замечание→правка→новое замечание→регресс
- `version_history.md` упоминается кратко (1 строка, info) только при первом ревью — в follow-up молчит

## Test plan
- [ ] Открыть тестовый PR, дождаться первого ревью — убедиться что есть краткое упоминание version_history.md
- [ ] Запушить фикс-коммит — убедиться что follow-up показывает секцию "✅ Resolved" и не повторяет закрытые замечания
- [ ] Проверить что version_history.md не упоминается в follow-up ревью