### PR TITLE
feat(checkpoints): TTMP-160 PR-1 — schema + CRUD types/templates

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -38,6 +38,8 @@ import transitionScreensRouter from './modules/transition-screens/transition-scr
 import workflowEngineRouter from './modules/workflow-engine/workflow-engine.router.js';
 import releaseStatusesRouter from './modules/releases/release-statuses.router.js';
 import releaseWorkflowsAdminRouter from './modules/releases/release-workflows-admin.router.js';
+import checkpointTypesRouter from './modules/releases/checkpoints/checkpoint-types.router.js';
+import checkpointTemplatesRouter from './modules/releases/checkpoints/checkpoint-templates.router.js';
 import roleSchemesRouter from './modules/project-role-schemes/project-role-schemes.router.js';
 import userGroupsRouter from './modules/user-groups/user-groups.router.js';
 import userSecurityRouter from './modules/user-security/user-security.router.js';
@@ -138,6 +140,8 @@ export function createApp() {
   app.use('/api/admin/transition-screens', transitionScreensRouter);
   app.use('/api/admin/release-statuses', releaseStatusesRouter);
   app.use('/api/admin/release-workflows', releaseWorkflowsAdminRouter);
+  app.use('/api/admin/checkpoint-types', checkpointTypesRouter);
+  app.use('/api/admin/checkpoint-templates', checkpointTemplatesRouter);
   app.use('/api/admin/role-schemes', roleSchemesRouter);
   app.use('/api/admin/user-groups', userGroupsRouter);
   app.use('/api', userSecurityRouter);

--- a/backend/src/modules/releases/checkpoints/checkpoint-templates.router.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint-templates.router.ts
@@ -1,0 +1,93 @@
+// TTMP-160 PR-1: CheckpointTemplate CRUD + clone router — mounted at /api/admin/checkpoint-templates.
+// SEC-1: management restricted to SUPER_ADMIN / ADMIN / RELEASE_MANAGER (FR-2).
+
+import { Router } from 'express';
+import { authenticate } from '../../../shared/middleware/auth.js';
+import { requireRole } from '../../../shared/middleware/rbac.js';
+import { validate } from '../../../shared/middleware/validate.js';
+import { logAudit } from '../../../shared/middleware/audit.js';
+import type { AuthRequest } from '../../../shared/types/index.js';
+import {
+  createCheckpointTemplateDto,
+  updateCheckpointTemplateDto,
+  cloneCheckpointTemplateDto,
+} from './checkpoint.dto.js';
+import * as service from './checkpoint-templates.service.js';
+
+const router = Router();
+
+router.use(authenticate);
+router.use(requireRole('SUPER_ADMIN', 'ADMIN', 'RELEASE_MANAGER'));
+
+router.get('/', async (_req, res, next) => {
+  try {
+    res.json(await service.listCheckpointTemplates());
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    res.json(await service.getCheckpointTemplate(req.params['id'] as string));
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', validate(createCheckpointTemplateDto), async (req: AuthRequest, res, next) => {
+  try {
+    const template = await service.createCheckpointTemplate(req.body, req.user!.userId);
+    await logAudit(req, 'checkpoint_template.created', 'checkpoint_template', template.id, {
+      name: template.name,
+      itemsCount: template.items.length,
+    });
+    res.status(201).json(template);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.patch('/:id', validate(updateCheckpointTemplateDto), async (req: AuthRequest, res, next) => {
+  try {
+    const id = req.params['id'] as string;
+    const template = await service.updateCheckpointTemplate(id, req.body);
+    await logAudit(req, 'checkpoint_template.updated', 'checkpoint_template', id, {
+      fields: Object.keys(req.body),
+    });
+    res.json(template);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:id', async (req: AuthRequest, res, next) => {
+  try {
+    const id = req.params['id'] as string;
+    await service.deleteCheckpointTemplate(id);
+    await logAudit(req, 'checkpoint_template.deleted', 'checkpoint_template', id);
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post(
+  '/:id/clone',
+  validate(cloneCheckpointTemplateDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const sourceId = req.params['id'] as string;
+      const clone = await service.cloneCheckpointTemplate(sourceId, req.body, req.user!.userId);
+      await logAudit(req, 'checkpoint_template.cloned', 'checkpoint_template', clone.id, {
+        fromTemplateId: sourceId,
+        name: clone.name,
+      });
+      res.status(201).json(clone);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/backend/src/modules/releases/checkpoints/checkpoint-templates.service.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint-templates.service.ts
@@ -1,0 +1,185 @@
+// TTMP-160 PR-1: CheckpointTemplate CRUD + clone service (FR-2).
+// Templates are ordered bundles of CheckpointTypes applied to a release in one action (PR-3).
+
+import type { Prisma } from '@prisma/client';
+import { prisma } from '../../../prisma/client.js';
+import { AppError } from '../../../shared/middleware/error-handler.js';
+import { isUniqueViolation } from '../../../shared/utils/prisma-errors.js';
+import type {
+  CreateCheckpointTemplateDto,
+  UpdateCheckpointTemplateDto,
+  CloneCheckpointTemplateDto,
+} from './checkpoint.dto.js';
+
+const templateInclude = {
+  items: {
+    orderBy: { orderIndex: 'asc' as const },
+    include: {
+      checkpointType: {
+        select: { id: true, name: true, color: true, weight: true, offsetDays: true, isActive: true },
+      },
+    },
+  },
+  createdBy: { select: { id: true, name: true, email: true } },
+} as const;
+
+export async function listCheckpointTemplates() {
+  return prisma.checkpointTemplate.findMany({
+    orderBy: [{ name: 'asc' }],
+    include: templateInclude,
+  });
+}
+
+export async function getCheckpointTemplate(id: string) {
+  const template = await prisma.checkpointTemplate.findUnique({
+    where: { id },
+    include: templateInclude,
+  });
+  if (!template) throw new AppError(404, 'Checkpoint template not found');
+  return template;
+}
+
+export async function createCheckpointTemplate(
+  dto: CreateCheckpointTemplateDto,
+  createdById: string,
+) {
+  await assertCheckpointTypesExist(dto.items.map((i) => i.checkpointTypeId));
+
+  try {
+    return await prisma.checkpointTemplate.create({
+      data: {
+        name: dto.name,
+        description: dto.description ?? null,
+        createdById,
+        items: {
+          create: dto.items.map((i) => ({
+            checkpointTypeId: i.checkpointTypeId,
+            orderIndex: i.orderIndex,
+          })),
+        },
+      },
+      include: templateInclude,
+    });
+  } catch (err) {
+    if (isUniqueViolation(err, 'name')) {
+      throw new AppError(409, 'CHECKPOINT_TEMPLATE_NAME_TAKEN');
+    }
+    throw err;
+  }
+}
+
+export async function updateCheckpointTemplate(id: string, dto: UpdateCheckpointTemplateDto) {
+  const existing = await prisma.checkpointTemplate.findUnique({ where: { id } });
+  if (!existing) throw new AppError(404, 'Checkpoint template not found');
+
+  if (dto.items) {
+    await assertCheckpointTypesExist(dto.items.map((i) => i.checkpointTypeId));
+  }
+
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const data: Prisma.CheckpointTemplateUpdateInput = {};
+      if (dto.name !== undefined) data.name = dto.name;
+      if (dto.description !== undefined) data.description = dto.description ?? null;
+      await tx.checkpointTemplate.update({ where: { id }, data });
+
+      if (dto.items) {
+        // Replace items wholesale — simpler than diff-merge for v1; template-size capped at 20.
+        await tx.checkpointTemplateItem.deleteMany({ where: { templateId: id } });
+        await tx.checkpointTemplateItem.createMany({
+          data: dto.items.map((i) => ({
+            templateId: id,
+            checkpointTypeId: i.checkpointTypeId,
+            orderIndex: i.orderIndex,
+          })),
+        });
+      }
+
+      return tx.checkpointTemplate.findUniqueOrThrow({ where: { id }, include: templateInclude });
+    });
+  } catch (err) {
+    if (isUniqueViolation(err, 'name')) {
+      throw new AppError(409, 'CHECKPOINT_TEMPLATE_NAME_TAKEN');
+    }
+    // Composite unique on (template_id, checkpoint_type_id): duplicate type slipped past Zod
+    // refine (service is callable from future internal callers that might bypass the DTO).
+    if (isUniqueViolation(err, 'template_id') || isUniqueViolation(err, 'checkpoint_type_id')) {
+      throw new AppError(400, 'CHECKPOINT_TEMPLATE_DUPLICATE_TYPE');
+    }
+    throw err;
+  }
+}
+
+// Safe to delete unconditionally: criteria and offsetDays are snapshot-copied into
+// ReleaseCheckpoint at apply-time (FR-15), so deleting a template does not affect any
+// release-checkpoint instance that was created from it. Template items cascade.
+export async function deleteCheckpointTemplate(id: string) {
+  const existing = await prisma.checkpointTemplate.findUnique({ where: { id } });
+  if (!existing) throw new AppError(404, 'Checkpoint template not found');
+
+  await prisma.checkpointTemplate.delete({ where: { id } });
+  return { ok: true };
+}
+
+export async function cloneCheckpointTemplate(
+  id: string,
+  dto: CloneCheckpointTemplateDto,
+  createdById: string,
+) {
+  const source = await prisma.checkpointTemplate.findUnique({
+    where: { id },
+    include: { items: true },
+  });
+  if (!source) throw new AppError(404, 'Checkpoint template not found');
+
+  const clonedName = dto.name ?? buildClonedName(source.name);
+
+  try {
+    return await prisma.checkpointTemplate.create({
+      data: {
+        name: clonedName,
+        description: source.description,
+        createdById,
+        items: {
+          create: source.items.map((i) => ({
+            checkpointTypeId: i.checkpointTypeId,
+            orderIndex: i.orderIndex,
+          })),
+        },
+      },
+      include: templateInclude,
+    });
+  } catch (err) {
+    if (isUniqueViolation(err, 'name')) {
+      throw new AppError(409, 'CHECKPOINT_TEMPLATE_NAME_TAKEN');
+    }
+    throw err;
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// Existence only — inactive types are intentionally allowed inside a template so that
+// templates remain stable artifacts when a type is temporarily archived. The apply-template
+// flow (PR-3) copies criteriaSnapshot at that point and may decide what to do with inactive
+// types there.
+async function assertCheckpointTypesExist(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const found = await prisma.checkpointType.findMany({
+    where: { id: { in: ids } },
+    select: { id: true },
+  });
+  const foundIds = new Set(found.map((t) => t.id));
+  const missing = ids.filter((id) => !foundIds.has(id));
+  if (missing.length > 0) {
+    throw new AppError(400, 'CHECKPOINT_TYPES_NOT_FOUND', { missingIds: missing });
+  }
+}
+
+function buildClonedName(originalName: string): string {
+  // Ant Design-style "Copy" suffix — short enough to fit within the 100-char cap.
+  const suffix = ' (копия)';
+  const maxLen = 100;
+  if (originalName.length + suffix.length <= maxLen) return `${originalName}${suffix}`;
+  return originalName.slice(0, maxLen - suffix.length) + suffix;
+}

--- a/backend/src/modules/releases/checkpoints/checkpoint-types.router.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint-types.router.ts
@@ -1,0 +1,75 @@
+// TTMP-160 PR-1: CheckpointType CRUD router — mounted at /api/admin/checkpoint-types.
+// SEC-1: management restricted to SUPER_ADMIN / ADMIN / RELEASE_MANAGER (FR-1).
+
+import { Router } from 'express';
+import { authenticate } from '../../../shared/middleware/auth.js';
+import { requireRole } from '../../../shared/middleware/rbac.js';
+import { validate } from '../../../shared/middleware/validate.js';
+import { logAudit } from '../../../shared/middleware/audit.js';
+import type { AuthRequest } from '../../../shared/types/index.js';
+import { createCheckpointTypeDto, updateCheckpointTypeDto } from './checkpoint.dto.js';
+import * as service from './checkpoint-types.service.js';
+
+const router = Router();
+
+router.use(authenticate);
+router.use(requireRole('SUPER_ADMIN', 'ADMIN', 'RELEASE_MANAGER'));
+
+router.get('/', async (req, res, next) => {
+  try {
+    const isActive =
+      req.query.isActive === 'true' ? true : req.query.isActive === 'false' ? false : undefined;
+    res.json(await service.listCheckpointTypes({ isActive }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    res.json(await service.getCheckpointType(req.params['id'] as string));
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', validate(createCheckpointTypeDto), async (req: AuthRequest, res, next) => {
+  try {
+    const type = await service.createCheckpointType(req.body);
+    await logAudit(req, 'checkpoint_type.created', 'checkpoint_type', type.id, {
+      name: type.name,
+      weight: type.weight,
+      offsetDays: type.offsetDays,
+      criteriaCount: Array.isArray(type.criteria) ? type.criteria.length : 0,
+    });
+    res.status(201).json(type);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.patch('/:id', validate(updateCheckpointTypeDto), async (req: AuthRequest, res, next) => {
+  try {
+    const id = req.params['id'] as string;
+    const type = await service.updateCheckpointType(id, req.body);
+    await logAudit(req, 'checkpoint_type.updated', 'checkpoint_type', id, {
+      fields: Object.keys(req.body),
+    });
+    res.json(type);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:id', async (req: AuthRequest, res, next) => {
+  try {
+    const id = req.params['id'] as string;
+    await service.deleteCheckpointType(id);
+    await logAudit(req, 'checkpoint_type.deleted', 'checkpoint_type', id);
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/modules/releases/checkpoints/checkpoint-types.service.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint-types.service.ts
@@ -1,0 +1,119 @@
+// TTMP-160 PR-1: CheckpointType CRUD service (FR-1).
+// Deletion is blocked while the type has active release_checkpoints (§12.11: 409 CHECKPOINT_TYPE_IN_USE).
+
+import type { Prisma } from '@prisma/client';
+import { prisma } from '../../../prisma/client.js';
+import { AppError } from '../../../shared/middleware/error-handler.js';
+import { isForeignKeyViolation, isUniqueViolation } from '../../../shared/utils/prisma-errors.js';
+import type { CreateCheckpointTypeDto, UpdateCheckpointTypeDto } from './checkpoint.dto.js';
+
+const typeInclude = {
+  _count: { select: { releaseCheckpoints: true, templateItems: true } },
+} as const;
+
+export async function listCheckpointTypes(filters: { isActive?: boolean } = {}) {
+  const where: Prisma.CheckpointTypeWhereInput = {};
+  if (filters.isActive !== undefined) where.isActive = filters.isActive;
+
+  return prisma.checkpointType.findMany({
+    where,
+    orderBy: [{ name: 'asc' }],
+    include: typeInclude,
+  });
+}
+
+export async function getCheckpointType(id: string) {
+  const type = await prisma.checkpointType.findUnique({ where: { id }, include: typeInclude });
+  if (!type) throw new AppError(404, 'Checkpoint type not found');
+  return type;
+}
+
+export async function createCheckpointType(dto: CreateCheckpointTypeDto) {
+  try {
+    return await prisma.checkpointType.create({
+      data: {
+        name: dto.name,
+        description: dto.description ?? null,
+        color: dto.color,
+        weight: dto.weight,
+        offsetDays: dto.offsetDays,
+        warningDays: dto.warningDays,
+        criteria: dto.criteria as unknown as Prisma.InputJsonValue,
+        webhookUrl: dto.webhookUrl ?? null,
+        minStableSeconds: dto.minStableSeconds,
+        isActive: dto.isActive,
+      },
+      include: typeInclude,
+    });
+  } catch (err) {
+    if (isUniqueViolation(err, 'name')) {
+      throw new AppError(409, 'CHECKPOINT_TYPE_NAME_TAKEN');
+    }
+    throw err;
+  }
+}
+
+export async function updateCheckpointType(id: string, dto: UpdateCheckpointTypeDto) {
+  const existing = await prisma.checkpointType.findUnique({ where: { id } });
+  if (!existing) throw new AppError(404, 'Checkpoint type not found');
+
+  const data: Prisma.CheckpointTypeUpdateInput = {};
+  if (dto.name !== undefined) data.name = dto.name;
+  if (dto.description !== undefined) data.description = dto.description ?? null;
+  if (dto.color !== undefined) data.color = dto.color;
+  if (dto.weight !== undefined) data.weight = dto.weight;
+  if (dto.offsetDays !== undefined) data.offsetDays = dto.offsetDays;
+  if (dto.warningDays !== undefined) data.warningDays = dto.warningDays;
+  if (dto.criteria !== undefined) data.criteria = dto.criteria as unknown as Prisma.InputJsonValue;
+  if (dto.webhookUrl !== undefined) data.webhookUrl = dto.webhookUrl ?? null;
+  if (dto.minStableSeconds !== undefined) data.minStableSeconds = dto.minStableSeconds;
+  if (dto.isActive !== undefined) data.isActive = dto.isActive;
+
+  try {
+    return await prisma.checkpointType.update({
+      where: { id },
+      data,
+      include: typeInclude,
+    });
+  } catch (err) {
+    if (isUniqueViolation(err, 'name')) {
+      throw new AppError(409, 'CHECKPOINT_TYPE_NAME_TAKEN');
+    }
+    throw err;
+  }
+}
+
+export async function deleteCheckpointType(id: string) {
+  const type = await prisma.checkpointType.findUnique({
+    where: { id },
+    include: {
+      releaseCheckpoints: {
+        select: { releaseId: true, release: { select: { name: true } } },
+        take: 20,
+      },
+      _count: { select: { releaseCheckpoints: true } },
+    },
+  });
+  if (!type) throw new AppError(404, 'Checkpoint type not found');
+
+  if (type._count.releaseCheckpoints > 0) {
+    throw new AppError(409, 'CHECKPOINT_TYPE_IN_USE', {
+      activeInstances: type.releaseCheckpoints.map((rc) => ({
+        releaseId: rc.releaseId,
+        releaseName: rc.release.name,
+      })),
+    });
+  }
+
+  try {
+    await prisma.checkpointType.delete({ where: { id } });
+  } catch (err) {
+    // TOCTOU: a concurrent apply-template could have linked this type between the read above
+    // and this delete. FK is ON DELETE RESTRICT, so Postgres surfaces P2003 — map to 409.
+    if (isForeignKeyViolation(err)) {
+      throw new AppError(409, 'CHECKPOINT_TYPE_IN_USE');
+    }
+    throw err;
+  }
+  return { ok: true };
+}

--- a/backend/src/modules/releases/checkpoints/checkpoint.dto.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint.dto.ts
@@ -1,0 +1,108 @@
+// TTMP-160: Zod DTOs for CheckpointType and CheckpointTemplate CRUD.
+// CheckpointCriterion is a discriminated union; AND-combined within a type (FR-24).
+// See docs/tz/TTMP-160.md §12.3.
+
+import { StatusCategory } from '@prisma/client';
+import { z } from 'zod';
+
+const hexColor = z.string().regex(/^#[0-9A-Fa-f]{6}$/, 'Color must be a #RRGGBB hex code');
+
+const issueTypesOpt = z.array(z.string().min(1)).max(20).optional();
+
+const criterionSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('STATUS_IN'),
+    categories: z.array(z.nativeEnum(StatusCategory)).min(1),
+    issueTypes: issueTypesOpt,
+  }),
+  z.object({
+    type: z.literal('DUE_BEFORE'),
+    days: z.number().int().min(-365).max(365),
+    issueTypes: issueTypesOpt,
+  }),
+  z.object({
+    type: z.literal('ASSIGNEE_SET'),
+    issueTypes: issueTypesOpt,
+  }),
+  z.object({
+    type: z.literal('CUSTOM_FIELD_VALUE'),
+    customFieldId: z.string().uuid(),
+    operator: z.enum(['EQUALS', 'NOT_EMPTY', 'IN']),
+    value: z.unknown().optional(),
+    issueTypes: issueTypesOpt,
+  }),
+  z.object({
+    type: z.literal('ALL_SUBTASKS_DONE'),
+    issueTypes: issueTypesOpt,
+  }),
+  z.object({
+    type: z.literal('NO_BLOCKING_LINKS'),
+    linkTypeKeys: z.array(z.string().min(1)).max(20).optional(),
+    issueTypes: issueTypesOpt,
+  }),
+]);
+
+export const checkpointCriterionSchema = criterionSchema;
+
+// ─── CheckpointType ──────────────────────────────────────────────────────────
+
+export const createCheckpointTypeDto = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().max(500).nullable().optional(),
+  color: hexColor.default('#888888'),
+  weight: z.enum(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']).default('MEDIUM'),
+  offsetDays: z.number().int().min(-365).max(365),
+  warningDays: z.number().int().min(0).max(30).default(3),
+  criteria: z.array(criterionSchema).min(1).max(10),
+  webhookUrl: z.string().url().nullable().optional(),
+  minStableSeconds: z.number().int().min(0).max(3600).default(300),
+  isActive: z.boolean().default(true),
+});
+
+export const updateCheckpointTypeDto = createCheckpointTypeDto.partial();
+
+// ─── CheckpointTemplate ──────────────────────────────────────────────────────
+
+const templateItemInputSchema = z.object({
+  checkpointTypeId: z.string().uuid(),
+  orderIndex: z.number().int().min(0).max(10000).default(0),
+});
+
+export const createCheckpointTemplateDto = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().max(500).nullable().optional(),
+  items: z
+    .array(templateItemInputSchema)
+    .min(1)
+    .max(20)
+    .refine(
+      (items) => new Set(items.map((i) => i.checkpointTypeId)).size === items.length,
+      'items.checkpointTypeId must be unique within a template',
+    ),
+});
+
+export const updateCheckpointTemplateDto = z.object({
+  name: z.string().min(1).max(100).optional(),
+  description: z.string().max(500).nullable().optional(),
+  items: z
+    .array(templateItemInputSchema)
+    .min(1)
+    .max(20)
+    .refine(
+      (items) => new Set(items.map((i) => i.checkpointTypeId)).size === items.length,
+      'items.checkpointTypeId must be unique within a template',
+    )
+    .optional(),
+});
+
+export const cloneCheckpointTemplateDto = z.object({
+  name: z.string().min(1).max(100).optional(),
+});
+
+// ─── Inferred TS types ───────────────────────────────────────────────────────
+
+export type CreateCheckpointTypeDto = z.infer<typeof createCheckpointTypeDto>;
+export type UpdateCheckpointTypeDto = z.infer<typeof updateCheckpointTypeDto>;
+export type CreateCheckpointTemplateDto = z.infer<typeof createCheckpointTemplateDto>;
+export type UpdateCheckpointTemplateDto = z.infer<typeof updateCheckpointTemplateDto>;
+export type CloneCheckpointTemplateDto = z.infer<typeof cloneCheckpointTemplateDto>;

--- a/backend/src/modules/releases/checkpoints/checkpoint.types.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint.types.ts
@@ -1,0 +1,40 @@
+// TTMP-160: Release Checkpoints — domain types.
+// CheckpointCriterion is the AND-combined rule format evaluated per issue in a release.
+// See docs/tz/TTMP-160.md §12.2–12.4 for algorithm.
+
+import type { StatusCategory } from '@prisma/client';
+
+export type CheckpointCriterion =
+  | { type: 'STATUS_IN'; categories: StatusCategory[]; issueTypes?: string[] }
+  | { type: 'DUE_BEFORE'; days: number; issueTypes?: string[] }
+  | { type: 'ASSIGNEE_SET'; issueTypes?: string[] }
+  | {
+      type: 'CUSTOM_FIELD_VALUE';
+      customFieldId: string;
+      operator: 'EQUALS' | 'NOT_EMPTY' | 'IN';
+      value?: unknown;
+      issueTypes?: string[];
+    }
+  | { type: 'ALL_SUBTASKS_DONE'; issueTypes?: string[] }
+  | { type: 'NO_BLOCKING_LINKS'; linkTypeKeys?: string[]; issueTypes?: string[] };
+
+export type CheckpointCriterionType = CheckpointCriterion['type'];
+
+export interface CheckpointViolation {
+  issueId: string;
+  issueKey: string;
+  issueTitle: string;
+  reason: string;
+  criterionType: CheckpointCriterionType;
+}
+
+export interface CheckpointBreakdown {
+  applicable: number;
+  passed: number;
+  violated: number;
+}
+
+export interface ReleaseRisk {
+  score: number; // 0..1
+  level: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+}

--- a/backend/src/prisma/migrations/20260422000000_release_checkpoints/migration.sql
+++ b/backend/src/prisma/migrations/20260422000000_release_checkpoints/migration.sql
@@ -1,0 +1,158 @@
+-- TTMP-160 PR-1: Release Checkpoints foundation (types, templates, release-checkpoints, violation events, burndown snapshots)
+
+-- Enums
+CREATE TYPE "CheckpointWeight" AS ENUM ('CRITICAL', 'HIGH', 'MEDIUM', 'LOW');
+CREATE TYPE "CheckpointState"  AS ENUM ('PENDING', 'OK', 'VIOLATED');
+
+-- checkpoint_types
+CREATE TABLE "checkpoint_types" (
+    "id"                 TEXT NOT NULL,
+    "name"               TEXT NOT NULL,
+    "description"        TEXT,
+    "color"              TEXT NOT NULL DEFAULT '#888888',
+    "weight"             "CheckpointWeight" NOT NULL DEFAULT 'MEDIUM',
+    "offset_days"        INTEGER NOT NULL,
+    "warning_days"       INTEGER NOT NULL DEFAULT 3,
+    "criteria"           JSONB NOT NULL,
+    "webhook_url"        TEXT,
+    "min_stable_seconds" INTEGER NOT NULL DEFAULT 300,
+    "is_active"          BOOLEAN NOT NULL DEFAULT true,
+    "created_at"         TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"         TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "checkpoint_types_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "checkpoint_types_name_key" ON "checkpoint_types"("name");
+CREATE INDEX "checkpoint_types_is_active_idx" ON "checkpoint_types"("is_active");
+
+-- checkpoint_templates
+CREATE TABLE "checkpoint_templates" (
+    "id"            TEXT NOT NULL,
+    "name"          TEXT NOT NULL,
+    "description"   TEXT,
+    "created_by_id" TEXT,
+    "created_at"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"    TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "checkpoint_templates_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "checkpoint_templates_name_key" ON "checkpoint_templates"("name");
+
+ALTER TABLE "checkpoint_templates"
+    ADD CONSTRAINT "checkpoint_templates_created_by_id_fkey"
+    FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- checkpoint_template_items
+CREATE TABLE "checkpoint_template_items" (
+    "id"                  TEXT NOT NULL,
+    "template_id"         TEXT NOT NULL,
+    "checkpoint_type_id"  TEXT NOT NULL,
+    "order_index"         INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "checkpoint_template_items_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "checkpoint_template_items_template_id_checkpoint_type_id_key"
+    ON "checkpoint_template_items"("template_id", "checkpoint_type_id");
+CREATE INDEX "checkpoint_template_items_template_id_idx"
+    ON "checkpoint_template_items"("template_id");
+
+ALTER TABLE "checkpoint_template_items"
+    ADD CONSTRAINT "checkpoint_template_items_template_id_fkey"
+    FOREIGN KEY ("template_id") REFERENCES "checkpoint_templates"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "checkpoint_template_items"
+    ADD CONSTRAINT "checkpoint_template_items_checkpoint_type_id_fkey"
+    FOREIGN KEY ("checkpoint_type_id") REFERENCES "checkpoint_types"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- release_checkpoints
+CREATE TABLE "release_checkpoints" (
+    "id"                   TEXT NOT NULL,
+    "release_id"           TEXT NOT NULL,
+    "checkpoint_type_id"   TEXT NOT NULL,
+    "criteria_snapshot"    JSONB NOT NULL,
+    "offset_days_snapshot" INTEGER NOT NULL,
+    "deadline"             DATE NOT NULL,
+    "state"                "CheckpointState" NOT NULL DEFAULT 'PENDING',
+    "last_evaluated_at"    TIMESTAMP(3),
+    "applicable_issue_ids" JSONB NOT NULL DEFAULT '[]',
+    "passed_issue_ids"     JSONB NOT NULL DEFAULT '[]',
+    "violations"           JSONB NOT NULL DEFAULT '[]',
+    "violations_hash"      TEXT NOT NULL DEFAULT '',
+    "last_webhook_sent_at" TIMESTAMP(3),
+    "created_at"           TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"           TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "release_checkpoints_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "release_checkpoints_release_id_checkpoint_type_id_key"
+    ON "release_checkpoints"("release_id", "checkpoint_type_id");
+CREATE INDEX "release_checkpoints_release_id_idx" ON "release_checkpoints"("release_id");
+CREATE INDEX "release_checkpoints_deadline_idx" ON "release_checkpoints"("deadline");
+CREATE INDEX "release_checkpoints_state_idx" ON "release_checkpoints"("state");
+
+ALTER TABLE "release_checkpoints"
+    ADD CONSTRAINT "release_checkpoints_release_id_fkey"
+    FOREIGN KEY ("release_id") REFERENCES "releases"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "release_checkpoints"
+    ADD CONSTRAINT "release_checkpoints_checkpoint_type_id_fkey"
+    FOREIGN KEY ("checkpoint_type_id") REFERENCES "checkpoint_types"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- checkpoint_violation_events
+CREATE TABLE "checkpoint_violation_events" (
+    "id"                    TEXT NOT NULL,
+    "release_checkpoint_id" TEXT NOT NULL,
+    "issue_id"              TEXT NOT NULL,
+    "issue_key"             TEXT NOT NULL,
+    "reason"                TEXT NOT NULL,
+    "criterion_type"        TEXT NOT NULL,
+    "occurred_at"           TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolved_at"           TIMESTAMP(3),
+
+    CONSTRAINT "checkpoint_violation_events_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "checkpoint_violation_events_release_checkpoint_id_idx"
+    ON "checkpoint_violation_events"("release_checkpoint_id");
+CREATE INDEX "checkpoint_violation_events_issue_id_idx"
+    ON "checkpoint_violation_events"("issue_id");
+CREATE INDEX "checkpoint_violation_events_occurred_at_idx"
+    ON "checkpoint_violation_events"("occurred_at");
+CREATE INDEX "checkpoint_violation_events_resolved_at_idx"
+    ON "checkpoint_violation_events"("resolved_at");
+
+ALTER TABLE "checkpoint_violation_events"
+    ADD CONSTRAINT "checkpoint_violation_events_release_checkpoint_id_fkey"
+    FOREIGN KEY ("release_checkpoint_id") REFERENCES "release_checkpoints"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- release_burndown_snapshots
+CREATE TABLE "release_burndown_snapshots" (
+    "id"                    TEXT NOT NULL,
+    "release_id"            TEXT NOT NULL,
+    "snapshot_date"         DATE NOT NULL,
+    "total_issues"          INTEGER NOT NULL,
+    "done_issues"           INTEGER NOT NULL,
+    "open_issues"           INTEGER NOT NULL,
+    "cancelled_issues"      INTEGER NOT NULL,
+    "total_estimated_hours" DECIMAL(8,2) NOT NULL,
+    "done_estimated_hours"  DECIMAL(8,2) NOT NULL,
+    "open_estimated_hours"  DECIMAL(8,2) NOT NULL,
+    "violated_checkpoints"  INTEGER NOT NULL DEFAULT 0,
+    "total_checkpoints"     INTEGER NOT NULL DEFAULT 0,
+    "captured_at"           TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "release_burndown_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "release_burndown_snapshots_release_id_snapshot_date_key"
+    ON "release_burndown_snapshots"("release_id", "snapshot_date");
+CREATE INDEX "release_burndown_snapshots_release_id_idx"
+    ON "release_burndown_snapshots"("release_id");
+CREATE INDEX "release_burndown_snapshots_snapshot_date_idx"
+    ON "release_burndown_snapshots"("snapshot_date");
+
+ALTER TABLE "release_burndown_snapshots"
+    ADD CONSTRAINT "release_burndown_snapshots_release_id_fkey"
+    FOREIGN KEY ("release_id") REFERENCES "releases"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -20,23 +20,24 @@ model User {
   createdAt          DateTime @default(now()) @map("created_at")
   updatedAt          DateTime @updatedAt @map("updated_at")
 
-  assignedIssues Issue[]        @relation("assignee")
-  createdIssues  Issue[]        @relation("creator")
-  refreshTokens  RefreshToken[]
-  auditLogs      AuditLog[]
-  comments       Comment[]
-  timeLogs       TimeLog[]
-  aiSessions     AiSession[]
-  teamMemberships    TeamMember[]
-  createdLinks       IssueLink[]
-  ownedProjects      Project[]               @relation("project_owner")
-  projectRoles       UserProjectRole[]
-  systemRoles        UserSystemRole[]
-  customFieldUpdates IssueCustomFieldValue[]
-  createdReleases    Release[]               @relation("releaseCreator")
-  addedReleaseItems  ReleaseItem[]           @relation("releaseItemAdder")
-  groupMemberships   UserGroupMember[]       @relation("GroupMemberUser")
-  addedGroupMembers  UserGroupMember[]       @relation("GroupMemberAddedBy")
+  assignedIssues             Issue[]                 @relation("assignee")
+  createdIssues              Issue[]                 @relation("creator")
+  refreshTokens              RefreshToken[]
+  auditLogs                  AuditLog[]
+  comments                   Comment[]
+  timeLogs                   TimeLog[]
+  aiSessions                 AiSession[]
+  teamMemberships            TeamMember[]
+  createdLinks               IssueLink[]
+  ownedProjects              Project[]               @relation("project_owner")
+  projectRoles               UserProjectRole[]
+  systemRoles                UserSystemRole[]
+  customFieldUpdates         IssueCustomFieldValue[]
+  createdReleases            Release[]               @relation("releaseCreator")
+  addedReleaseItems          ReleaseItem[]           @relation("releaseItemAdder")
+  groupMemberships           UserGroupMember[]       @relation("GroupMemberUser")
+  addedGroupMembers          UserGroupMember[]       @relation("GroupMemberAddedBy")
+  checkpointTemplatesCreated CheckpointTemplate[]    @relation("checkpointTemplateCreator")
 
   @@map("users")
 }
@@ -94,9 +95,9 @@ model UserProjectRole {
   userId    String               @map("user_id")
   projectId String               @map("project_id")
   role      ProjectRole
-  roleId    String?              @map("role_id")         // nullable на фазе 1
-  schemeId  String?              @map("scheme_id")       // must match the scheme of roleId (see migration 20260417000000_user_project_role_scheme_fk)
-  source    RoleAssignmentSource @default(DIRECT)        // TTSEC-2
+  roleId    String?              @map("role_id") // nullable на фазе 1
+  schemeId  String?              @map("scheme_id") // must match the scheme of roleId (see migration 20260417000000_user_project_role_scheme_fk)
+  source    RoleAssignmentSource @default(DIRECT) // TTSEC-2
   createdAt DateTime             @default(now()) @map("created_at")
 
   user           User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -139,11 +140,11 @@ model Project {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
-  owner    User?            @relation("project_owner", fields: [ownerId], references: [id], onDelete: SetNull)
-  category ProjectCategory? @relation(fields: [categoryId], references: [id], onDelete: SetNull)
-  issues   Issue[]
-  sprints  Sprint[]
-  releases Release[]
+  owner               User?                     @relation("project_owner", fields: [ownerId], references: [id], onDelete: SetNull)
+  category            ProjectCategory?          @relation(fields: [categoryId], references: [id], onDelete: SetNull)
+  issues              Issue[]
+  sprints             Sprint[]
+  releases            Release[]
   issueTypeScheme     IssueTypeSchemeProject?
   userRoles           UserProjectRole[]
   groupRoles          ProjectGroupRole[]
@@ -222,19 +223,19 @@ model IssueTypeSchemeProject {
 // ===== ISSUES (TASK HIERARCHY) =====
 
 model Issue {
-  id          String        @id @default(uuid())
-  projectId   String        @map("project_id")
-  number      Int
-  title       String
-  description String?
-  issueTypeConfigId String? @map("issue_type_config_id")
-  status      IssueStatus   @default(OPEN)
-  priority    IssuePriority @default(MEDIUM)
-  orderIndex  Int           @default(0) @map("order_index")
+  id                String        @id @default(uuid())
+  projectId         String        @map("project_id")
+  number            Int
+  title             String
+  description       String?
+  issueTypeConfigId String?       @map("issue_type_config_id")
+  status            IssueStatus   @default(OPEN)
+  priority          IssuePriority @default(MEDIUM)
+  orderIndex        Int           @default(0) @map("order_index")
 
-  aiEligible        Boolean          @default(false)     @map("ai_eligible")
+  aiEligible        Boolean           @default(false) @map("ai_eligible")
   aiExecutionStatus AiExecutionStatus @default(NOT_STARTED) @map("ai_execution_status")
-  aiAssigneeType    AiAssigneeType   @default(HUMAN)    @map("ai_assignee_type")
+  aiAssigneeType    AiAssigneeType    @default(HUMAN) @map("ai_assignee_type")
 
   parentId String? @map("parent_id")
   parent   Issue?  @relation("issueHierarchy", fields: [parentId], references: [id])
@@ -247,29 +248,29 @@ model Issue {
 
   sprintId  String?  @map("sprint_id")
   sprint    Sprint?  @relation(fields: [sprintId], references: [id])
-  releaseId String? @map("release_id")
+  releaseId String?  @map("release_id")
   release   Release? @relation(fields: [releaseId], references: [id])
 
-  estimatedHours      Decimal? @map("estimated_hours") @db.Decimal(6, 2)
-  dueDate             DateTime? @map("due_date") @db.Date
-  acceptanceCriteria  String?  @map("acceptance_criteria")
-  aiReasoning         String?  @map("ai_reasoning")
+  estimatedHours     Decimal?  @map("estimated_hours") @db.Decimal(6, 2)
+  dueDate            DateTime? @map("due_date") @db.Date
+  acceptanceCriteria String?   @map("acceptance_criteria")
+  aiReasoning        String?   @map("ai_reasoning")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
   workflowStatusId String? @map("workflow_status_id")
 
-  issueTypeConfig  IssueTypeConfig?  @relation(fields: [issueTypeConfigId], references: [id])
-  workflowStatus   WorkflowStatus?   @relation(fields: [workflowStatusId], references: [id])
-  project          Project           @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  comments         Comment[]
-  timeLogs         TimeLog[]
-  aiSessions       AiSession[]
-  sourceLinks      IssueLink[]             @relation("linkSource")
-  targetLinks      IssueLink[]             @relation("linkTarget")
+  issueTypeConfig   IssueTypeConfig?        @relation(fields: [issueTypeConfigId], references: [id])
+  workflowStatus    WorkflowStatus?         @relation(fields: [workflowStatusId], references: [id])
+  project           Project                 @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  comments          Comment[]
+  timeLogs          TimeLog[]
+  aiSessions        AiSession[]
+  sourceLinks       IssueLink[]             @relation("linkSource")
+  targetLinks       IssueLink[]             @relation("linkTarget")
   customFieldValues IssueCustomFieldValue[]
-  releaseItems     ReleaseItem[]
+  releaseItems      ReleaseItem[]
 
   @@unique([projectId, number])
   @@index([projectId, status])
@@ -285,8 +286,6 @@ model Issue {
   @@index([dueDate])
   @@map("issues")
 }
-
-
 
 enum IssueStatus {
   OPEN
@@ -319,19 +318,19 @@ enum AiAssigneeType {
 // ===== SPRINTS =====
 
 model Sprint {
-  id        String      @id @default(uuid())
-  projectId String      @map("project_id")
-  name      String
-  goal      String?
-  startDate DateTime?   @map("start_date")
-  endDate   DateTime?   @map("end_date")
-  state     SprintState @default(PLANNED)
-  projectTeamId        String? @map("project_team_id")
-  businessTeamId       String? @map("business_team_id")
-  flowTeamId           String? @map("flow_team_id")
-  releaseId String? @map("release_id")
-  createdAt DateTime    @default(now()) @map("created_at")
-  updatedAt DateTime    @updatedAt @map("updated_at")
+  id             String      @id @default(uuid())
+  projectId      String      @map("project_id")
+  name           String
+  goal           String?
+  startDate      DateTime?   @map("start_date")
+  endDate        DateTime?   @map("end_date")
+  state          SprintState @default(PLANNED)
+  projectTeamId  String?     @map("project_team_id")
+  businessTeamId String?     @map("business_team_id")
+  flowTeamId     String?     @map("flow_team_id")
+  releaseId      String?     @map("release_id")
+  createdAt      DateTime    @default(now()) @map("created_at")
+  updatedAt      DateTime    @updatedAt @map("updated_at")
 
   project      Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
   issues       Issue[]
@@ -358,27 +357,27 @@ enum SprintState {
 // ===== RELEASES =====
 
 enum ReleaseType {
-  ATOMIC       // атомарный — одна система/проект
-  INTEGRATION  // интеграционный — кросс-проектный
+  ATOMIC // атомарный — одна система/проект
+  INTEGRATION // интеграционный — кросс-проектный
 }
 
 enum ReleaseLevel {
-  MINOR   // мелкие улучшения, баг-фиксы
-  MAJOR   // новые фичи
+  MINOR // мелкие улучшения, баг-фиксы
+  MAJOR // новые фичи
 }
 
 // Deprecated: replaced by ReleaseStatus + ReleaseWorkflow. Kept for migration only.
 enum ReleaseState {
-  DRAFT    // сбор задач
-  READY    // готов к выпуску
+  DRAFT // сбор задач
+  READY // готов к выпуску
   RELEASED // выпущен
 }
 
 enum ReleaseStatusCategory {
-  PLANNING      // сбор, планирование
-  IN_PROGRESS   // в работе (сборка, тестирование, стабилизация)
-  DONE          // выпущен, закрыт
-  CANCELLED     // отменён
+  PLANNING // сбор, планирование
+  IN_PROGRESS // в работе (сборка, тестирование, стабилизация)
+  DONE // выпущен, закрыт
+  CANCELLED // отменён
 }
 
 model ReleaseStatus {
@@ -466,28 +465,30 @@ model ReleaseItem {
 }
 
 model Release {
-  id          String        @id @default(uuid())
-  type        ReleaseType   @default(ATOMIC)
-  projectId   String?       @map("project_id")         // nullable для INTEGRATION
+  id          String       @id @default(uuid())
+  type        ReleaseType  @default(ATOMIC)
+  projectId   String?      @map("project_id") // nullable для INTEGRATION
   name        String
   description String?
-  level       ReleaseLevel  @default(MINOR)
-  state       ReleaseState  @default(DRAFT)             // deprecated, kept for migration
-  statusId    String?       @map("status_id")           // FK на ReleaseStatus
-  workflowId  String?       @map("workflow_id")         // FK на ReleaseWorkflow
-  releaseDate DateTime?     @map("release_date") @db.Date
-  plannedDate DateTime?     @map("planned_date") @db.Date
-  createdById String?       @map("created_by_id")       // автор релиза
-  createdAt   DateTime      @default(now()) @map("created_at")
-  updatedAt   DateTime      @updatedAt @map("updated_at")
+  level       ReleaseLevel @default(MINOR)
+  state       ReleaseState @default(DRAFT) // deprecated, kept for migration
+  statusId    String?      @map("status_id") // FK на ReleaseStatus
+  workflowId  String?      @map("workflow_id") // FK на ReleaseWorkflow
+  releaseDate DateTime?    @map("release_date") @db.Date
+  plannedDate DateTime?    @map("planned_date") @db.Date
+  createdById String?      @map("created_by_id") // автор релиза
+  createdAt   DateTime     @default(now()) @map("created_at")
+  updatedAt   DateTime     @updatedAt @map("updated_at")
 
-  project   Project?         @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  status    ReleaseStatus?   @relation(fields: [statusId], references: [id])
-  workflow  ReleaseWorkflow? @relation(fields: [workflowId], references: [id])
-  createdBy User?            @relation("releaseCreator", fields: [createdById], references: [id])
-  items     ReleaseItem[]
-  issues    Issue[]
-  sprints   Sprint[]
+  project           Project?                  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  status            ReleaseStatus?            @relation(fields: [statusId], references: [id])
+  workflow          ReleaseWorkflow?          @relation(fields: [workflowId], references: [id])
+  createdBy         User?                     @relation("releaseCreator", fields: [createdById], references: [id])
+  items             ReleaseItem[]
+  issues            Issue[]
+  sprints           Sprint[]
+  checkpoints       ReleaseCheckpoint[]
+  burndownSnapshots ReleaseBurndownSnapshot[]
 
   @@unique([projectId, name], map: "releases_project_id_name_key")
   @@index([projectId])
@@ -518,25 +519,25 @@ model Comment {
 // ===== TIME TRACKING =====
 
 model TimeLog {
-  id             String       @id @default(uuid())
-  issueId        String       @map("issue_id")
-  userId         String?      @map("user_id")
-  hours          Decimal      @db.Decimal(6, 2)
-  note           String?
-  startedAt      DateTime?    @map("started_at")
-  stoppedAt      DateTime?    @map("stopped_at")
-  logDate        DateTime     @default(now()) @map("log_date") @db.Date
-  createdAt      DateTime     @default(now()) @map("created_at")
+  id        String    @id @default(uuid())
+  issueId   String    @map("issue_id")
+  userId    String?   @map("user_id")
+  hours     Decimal   @db.Decimal(6, 2)
+  note      String?
+  startedAt DateTime? @map("started_at")
+  stoppedAt DateTime? @map("stopped_at")
+  logDate   DateTime  @default(now()) @map("log_date") @db.Date
+  createdAt DateTime  @default(now()) @map("created_at")
 
   // Источник времени: человек или агент
-  source         TimeSource   @default(HUMAN)
+  source TimeSource @default(HUMAN)
 
   // Связь с сессией ИИ (если source = AGENT и лог получен из AiSession)
-  agentSessionId String?      @map("agent_session_id")
-  agentSession   AiSession?   @relation(fields: [agentSessionId], references: [id])
+  agentSessionId String?    @map("agent_session_id")
+  agentSession   AiSession? @relation(fields: [agentSessionId], references: [id])
 
-   // Денежная стоимость этого лога (для AGENT-логов — доля costMoney сессии)
-  costMoney      Decimal?     @db.Decimal(10, 4) @map("cost_money")
+  // Денежная стоимость этого лога (для AGENT-логов — доля costMoney сессии)
+  costMoney Decimal? @map("cost_money") @db.Decimal(10, 4)
 
   issue Issue @relation(fields: [issueId], references: [id], onDelete: Cascade)
   user  User? @relation(fields: [userId], references: [id])
@@ -556,22 +557,22 @@ enum TimeSource {
 // ===== AI SESSIONS =====
 
 model AiSession {
-  id           String    @id @default(uuid())
-  issueId      String?   @map("issue_id")
-  userId       String?   @map("user_id")
+  id           String   @id @default(uuid())
+  issueId      String?  @map("issue_id")
+  userId       String?  @map("user_id")
   model        String
   provider     String
-  startedAt    DateTime  @map("started_at")
-  finishedAt   DateTime  @map("finished_at")
-  tokensInput  Int       @map("tokens_input")
-  tokensOutput Int       @map("tokens_output")
-  costMoney    Decimal   @db.Decimal(10, 4)
+  startedAt    DateTime @map("started_at")
+  finishedAt   DateTime @map("finished_at")
+  tokensInput  Int      @map("tokens_input")
+  tokensOutput Int      @map("tokens_output")
+  costMoney    Decimal  @db.Decimal(10, 4)
   notes        String?
-  createdAt    DateTime  @default(now()) @map("created_at")
+  createdAt    DateTime @default(now()) @map("created_at")
 
-  issue  Issue? @relation(fields: [issueId], references: [id])
-  user   User?  @relation(fields: [userId], references: [id])
-  logs   TimeLog[]
+  issue Issue?    @relation(fields: [issueId], references: [id])
+  user  User?     @relation(fields: [userId], references: [id])
+  logs  TimeLog[]
 
   @@index([issueId])
   @@index([userId])
@@ -603,14 +604,14 @@ model AuditLog {
 // ===== ISSUE LINKS =====
 
 model IssueLinkType {
-  id           String      @id @default(uuid())
-  name         String      @unique
-  outboundName String      @map("outbound_name")
-  inboundName  String      @map("inbound_name")
-  isActive     Boolean     @default(true) @map("is_active")
-  isSystem     Boolean     @default(false) @map("is_system")
-  createdAt    DateTime    @default(now()) @map("created_at")
-  updatedAt    DateTime    @updatedAt @map("updated_at")
+  id           String   @id @default(uuid())
+  name         String   @unique
+  outboundName String   @map("outbound_name")
+  inboundName  String   @map("inbound_name")
+  isActive     Boolean  @default(true) @map("is_active")
+  isSystem     Boolean  @default(false) @map("is_system")
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
 
   links IssueLink[]
 
@@ -661,13 +662,13 @@ model CustomField {
   fieldType   CustomFieldType @map("field_type")
   options     Json?
   isSystem    Boolean         @default(false) @map("is_system")
-  isEnabled   Boolean         @default(true)  @map("is_enabled")
-  orderIndex  Int             @default(0)      @map("order_index")
-  createdAt   DateTime        @default(now())  @map("created_at")
-  updatedAt   DateTime        @updatedAt       @map("updated_at")
+  isEnabled   Boolean         @default(true) @map("is_enabled")
+  orderIndex  Int             @default(0) @map("order_index")
+  createdAt   DateTime        @default(now()) @map("created_at")
+  updatedAt   DateTime        @updatedAt @map("updated_at")
 
-  schemaItems          FieldSchemaItem[]
-  values               IssueCustomFieldValue[]
+  schemaItems           FieldSchemaItem[]
+  values                IssueCustomFieldValue[]
   transitionScreenItems TransitionScreenItem[]
 
   @@map("custom_fields")
@@ -714,7 +715,7 @@ model FieldSchema {
   isDefault    Boolean           @default(false) @map("is_default")
   copiedFromId String?           @map("copied_from_id")
   createdAt    DateTime          @default(now()) @map("created_at")
-  updatedAt    DateTime          @updatedAt      @map("updated_at")
+  updatedAt    DateTime          @updatedAt @map("updated_at")
 
   items      FieldSchemaItem[]
   bindings   FieldSchemaBinding[]
@@ -728,7 +729,7 @@ model FieldSchemaItem {
   id            String  @id @default(uuid())
   schemaId      String  @map("schema_id")
   customFieldId String  @map("custom_field_id")
-  orderIndex    Int     @default(0)     @map("order_index")
+  orderIndex    Int     @default(0) @map("order_index")
   isRequired    Boolean @default(false) @map("is_required")
   showOnKanban  Boolean @default(false) @map("show_on_kanban")
 
@@ -772,11 +773,11 @@ model SystemSetting {
 // ===== TEAMS =====
 
 model Team {
-  id          String        @id @default(uuid())
+  id          String   @id @default(uuid())
   name        String
   description String?
-  createdAt   DateTime      @default(now()) @map("created_at")
-  updatedAt   DateTime      @updatedAt @map("updated_at")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
   members TeamMember[]
 
@@ -791,7 +792,7 @@ model TeamMember {
   id        String   @id @default(uuid())
   teamId    String   @map("team_id")
   userId    String   @map("user_id")
-  role      String?  // optional per-team role, e.g. "LEAD", "DEVELOPER"
+  role      String? // optional per-team role, e.g. "LEAD", "DEVELOPER"
   createdAt DateTime @default(now()) @map("created_at")
 
   team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
@@ -848,11 +849,11 @@ model Workflow {
 }
 
 model WorkflowStep {
-  id         String   @id @default(uuid())
-  workflowId String   @map("workflow_id")
-  statusId   String   @map("status_id")
-  isInitial  Boolean  @default(false) @map("is_initial")
-  orderIndex Int      @default(0) @map("order_index")
+  id         String  @id @default(uuid())
+  workflowId String  @map("workflow_id")
+  statusId   String  @map("status_id")
+  isInitial  Boolean @default(false) @map("is_initial")
+  orderIndex Int     @default(0) @map("order_index")
 
   workflow Workflow       @relation(fields: [workflowId], references: [id], onDelete: Cascade)
   status   WorkflowStatus @relation(fields: [statusId], references: [id], onDelete: Restrict)
@@ -862,23 +863,23 @@ model WorkflowStep {
 }
 
 model WorkflowTransition {
-  id           String   @id @default(uuid())
-  workflowId   String   @map("workflow_id")
-  name         String
-  fromStatusId String?  @map("from_status_id")
-  toStatusId   String   @map("to_status_id")
-  isGlobal     Boolean  @default(false) @map("is_global")
-  orderIndex   Int      @default(0) @map("order_index")
-  conditions   Json?
-  validators   Json?
-  postFunctions Json?   @map("post_functions")
-  screenId     String?  @map("screen_id")
-  createdAt    DateTime @default(now()) @map("created_at")
-  updatedAt    DateTime @updatedAt @map("updated_at")
+  id            String   @id @default(uuid())
+  workflowId    String   @map("workflow_id")
+  name          String
+  fromStatusId  String?  @map("from_status_id")
+  toStatusId    String   @map("to_status_id")
+  isGlobal      Boolean  @default(false) @map("is_global")
+  orderIndex    Int      @default(0) @map("order_index")
+  conditions    Json?
+  validators    Json?
+  postFunctions Json?    @map("post_functions")
+  screenId      String?  @map("screen_id")
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
 
-  workflow   Workflow        @relation(fields: [workflowId], references: [id], onDelete: Cascade)
-  fromStatus WorkflowStatus? @relation("transitionFrom", fields: [fromStatusId], references: [id], onDelete: Restrict)
-  toStatus   WorkflowStatus  @relation("transitionTo", fields: [toStatusId], references: [id], onDelete: Restrict)
+  workflow   Workflow          @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+  fromStatus WorkflowStatus?   @relation("transitionFrom", fields: [fromStatusId], references: [id], onDelete: Restrict)
+  toStatus   WorkflowStatus    @relation("transitionTo", fields: [toStatusId], references: [id], onDelete: Restrict)
   screen     TransitionScreen? @relation(fields: [screenId], references: [id], onDelete: SetNull)
 
   @@index([workflowId])
@@ -971,31 +972,31 @@ enum ProjectPermission {
   ISSUES_CHANGE_STATUS
   ISSUES_CHANGE_TYPE
   SPRINTS_VIEW
-  SPRINTS_CREATE            // TTSEC-2
-  SPRINTS_EDIT              // TTSEC-2
-  SPRINTS_DELETE            // TTSEC-2
-  SPRINTS_MANAGE            // deprecated: Postgres не поддерживает DROP VALUE, скрыто из UI-матрицы
+  SPRINTS_CREATE // TTSEC-2
+  SPRINTS_EDIT // TTSEC-2
+  SPRINTS_DELETE // TTSEC-2
+  SPRINTS_MANAGE // deprecated: Postgres не поддерживает DROP VALUE, скрыто из UI-матрицы
   RELEASES_VIEW
-  RELEASES_CREATE           // TTSEC-2
-  RELEASES_EDIT             // TTSEC-2
-  RELEASES_DELETE           // TTSEC-2
-  RELEASES_MANAGE           // deprecated
+  RELEASES_CREATE // TTSEC-2
+  RELEASES_EDIT // TTSEC-2
+  RELEASES_DELETE // TTSEC-2
+  RELEASES_MANAGE // deprecated
   MEMBERS_VIEW
   MEMBERS_MANAGE
   TIME_LOGS_VIEW
   TIME_LOGS_CREATE
-  TIME_LOGS_DELETE_OTHERS   // TTSEC-2: модерация чужих time logs
+  TIME_LOGS_DELETE_OTHERS // TTSEC-2: модерация чужих time logs
   TIME_LOGS_MANAGE
   COMMENTS_VIEW
   COMMENTS_CREATE
-  COMMENTS_DELETE_OTHERS    // TTSEC-2: модерация чужих комментариев
+  COMMENTS_DELETE_OTHERS // TTSEC-2: модерация чужих комментариев
   COMMENTS_MANAGE
   PROJECT_SETTINGS_VIEW
   PROJECT_SETTINGS_EDIT
   BOARDS_VIEW
   BOARDS_MANAGE
-  USER_GROUP_VIEW           // TTSEC-2: system-level
-  USER_GROUP_MANAGE         // TTSEC-2: system-level
+  USER_GROUP_VIEW // TTSEC-2: system-level
+  USER_GROUP_MANAGE // TTSEC-2: system-level
 }
 
 model ProjectRoleScheme {
@@ -1004,7 +1005,7 @@ model ProjectRoleScheme {
   description String?
   isDefault   Boolean  @default(false) @map("is_default")
   createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt      @map("updated_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
   roles    ProjectRoleDefinition[]
   projects ProjectRoleSchemeProject[]
@@ -1021,7 +1022,7 @@ model ProjectRoleDefinition {
   color       String?
   isSystem    Boolean  @default(false) @map("is_system")
   createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt      @map("updated_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
   scheme            ProjectRoleScheme       @relation(fields: [schemeId], references: [id], onDelete: Cascade)
   permissions       ProjectRolePermission[]
@@ -1063,7 +1064,7 @@ model ProjectRoleSchemeProject {
 // ===== USER GROUPS (TTSEC-2) =====
 
 model UserGroup {
-  id   String @id @default(uuid())
+  id          String   @id @default(uuid())
   // TTSEC-2: `name` — глобально уникален. Система single-tenant, `Project.key`
   // уже глобально уникален, поэтому Legacy-имя `Legacy: {project.key} — {role.name}`
   // детерминировано, а `ON CONFLICT (name) DO NOTHING` делает Legacy-backfill идемпотентным.
@@ -1072,7 +1073,7 @@ model UserGroup {
   name        String   @unique
   description String?
   createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt      @map("updated_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
   members      UserGroupMember[]
   projectRoles ProjectGroupRole[]
@@ -1116,4 +1117,139 @@ model ProjectGroupRole {
   @@index([projectId])
   @@index([groupId])
   @@map("project_group_roles")
+}
+
+// ===== TTMP-160: RELEASE CHECKPOINTS =====
+
+enum CheckpointWeight {
+  CRITICAL
+  HIGH
+  MEDIUM
+  LOW
+}
+
+enum CheckpointState {
+  PENDING
+  OK
+  VIOLATED
+}
+
+model CheckpointType {
+  id               String           @id @default(uuid())
+  name             String           @unique
+  description      String?
+  color            String           @default("#888888")
+  weight           CheckpointWeight @default(MEDIUM)
+  offsetDays       Int              @map("offset_days")
+  warningDays      Int              @default(3) @map("warning_days")
+  criteria         Json // CheckpointCriterion[], AND-combined
+  webhookUrl       String?          @map("webhook_url")
+  minStableSeconds Int              @default(300) @map("min_stable_seconds")
+  isActive         Boolean          @default(true) @map("is_active")
+  createdAt        DateTime         @default(now()) @map("created_at")
+  updatedAt        DateTime         @updatedAt @map("updated_at")
+
+  templateItems      CheckpointTemplateItem[]
+  releaseCheckpoints ReleaseCheckpoint[]
+
+  @@index([isActive])
+  @@map("checkpoint_types")
+}
+
+model CheckpointTemplate {
+  id          String   @id @default(uuid())
+  name        String   @unique
+  description String?
+  createdById String?  @map("created_by_id")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  createdBy User?                    @relation("checkpointTemplateCreator", fields: [createdById], references: [id])
+  items     CheckpointTemplateItem[]
+
+  @@map("checkpoint_templates")
+}
+
+model CheckpointTemplateItem {
+  id               String @id @default(uuid())
+  templateId       String @map("template_id")
+  checkpointTypeId String @map("checkpoint_type_id")
+  orderIndex       Int    @default(0) @map("order_index")
+
+  template       CheckpointTemplate @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  checkpointType CheckpointType     @relation(fields: [checkpointTypeId], references: [id], onDelete: Restrict)
+
+  @@unique([templateId, checkpointTypeId])
+  @@index([templateId])
+  @@map("checkpoint_template_items")
+}
+
+model ReleaseCheckpoint {
+  id                 String          @id @default(uuid())
+  releaseId          String          @map("release_id")
+  checkpointTypeId   String          @map("checkpoint_type_id")
+  criteriaSnapshot   Json            @map("criteria_snapshot")
+  offsetDaysSnapshot Int             @map("offset_days_snapshot")
+  deadline           DateTime        @db.Date
+  state              CheckpointState @default(PENDING)
+  lastEvaluatedAt    DateTime?       @map("last_evaluated_at")
+  applicableIssueIds Json            @default("[]") @map("applicable_issue_ids")
+  passedIssueIds     Json            @default("[]") @map("passed_issue_ids")
+  violations         Json            @default("[]")
+  violationsHash     String          @default("") @map("violations_hash")
+  lastWebhookSentAt  DateTime?       @map("last_webhook_sent_at")
+  createdAt          DateTime        @default(now()) @map("created_at")
+  updatedAt          DateTime        @updatedAt @map("updated_at")
+
+  release         Release                    @relation(fields: [releaseId], references: [id], onDelete: Cascade)
+  checkpointType  CheckpointType             @relation(fields: [checkpointTypeId], references: [id], onDelete: Restrict)
+  violationEvents CheckpointViolationEvent[]
+
+  @@unique([releaseId, checkpointTypeId])
+  @@index([releaseId])
+  @@index([deadline])
+  @@index([state])
+  @@map("release_checkpoints")
+}
+
+model CheckpointViolationEvent {
+  id                  String    @id @default(uuid())
+  releaseCheckpointId String    @map("release_checkpoint_id")
+  issueId             String    @map("issue_id")
+  issueKey            String    @map("issue_key")
+  reason              String
+  criterionType       String    @map("criterion_type")
+  occurredAt          DateTime  @default(now()) @map("occurred_at")
+  resolvedAt          DateTime? @map("resolved_at")
+
+  releaseCheckpoint ReleaseCheckpoint @relation(fields: [releaseCheckpointId], references: [id], onDelete: Cascade)
+
+  @@index([releaseCheckpointId])
+  @@index([issueId])
+  @@index([occurredAt])
+  @@index([resolvedAt])
+  @@map("checkpoint_violation_events")
+}
+
+model ReleaseBurndownSnapshot {
+  id                  String   @id @default(uuid())
+  releaseId           String   @map("release_id")
+  snapshotDate        DateTime @map("snapshot_date") @db.Date
+  totalIssues         Int      @map("total_issues")
+  doneIssues          Int      @map("done_issues")
+  openIssues          Int      @map("open_issues")
+  cancelledIssues     Int      @map("cancelled_issues")
+  totalEstimatedHours Decimal  @map("total_estimated_hours") @db.Decimal(8, 2)
+  doneEstimatedHours  Decimal  @map("done_estimated_hours") @db.Decimal(8, 2)
+  openEstimatedHours  Decimal  @map("open_estimated_hours") @db.Decimal(8, 2)
+  violatedCheckpoints Int      @default(0) @map("violated_checkpoints")
+  totalCheckpoints    Int      @default(0) @map("total_checkpoints")
+  capturedAt          DateTime @default(now()) @map("captured_at")
+
+  release Release @relation(fields: [releaseId], references: [id], onDelete: Cascade)
+
+  @@unique([releaseId, snapshotDate])
+  @@index([releaseId])
+  @@index([snapshotDate])
+  @@map("release_burndown_snapshots")
 }

--- a/backend/src/shared/utils/prisma-errors.ts
+++ b/backend/src/shared/utils/prisma-errors.ts
@@ -1,0 +1,17 @@
+// Narrow helpers for Prisma error-code inspection. Kept off Prisma's known-request-error class
+// so callers don't need to import the generated runtime type.
+
+export function isUniqueViolation(err: unknown, field: string): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { code?: string; meta?: { target?: unknown } };
+  if (e.code !== 'P2002') return false;
+  const target = e.meta?.target;
+  if (Array.isArray(target)) return target.includes(field);
+  if (typeof target === 'string') return target.includes(field);
+  return false;
+}
+
+export function isForeignKeyViolation(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  return (err as { code?: string }).code === 'P2003';
+}

--- a/backend/tests/checkpoints-dto.unit.test.ts
+++ b/backend/tests/checkpoints-dto.unit.test.ts
@@ -1,0 +1,165 @@
+/**
+ * TTMP-160 PR-1 — unit tests for Zod DTOs.
+ * Exercises the discriminated criterion union and CRUD schemas without a DB.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  createCheckpointTypeDto,
+  updateCheckpointTypeDto,
+  createCheckpointTemplateDto,
+  cloneCheckpointTemplateDto,
+} from '../src/modules/releases/checkpoints/checkpoint.dto.js';
+
+describe('createCheckpointTypeDto', () => {
+  const base = {
+    name: 'Code freeze',
+    color: '#52C41A',
+    weight: 'HIGH' as const,
+    offsetDays: -7,
+    warningDays: 2,
+    criteria: [{ type: 'STATUS_IN' as const, categories: ['DONE' as const, 'IN_PROGRESS' as const] }],
+  };
+
+  it('accepts a valid payload and applies defaults', () => {
+    const parsed = createCheckpointTypeDto.parse(base);
+    expect(parsed.warningDays).toBe(2);
+    expect(parsed.minStableSeconds).toBe(300);
+    expect(parsed.isActive).toBe(true);
+  });
+
+  it('rejects non-hex color', () => {
+    expect(() => createCheckpointTypeDto.parse({ ...base, color: 'green' })).toThrow();
+  });
+
+  it('rejects empty criteria', () => {
+    expect(() => createCheckpointTypeDto.parse({ ...base, criteria: [] })).toThrow();
+  });
+
+  it('rejects offsetDays beyond ±365', () => {
+    expect(() => createCheckpointTypeDto.parse({ ...base, offsetDays: 500 })).toThrow();
+    expect(() => createCheckpointTypeDto.parse({ ...base, offsetDays: -500 })).toThrow();
+  });
+
+  it('accepts all six criterion types', () => {
+    const uuid = '00000000-0000-0000-0000-000000000000';
+    const criteria = [
+      { type: 'STATUS_IN' as const, categories: ['DONE' as const] },
+      { type: 'DUE_BEFORE' as const, days: 0 },
+      { type: 'ASSIGNEE_SET' as const },
+      { type: 'CUSTOM_FIELD_VALUE' as const, customFieldId: uuid, operator: 'NOT_EMPTY' as const },
+      { type: 'ALL_SUBTASKS_DONE' as const },
+      { type: 'NO_BLOCKING_LINKS' as const, linkTypeKeys: ['BLOCKS'] },
+    ];
+    const parsed = createCheckpointTypeDto.parse({ ...base, criteria });
+    expect(parsed.criteria).toHaveLength(6);
+  });
+
+  it('rejects an unknown criterion.type', () => {
+    expect(() =>
+      createCheckpointTypeDto.parse({
+        ...base,
+        criteria: [{ type: 'UNKNOWN', foo: 'bar' } as unknown as (typeof base)['criteria'][number]],
+      }),
+    ).toThrow();
+  });
+
+  it('rejects CUSTOM_FIELD_VALUE without a UUID', () => {
+    expect(() =>
+      createCheckpointTypeDto.parse({
+        ...base,
+        criteria: [
+          { type: 'CUSTOM_FIELD_VALUE' as const, customFieldId: 'not-a-uuid', operator: 'EQUALS' as const },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it('rejects STATUS_IN with empty categories', () => {
+    expect(() =>
+      createCheckpointTypeDto.parse({
+        ...base,
+        criteria: [{ type: 'STATUS_IN' as const, categories: [] }],
+      }),
+    ).toThrow();
+  });
+
+  it('rejects webhookUrl that is not a URL', () => {
+    expect(() =>
+      createCheckpointTypeDto.parse({ ...base, webhookUrl: 'not-a-url' }),
+    ).toThrow();
+  });
+
+  it('allows webhookUrl to be null', () => {
+    const parsed = createCheckpointTypeDto.parse({ ...base, webhookUrl: null });
+    expect(parsed.webhookUrl).toBeNull();
+  });
+});
+
+describe('updateCheckpointTypeDto', () => {
+  it('accepts an empty patch', () => {
+    expect(updateCheckpointTypeDto.parse({})).toEqual({});
+  });
+
+  it('accepts a single-field patch', () => {
+    const parsed = updateCheckpointTypeDto.parse({ name: 'Renamed' });
+    expect(parsed.name).toBe('Renamed');
+  });
+});
+
+describe('createCheckpointTemplateDto', () => {
+  const typeId1 = '11111111-1111-1111-1111-111111111111';
+  const typeId2 = '22222222-2222-2222-2222-222222222222';
+
+  it('accepts a valid template with multiple items', () => {
+    const parsed = createCheckpointTemplateDto.parse({
+      name: 'Standard release',
+      items: [
+        { checkpointTypeId: typeId1, orderIndex: 0 },
+        { checkpointTypeId: typeId2, orderIndex: 1 },
+      ],
+    });
+    expect(parsed.items).toHaveLength(2);
+  });
+
+  it('rejects an empty items array', () => {
+    expect(() =>
+      createCheckpointTemplateDto.parse({ name: 'Empty', items: [] }),
+    ).toThrow();
+  });
+
+  it('rejects duplicate checkpointTypeId in items', () => {
+    expect(() =>
+      createCheckpointTemplateDto.parse({
+        name: 'Dup',
+        items: [
+          { checkpointTypeId: typeId1, orderIndex: 0 },
+          { checkpointTypeId: typeId1, orderIndex: 1 },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it('rejects non-UUID checkpointTypeId', () => {
+    expect(() =>
+      createCheckpointTemplateDto.parse({
+        name: 'Bad',
+        items: [{ checkpointTypeId: 'not-a-uuid', orderIndex: 0 }],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('cloneCheckpointTemplateDto', () => {
+  it('accepts an empty body (name is optional)', () => {
+    expect(cloneCheckpointTemplateDto.parse({})).toEqual({});
+  });
+
+  it('accepts a custom name', () => {
+    const parsed = cloneCheckpointTemplateDto.parse({ name: 'My clone' });
+    expect(parsed.name).toBe('My clone');
+  });
+
+  it('rejects an empty string name', () => {
+    expect(() => cloneCheckpointTemplateDto.parse({ name: '' })).toThrow();
+  });
+});

--- a/backend/tests/checkpoints.test.ts
+++ b/backend/tests/checkpoints.test.ts
@@ -1,0 +1,406 @@
+/**
+ * TTMP-160 PR-1 — integration tests for checkpoint-types & checkpoint-templates routers.
+ *
+ * Covers:
+ *   - RBAC: plain USER → 403; RELEASE_MANAGER, ADMIN, SUPER_ADMIN → 2xx (SEC-1)
+ *   - CheckpointType CRUD (FR-1) + 409 on delete when used by a release checkpoint
+ *   - CheckpointTemplate CRUD + clone (FR-2) + 400 when referencing a missing type
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { request, createTestUser } from './helpers.js';
+
+const prisma = new PrismaClient();
+
+let superAdminToken: string;
+let adminToken: string;
+let rmToken: string;
+let plainToken: string;
+
+const VALID_CRITERIA = [
+  { type: 'STATUS_IN', categories: ['DONE', 'IN_PROGRESS'] },
+];
+
+async function grantSystemRole(userId: string, role: string) {
+  await prisma.userSystemRole.upsert({
+    where: { userId_role: { userId, role: role as never } },
+    create: { userId, role: role as never },
+    update: {},
+  });
+}
+
+async function loginAs(email: string): Promise<string> {
+  const res = await request.post('/api/auth/login').send({ email, password: 'Password123' });
+  return res.body.accessToken as string;
+}
+
+beforeEach(async () => {
+  await prisma.auditLog.deleteMany();
+  await prisma.checkpointViolationEvent.deleteMany();
+  await prisma.releaseCheckpoint.deleteMany();
+  await prisma.checkpointTemplateItem.deleteMany();
+  await prisma.checkpointTemplate.deleteMany();
+  await prisma.checkpointType.deleteMany();
+  await prisma.releaseBurndownSnapshot.deleteMany();
+  await prisma.release.deleteMany();
+  await prisma.project.deleteMany();
+  await prisma.refreshToken.deleteMany();
+  await prisma.userSystemRole.deleteMany();
+  await prisma.user.deleteMany();
+
+  const superRes = await createTestUser('super@ttmp160.test', 'Password123', 'Super');
+  await grantSystemRole(superRes.user.id, 'SUPER_ADMIN');
+  superAdminToken = await loginAs('super@ttmp160.test');
+
+  const adminRes = await createTestUser('admin@ttmp160.test', 'Password123', 'Admin');
+  await grantSystemRole(adminRes.user.id, 'ADMIN');
+  adminToken = await loginAs('admin@ttmp160.test');
+
+  const rmRes = await createTestUser('rm@ttmp160.test', 'Password123', 'Release Manager');
+  await grantSystemRole(rmRes.user.id, 'RELEASE_MANAGER');
+  rmToken = await loginAs('rm@ttmp160.test');
+
+  const plainRes = await createTestUser('plain@ttmp160.test', 'Password123', 'Plain User');
+  plainToken = plainRes.accessToken;
+});
+
+// ============================================================
+// /api/admin/checkpoint-types
+// ============================================================
+
+describe('POST /api/admin/checkpoint-types', () => {
+  const body = {
+    name: 'Code freeze',
+    color: '#52C41A',
+    weight: 'HIGH',
+    offsetDays: -7,
+    criteria: VALID_CRITERIA,
+  };
+
+  it('SUPER_ADMIN can create a checkpoint type', async () => {
+    const res = await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${superAdminToken}`)
+      .send(body);
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Code freeze');
+    expect(res.body.weight).toBe('HIGH');
+    expect(res.body.isActive).toBe(true);
+  });
+
+  it('ADMIN can create a checkpoint type', async () => {
+    const res = await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ ...body, name: 'By admin' });
+    expect(res.status).toBe(201);
+  });
+
+  it('RELEASE_MANAGER can create a checkpoint type', async () => {
+    const res = await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${rmToken}`)
+      .send({ ...body, name: 'By RM' });
+    expect(res.status).toBe(201);
+  });
+
+  it('plain USER cannot create a checkpoint type (403)', async () => {
+    const res = await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${plainToken}`)
+      .send(body);
+    expect(res.status).toBe(403);
+  });
+
+  it('unauthenticated request is rejected (401)', async () => {
+    const res = await request.post('/api/admin/checkpoint-types').send(body);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 on invalid criteria shape', async () => {
+    const res = await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ ...body, criteria: [{ type: 'BOGUS' }] });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Validation failed');
+  });
+
+  it('returns 409 on duplicate name', async () => {
+    await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send(body);
+    const dup = await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send(body);
+    expect(dup.status).toBe(409);
+    expect(dup.body.error).toBe('CHECKPOINT_TYPE_NAME_TAKEN');
+  });
+
+  it('persists an audit log for checkpoint_type.created', async () => {
+    const res = await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ ...body, name: 'Audited' });
+    expect(res.status).toBe(201);
+    const audit = await prisma.auditLog.findFirst({
+      where: { entityType: 'checkpoint_type', entityId: res.body.id },
+    });
+    expect(audit?.action).toBe('checkpoint_type.created');
+  });
+});
+
+describe('GET /api/admin/checkpoint-types', () => {
+  it('returns created types sorted by name', async () => {
+    await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'B-type', color: '#888888', offsetDays: 0, criteria: VALID_CRITERIA });
+    await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'A-type', color: '#888888', offsetDays: 0, criteria: VALID_CRITERIA });
+
+    const res = await request
+      .get('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.map((t: { name: string }) => t.name)).toEqual(['A-type', 'B-type']);
+  });
+
+  it('plain USER cannot list (403)', async () => {
+    const res = await request
+      .get('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${plainToken}`);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('PATCH /api/admin/checkpoint-types/:id', () => {
+  it('updates name and criteria', async () => {
+    const created = await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'To-update', color: '#888888', offsetDays: 0, criteria: VALID_CRITERIA });
+
+    const res = await request
+      .patch(`/api/admin/checkpoint-types/${created.body.id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Updated', criteria: [{ type: 'ASSIGNEE_SET' }] });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Updated');
+    expect(res.body.criteria).toEqual([{ type: 'ASSIGNEE_SET' }]);
+  });
+
+  it('returns 404 for unknown id', async () => {
+    const res = await request
+      .patch('/api/admin/checkpoint-types/00000000-0000-0000-0000-000000000000')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'x' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/admin/checkpoint-types/:id', () => {
+  it('deletes an unused type', async () => {
+    const created = await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Delete-me', color: '#888888', offsetDays: 0, criteria: VALID_CRITERIA });
+
+    const res = await request
+      .delete(`/api/admin/checkpoint-types/${created.body.id}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('returns 409 CHECKPOINT_TYPE_IN_USE when used by a release checkpoint', async () => {
+    // Create type, release, and a ReleaseCheckpoint directly via Prisma.
+    const created = await request
+      .post('/api/admin/checkpoint-types')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'In-use', color: '#888888', offsetDays: -3, criteria: VALID_CRITERIA });
+
+    const project = await prisma.project.create({
+      data: { name: 'Test Project', key: 'TTMP160' },
+    });
+    const release = await prisma.release.create({
+      data: { name: 'rel-1', projectId: project.id, plannedDate: new Date('2026-06-01') },
+    });
+    await prisma.releaseCheckpoint.create({
+      data: {
+        releaseId: release.id,
+        checkpointTypeId: created.body.id,
+        criteriaSnapshot: VALID_CRITERIA,
+        offsetDaysSnapshot: -3,
+        deadline: new Date('2026-05-29'),
+      },
+    });
+
+    const res = await request
+      .delete(`/api/admin/checkpoint-types/${created.body.id}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('CHECKPOINT_TYPE_IN_USE');
+    expect(res.body.activeInstances).toHaveLength(1);
+    expect(res.body.activeInstances[0].releaseName).toBe('rel-1');
+  });
+});
+
+// ============================================================
+// /api/admin/checkpoint-templates
+// ============================================================
+
+async function createType(name: string, token = adminToken): Promise<string> {
+  const res = await request
+    .post('/api/admin/checkpoint-types')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ name, color: '#888888', offsetDays: 0, criteria: VALID_CRITERIA });
+  return res.body.id;
+}
+
+describe('POST /api/admin/checkpoint-templates', () => {
+  it('RELEASE_MANAGER can create a template', async () => {
+    const typeId = await createType('Freeze');
+    const res = await request
+      .post('/api/admin/checkpoint-templates')
+      .set('Authorization', `Bearer ${rmToken}`)
+      .send({ name: 'Standard', items: [{ checkpointTypeId: typeId, orderIndex: 0 }] });
+    expect(res.status).toBe(201);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.createdBy?.email).toBe('rm@ttmp160.test');
+  });
+
+  it('plain USER cannot create a template (403)', async () => {
+    const typeId = await createType('Freeze2');
+    const res = await request
+      .post('/api/admin/checkpoint-templates')
+      .set('Authorization', `Bearer ${plainToken}`)
+      .send({ name: 'Standard', items: [{ checkpointTypeId: typeId, orderIndex: 0 }] });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when referencing a missing type', async () => {
+    const res = await request
+      .post('/api/admin/checkpoint-templates')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        name: 'Broken',
+        items: [{ checkpointTypeId: '00000000-0000-0000-0000-000000000000', orderIndex: 0 }],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('CHECKPOINT_TYPES_NOT_FOUND');
+  });
+
+  it('returns 400 on duplicate types within a template', async () => {
+    const typeId = await createType('Once');
+    const res = await request
+      .post('/api/admin/checkpoint-templates')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        name: 'DupItems',
+        items: [
+          { checkpointTypeId: typeId, orderIndex: 0 },
+          { checkpointTypeId: typeId, orderIndex: 1 },
+        ],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Validation failed');
+  });
+
+  it('returns 409 on duplicate template name', async () => {
+    const typeId = await createType('DupName');
+    await request
+      .post('/api/admin/checkpoint-templates')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Same', items: [{ checkpointTypeId: typeId, orderIndex: 0 }] });
+    const dup = await request
+      .post('/api/admin/checkpoint-templates')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Same', items: [{ checkpointTypeId: typeId, orderIndex: 0 }] });
+    expect(dup.status).toBe(409);
+    expect(dup.body.error).toBe('CHECKPOINT_TEMPLATE_NAME_TAKEN');
+  });
+});
+
+describe('PATCH /api/admin/checkpoint-templates/:id', () => {
+  it('replaces items when items is provided', async () => {
+    const t1 = await createType('T1');
+    const t2 = await createType('T2');
+    const created = await request
+      .post('/api/admin/checkpoint-templates')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Patchable', items: [{ checkpointTypeId: t1, orderIndex: 0 }] });
+
+    const res = await request
+      .patch(`/api/admin/checkpoint-templates/${created.body.id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ items: [{ checkpointTypeId: t2, orderIndex: 0 }] });
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].checkpointTypeId).toBe(t2);
+  });
+});
+
+describe('POST /api/admin/checkpoint-templates/:id/clone', () => {
+  it('clones items with a default "(копия)" suffix', async () => {
+    const t1 = await createType('Cloned type');
+    const source = await request
+      .post('/api/admin/checkpoint-templates')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        name: 'Source',
+        description: 'src',
+        items: [{ checkpointTypeId: t1, orderIndex: 0 }],
+      });
+
+    const res = await request
+      .post(`/api/admin/checkpoint-templates/${source.body.id}/clone`)
+      .set('Authorization', `Bearer ${rmToken}`)
+      .send({});
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Source (копия)');
+    expect(res.body.description).toBe('src');
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].checkpointTypeId).toBe(t1);
+    expect(res.body.id).not.toBe(source.body.id);
+  });
+
+  it('honours a custom clone name', async () => {
+    const t1 = await createType('Ct-2');
+    const source = await request
+      .post('/api/admin/checkpoint-templates')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Src-2', items: [{ checkpointTypeId: t1, orderIndex: 0 }] });
+
+    const res = await request
+      .post(`/api/admin/checkpoint-templates/${source.body.id}/clone`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'My Clone' });
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('My Clone');
+  });
+});
+
+describe('DELETE /api/admin/checkpoint-templates/:id', () => {
+  it('deletes template and its items (cascade)', async () => {
+    const t1 = await createType('DelTemplate');
+    const created = await request
+      .post('/api/admin/checkpoint-templates')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'DelMe', items: [{ checkpointTypeId: t1, orderIndex: 0 }] });
+
+    const res = await request
+      .delete(`/api/admin/checkpoint-templates/${created.body.id}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+
+    const remaining = await prisma.checkpointTemplateItem.findMany({
+      where: { templateId: created.body.id },
+    });
+    expect(remaining).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **First PR** for TTMP-160 (Release Checkpoints module). Implements the *foundation* slice per [docs/tz/TTMP-160.md](../blob/main/docs/tz/TTMP-160.md) §13.3 PR-1 scope: Prisma schema + admin CRUD for CheckpointType and CheckpointTemplate. Engine, triggers, release-binding, burndown, and UI come in later PRs (PR-2 … PR-12).
- New tables: `checkpoint_types`, `checkpoint_templates`, `checkpoint_template_items`, `release_checkpoints`, `checkpoint_violation_events`, `release_burndown_snapshots` + enums `CheckpointWeight`, `CheckpointState`. Migration `20260422000000_release_checkpoints` is append-only (after the latest applied migration `20260421000001`; spec used `20260419` but that would predate already-deployed TTSEC-2 migrations).
- New endpoints mounted at `/api/admin/checkpoint-types/*` and `/api/admin/checkpoint-templates/*`. Gated by `requireRole(SUPER_ADMIN, ADMIN, RELEASE_MANAGER)` per SEC-1. Audit actions match §12.10.

## Design notes

- **FR-15 snapshot model** already in the schema: `ReleaseCheckpoint.criteriaSnapshot` / `offsetDaysSnapshot` + `applicableIssueIds` / `passedIssueIds` / `violations` / `violationsHash`. PR-1 only writes these in a test fixture; PR-2/PR-3 will drive them from the engine.
- **Template delete is unguarded** — snapshot copies decouple templates from live checkpoints, so deleting a template cannot corrupt running releases (intent noted in [checkpoint-templates.service.ts](../blob/ttmp-160/foundation/backend/src/modules/releases/checkpoints/checkpoint-templates.service.ts)).
- **Delete-type protection** checks `_count.releaseCheckpoints > 0` first (returns 409 with `activeInstances`), and also maps P2003 from the actual `delete` call to 409 to close the TOCTOU window.
- **Composite-unique protection**: template update catches P2002 on `(template_id, checkpoint_type_id)` and maps to 400, in case a future internal caller bypasses the DTO Zod refine.
- **StatusCategory**: DTO uses `z.nativeEnum(StatusCategory)` from `@prisma/client` so the criterion stays in sync with the Prisma enum.
- **Error helpers** extracted to [backend/src/shared/utils/prisma-errors.ts](../blob/ttmp-160/foundation/backend/src/shared/utils/prisma-errors.ts) (`isUniqueViolation`, `isForeignKeyViolation`) so future PRs can reuse.

## Out of scope (coming later)

- PR-2: engine + `evaluateCriterion`.
- PR-3: release-binding endpoints, apply-template, preview-template, recompute, breakdown N/M/K, inline `GET /api/issues/:id?include=checkpoints`.
- PR-4: cron scheduler + event hooks + Redis lock.
- PR-5+: admin UI, release/issue UI, board indicators, bulk-apply, webhook, audit page, matrix view, burndown.

## Test plan

- [x] `make lint` — passes (only pre-existing warnings).
- [x] `npx tsc --noEmit` — passes.
- [x] `make test` — all 398 tests green, including:
  - 19 Zod DTO unit tests (`tests/checkpoints-dto.unit.test.ts`)
  - 23 integration tests (`tests/checkpoints.test.ts`) covering RBAC 401/403/200 for SUPER_ADMIN / ADMIN / RELEASE_MANAGER / plain user, duplicate-name 409, in-use 409 with `activeInstances` payload, template clone with `(копия)` suffix and description copy, cascade delete of template items, audit-log persistence.

### Post-merge smoke (staging)

- `curl -X POST /api/admin/checkpoint-types` with RM token → creates.
- `curl GET /api/admin/checkpoint-types` → sees it.
- Create a template referencing that type; clone; delete — audit rows in `audit_logs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)