### PR TITLE
feat(checkpoints): TTMP-160 PR-2 — engine + evaluateCriterion

### DIFF
--- a/backend/src/modules/releases/checkpoints/checkpoint-engine.service.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint-engine.service.ts
@@ -1,0 +1,187 @@
+// TTMP-160 PR-2: per-checkpoint evaluator + release-risk aggregator.
+// Pure functions over pre-loaded data — no Prisma / Redis / Express dependencies here.
+// PR-3 wires DB loading + persistence; PR-4 drives scheduling.
+//
+// See docs/tz/TTMP-160.md §12.4 for the state machine and risk formula.
+
+import { createHash } from 'node:crypto';
+import type { CheckpointState, CheckpointWeight } from '@prisma/client';
+
+import type {
+  CheckpointCriterion,
+  CheckpointViolation,
+  CheckpointBreakdown,
+  ReleaseRisk,
+} from './checkpoint.types.js';
+import type { EvaluationContext, EvaluationIssue } from './evaluate-criterion.js';
+import { evaluateCriterion } from './evaluate-criterion.js';
+
+// ─── Checkpoint evaluation ───────────────────────────────────────────────────
+
+export interface CheckpointEvaluationInput {
+  // Checkpoint identity is the caller's concern — the engine works on the snapshotted
+  // criteria + deadline only (FR-15 keeps instance evaluation decoupled from the CheckpointType
+  // row, which may be edited after the checkpoint was applied).
+  criteria: CheckpointCriterion[];
+  deadline: Date;
+  warningDays: number;
+  issues: EvaluationIssue[];
+  context: EvaluationContext;
+}
+
+export interface CheckpointEvaluationResult {
+  state: CheckpointState;
+  // YELLOW tile on the traffic light: PENDING + deadline within warningDays + violations exist.
+  isWarning: boolean;
+  applicableIssueIds: string[];
+  passedIssueIds: string[];
+  violations: CheckpointViolation[];
+  // sha1 of the sorted-by-issueId violations payload — used by PR-3 to skip writes when a
+  // recompute yields the same result (§4 R-7 dedup).
+  violationsHash: string;
+  breakdown: CheckpointBreakdown;
+}
+
+export function evaluateCheckpoint(
+  input: CheckpointEvaluationInput,
+  now: Date,
+): CheckpointEvaluationResult {
+  const applicableIssueIds: string[] = [];
+  const passedIssueIds: string[] = [];
+  const violations: CheckpointViolation[] = [];
+
+  for (const issue of input.issues) {
+    const results = input.criteria.map((c) => evaluateCriterion(c, issue, input.context));
+    const applicableResults = results.filter((r) => r.applicable);
+    if (applicableResults.length === 0) continue;
+
+    applicableIssueIds.push(issue.id);
+
+    const failed = applicableResults.filter((r) => r.applicable && r.passed === false) as Array<
+      Extract<ReturnType<typeof evaluateCriterion>, { applicable: true; passed: false }>
+    >;
+
+    if (failed.length === 0) {
+      passedIssueIds.push(issue.id);
+      continue;
+    }
+
+    violations.push({
+      issueId: issue.id,
+      issueKey: issue.key,
+      issueTitle: issue.title,
+      // Concatenate human reasons so the violation row carries the full "why" in one field.
+      // criterionType takes the first failing criterion — good enough for filtering/analytics;
+      // the joined reason preserves detail.
+      reason: failed.map((f) => f.reason).join('; '),
+      criterionType: failed[0]!.criterionType,
+    });
+  }
+
+  const state = computeState(violations.length, input.deadline, now);
+  const isWarning = computeIsWarning(state, violations.length, input.deadline, input.warningDays, now);
+  const violationsHash = computeViolationsHash(violations);
+
+  return {
+    state,
+    isWarning,
+    applicableIssueIds,
+    passedIssueIds,
+    violations,
+    violationsHash,
+    breakdown: {
+      applicable: applicableIssueIds.length,
+      passed: passedIssueIds.length,
+      violated: violations.length,
+    },
+  };
+}
+
+function computeState(
+  violationsCount: number,
+  deadline: Date,
+  now: Date,
+): CheckpointState {
+  if (violationsCount === 0) return 'OK';
+  return now.getTime() >= deadline.getTime() ? 'VIOLATED' : 'PENDING';
+}
+
+function computeIsWarning(
+  state: CheckpointState,
+  violationsCount: number,
+  deadline: Date,
+  warningDays: number,
+  now: Date,
+): boolean {
+  if (state !== 'PENDING') return false;
+  if (violationsCount === 0) return false;
+  // Compare in whole days. `Math.ceil` ensures a 2h-before-deadline moment (0.083 days)
+  // rounds up to 1 day, so `1 <= warningDays` stays deterministic and matches the spec's
+  // integer-day intent. Fractional comparisons would flicker in/out of the warning band
+  // across sub-minute scheduler ticks.
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const daysUntil = Math.ceil((deadline.getTime() - now.getTime()) / msPerDay);
+  return daysUntil <= warningDays;
+}
+
+/**
+ * Deterministic fingerprint of a violation set — used by PR-3 to skip DB writes when a
+ * recompute produces the same semantic result (R-7 skip-write without diff).
+ *
+ * Only stable, user-meaningful fields contribute: `{ issueId, reason, criterionType }`.
+ * `issueKey` and `issueTitle` are intentionally excluded so that renaming an issue does not
+ * force a spurious write with no semantic change.
+ *
+ * An empty array returns `''` — same sentinel as the schema default on `violations_hash`.
+ * Callers MUST NOT use hash equality alone to infer "never evaluated"; use
+ * `lastEvaluatedAt IS NULL` for that.
+ */
+export function computeViolationsHash(violations: CheckpointViolation[]): string {
+  if (violations.length === 0) return '';
+  const sorted = [...violations].sort((a, b) => (a.issueId < b.issueId ? -1 : a.issueId > b.issueId ? 1 : 0));
+  const payload = JSON.stringify(
+    sorted.map((v) => ({
+      issueId: v.issueId,
+      reason: v.reason,
+      criterionType: v.criterionType,
+    })),
+  );
+  return createHash('sha1').update(payload).digest('hex');
+}
+
+// ─── Release-level risk ──────────────────────────────────────────────────────
+
+const WEIGHT_VALUES: Record<CheckpointWeight, number> = {
+  CRITICAL: 8,
+  HIGH: 4,
+  MEDIUM: 2,
+  LOW: 1,
+};
+
+export interface CheckpointForRisk {
+  weight: CheckpointWeight;
+  state: CheckpointState;
+}
+
+export function computeReleaseRisk(checkpoints: CheckpointForRisk[]): ReleaseRisk {
+  if (checkpoints.length === 0) return { score: 0, level: 'LOW' };
+
+  let total = 0;
+  let violated = 0;
+  for (const cp of checkpoints) {
+    const w = WEIGHT_VALUES[cp.weight];
+    total += w;
+    if (cp.state === 'VIOLATED') violated += w;
+  }
+
+  if (total === 0) return { score: 0, level: 'LOW' };
+  const score = violated / total;
+
+  let level: ReleaseRisk['level'];
+  if (score === 0) level = 'LOW';
+  else if (score <= 0.3) level = 'MEDIUM';
+  else if (score <= 0.7) level = 'HIGH';
+  else level = 'CRITICAL';
+
+  return { score, level };
+}

