### PR TITLE
fix(deploy): down --remove-orphans перед up чтобы освободить порты

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -111,7 +111,9 @@ if [ "${BOOTSTRAP_ENABLED:-}" = "true" ]; then
 else
   echo "Skipping bootstrap: BOOTSTRAP_ENABLED is not true in $BACKEND_ENV_FILE"
 fi
-docker compose --env-file "$COMPOSE_ENV_FILE" -f "$COMPOSE_FILE" up -d --force-recreate
+# Stop and remove all stack containers first to release ports held by docker-proxy
+docker compose --env-file "$COMPOSE_ENV_FILE" -f "$COMPOSE_FILE" down --remove-orphans 2>/dev/null || true
+docker compose --env-file "$COMPOSE_ENV_FILE" -f "$COMPOSE_FILE" up -d
 
 MAX_RETRIES=12
 RETRY_INTERVAL=5

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,17 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.10**
+**Last version: 2.11**
+
+---
+
+## [2.11] [2026-04-18] fix(deploy): down --remove-orphans перед up, fix port conflict
+
+**PR:** [#78](https://github.com/NovakPAai/tasktime-mvp/pull/78)
+**Ветка:** `claude/jack-fix-port-conflict`
+
+### Что изменилось
+- `deploy/scripts/deploy.sh`: перед `docker compose up` добавлен `docker compose down --remove-orphans` — гарантирует освобождение портов docker-proxy от старых контейнеров (фикс `port 3002 already allocated` для MCP)
 
 ---
 


### PR DESCRIPTION
## Summary
- Перед `docker compose up` добавлен `docker compose down --remove-orphans`
- Это гарантирует что docker-proxy от старых контейнеров освобождает порты (в частности 3002 для MCP)
- `--force-recreate` убран — после `down` он не нужен

## Root cause
`docker compose up --force-recreate` останавливает старый контейнер, но docker-proxy иногда не успевает освободить порт, что приводит к `Bind for 0.0.0.0:3002 failed: port is already allocated`.

## Test plan
- [ ] Задеплоить на staging — деплой должен пройти без конфликта портов