### PR TITLE
feat(rbac): TTSEC-2 Phase 4.1 — FEATURES_DIRECT_ROLES_DISABLED cutover flag

### DIFF
--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -8,7 +8,7 @@ import { hashPassword } from '../../shared/utils/password.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { invalidateProjectPermissionCache } from '../../shared/middleware/rbac.js';
 import { getSchemeForProject } from '../project-role-schemes/project-role-schemes.service.js';
-import { features } from '../../shared/features.js';
+import { isDirectRolesDisabled } from '../../shared/features.js';
 import type { CreateUserDto, UpdateUserAdminDto, AssignProjectRoleDto } from './admin.dto.js';
 
 function flattenRoles<T extends { systemRoles: { role: SystemRoleType }[] }>(
@@ -369,9 +369,9 @@ export async function assignProjectRole(actorId: string, userId: string, dto: As
   // TTSEC-2 Phase 4 cutover: when `FEATURES_DIRECT_ROLES_DISABLED=true` is set (prod after
   // staging validation), new direct per-user role assignments are rejected. Admins must use
   // user groups instead. Existing direct rows stay functional — they can be migrated out or
-  // left as a break-glass escape hatch. The flag is read at runtime so ops can flip it
-  // without a redeploy once they're confident in the group-based permission flow.
-  if (features.directRolesDisabled) {
+  // left as a break-glass escape hatch. `isDirectRolesDisabled()` reads env.process lazily so
+  // ops can flip the flag without a process restart (AI review #72 🟠).
+  if (isDirectRolesDisabled()) {
     throw new AppError(
       403,
       'Прямые назначения ролей отключены. Используйте группы пользователей (/admin/user-groups).',

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -8,6 +8,7 @@ import { hashPassword } from '../../shared/utils/password.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { invalidateProjectPermissionCache } from '../../shared/middleware/rbac.js';
 import { getSchemeForProject } from '../project-role-schemes/project-role-schemes.service.js';
+import { features } from '../../shared/features.js';
 import type { CreateUserDto, UpdateUserAdminDto, AssignProjectRoleDto } from './admin.dto.js';
 
 function flattenRoles<T extends { systemRoles: { role: SystemRoleType }[] }>(
@@ -365,6 +366,18 @@ const USER_PROJECT_ROLE_INCLUDE = {
 } as const;
 
 export async function assignProjectRole(actorId: string, userId: string, dto: AssignProjectRoleDto) {
+  // TTSEC-2 Phase 4 cutover: when `FEATURES_DIRECT_ROLES_DISABLED=true` is set (prod after
+  // staging validation), new direct per-user role assignments are rejected. Admins must use
+  // user groups instead. Existing direct rows stay functional — they can be migrated out or
+  // left as a break-glass escape hatch. The flag is read at runtime so ops can flip it
+  // without a redeploy once they're confident in the group-based permission flow.
+  if (features.directRolesDisabled) {
+    throw new AppError(
+      403,
+      'Прямые назначения ролей отключены. Используйте группы пользователей (/admin/user-groups).',
+    );
+  }
+
   const [user, project] = await Promise.all([
     prisma.user.findUnique({ where: { id: userId } }),
     prisma.project.findUnique({ where: { id: dto.projectId } }),

--- a/backend/src/shared/features.ts
+++ b/backend/src/shared/features.ts
@@ -7,6 +7,7 @@
  *   FEATURES_MCP=true
  *   FEATURES_GITLAB=true
  *   FEATURES_TELEGRAM=true
+ *   FEATURES_DIRECT_ROLES_DISABLED=false   # TTSEC-2 Phase 4 cutover flag
  *   AI_PROVIDER=anthropic   # anthropic | heuristic
  */
 
@@ -21,6 +22,13 @@ export const features = {
   mcp: flag('FEATURES_MCP', true),
   gitlab: flag('FEATURES_GITLAB', true),
   telegram: flag('FEATURES_TELEGRAM', false),
+  /**
+   * TTSEC-2 Phase 4 cutover flag. When `true`, new direct project-role assignments
+   * (admin.service.assignProjectRole) are rejected with 403 — admins must use user groups.
+   * Existing direct rows remain functional; they can be migrated out manually or left in place
+   * as a break-glass escape hatch. Default: `false` (direct assignments still allowed).
+   */
+  directRolesDisabled: flag('FEATURES_DIRECT_ROLES_DISABLED', false),
   aiProvider: (process.env.AI_PROVIDER ?? 'heuristic') as 'anthropic' | 'heuristic',
 } as const;
 

--- a/backend/src/shared/features.ts
+++ b/backend/src/shared/features.ts
@@ -22,14 +22,23 @@ export const features = {
   mcp: flag('FEATURES_MCP', true),
   gitlab: flag('FEATURES_GITLAB', true),
   telegram: flag('FEATURES_TELEGRAM', false),
-  /**
-   * TTSEC-2 Phase 4 cutover flag. When `true`, new direct project-role assignments
-   * (admin.service.assignProjectRole) are rejected with 403 — admins must use user groups.
-   * Existing direct rows remain functional; they can be migrated out manually or left in place
-   * as a break-glass escape hatch. Default: `false` (direct assignments still allowed).
-   */
-  directRolesDisabled: flag('FEATURES_DIRECT_ROLES_DISABLED', false),
   aiProvider: (process.env.AI_PROVIDER ?? 'heuristic') as 'anthropic' | 'heuristic',
 } as const;
 
 export type Features = typeof features;
+
+/**
+ * TTSEC-2 Phase 4 cutover flag. When `true`, new direct project-role assignments
+ * (admin.service.assignProjectRole) are rejected with 403 — admins must use user groups.
+ * Existing direct rows remain functional; they can be migrated out manually or left in place
+ * as a break-glass escape hatch. Default: `false`.
+ *
+ * AI review #72 🟠 — read LAZILY at each call (NOT cached into the `features` const at import
+ * time). Ops need to flip `FEATURES_DIRECT_ROLES_DISABLED=true` without a redeploy — a
+ * module-load-time snapshot would require process restart to pick up the new value.
+ *
+ * Call at the top of any code path that creates a direct UserProjectRole row.
+ */
+export function isDirectRolesDisabled(): boolean {
+  return flag('FEATURES_DIRECT_ROLES_DISABLED', false);
+}

--- a/backend/tests/direct-roles-flag.unit.test.ts
+++ b/backend/tests/direct-roles-flag.unit.test.ts
@@ -1,10 +1,10 @@
 /**
  * Unit-тест на TTSEC-2 Phase 4 cutover флаг `FEATURES_DIRECT_ROLES_DISABLED`.
  *
- * Проверяем, что при `features.directRolesDisabled=true` сервис `admin.assignProjectRole`
- * отклоняет запрос с 403 до каких-либо запросов в БД. Это важно для prod-cutover: флаг
- * включается ПОСЛЕ миграции всех прямых ролей в группы, и с этого момента новых прямых
- * назначений быть не должно.
+ * Проверяем, что при `isDirectRolesDisabled()=true` сервис `admin.assignProjectRole`
+ * отклоняет запрос с 403 до каких-либо запросов в БД, и что флаг читается ЛЕНИВО —
+ * ops могут флипнуть `process.env.FEATURES_DIRECT_ROLES_DISABLED` без restart-а процесса,
+ * и следующий запрос уже видит новое значение (AI review #72 🟠).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -32,44 +32,35 @@ vi.mock('../src/modules/project-role-schemes/project-role-schemes.service.js', (
   getSchemeForProject: vi.fn(),
 }));
 
-const featuresMock = { directRolesDisabled: false };
-vi.mock('../src/shared/features.js', () => ({
-  get features() { return featuresMock; },
-}));
-
 vi.mock('../src/config.js', () => ({ config: { defaultProjectRole: 'USER' } }));
 
 const { assignProjectRole } = await import('../src/modules/admin/admin.service.js');
 
 beforeEach(() => {
   vi.clearAllMocks();
-  featuresMock.directRolesDisabled = false;
+  delete process.env.FEATURES_DIRECT_ROLES_DISABLED;
 });
 
-describe('FEATURES_DIRECT_ROLES_DISABLED enforcement', () => {
-  it('allows direct role assignment when flag is false (default)', async () => {
-    featuresMock.directRolesDisabled = false;
+describe('FEATURES_DIRECT_ROLES_DISABLED enforcement (lazy-read)', () => {
+  it('allows direct role assignment when flag is unset (default)', async () => {
     mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1' });
     mockPrisma.project.findUnique.mockResolvedValue({ id: 'p1' });
-    // Not fully wiring the success path — we only need to confirm the flag guard lets
-    // the function proceed past the initial check. Any post-check failure is fine.
     await expect(
       assignProjectRole('actor', 'u1', { projectId: 'p1', role: 'USER' } as never),
     ).rejects.not.toMatchObject({ statusCode: 403, code: expect.stringContaining('Прямые назначения') });
   });
 
-  it('rejects direct role assignment with 403 when flag is true', async () => {
-    featuresMock.directRolesDisabled = true;
+  it('rejects direct role assignment with 403 when env flag is true', async () => {
+    process.env.FEATURES_DIRECT_ROLES_DISABLED = 'true';
     await expect(
       assignProjectRole('actor', 'u1', { projectId: 'p1', role: 'USER' } as never),
     ).rejects.toMatchObject({ statusCode: 403 });
-    // Guard fires BEFORE any DB hits.
     expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
     expect(mockPrisma.project.findUnique).not.toHaveBeenCalled();
   });
 
   it('error message mentions user groups so admins know the alternative', async () => {
-    featuresMock.directRolesDisabled = true;
+    process.env.FEATURES_DIRECT_ROLES_DISABLED = 'true';
     try {
       await assignProjectRole('actor', 'u1', { projectId: 'p1', role: 'USER' } as never);
       throw new Error('should not reach');
@@ -77,5 +68,28 @@ describe('FEATURES_DIRECT_ROLES_DISABLED enforcement', () => {
       const err = e as { message?: string };
       expect(err.message).toMatch(/групп/i);
     }
+  });
+
+  it('flag is evaluated lazily: flipping process.env mid-session takes effect on the next call', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1' });
+    mockPrisma.project.findUnique.mockResolvedValue({ id: 'p1' });
+
+    // 1. unset → guard passes through (downstream errors are expected and fine).
+    delete process.env.FEATURES_DIRECT_ROLES_DISABLED;
+    await expect(
+      assignProjectRole('actor', 'u1', { projectId: 'p1', role: 'USER' } as never),
+    ).rejects.not.toMatchObject({ statusCode: 403, code: expect.stringContaining('Прямые назначения') });
+
+    // 2. Flip env WITHOUT re-importing — guard must activate immediately.
+    process.env.FEATURES_DIRECT_ROLES_DISABLED = 'true';
+    await expect(
+      assignProjectRole('actor', 'u1', { projectId: 'p1', role: 'USER' } as never),
+    ).rejects.toMatchObject({ statusCode: 403 });
+
+    // 3. Flip back — same request type proceeds past the guard again.
+    process.env.FEATURES_DIRECT_ROLES_DISABLED = 'false';
+    await expect(
+      assignProjectRole('actor', 'u1', { projectId: 'p1', role: 'USER' } as never),
+    ).rejects.not.toMatchObject({ statusCode: 403, code: expect.stringContaining('Прямые назначения') });
   });
 });

--- a/backend/tests/direct-roles-flag.unit.test.ts
+++ b/backend/tests/direct-roles-flag.unit.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit-тест на TTSEC-2 Phase 4 cutover флаг `FEATURES_DIRECT_ROLES_DISABLED`.
+ *
+ * Проверяем, что при `features.directRolesDisabled=true` сервис `admin.assignProjectRole`
+ * отклоняет запрос с 403 до каких-либо запросов в БД. Это важно для prod-cutover: флаг
+ * включается ПОСЛЕ миграции всех прямых ролей в группы, и с этого момента новых прямых
+ * назначений быть не должно.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPrisma } = vi.hoisted(() => {
+  const mockPrisma = {
+    user: { findUnique: vi.fn() },
+    project: { findUnique: vi.fn() },
+    userProjectRole: { findFirst: vi.fn(), create: vi.fn() },
+    auditLog: { create: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
+vi.mock('../src/shared/redis.js', () => ({
+  getCachedJson: vi.fn(),
+  setCachedJson: vi.fn(),
+  delCachedJson: vi.fn(),
+  delCacheByPrefix: vi.fn(),
+}));
+vi.mock('../src/shared/middleware/rbac.js', () => ({
+  invalidateProjectPermissionCache: vi.fn(),
+}));
+vi.mock('../src/modules/project-role-schemes/project-role-schemes.service.js', () => ({
+  getSchemeForProject: vi.fn(),
+}));
+
+const featuresMock = { directRolesDisabled: false };
+vi.mock('../src/shared/features.js', () => ({
+  get features() { return featuresMock; },
+}));
+
+vi.mock('../src/config.js', () => ({ config: { defaultProjectRole: 'USER' } }));
+
+const { assignProjectRole } = await import('../src/modules/admin/admin.service.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  featuresMock.directRolesDisabled = false;
+});
+
+describe('FEATURES_DIRECT_ROLES_DISABLED enforcement', () => {
+  it('allows direct role assignment when flag is false (default)', async () => {
+    featuresMock.directRolesDisabled = false;
+    mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1' });
+    mockPrisma.project.findUnique.mockResolvedValue({ id: 'p1' });
+    // Not fully wiring the success path — we only need to confirm the flag guard lets
+    // the function proceed past the initial check. Any post-check failure is fine.
+    await expect(
+      assignProjectRole('actor', 'u1', { projectId: 'p1', role: 'USER' } as never),
+    ).rejects.not.toMatchObject({ statusCode: 403, code: expect.stringContaining('Прямые назначения') });
+  });
+
+  it('rejects direct role assignment with 403 when flag is true', async () => {
+    featuresMock.directRolesDisabled = true;
+    await expect(
+      assignProjectRole('actor', 'u1', { projectId: 'p1', role: 'USER' } as never),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    // Guard fires BEFORE any DB hits.
+    expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+    expect(mockPrisma.project.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('error message mentions user groups so admins know the alternative', async () => {
+    featuresMock.directRolesDisabled = true;
+    try {
+      await assignProjectRole('actor', 'u1', { projectId: 'p1', role: 'USER' } as never);
+      throw new Error('should not reach');
+    } catch (e: unknown) {
+      const err = e as { message?: string };
+      expect(err.message).toMatch(/групп/i);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- **Phase 4.1 / 4** of TTSEC-2 — cutover feature flag. Smallest piece of the Phase 4 followups. 1 env var + 1 guard + 3 unit tests.
- `FEATURES_DIRECT_ROLES_DISABLED=true` → admin.assignProjectRole rejects new direct per-user role assignments with 403, pointing to user groups as the alternative.
- Default: `false`. Merging this PR does NOT change prod behavior.

## Rollout
1. Merge → flag is off everywhere. No functional change.
2. After TTSEC-15.1 integration tests validate group-based flow on staging, flip `FEATURES_DIRECT_ROLES_DISABLED=true` on staging and confirm admin UI surfaces a clear 403 on direct assignments.
3. Prod cutover: set the env var (no redeploy — flag is read at request time).
4. Existing direct UserProjectRole rows stay functional. They can be migrated out later or left as break-glass.

## Why at the service top?
Guard fires BEFORE any DB lookup so flipping the flag takes effect immediately without waiting for cache TTL / role-scheme reload. Admin error message includes `/admin/user-groups` so operators know the alternative path.

## Test plan
- [x] `npx tsc --noEmit` green
- [x] 3 unit tests pass (direct-roles-flag.unit.test.ts):
  - off → default behavior (no 403 from guard)
  - on → 403 with no DB calls
  - error message mentions groups
- [ ] Full CI on main base
- [ ] After merge, verify on staging: set env true, hit `POST /admin/users/:id/project-roles`, expect 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