--- a/backend/src/modules/releases/checkpoints/evaluate-criterion.ts
+++ b/backend/src/modules/releases/checkpoints/evaluate-criterion.ts
@@ -1,0 +1,288 @@
+// TTMP-160 PR-2: pure per-issue criterion evaluator.
+// See docs/tz/TTMP-160.md §12.4 for the algorithm.
+//
+// The engine is decoupled from Prisma: callers (PR-3 loaders) normalise rows into
+// EvaluationIssue + EvaluationContext once per release. Keeping the function pure makes
+// unit tests fast and deterministic, and lets the scheduler (PR-4) batch-evaluate without
+// re-hitting the DB per criterion.
+
+import type { StatusCategory } from '@prisma/client';
+import type { CheckpointCriterion, CheckpointCriterionType } from './checkpoint.types.js';
+
+// ─── Engine input types ──────────────────────────────────────────────────────
+
+export interface EvaluationIssue {
+  id: string;
+  key: string;
+  title: string;
+  // systemKey of the IssueTypeConfig — null if the issue has no type (legacy rows).
+  issueTypeSystemKey: string | null;
+  statusCategory: StatusCategory;
+  statusName: string;
+  assigneeId: string | null;
+  dueDate: Date | null;
+  // customFieldId → parsed value. Missing keys mean "no row in issue_custom_field_values".
+  customFieldValues: Map<string, unknown>;
+  // customFieldId → field name, for reason strings. Optional: loader may omit to save time.
+  customFieldNames?: Map<string, string>;
+  subtasks: EvaluationSubtask[];
+  blockers: EvaluationBlocker[];
+}
+
+export interface EvaluationSubtask {
+  id: string;
+  key: string;
+  statusCategory: StatusCategory;
+}
+
+// One "blocker" = one outbound/inbound link (normalised by the loader) that causes
+// `this` issue to be blocked. `linkTypeKey` is a stable machine key the loader assigns to
+// the link type (e.g. 'BLOCKS'); criterion.linkTypeKeys filters on it.
+export interface EvaluationBlocker {
+  issueKey: string;
+  statusCategory: StatusCategory;
+  linkTypeKey: string;
+}
+
+export interface EvaluationContext {
+  // Anchor for DUE_BEFORE. Date-only (no time) semantics match Release.plannedDate @db.Date.
+  releasePlannedDate: Date;
+}
+
+// ─── Result ──────────────────────────────────────────────────────────────────
+
+export type CriterionEvaluation =
+  | { applicable: false }
+  | { applicable: true; passed: true }
+  | { applicable: true; passed: false; reason: string; criterionType: CheckpointCriterionType };
+
+// ─── Evaluator ───────────────────────────────────────────────────────────────
+
+export function evaluateCriterion(
+  criterion: CheckpointCriterion,
+  issue: EvaluationIssue,
+  context: EvaluationContext,
+): CriterionEvaluation {
+  // issueTypes filter — if set, the criterion only applies to issues whose type systemKey
+  // is in the allowlist. An issue with no systemKey (legacy rows with no IssueTypeConfig)
+  // is never matched by an allowlist — spec pseudocode assumes the relation is present,
+  // we fall through to applicable:false to model pre-IssueTypeConfig rows safely.
+  if (criterion.issueTypes && criterion.issueTypes.length > 0) {
+    if (issue.issueTypeSystemKey == null) return { applicable: false };
+    if (!criterion.issueTypes.includes(issue.issueTypeSystemKey)) return { applicable: false };
+  }
+
+  switch (criterion.type) {
+    case 'STATUS_IN':
+      return evalStatusIn(criterion, issue);
+    case 'DUE_BEFORE':
+      return evalDueBefore(criterion, issue, context);
+    case 'ASSIGNEE_SET':
+      return evalAssigneeSet(issue);
+    case 'CUSTOM_FIELD_VALUE':
+      return evalCustomFieldValue(criterion, issue);
+    case 'ALL_SUBTASKS_DONE':
+      return evalAllSubtasksDone(issue);
+    case 'NO_BLOCKING_LINKS':
+      return evalNoBlockingLinks(criterion, issue);
+  }
+}
+
+function evalStatusIn(
+  c: Extract<CheckpointCriterion, { type: 'STATUS_IN' }>,
+  issue: EvaluationIssue,
+): CriterionEvaluation {
+  if (c.categories.includes(issue.statusCategory)) {
+    return { applicable: true, passed: true };
+  }
+  return {
+    applicable: true,
+    passed: false,
+    criterionType: 'STATUS_IN',
+    reason: `Статус «${issue.statusName}» не входит в ${c.categories.join('/')}`,
+  };
+}
+
+function evalDueBefore(
+  c: Extract<CheckpointCriterion, { type: 'DUE_BEFORE' }>,
+  issue: EvaluationIssue,
+  context: EvaluationContext,
+): CriterionEvaluation {
+  const target = addDays(context.releasePlannedDate, c.days);
+  const targetStr = formatDateOnly(target);
+
+  if (issue.dueDate == null) {
+    return {
+      applicable: true,
+      passed: false,
+      criterionType: 'DUE_BEFORE',
+      reason: `Срок (dueDate) не задан, ожидается ≤ ${targetStr}`,
+    };
+  }
+  if (issue.dueDate.getTime() <= target.getTime()) {
+    return { applicable: true, passed: true };
+  }
+  return {
+    applicable: true,
+    passed: false,
+    criterionType: 'DUE_BEFORE',
+    reason: `Срок ${formatDateOnly(issue.dueDate)} позже ${targetStr}`,
+  };
+}
+
+function evalAssigneeSet(issue: EvaluationIssue): CriterionEvaluation {
+  if (issue.assigneeId != null) return { applicable: true, passed: true };
+  return {
+    applicable: true,
+    passed: false,
+    criterionType: 'ASSIGNEE_SET',
+    reason: 'Исполнитель не назначен',
+  };
+}
+
+function evalCustomFieldValue(
+  c: Extract<CheckpointCriterion, { type: 'CUSTOM_FIELD_VALUE' }>,
+  issue: EvaluationIssue,
+): CriterionEvaluation {
+  const fieldName = issue.customFieldNames?.get(c.customFieldId) ?? 'поле';
+  const has = issue.customFieldValues.has(c.customFieldId);
+  const value = has ? issue.customFieldValues.get(c.customFieldId) : undefined;
+
+  switch (c.operator) {
+    case 'NOT_EMPTY': {
+      if (isNonEmpty(value)) return { applicable: true, passed: true };
+      return {
+        applicable: true,
+        passed: false,
+        criterionType: 'CUSTOM_FIELD_VALUE',
+        reason: `Поле «${fieldName}» не заполнено`,
+      };
+    }
+    case 'EQUALS': {
+      // NOTE: deepEqual is order-sensitive for arrays. For MULTI_SELECT fields, the PR-3
+      // loader MUST sort array values canonically before placing them in customFieldValues
+      // to avoid phantom violations from non-semantic reordering of stored options.
+      if (deepEqual(value ?? null, c.value ?? null)) return { applicable: true, passed: true };
+      return {
+        applicable: true,
+        passed: false,
+        criterionType: 'CUSTOM_FIELD_VALUE',
+        reason: `Поле «${fieldName}»: ожидается ${stringifyValue(c.value)}, текущее ${stringifyValue(value)}`,
+      };
+    }
+    case 'IN': {
+      // Spec §12.4: `c.value.includes(val)` — SameValueZero, scalar match only. This keeps
+      // IN semantically distinct from EQUALS (which does deep-equal for structured values).
+      if (Array.isArray(c.value) && c.value.includes(value)) {
+        return { applicable: true, passed: true };
+      }
+      const allowed = Array.isArray(c.value) ? c.value.map(stringifyValue).join(', ') : '[]';
+      return {
+        applicable: true,
+        passed: false,
+        criterionType: 'CUSTOM_FIELD_VALUE',
+        reason: `Поле «${fieldName}»: значение ${stringifyValue(value)} не в [${allowed}]`,
+      };
+    }
+  }
+}
+
+function evalAllSubtasksDone(issue: EvaluationIssue): CriterionEvaluation {
+  if (issue.subtasks.length === 0) return { applicable: true, passed: true };
+  // Spec §12.4 pseudocode uses ['DONE','CANCELLED'] but the Prisma StatusCategory enum has
+  // only TODO/IN_PROGRESS/DONE — cancelled statuses are workflow statuses whose category is
+  // DONE (see backend/src/prisma/seed-workflow.ts), so `!== 'DONE'` correctly treats both
+  // completed and cancelled subtasks as "closed".
+  const openSubtasks = issue.subtasks.filter((s) => s.statusCategory !== 'DONE');
+  if (openSubtasks.length === 0) return { applicable: true, passed: true };
+  const keys = openSubtasks.map((s) => s.key).slice(0, 5);
+  const tail = openSubtasks.length > keys.length ? ` и ещё ${openSubtasks.length - keys.length}` : '';
+  return {
+    applicable: true,
+    passed: false,
+    criterionType: 'ALL_SUBTASKS_DONE',
+    reason: `Подзадачи не закрыты: ${keys.join(', ')}${tail}`,
+  };
+}
+
+function evalNoBlockingLinks(
+  c: Extract<CheckpointCriterion, { type: 'NO_BLOCKING_LINKS' }>,
+  issue: EvaluationIssue,
+): CriterionEvaluation {
+  const typeFilter =
+    c.linkTypeKeys && c.linkTypeKeys.length > 0 ? new Set(c.linkTypeKeys) : null;
+
+  const openBlockers = issue.blockers.filter((b) => {
+    if (typeFilter && !typeFilter.has(b.linkTypeKey)) return false;
+    // See evalAllSubtasksDone: cancelled = category DONE in the 3-value StatusCategory enum.
+    return b.statusCategory !== 'DONE';
+  });
+
+  if (openBlockers.length === 0) return { applicable: true, passed: true };
+  const keys = openBlockers.map((b) => b.issueKey).slice(0, 5);
+  const tail = openBlockers.length > keys.length ? ` и ещё ${openBlockers.length - keys.length}` : '';
+  return {
+    applicable: true,
+    passed: false,
+    criterionType: 'NO_BLOCKING_LINKS',
+    reason: `Блокируется незавершёнными: ${keys.join(', ')}${tail}`,
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function isNonEmpty(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === 'string') return value.length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const aKeys = Object.keys(ao);
+    const bKeys = Object.keys(bo);
+    if (aKeys.length !== bKeys.length) return false;
+    for (const k of aKeys) {
+      if (!deepEqual(ao[k], bo[k])) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+function stringifyValue(value: unknown): string {
+  if (value === undefined || value === null) return '∅';
+  if (typeof value === 'string') return `«${value}»`;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function addDays(base: Date, days: number): Date {
+  const d = new Date(base.getTime());
+  d.setUTCDate(d.getUTCDate() + days);
+  return d;
+}
+
+function formatDateOnly(d: Date): string {
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/backend/tests/checkpoint-engine.unit.test.ts
+++ b/backend/tests/checkpoint-engine.unit.test.ts
@@ -1,0 +1,774 @@
+/**
+ * TTMP-160 PR-2 — unit tests for the checkpoint engine.
+ *
+ * Coverage:
+ *   - evaluateCriterion: 6 types × (applicable / inapplicable / passed / failed / edge) cases
+ *   - evaluateCheckpoint: state transitions (OK / PENDING / VIOLATED) + isWarning window
+ *                        + applicable/passed/violated breakdown + violationsHash stability
+ *   - computeReleaseRisk: empty, all-ok, weight-weighted bands (LOW/MEDIUM/HIGH/CRITICAL)
+ *
+ * No DB, no HTTP — fully deterministic, fast.
+ */
+import { describe, expect, it } from 'vitest';
+import type { CheckpointCriterion } from '../src/modules/releases/checkpoints/checkpoint.types.js';
+import { evaluateCriterion } from '../src/modules/releases/checkpoints/evaluate-criterion.js';
+import type {
+  EvaluationContext,
+  EvaluationIssue,
+} from '../src/modules/releases/checkpoints/evaluate-criterion.js';
+import {
+  computeReleaseRisk,
+  computeViolationsHash,
+  evaluateCheckpoint,
+} from '../src/modules/releases/checkpoints/checkpoint-engine.service.js';
+
+type CheckpointForRiskLocal = Parameters<typeof computeReleaseRisk>[0][number];
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const RELEASE_DATE = new Date('2026-05-30T00:00:00Z');
+const CONTEXT: EvaluationContext = { releasePlannedDate: RELEASE_DATE };
+
+function issue(overrides: Partial<EvaluationIssue> = {}): EvaluationIssue {
+  return {
+    id: overrides.id ?? 'i1',
+    key: overrides.key ?? 'TTMP-1',
+    title: overrides.title ?? 'Task',
+    issueTypeSystemKey: overrides.issueTypeSystemKey ?? 'TASK',
+    statusCategory: overrides.statusCategory ?? 'IN_PROGRESS',
+    statusName: overrides.statusName ?? 'В работе',
+    assigneeId: overrides.assigneeId === undefined ? 'u1' : overrides.assigneeId,
+    dueDate: overrides.dueDate === undefined ? null : overrides.dueDate,
+    customFieldValues: overrides.customFieldValues ?? new Map(),
+    customFieldNames: overrides.customFieldNames,
+    subtasks: overrides.subtasks ?? [],
+    blockers: overrides.blockers ?? [],
+  };
+}
+
+// ─── issueTypes filter ───────────────────────────────────────────────────────
+
+describe('evaluateCriterion — issueTypes filter', () => {
+  const c: CheckpointCriterion = {
+    type: 'ASSIGNEE_SET',
+    issueTypes: ['BUG'],
+  };
+
+  it('returns applicable=false when issueTypes is set and issue type is not in list', () => {
+    const r = evaluateCriterion(c, issue({ issueTypeSystemKey: 'TASK' }), CONTEXT);
+    expect(r.applicable).toBe(false);
+  });
+
+  it('returns applicable=false when issue has no systemKey but filter is set', () => {
+    const r = evaluateCriterion(c, issue({ issueTypeSystemKey: null }), CONTEXT);
+    expect(r.applicable).toBe(false);
+  });
+
+  it('evaluates normally when issueTypes is undefined', () => {
+    const nc: CheckpointCriterion = { type: 'ASSIGNEE_SET' };
+    const r = evaluateCriterion(nc, issue({ issueTypeSystemKey: null, assigneeId: null }), CONTEXT);
+    expect(r.applicable).toBe(true);
+    if (r.applicable) expect(r.passed).toBe(false);
+  });
+});
+
+// ─── STATUS_IN ───────────────────────────────────────────────────────────────
+
+describe('evaluateCriterion — STATUS_IN', () => {
+  const c: CheckpointCriterion = { type: 'STATUS_IN', categories: ['DONE'] };
+
+  it('passes when status category is in the list', () => {
+    const r = evaluateCriterion(c, issue({ statusCategory: 'DONE' }), CONTEXT);
+    expect(r).toEqual({ applicable: true, passed: true });
+  });
+
+  it('fails with a human-readable reason when status is outside the list', () => {
+    const r = evaluateCriterion(
+      c,
+      issue({ statusCategory: 'IN_PROGRESS', statusName: 'В работе' }),
+      CONTEXT,
+    );
+    if (!r.applicable || r.passed !== false) throw new Error('expected failure');
+    expect(r.criterionType).toBe('STATUS_IN');
+    expect(r.reason).toContain('В работе');
+    expect(r.reason).toContain('DONE');
+  });
+
+  it('multiple categories: passes if issue is in any of them', () => {
+    const multi: CheckpointCriterion = {
+      type: 'STATUS_IN',
+      categories: ['DONE', 'IN_PROGRESS'],
+    };
+    const r = evaluateCriterion(multi, issue({ statusCategory: 'IN_PROGRESS' }), CONTEXT);
+    expect(r.applicable && r.passed).toBe(true);
+  });
+
+  it('multiple categories: fails if issue is TODO', () => {
+    const multi: CheckpointCriterion = {
+      type: 'STATUS_IN',
+      categories: ['DONE', 'IN_PROGRESS'],
+    };
+    const r = evaluateCriterion(multi, issue({ statusCategory: 'TODO' }), CONTEXT);
+    expect(r.applicable && r.passed === false).toBe(true);
+  });
+});
+
+// ─── DUE_BEFORE ──────────────────────────────────────────────────────────────
+
+describe('evaluateCriterion — DUE_BEFORE', () => {
+  it('passes when dueDate equals plannedDate + days', () => {
+    const c: CheckpointCriterion = { type: 'DUE_BEFORE', days: -3 };
+    const r = evaluateCriterion(c, issue({ dueDate: new Date('2026-05-27T00:00:00Z') }), CONTEXT);
+    expect(r).toEqual({ applicable: true, passed: true });
+  });
+
+  it('passes when dueDate is earlier than plannedDate + days', () => {
+    const c: CheckpointCriterion = { type: 'DUE_BEFORE', days: 0 };
+    const r = evaluateCriterion(c, issue({ dueDate: new Date('2026-05-01T00:00:00Z') }), CONTEXT);
+    expect(r.applicable && r.passed).toBe(true);
+  });
+
+  it('fails when dueDate is later than plannedDate + days', () => {
+    const c: CheckpointCriterion = { type: 'DUE_BEFORE', days: 0 };
+    const r = evaluateCriterion(c, issue({ dueDate: new Date('2026-06-10T00:00:00Z') }), CONTEXT);
+    if (!r.applicable || r.passed !== false) throw new Error('expected failure');
+    expect(r.reason).toMatch(/2026-06-10/);
+    expect(r.reason).toMatch(/2026-05-30/);
+  });
+
+  it('fails with explicit reason when dueDate is null', () => {
+    const c: CheckpointCriterion = { type: 'DUE_BEFORE', days: -7 };
+    const r = evaluateCriterion(c, issue({ dueDate: null }), CONTEXT);
+    if (!r.applicable || r.passed !== false) throw new Error('expected failure');
+    expect(r.reason).toContain('не задан');
+    expect(r.reason).toContain('2026-05-23');
+  });
+
+  it('handles positive day offsets (post-release windows)', () => {
+    const c: CheckpointCriterion = { type: 'DUE_BEFORE', days: 7 };
+    const r = evaluateCriterion(c, issue({ dueDate: new Date('2026-06-06T00:00:00Z') }), CONTEXT);
+    expect(r.applicable && r.passed).toBe(true);
+  });
+});
+
+// ─── ASSIGNEE_SET ────────────────────────────────────────────────────────────
+
+describe('evaluateCriterion — ASSIGNEE_SET', () => {
+  const c: CheckpointCriterion = { type: 'ASSIGNEE_SET' };
+
+  it('passes when assigneeId is non-null', () => {
+    expect(evaluateCriterion(c, issue({ assigneeId: 'u1' }), CONTEXT)).toEqual({
+      applicable: true,
+      passed: true,
+    });
+  });
+
+  it('fails when assigneeId is null', () => {
+    const r = evaluateCriterion(c, issue({ assigneeId: null }), CONTEXT);
+    if (!r.applicable || r.passed !== false) throw new Error('expected failure');
+    expect(r.reason).toContain('Исполнитель');
+  });
+});
+
+// ─── CUSTOM_FIELD_VALUE ──────────────────────────────────────────────────────
+
+describe('evaluateCriterion — CUSTOM_FIELD_VALUE', () => {
+  const FIELD_ID = '11111111-1111-1111-1111-111111111111';
+
+  describe('NOT_EMPTY', () => {
+    const c: CheckpointCriterion = {
+      type: 'CUSTOM_FIELD_VALUE',
+      customFieldId: FIELD_ID,
+      operator: 'NOT_EMPTY',
+    };
+
+    it('passes for a non-empty string', () => {
+      const r = evaluateCriterion(
+        c,
+        issue({ customFieldValues: new Map([[FIELD_ID, 'x']]) }),
+        CONTEXT,
+      );
+      expect(r.applicable && r.passed).toBe(true);
+    });
+
+    it('fails for missing key', () => {
+      const r = evaluateCriterion(c, issue({ customFieldValues: new Map() }), CONTEXT);
+      expect(r.applicable && r.passed === false).toBe(true);
+    });
+
+    it('fails for null value', () => {
+      const r = evaluateCriterion(
+        c,
+        issue({ customFieldValues: new Map([[FIELD_ID, null]]) }),
+        CONTEXT,
+      );
+      expect(r.applicable && r.passed === false).toBe(true);
+    });
+
+    it('fails for empty string', () => {
+      const r = evaluateCriterion(
+        c,
+        issue({ customFieldValues: new Map([[FIELD_ID, '']]) }),
+        CONTEXT,
+      );
+      expect(r.applicable && r.passed === false).toBe(true);
+    });
+
+    it('fails for empty array (MULTI_SELECT)', () => {
+      const r = evaluateCriterion(
+        c,
+        issue({ customFieldValues: new Map([[FIELD_ID, []]]) }),
+        CONTEXT,
+      );
+      expect(r.applicable && r.passed === false).toBe(true);
+    });
+
+    it('passes for boolean false (FR: present ≠ empty)', () => {
+      const r = evaluateCriterion(
+        c,
+        issue({ customFieldValues: new Map([[FIELD_ID, false]]) }),
+        CONTEXT,
+      );
+      expect(r.applicable && r.passed).toBe(true);
+    });
+
+    it('uses the field name in the reason when provided', () => {
+      const r = evaluateCriterion(
+        c,
+        issue({
+          customFieldValues: new Map([[FIELD_ID, null]]),
+          customFieldNames: new Map([[FIELD_ID, 'Regression Status']]),
+        }),
+        CONTEXT,
+      );
+      if (!r.applicable || r.passed !== false) throw new Error('expected failure');
+      expect(r.reason).toContain('Regression Status');
+    });
+  });
+
+  describe('EQUALS', () => {
+    it('passes for primitive match', () => {
+      const c: CheckpointCriterion = {
+        type: 'CUSTOM_FIELD_VALUE',
+        customFieldId: FIELD_ID,
+        operator: 'EQUALS',
+        value: 'PASSED',
+      };
+      const r = evaluateCriterion(
+        c,
+        issue({ customFieldValues: new Map([[FIELD_ID, 'PASSED']]) }),
+        CONTEXT,
+      );
+      expect(r.applicable && r.passed).toBe(true);
+    });
+
+    it('fails for primitive mismatch', () => {
+      const c: CheckpointCriterion = {
+        type: 'CUSTOM_FIELD_VALUE',
+        customFieldId: FIELD_ID,
+        operator: 'EQUALS',
+        value: 'PASSED',
+      };
+      const r = evaluateCriterion(
+        c,
+        issue({ customFieldValues: new Map([[FIELD_ID, 'FAILED']]) }),
+        CONTEXT,
+      );
+      expect(r.applicable && r.passed === false).toBe(true);
+    });
+
+    it('passes for array match (same order)', () => {
+      const c: CheckpointCriterion = {
+        type: 'CUSTOM_FIELD_VALUE',
+        customFieldId: FIELD_ID,
+        operator: 'EQUALS',
+        value: ['a', 'b'],
+      };
+      const r = evaluateCriterion(
+        c,
+        issue({ customFieldValues: new Map([[FIELD_ID, ['a', 'b']]]) }),
+        CONTEXT,
+      );
+      expect(r.applicable && r.passed).toBe(true);
+    });
+
+    it('fails for array mismatch (different order, strict deep-equals)', () => {
+      const c: CheckpointCriterion = {
+        type: 'CUSTOM_FIELD_VALUE',
+        customFieldId: FIELD_ID,
+        operator: 'EQUALS',
+        value: ['a', 'b'],
+      };
+      const r = evaluateCriterion(
+        c,
+        issue({ customFieldValues: new Map([[FIELD_ID, ['b', 'a']]]) }),
+        CONTEXT,
+      );
+      expect(r.applicable && r.passed === false).toBe(true);
+    });
+  });
+
+  describe('IN', () => {
+    const c: CheckpointCriterion = {
+      type: 'CUSTOM_FIELD_VALUE',
+      customFieldId: FIELD_ID,
+      operator: 'IN',
+      value: ['PASSED', 'SKIPPED'],
+    };
+
+    it('passes when value is in the allowed list', () => {
+      const r = evaluateCriterion(
+        c,
+        issue({ customFieldValues: new Map([[FIELD_ID, 'SKIPPED']]) }),
+        CONTEXT,
+      );
+      expect(r.applicable && r.passed).toBe(true);
+    });
+
+    it('fails when value is not in the allowed list', () => {
+      const r = evaluateCriterion(
+        c,
+        issue({ customFieldValues: new Map([[FIELD_ID, 'FAILED']]) }),
+        CONTEXT,
+      );
+      expect(r.applicable && r.passed === false).toBe(true);
+    });
+
+    it('fails with a readable reason when value is missing', () => {
+      const r = evaluateCriterion(c, issue({ customFieldValues: new Map() }), CONTEXT);
+      if (!r.applicable || r.passed !== false) throw new Error('expected failure');
+      expect(r.reason).toContain('PASSED');
+      expect(r.reason).toContain('SKIPPED');
+    });
+
+    it('uses === (SameValueZero) semantics, not deep-equal, for array members', () => {
+      // Spec: `c.value.includes(val)`. Object values in the allowlist require reference
+      // equality, not structural equality — EQUALS is the operator for structural match.
+      const objC: CheckpointCriterion = {
+        type: 'CUSTOM_FIELD_VALUE',
+        customFieldId: FIELD_ID,
+        operator: 'IN',
+        value: [{ id: 'opt1' }],
+      };
+      const r = evaluateCriterion(
+        objC,
+        issue({ customFieldValues: new Map([[FIELD_ID, { id: 'opt1' }]]) }),
+        CONTEXT,
+      );
+      // Different object references, so `.includes` returns false.
+      expect(r.applicable && r.passed === false).toBe(true);
+    });
+  });
+});
+
+// ─── ALL_SUBTASKS_DONE ───────────────────────────────────────────────────────
+
+describe('evaluateCriterion — ALL_SUBTASKS_DONE', () => {
+  const c: CheckpointCriterion = { type: 'ALL_SUBTASKS_DONE' };
+
+  it('passes when there are no subtasks', () => {
+    const r = evaluateCriterion(c, issue({ subtasks: [] }), CONTEXT);
+    expect(r.applicable && r.passed).toBe(true);
+  });
+
+  it('passes when every subtask is DONE', () => {
+    const r = evaluateCriterion(
+      c,
+      issue({
+        subtasks: [
+          { id: 's1', key: 'S-1', statusCategory: 'DONE' },
+          { id: 's2', key: 'S-2', statusCategory: 'DONE' },
+        ],
+      }),
+      CONTEXT,
+    );
+    expect(r.applicable && r.passed).toBe(true);
+  });
+
+  it('fails when any subtask is not DONE', () => {
+    const r = evaluateCriterion(
+      c,
+      issue({
+        subtasks: [
+          { id: 's1', key: 'S-1', statusCategory: 'DONE' },
+          { id: 's2', key: 'S-2', statusCategory: 'IN_PROGRESS' },
+        ],
+      }),
+      CONTEXT,
+    );
+    if (!r.applicable || r.passed !== false) throw new Error('expected failure');
+    expect(r.reason).toContain('S-2');
+  });
+
+  it('truncates the list in the reason to 5 keys + "и ещё N"', () => {
+    const subtasks = Array.from({ length: 8 }).map((_, i) => ({
+      id: `s${i}`,
+      key: `S-${i}`,
+      statusCategory: 'TODO' as const,
+    }));
+    const r = evaluateCriterion(c, issue({ subtasks }), CONTEXT);
+    if (!r.applicable || r.passed !== false) throw new Error('expected failure');
+    expect(r.reason).toContain('и ещё 3');
+  });
+});
+
+// ─── NO_BLOCKING_LINKS ───────────────────────────────────────────────────────
+
+describe('evaluateCriterion — NO_BLOCKING_LINKS', () => {
+  const c: CheckpointCriterion = { type: 'NO_BLOCKING_LINKS' };
+
+  it('passes when there are no blockers', () => {
+    const r = evaluateCriterion(c, issue({ blockers: [] }), CONTEXT);
+    expect(r.applicable && r.passed).toBe(true);
+  });
+
+  it('passes when all blockers are DONE', () => {
+    const r = evaluateCriterion(
+      c,
+      issue({
+        blockers: [
+          { issueKey: 'TTMP-2', statusCategory: 'DONE', linkTypeKey: 'BLOCKS' },
+          { issueKey: 'TTMP-3', statusCategory: 'DONE', linkTypeKey: 'BLOCKS' },
+        ],
+      }),
+      CONTEXT,
+    );
+    expect(r.applicable && r.passed).toBe(true);
+  });
+
+  it('fails when any blocker is open', () => {
+    const r = evaluateCriterion(
+      c,
+      issue({
+        blockers: [{ issueKey: 'TTMP-5', statusCategory: 'IN_PROGRESS', linkTypeKey: 'BLOCKS' }],
+      }),
+      CONTEXT,
+    );
+    if (!r.applicable || r.passed !== false) throw new Error('expected failure');
+    expect(r.reason).toContain('TTMP-5');
+  });
+
+  it('applies linkTypeKeys filter to ignore non-matching types', () => {
+    const filtered: CheckpointCriterion = {
+      type: 'NO_BLOCKING_LINKS',
+      linkTypeKeys: ['BLOCKS'],
+    };
+    const r = evaluateCriterion(
+      filtered,
+      issue({
+        blockers: [
+          // Open blocker under a non-filtered type — ignored.
+          { issueKey: 'TTMP-7', statusCategory: 'IN_PROGRESS', linkTypeKey: 'RELATES' },
+        ],
+      }),
+      CONTEXT,
+    );
+    expect(r.applicable && r.passed).toBe(true);
+  });
+
+  it('truncates blocker list to 5 keys + "и ещё N"', () => {
+    const blockers = Array.from({ length: 7 }).map((_, i) => ({
+      issueKey: `TTMP-${100 + i}`,
+      statusCategory: 'IN_PROGRESS' as const,
+      linkTypeKey: 'BLOCKS',
+    }));
+    const r = evaluateCriterion(c, issue({ blockers }), CONTEXT);
+    if (!r.applicable || r.passed !== false) throw new Error('expected failure');
+    expect(r.reason).toContain('и ещё 2');
+  });
+});
+
+// ─── evaluateCheckpoint — integration of criteria + state ────────────────────
+
+describe('evaluateCheckpoint', () => {
+  const STATUS_IN_DONE: CheckpointCriterion = { type: 'STATUS_IN', categories: ['DONE'] };
+
+  it('empty applicable set → OK with zero breakdown', () => {
+    const r = evaluateCheckpoint(
+      {
+        criteria: [{ type: 'ASSIGNEE_SET', issueTypes: ['BUG'] }],
+        deadline: new Date('2026-05-23T00:00:00Z'),
+        warningDays: 3,
+        issues: [issue({ issueTypeSystemKey: 'TASK' })],
+        context: CONTEXT,
+      },
+      new Date('2026-05-20T00:00:00Z'),
+    );
+    expect(r.state).toBe('OK');
+    expect(r.breakdown).toEqual({ applicable: 0, passed: 0, violated: 0 });
+    expect(r.isWarning).toBe(false);
+    expect(r.violationsHash).toBe('');
+  });
+
+  it('all applicable issues pass → OK', () => {
+    const r = evaluateCheckpoint(
+      {
+        criteria: [STATUS_IN_DONE],
+        deadline: new Date('2026-05-23T00:00:00Z'),
+        warningDays: 3,
+        issues: [
+          issue({ id: 'a', key: 'A-1', statusCategory: 'DONE' }),
+          issue({ id: 'b', key: 'B-1', statusCategory: 'DONE' }),
+        ],
+        context: CONTEXT,
+      },
+      new Date('2026-05-20T00:00:00Z'),
+    );
+    expect(r.state).toBe('OK');
+    expect(r.breakdown).toEqual({ applicable: 2, passed: 2, violated: 0 });
+    expect(r.passedIssueIds).toEqual(['a', 'b']);
+  });
+
+  it('pre-deadline with violations → PENDING (not yet VIOLATED)', () => {
+    const r = evaluateCheckpoint(
+      {
+        criteria: [STATUS_IN_DONE],
+        deadline: new Date('2026-05-23T00:00:00Z'),
+        warningDays: 3,
+        issues: [issue({ id: 'x', key: 'X-1', statusCategory: 'IN_PROGRESS' })],
+        context: CONTEXT,
+      },
+      new Date('2026-05-10T00:00:00Z'),
+    );
+    expect(r.state).toBe('PENDING');
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0]!.issueKey).toBe('X-1');
+  });
+
+  it('post-deadline with violations → VIOLATED', () => {
+    const r = evaluateCheckpoint(
+      {
+        criteria: [STATUS_IN_DONE],
+        deadline: new Date('2026-05-23T00:00:00Z'),
+        warningDays: 3,
+        issues: [issue({ id: 'x', key: 'X-1', statusCategory: 'IN_PROGRESS' })],
+        context: CONTEXT,
+      },
+      new Date('2026-05-25T00:00:00Z'),
+    );
+    expect(r.state).toBe('VIOLATED');
+    expect(r.isWarning).toBe(false);
+  });
+
+  it('isWarning=true: PENDING + within warningDays + violations exist', () => {
+    const r = evaluateCheckpoint(
+      {
+        criteria: [STATUS_IN_DONE],
+        deadline: new Date('2026-05-23T00:00:00Z'),
+        warningDays: 3,
+        issues: [issue({ statusCategory: 'IN_PROGRESS' })],
+        context: CONTEXT,
+      },
+      new Date('2026-05-22T00:00:00Z'), // 1 day before
+    );
+    expect(r.state).toBe('PENDING');
+    expect(r.isWarning).toBe(true);
+  });
+
+  it('isWarning=false when outside warningDays window', () => {
+    const r = evaluateCheckpoint(
+      {
+        criteria: [STATUS_IN_DONE],
+        deadline: new Date('2026-05-23T00:00:00Z'),
+        warningDays: 3,
+        issues: [issue({ statusCategory: 'IN_PROGRESS' })],
+        context: CONTEXT,
+      },
+      new Date('2026-05-15T00:00:00Z'), // 8 days before
+    );
+    expect(r.isWarning).toBe(false);
+  });
+
+  it('AND across criteria: one failing criterion marks the issue violated', () => {
+    const r = evaluateCheckpoint(
+      {
+        criteria: [STATUS_IN_DONE, { type: 'ASSIGNEE_SET' }],
+        deadline: new Date('2026-05-23T00:00:00Z'),
+        warningDays: 3,
+        issues: [
+          // status OK, assignee null → violates because of ASSIGNEE_SET
+          issue({ id: 'x', key: 'X', statusCategory: 'DONE', assigneeId: null }),
+        ],
+        context: CONTEXT,
+      },
+      new Date('2026-05-20T00:00:00Z'),
+    );
+    expect(r.breakdown).toEqual({ applicable: 1, passed: 0, violated: 1 });
+    expect(r.violations[0]!.criterionType).toBe('ASSIGNEE_SET');
+  });
+
+  it('concatenates reasons when multiple criteria fail on the same issue', () => {
+    const r = evaluateCheckpoint(
+      {
+        criteria: [STATUS_IN_DONE, { type: 'ASSIGNEE_SET' }],
+        deadline: new Date('2026-05-23T00:00:00Z'),
+        warningDays: 3,
+        issues: [
+          issue({ id: 'x', key: 'X', statusCategory: 'IN_PROGRESS', assigneeId: null }),
+        ],
+        context: CONTEXT,
+      },
+      new Date('2026-05-20T00:00:00Z'),
+    );
+    expect(r.violations[0]!.reason).toContain(';');
+    expect(r.violations[0]!.reason).toMatch(/Статус|Исполнитель/);
+  });
+
+  it('excludes inapplicable issues from the applicable set', () => {
+    const r = evaluateCheckpoint(
+      {
+        criteria: [{ type: 'ASSIGNEE_SET', issueTypes: ['BUG'] }],
+        deadline: new Date('2026-05-23T00:00:00Z'),
+        warningDays: 3,
+        issues: [
+          issue({ id: 'bug1', issueTypeSystemKey: 'BUG', assigneeId: 'u1' }),
+          issue({ id: 'task1', issueTypeSystemKey: 'TASK', assigneeId: null }),
+        ],
+        context: CONTEXT,
+      },
+      new Date('2026-05-20T00:00:00Z'),
+    );
+    expect(r.applicableIssueIds).toEqual(['bug1']);
+    expect(r.passedIssueIds).toEqual(['bug1']);
+  });
+});
+
+// ─── violationsHash stability ────────────────────────────────────────────────
+
+describe('computeViolationsHash', () => {
+  it('returns an empty string for no violations', () => {
+    expect(computeViolationsHash([])).toBe('');
+  });
+
+  it('is stable across permutations of the input', () => {
+    const a = {
+      issueId: 'i1',
+      issueKey: 'A',
+      issueTitle: 'T',
+      reason: 'r',
+      criterionType: 'STATUS_IN' as const,
+    };
+    const b = {
+      issueId: 'i2',
+      issueKey: 'B',
+      issueTitle: 'T',
+      reason: 'r',
+      criterionType: 'STATUS_IN' as const,
+    };
+    expect(computeViolationsHash([a, b])).toBe(computeViolationsHash([b, a]));
+  });
+
+  it('differs when the reason text changes', () => {
+    const base = {
+      issueId: 'i1',
+      issueKey: 'A',
+      issueTitle: 'T',
+      reason: 'r',
+      criterionType: 'STATUS_IN' as const,
+    };
+    const mutated = { ...base, reason: 'different' };
+    expect(computeViolationsHash([base])).not.toBe(computeViolationsHash([mutated]));
+  });
+
+  it('is insensitive to issueKey/issueTitle changes (avoid spurious writes on rename)', () => {
+    const base = {
+      issueId: 'i1',
+      issueKey: 'OLD-1',
+      issueTitle: 'Old title',
+      reason: 'r',
+      criterionType: 'STATUS_IN' as const,
+    };
+    const renamed = { ...base, issueKey: 'NEW-42', issueTitle: 'New title' };
+    expect(computeViolationsHash([base])).toBe(computeViolationsHash([renamed]));
+  });
+});
+
+// ─── computeReleaseRisk ──────────────────────────────────────────────────────
+
+describe('computeReleaseRisk', () => {
+  it('empty checkpoint set → LOW, score 0', () => {
+    expect(computeReleaseRisk([])).toEqual({ score: 0, level: 'LOW' });
+  });
+
+  it('all OK → LOW, score 0', () => {
+    expect(
+      computeReleaseRisk([
+        { weight: 'CRITICAL', state: 'OK' },
+        { weight: 'HIGH', state: 'OK' },
+      ]),
+    ).toEqual({ score: 0, level: 'LOW' });
+  });
+
+  it('PENDING without VIOLATED → LOW', () => {
+    expect(
+      computeReleaseRisk([
+        { weight: 'HIGH', state: 'PENDING' },
+        { weight: 'MEDIUM', state: 'OK' },
+      ]),
+    ).toEqual({ score: 0, level: 'LOW' });
+  });
+
+  it('any non-zero violation ratio exits LOW (single LOW violation in 100 LOW checkpoints)', () => {
+    const many: CheckpointForRiskLocal[] = Array.from({ length: 100 }).map(() => ({
+      weight: 'LOW',
+      state: 'OK',
+    }));
+    many[0]!.state = 'VIOLATED';
+    const r = computeReleaseRisk(many);
+    expect(r.score).toBe(0.01);
+    expect(r.level).toBe('MEDIUM');
+  });
+
+  it('MEDIUM band: a low-weight violation inside a heavy set', () => {
+    // total = 8 + 1 = 9; violated = 1; score ≈ 0.111 → MEDIUM
+    const r = computeReleaseRisk([
+      { weight: 'CRITICAL', state: 'OK' },
+      { weight: 'LOW', state: 'VIOLATED' },
+    ]);
+    expect(r.level).toBe('MEDIUM');
+    expect(r.score).toBeCloseTo(1 / 9, 5);
+  });
+
+  it('HIGH band: violation ratio inside (0.30, 0.70]', () => {
+    // total = 4 + 2 = 6; violated = 2; score ≈ 0.333 → HIGH
+    const r = computeReleaseRisk([
+      { weight: 'HIGH', state: 'OK' },
+      { weight: 'MEDIUM', state: 'VIOLATED' },
+    ]);
+    expect(r.level).toBe('HIGH');
+  });
+
+  it('CRITICAL band: violation ratio > 0.70', () => {
+    const r = computeReleaseRisk([
+      { weight: 'CRITICAL', state: 'VIOLATED' },
+      { weight: 'LOW', state: 'OK' },
+    ]);
+    // 8 / 9 ≈ 0.888 → CRITICAL
+    expect(r.level).toBe('CRITICAL');
+  });
+
+  it('CRITICAL band: all checkpoints violated → score 1.0', () => {
+    const r = computeReleaseRisk([
+      { weight: 'HIGH', state: 'VIOLATED' },
+      { weight: 'LOW', state: 'VIOLATED' },
+    ]);
+    expect(r.score).toBe(1);
+    expect(r.level).toBe('CRITICAL');
+  });
+
+  it('boundary: score exactly 0.30 lands in MEDIUM, 0.70 in HIGH', () => {
+    // 2 MEDIUM + 2 HIGH + 1 CRITICAL — violated: one MEDIUM → 2/18 = 0.111 (MEDIUM).
+    // Explicit exact boundary test: need score === 0.30. 3/10 = 0.30.
+    // Weight LOW=1, MEDIUM=2. Build 10 LOWs with 3 VIOLATED.
+    const ten = Array.from({ length: 10 }).map<CheckpointForRiskLocal>(() => ({
+      weight: 'LOW',
+      state: 'OK',
+    }));
+    for (let i = 0; i < 3; i++) ten[i]!.state = 'VIOLATED';
+    expect(computeReleaseRisk(ten).level).toBe('MEDIUM');
+
+    // 7/10 = 0.70 → HIGH
+    for (let i = 3; i < 7; i++) ten[i]!.state = 'VIOLATED';
+    expect(computeReleaseRisk(ten).level).toBe('HIGH');
+  });
+});


### PR DESCRIPTION
> Stacked on top of #79 (PR-1 foundation). **Merge #79 first.** Once the base branch moves to `main`, this PR's diff will shrink to just the engine files.

## Summary

- Pure-function engine on top of the PR-1 schema. Evaluates the 6 criterion types (`STATUS_IN`, `DUE_BEFORE`, `ASSIGNEE_SET`, `CUSTOM_FIELD_VALUE` × `NOT_EMPTY|EQUALS|IN`, `ALL_SUBTASKS_DONE`, `NO_BLOCKING_LINKS`) into pass/fail + Russian reason strings, aggregates into checkpoint state (`OK` / `PENDING` / `VIOLATED`), and computes release risk (`LOW` / `MEDIUM` / `HIGH` / `CRITICAL`).
- **No DB, no HTTP.** Callers in PR-3 will load rows once and call into this engine. That keeps the algorithm unit-testable in milliseconds and lets the PR-4 scheduler batch-evaluate without re-hitting Postgres per criterion.
- 60 unit tests (~7 ms total), all branches + boundary values + hash stability.

## Design highlights

- **`CANCELLED` note** — the Prisma `StatusCategory` enum has only `TODO` / `IN_PROGRESS` / `DONE`; cancelled workflow statuses are modelled as workflow-status rows under `category = DONE` (see `seed-workflow.ts`). So `category !== 'DONE'` correctly treats cancelled subtasks and blockers as closed. The spec pseudocode uses `[DONE, CANCELLED]` which maps 1:1 onto our enum — code matches intent.
- **`violationsHash`** intentionally excludes `issueKey` and `issueTitle`. Renaming an issue should not force a DB write when no violation changed. PR-3 dedup relies on this for R-7.
- **`isWarning`** compares using `Math.ceil(daysUntil)` so the warning band does not flicker between sub-minute scheduler ticks. Spec intent is integer-day.
- **`IN` vs `EQUALS`** — `IN` uses `Array.prototype.includes` (SameValueZero) per spec, keeping it distinct from `EQUALS` (deep-equal). Array `EQUALS` is order-sensitive; the PR-3 loader contract is to canonically sort `MULTI_SELECT` array values before handing them to the engine (noted inline).
- **`issueTypes` filter** — a criterion with an `issueTypes` allowlist on an issue with `null` `issueTypeSystemKey` returns `applicable: false` (safely handles legacy rows with no `IssueTypeConfig`).

## What this PR is NOT

- No router, no service wiring to Prisma, no migration, no UI.
- No cron scheduler, no Redis lock.
- No integration tests — the engine is pure and has no side effects to observe.

All those land in PR-3 (release binding), PR-4 (triggers), PR-6 (UI) per TTMP-160.md §13.3.

## Test plan

- [x] `make lint` — clean (only pre-existing warnings).
- [x] `npx tsc --noEmit` — clean.
- [x] `SKIP_DB_SETUP=1 npx vitest run tests/checkpoint-engine.unit.test.ts` — 60 / 60 in 7 ms.
- [x] `make test` on the full suite (458 tests across 35 files) — green.

### Pre-push review round summary

Ran the pre-push reviewer. All HIGH / MEDIUM items addressed before push:
- `isWarning` → `Math.ceil` days.
- `violationsHash` drops `issueKey` / `issueTitle`; new rename-insensitivity test added.
- `IN` operator switched to `includes` (`===`); new test for object-allowlist non-match.
- Reviewer's `CANCELLED` HIGHs were based on the 4-value enum in the spec pseudocode; resolved by documenting the 3-value Prisma reality in-code.
- Type alias moved to top of the test file.
- Added boundary test: single violation in 100 LOW checkpoints lands in `MEDIUM`.
- Added `JSDoc` on `computeViolationsHash` documenting the `''` sentinel contract (freshly-applied vs clean-evaluated require `lastEvaluatedAt IS NULL` check, not hash equality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
