### PR TITLE
docs(tz): синхронизация docs/tz — TTMP-160.json, TTUI-90, TTSRH-1

### DIFF
--- a/docs/tz/TTMP-160.json
+++ b/docs/tz/TTMP-160.json
@@ -1,0 +1,216 @@
+{
+  "key": "TTMP-160",
+  "title": "Модуль контрольных точек релизов",
+  "generatedAt": "2026-04-18T11:30:00.000Z",
+  "updatedAt": "2026-04-18T12:15:00.000Z",
+  "version": "v4 (+ zero-context impl details §12 + PR plan §13)",
+  "generatedBy": "claude-code",
+  "source": {
+    "apiUrl": "http://5.129.242.171:8080/api",
+    "issueId": "29a09ec2-bb96-4a27-8dc7-9908faa37e76",
+    "fetchedAt": "2026-04-18T11:30:00.000Z"
+  },
+  "issue": {
+    "type": "EPIC",
+    "status": "OPEN",
+    "priority": "HIGH",
+    "project": "TTMP",
+    "assignee": null,
+    "creator": "Admin User",
+    "estimatedHours": 126,
+    "description": "См. docs/tz/TTMP-160.md",
+    "acceptanceCriteria": "См. docs/tz/TTMP-160.md §7"
+  },
+  "dependencies": {
+    "backendModules": [
+      "releases (new subdir checkpoints/, new burndown.service)",
+      "issues (hook in updateIssue / bulk* / custom-field setter)",
+      "custom-fields (read-only metadata + blocked delete when used)",
+      "workflow-engine (reuse ValidatorRule format; extend post-functions with CHECKPOINT_WEBHOOK)",
+      "shared/redis (acquireLock for scheduler + debounce state + burndown cache)",
+      "shared/config (new env vars CHECKPOINTS_SCHEDULER_*, BURNDOWN_*)",
+      "admin (new audit page)"
+    ],
+    "frontendComponents": [
+      "GlobalReleasesPage.tsx (risk badge, CheckpointsBlock, filter, sort, bulk-apply, Burndown tab)",
+      "ReleasesPage.tsx",
+      "IssueDetailPage.tsx (grouped CheckpointsBlock + history block)",
+      "BoardPage.tsx + ProjectDetailPage.tsx (IssueCheckpointIndicator)",
+      "DashboardPage.tsx + TimePage.tsx (my-issues-at-risk filter)",
+      "layout/TopBar.tsx (violation badge)",
+      "pages/admin/AdminReleaseCheckpointTypesPage.tsx",
+      "pages/admin/AdminReleaseCheckpointTemplatesPage.tsx",
+      "pages/admin/AdminCheckpointAuditPage.tsx",
+      "components/releases/CheckpointTrafficLight.tsx (a11y)",
+      "components/releases/ReleaseRiskBadge.tsx",
+      "components/releases/CheckpointsBlock.tsx (с разбивкой N/M/K)",
+      "components/releases/CheckpointsMatrix.tsx (FR-26)",
+      "components/releases/ApplyCheckpointTemplateModal.tsx (с превью)",
+      "components/releases/CheckpointRiskFilter.tsx",
+      "components/releases/ReleaseBurndownChart.tsx (FR-29, FR-30, Recharts)",
+      "components/issues/IssueCheckpointIndicator.tsx",
+      "api/release-checkpoints.ts, api/release-checkpoint-types.ts, api/release-checkpoint-templates.ts, api/release-burndown.ts",
+      "types/release.types.ts (Checkpoint*, BurndownSnapshot, BurndownSeries)"
+    ],
+    "prismaModels": [
+      "CheckpointType",
+      "CheckpointTemplate",
+      "CheckpointTemplateItem",
+      "ReleaseCheckpoint (+ criteriaSnapshot, offsetDaysSnapshot, violationsHash, applicableIssueIds, passedIssueIds)",
+      "CheckpointViolationEvent",
+      "ReleaseBurndownSnapshot (FR-28)",
+      "enum CheckpointWeight",
+      "enum CheckpointState"
+    ],
+    "externalPackages": [
+      "node-cron (MIT, для двух cron-джобов: КТ и burndown)",
+      "recharts (MIT, для burndown-диаграммы)",
+      "axe-core (Playwright, a11y)"
+    ],
+    "blockers": []
+  },
+  "risks": [
+    { "id": 1, "description": "N+1 при массовых обновлениях", "probability": "HIGH", "mitigation": "Агрегация по releaseId." },
+    { "id": 2, "description": "Гонки cron между инстансами", "probability": "MEDIUM", "mitigation": "Redis lock 300s." },
+    { "id": 3, "description": "Смена plannedDate → устаревшие deadlines", "probability": "MEDIUM", "mitigation": "updateRelease → recompute." },
+    { "id": 4, "description": "Удалённая задача в violations", "probability": "LOW", "mitigation": "removeReleaseItems → recompute." },
+    { "id": 5, "description": "Удалённое CustomField в критерии", "probability": "LOW", "mitigation": "Блокировка удаления поля 409." },
+    { "id": 6, "description": "Перегрузка cron", "probability": "LOW", "mitigation": "Окно ±30d + пагинация 50." },
+    { "id": 7, "description": "Двойной пересчёт cron+event", "probability": "MEDIUM", "mitigation": "violationsHash diff-skip." },
+    { "id": 8, "description": "Расширение ValidatorRule ломает workflow", "probability": "LOW", "mitigation": "Отдельный union CheckpointCriterion." },
+    { "id": 9, "description": "Ретроспективное редактирование типа КТ", "probability": "HIGH", "mitigation": "FR-15 snapshot в ReleaseCheckpoint." },
+    { "id": 10, "description": "Лишний запрос на IssueDetailPage", "probability": "MEDIUM", "mitigation": "FR-19 inline include." },
+    { "id": 11, "description": "Webhook flapping", "probability": "MEDIUM", "mitigation": "FR-17 debounce minStableSeconds=300." },
+    { "id": 12, "description": "A11y светофора", "probability": "MEDIUM", "mitigation": "FR-18 цвет+иконка+текст." },
+    { "id": 13, "description": "Неограниченный рост burndown-снапшотов", "probability": "MEDIUM", "mitigation": "FR-32: 90d после DONE + weekly-aggregation после 365d." },
+    { "id": 14, "description": "Burndown без достоверного initial для старых релизов", "probability": "MEDIUM", "mitigation": "Initial = max(createdAt, now-30d); пометка даты старта снапшотов в UI." },
+    { "id": 15, "description": "Пересчёт applicable/passed для больших релизов — O(N×M)", "probability": "LOW", "mitigation": "Храним только ID; UI тянет title пачкой; Redis-кэш 60s." }
+  ],
+  "requirements": {
+    "functional": {
+      "core_mvp": [
+        "FR-1: CRUD типов КТ",
+        "FR-2: CRUD шаблонов + clone",
+        "FR-3: Применение шаблона к релизу + CRUD КТ на релизе + ручной recompute",
+        "FR-4: state/deadline/violations/lastEvaluatedAt",
+        "FR-5: Бейдж риска + список КТ со светофором",
+        "FR-6: Блок применимых КТ на задаче",
+        "FR-7: Cron + event-hook триггеры",
+        "FR-8: Риск sum(weight_violated)/sum(weight_all) → LOW/MEDIUM/HIGH/CRITICAL",
+        "FR-9: 6 типов критериев",
+        "FR-10: Аудит всех действий"
+      ],
+      "ux_phase_2": [
+        "FR-11: Индикатор на карточке задачи",
+        "FR-12: TopBar badge + DashboardPage фильтр",
+        "FR-13: Фильтр/сортировка релизов по риску",
+        "FR-14: Preview-template",
+        "FR-15: Snapshot criteria + offsetDays",
+        "FR-16: Human-readable reason + inline-actions",
+        "FR-17: CHECKPOINT_WEBHOOK с debounce",
+        "FR-18: A11y светофора",
+        "FR-19: Inline ?include=checkpoints",
+        "FR-20: Группировка КТ по релизу на задаче",
+        "FR-21: Bulk-apply шаблона",
+        "FR-22: История КТ на задаче",
+        "FR-23: /admin/checkpoint-audit + CSV",
+        "FR-24: AND между критериями"
+      ],
+      "rm_visibility": [
+        "FR-25: Разбивка N applicable / M passed / K violated в CheckpointsBlock",
+        "FR-26: Матричный вид «Задачи × КТ» с CSV",
+        "FR-27: Расширенный GET /checkpoints с passedIssues/violatedIssues"
+      ],
+      "burndown": [
+        "FR-28: Ежедневный снапшот в ReleaseBurndownSnapshot (cron 5 0 * * *)",
+        "FR-29: GET /api/releases/:id/burndown?metric=issues|hours|violations",
+        "FR-30: UI Burndown-диаграммы (вкладка в DetailPanel, Recharts, переключатель метрики)",
+        "FR-31: POST /burndown/backfill (ADMIN)",
+        "FR-32: Политика хранения (90d после DONE + weekly agg после 365d)"
+      ]
+    },
+    "nonFunctional": [
+      "API < 200ms p95",
+      "recomputeForRelease < 500ms для 200 задач × 10 КТ",
+      "Cron-тик ≤ 100 ms подряд event-loop",
+      "Event-hook не увеличивает p95 PATCH /issues/:id > 20ms",
+      "Burndown GET < 300ms с Redis-cache",
+      "Матрица с 500 задач × 10 КТ: виртуализация, рендер < 200ms"
+    ],
+    "security": [
+      "SEC-1: Типы/шаблоны — только SUPER_ADMIN/ADMIN/RELEASE_MANAGER",
+      "SEC-2: КТ на релизе — RELEASE_MANAGER или ProjectPermission.RELEASE_MANAGE",
+      "SEC-3: violations без PII",
+      "SEC-4: CustomField delete блокируется 409",
+      "SEC-5: apply-bulk per-release RBAC",
+      "SEC-6: /admin/checkpoint-audit только AUDITOR+",
+      "SEC-7: TopBar badge — только свои",
+      "SEC-8: burndown backfill — только ADMIN/SUPER_ADMIN",
+      "SEC-9: CSV без PII (только key/title/status)"
+    ]
+  },
+  "estimation": {
+    "analysis": 4,
+    "backend": 56,
+    "frontend": 56,
+    "testing": 14,
+    "review": 8,
+    "documentation": 4,
+    "total": 126
+  },
+  "phases": {
+    "phase1_mvp_hours": 79,
+    "phase1_stories": ["S-1", "S-2", "S-3", "S-4", "S-5", "S-6", "S-11 (basic)"],
+    "phase2_extension_hours": 47,
+    "phase2_stories": ["S-7", "S-8", "S-9 matrix", "S-10 burndown", "S-11 (finalize)"]
+  },
+  "stories": [
+    { "id": "S-1", "title": "DB + CRUD типов/шаблонов (snapshot, events)", "hours": 10 },
+    { "id": "S-2", "title": "Движок критериев + human reason + breakdown", "hours": 10 },
+    { "id": "S-3", "title": "Привязка к релизу + риск + превью + inline + breakdown API", "hours": 14 },
+    { "id": "S-4", "title": "Cron + event-hooks + debounce", "hours": 8 },
+    { "id": "S-5", "title": "Админ-UI (типы, шаблоны, превью, sync)", "hours": 15 },
+    { "id": "S-6", "title": "UI релиза и задачи (светофор, N/M/K, группировка, история)", "hours": 16 },
+    { "id": "S-7", "title": "Индикаторы в карточках + TopBar + DashboardPage", "hours": 8 },
+    { "id": "S-8", "title": "Bulk-apply + webhook + аудит-страница + CSV", "hours": 10 },
+    { "id": "S-9", "title": "Матрица «Задачи × КТ» + CSV", "hours": 8 },
+    { "id": "S-10", "title": "Burndown (model, cron, API, Recharts)", "hours": 16 },
+    { "id": "S-11", "title": "E2E + a11y + документация по ролям + features/burndown.md", "hours": 11 }
+  ],
+  "roles": {
+    "SUPER_ADMIN": ["CRUD всего", "sync-instances", "backfill burndown", "аудит", "recompute"],
+    "ADMIN": ["CRUD всего", "sync-instances", "backfill burndown", "аудит", "recompute"],
+    "RELEASE_MANAGER": [
+      "CRUD типов/шаблонов",
+      "Применение (одиночное и bulk)",
+      "Разбивка N/M/K для каждой КТ",
+      "Матрица «Задачи × КТ»",
+      "Burndown-диаграмма (3 метрики)",
+      "Ручной recompute"
+    ],
+    "MANAGER": [
+      "Применить готовый шаблон к своему ATOMIC-релизу",
+      "Удалить КТ",
+      "Ручной recompute",
+      "Burndown своих релизов (read-only)"
+    ],
+    "MEMBER_USER": [
+      "Блок КТ на своих задачах",
+      "Красная полоска на карточке",
+      "TopBar badge",
+      "Фильтр 'Мои в риске'",
+      "Burndown релиза (read-only)"
+    ],
+    "AUDITOR": [
+      "Просмотр /admin/checkpoint-audit",
+      "CSV-экспорт",
+      "Burndown всех релизов (read-only)"
+    ]
+  },
+  "relatedIssues": {
+    "parent": null,
+    "children": [],
+    "blocks": [],
+    "dependsOn": ["TTMP-140", "TTMP-223"]
+  }
+}

--- a/docs/tz/TTSRH-1-goldenset.jql
+++ b/docs/tz/TTSRH-1-goldenset.jql
@@ -1,0 +1,187 @@
+-- TTSRH-1 Golden-set JQL
+-- Каждый запрос ДОЛЖЕН успешно парситься, валидироваться и выполняться на тестовом сиде.
+-- Блокирует merge PR'ов по TTSRH-1.
+
+-- ─── 1. Мои задачи / фокус ────────────────────────────────────────────────
+-- 01
+assignee = currentUser() AND statusCategory != DONE ORDER BY priority DESC, updated DESC
+-- 02
+assignee = currentUser() AND status = "REVIEW" AND updated < "-3d"
+-- 03
+myOpenIssues() ORDER BY due ASC
+-- 04
+assignee = currentUser() AND due <= today() AND statusCategory != DONE
+
+-- ─── 2. Просрочки / дедлайны ──────────────────────────────────────────────
+-- 05
+due < now() AND statusCategory != DONE ORDER BY due ASC
+-- 06
+due >= startOfWeek() AND due <= endOfWeek() AND assignee = currentUser()
+-- 07
+due IS NOT EMPTY AND priority IN (CRITICAL, HIGH) ORDER BY due ASC, priority DESC
+
+-- ─── 3. Спринты ───────────────────────────────────────────────────────────
+-- 08
+sprint in openSprints() AND statusCategory != DONE ORDER BY priority DESC
+-- 09
+sprint IS EMPTY AND status = OPEN AND project = "TTMP"
+-- 10
+sprint in futureSprints() AND project IN (TTMP, TTUI)
+
+-- ─── 4. Релизы / версии ───────────────────────────────────────────────────
+-- 11
+release = "v2.5.0" AND statusCategory = DONE
+-- 12
+release in unreleasedVersions("TTMP") AND priority = CRITICAL
+-- 13
+release = earliestUnreleasedVersion("TTMP")
+
+-- ─── 5. Кастомные поля ────────────────────────────────────────────────────
+-- 14
+"Story Points" > 5 AND sprint in openSprints()
+-- 15
+"Story Points" IS EMPTY AND priority = HIGH
+-- 16
+cf[12345678-1234-1234-1234-123456789abc] = "Done" AND project = "TTMP"
+-- 17
+"Business Value" >= 50 AND "Effort" <= 13 ORDER BY "Business Value" DESC
+
+-- ─── 6. Связи ─────────────────────────────────────────────────────────────
+-- 18
+issue in linkedIssues("TTMP-42", "blocks") AND statusCategory != DONE
+-- 19
+issue in subtasksOf("TTMP-10")
+-- 20
+issue in epicIssues("TTMP-1") AND statusCategory != DONE
+
+-- ─── 7. Логика / группы ───────────────────────────────────────────────────
+-- 21
+NOT (status = DONE OR status = CANCELLED) AND assignee = currentUser()
+-- 22
+(priority = CRITICAL OR (priority = HIGH AND due <= "7d")) AND statusCategory != DONE
+-- 23
+assignee in membersOf("flow-team-1") AND due < now() AND statusCategory != DONE
+-- 24
+assignee IS EMPTY AND priority IN (CRITICAL, HIGH) AND project IN (TTMP, TTUI, TTSEC)
+
+-- ─── 8. Текстовый поиск ───────────────────────────────────────────────────
+-- 25
+summary ~ "аутентификация" OR description ~ "аутентификация"
+-- 26
+comment ~ "LGTM" AND updated >= "-1d"
+-- 27
+summary !~ "[DRAFT]" AND statusCategory != DONE
+
+-- ─── 9. Типы / статусы / приоритеты ───────────────────────────────────────
+-- 28
+type = EPIC AND statusCategory != DONE
+-- 29
+type IN (BUG, INCIDENT) AND priority = CRITICAL
+-- 30
+status IN ("Blocked", "Waiting for review") AND project = "TTMP"
+
+-- ─── 10. Время ────────────────────────────────────────────────────────────
+-- 31
+timeSpent > 8 AND assignee = currentUser()
+-- 32
+estimatedHours IS EMPTY AND priority = CRITICAL
+-- 33
+timeRemaining < 0 AND statusCategory = IN_PROGRESS
+
+-- ─── 11. Даты (абсолютные и относительные) ────────────────────────────────
+-- 34
+created >= startOfWeek() AND created < endOfWeek()
+-- 35
+created >= "2026-01-01" AND created < "2026-04-01"
+-- 36
+updated >= "-7d" AND assignee = currentUser()
+-- 37
+resolvedAt >= startOfMonth("-1M") AND resolvedAt < startOfMonth()
+
+-- ─── 12. AI-флаги ─────────────────────────────────────────────────────────
+-- 38
+aiEligible = true AND aiAssigneeType = AGENT AND statusCategory != DONE
+-- 39
+aiStatus = FAILED AND aiEligible = true
+
+-- ─── 13. Labels ───────────────────────────────────────────────────────────
+-- 40
+labels in ("backend", "security") AND statusCategory != DONE
+-- 41
+labels IS EMPTY AND priority = CRITICAL
+
+-- ─── 14. Иерархия ─────────────────────────────────────────────────────────
+-- 42
+parent IS EMPTY AND type IN (TASK, STORY) AND statusCategory != DONE
+-- 43
+epic = "TTMP-10" ORDER BY priority DESC
+-- 44
+hasChildren = true AND statusCategory = DONE AND type != EPIC
+
+-- ─── 15. Комплексные ──────────────────────────────────────────────────────
+-- 45
+project IN (TTMP, TTUI, TTSEC) AND assignee in membersOf("backend-guild")
+  AND priority IN (CRITICAL, HIGH) AND statusCategory != DONE
+  AND sprint in openSprints()
+  ORDER BY priority DESC, due ASC, updated DESC
+-- 46
+(assignee = currentUser() OR reporter = currentUser())
+  AND updated >= "-14d" AND statusCategory != DONE
+-- 47
+"Story Points" > 3 AND "Story Points" <= 8
+  AND sprint in openSprints() AND assignee IS EMPTY
+-- 48
+type = BUG AND priority = CRITICAL AND (labels in ("p0", "hotfix") OR due <= "2d")
+  AND statusCategory != DONE
+-- 49
+NOT (project = "ARCHIVE") AND reporter in membersOf("qa-team")
+  AND created >= startOfMonth() ORDER BY created DESC
+-- 50
+release = latestReleasedVersion("TTMP") AND type = BUG AND statusCategory != DONE
+  ORDER BY priority DESC
+
+-- ─── 16. Нарушения контрольных точек (КТ) ────────────────────────────────
+-- 51: Все задачи с активными нарушениями КТ
+issue in violatedCheckpoints() ORDER BY priority DESC
+
+-- 52: Задачи с нарушением конкретного типа КТ
+issue in violatedCheckpoints("Go-live")
+
+-- 53: То же через булев алиас
+hasCheckpointViolation = true AND assignee = currentUser()
+
+-- 54: Нарушения в конкретном релизе
+issue in violatedCheckpointsOf("REL-2.5.0")
+
+-- 55: Нарушения в релизе, только по типу «Code review»
+issue in violatedCheckpointsOf("REL-2.5.0", "Code review")
+
+-- 56: Задачи в релизах, где КТ в состоянии WARNING/OVERDUE/ERROR
+issue in checkpointsAtRisk()
+
+-- 57: То же, но только по типу «Release readiness»
+issue in checkpointsAtRisk("Release readiness")
+
+-- 58: Задачи в релизах с просроченными КТ
+issue in checkpointsInState(OVERDUE)
+
+-- 59: Мои задачи, нарушающие КТ «Deploy»
+assignee = currentUser() AND issue in violatedCheckpoints("Deploy")
+
+-- 60: Фильтр по типу нарушения (несколько)
+checkpointViolationType IN ("Go-live", "Deploy", "Release readiness")
+  AND priority IN (CRITICAL, HIGH)
+  ORDER BY priority DESC, due ASC
+
+-- 61: Поиск по причине нарушения
+checkpointViolationReason ~ "Срок задачи" AND statusCategory != DONE
+
+-- 62: Критичные задачи, не нарушающие КТ (для отчёта «всё ОК»)
+priority = CRITICAL AND hasCheckpointViolation = false
+  AND statusCategory != DONE
+
+-- 63: Комплекс: мои блокеры в просроченных КТ релиза
+assignee = currentUser()
+  AND issue in violatedCheckpointsOf("REL-2.5.0")
+  AND (priority = CRITICAL OR labels IN ("blocker"))
+  ORDER BY priority DESC, due ASC

--- a/docs/tz/TTSRH-1.json
+++ b/docs/tz/TTSRH-1.json
@@ -1,0 +1,356 @@
+{
+  "key": "TTSRH-1",
+  "title": "Внутренний язык запросов TTS-QL (JQL-совместимый) + страница поиска задач с сохраняемыми фильтрами",
+  "generatedAt": "2026-04-18T00:00:00.000Z",
+  "generatedBy": "claude-code",
+  "source": {
+    "basedOn": [
+      "backend/src/modules/issues/issues.router.ts",
+      "backend/src/modules/issues/issues.service.ts",
+      "backend/src/prisma/schema.prisma",
+      "frontend/src/components/layout/Sidebar.tsx",
+      "frontend/src/App.tsx",
+      "frontend/src/pages/ProjectDetailPage.tsx",
+      "docs/tz/TTUI-90.md"
+    ],
+    "analysedAt": "2026-04-18T00:00:00.000Z"
+  },
+  "issue": {
+    "type": "STORY",
+    "status": "OPEN",
+    "priority": "HIGH",
+    "project": "TTSRH",
+    "assignee": null,
+    "creator": "drashkinson@gmail.com",
+    "estimatedHours": 278,
+    "description": "Реализовать декларативный язык TTS-QL, максимально совместимый с JQL. Вынести поиск задач в отдельный пункт меню. UI — в UX-модели Jira Issue Navigator: basic/advanced, конфигурируемые колонки, сохраняемые фильтры, приватность/шаринг, избранное.",
+    "acceptanceCriteria": "См. раздел 7 TTSRH-1.md (Definition of Done)."
+  },
+  "currentStateIssues": [
+    {"id": "P1", "problem": "GET /issues/search ограничен подстрочным поиском по title/key (50 строк), только для связывания"},
+    {"id": "P2", "problem": "GET /projects/:id/issues требует projectId, поддерживает только AND/equals/IN для плоского набора полей"},
+    {"id": "P3", "problem": "Нет кросс-проектного продвинутого поиска"},
+    {"id": "P4", "problem": "Кастомные поля не участвуют в фильтрах"},
+    {"id": "P5", "problem": "Связи (IssueLink) не используются в поиске"},
+    {"id": "P6", "problem": "Фильтр нельзя сохранить, нет шаринга, нет избранного"},
+    {"id": "P7", "problem": "Нельзя настраивать колонки результата (включая custom fields)"},
+    {"id": "P8", "problem": "Нет модели SavedFilter / UserPreferences в Prisma"},
+    {"id": "P9", "problem": "Нет пункта «Поиск задач» в сайдбаре"}
+  ],
+  "queryLanguage": {
+    "name": "TTS-QL",
+    "compatibility": "JQL (JIRA Query Language) — максимальное покрытие операторов, функций, полей",
+    "grammarFile": "docs/tz/TTSRH-1.md#51-грамматика-tts-ql-ebnf",
+    "operators": [
+      {"op": "=", "types": ["all"]},
+      {"op": "!=", "types": ["all"]},
+      {"op": ">", "types": ["NUMBER", "DATE", "DATETIME"]},
+      {"op": ">=", "types": ["NUMBER", "DATE", "DATETIME"]},
+      {"op": "<", "types": ["NUMBER", "DATE", "DATETIME"]},
+      {"op": "<=", "types": ["NUMBER", "DATE", "DATETIME"]},
+      {"op": "~", "types": ["TEXT"], "note": "contains (ILIKE)"},
+      {"op": "!~", "types": ["TEXT"]},
+      {"op": "IN", "types": ["all"]},
+      {"op": "NOT IN", "types": ["all"]},
+      {"op": "IS EMPTY", "types": ["all nullable"]},
+      {"op": "IS NOT EMPTY", "types": ["all nullable"]},
+      {"op": "WAS", "types": ["Status"], "phase": 2},
+      {"op": "WAS NOT", "types": ["Status"], "phase": 2},
+      {"op": "WAS IN", "types": ["Status"], "phase": 2},
+      {"op": "WAS NOT IN", "types": ["Status"], "phase": 2},
+      {"op": "CHANGED", "types": ["any trackable"], "phase": 2},
+      {"op": "CHANGED FROM", "types": ["any trackable"], "phase": 2},
+      {"op": "CHANGED TO", "types": ["any trackable"], "phase": 2},
+      {"op": "CHANGED AFTER", "types": ["any trackable"], "phase": 2},
+      {"op": "CHANGED BEFORE", "types": ["any trackable"], "phase": 2},
+      {"op": "CHANGED ON", "types": ["any trackable"], "phase": 2},
+      {"op": "CHANGED DURING", "types": ["any trackable"], "phase": 2},
+      {"op": "CHANGED BY", "types": ["any trackable"], "phase": 2}
+    ],
+    "logicalOperators": ["AND", "OR", "NOT", "parentheses"],
+    "precedence": "NOT > AND > OR",
+    "orderBy": "ORDER BY field [ASC|DESC] (, field [ASC|DESC])*",
+    "fields": [
+      "project", "key", "summary", "description", "status", "statusCategory",
+      "priority", "type", "assignee", "reporter", "sprint", "release",
+      "parent", "epic", "due", "created", "updated", "resolvedAt",
+      "estimatedHours", "timeSpent", "timeRemaining",
+      "aiEligible", "aiStatus", "aiAssigneeType",
+      "labels", "comment", "orderIndex", "linkedIssue", "hasChildren",
+      "customField:cf[UUID]", "customField:\"Имя\""
+    ],
+    "functions": {
+      "mvp": [
+        "currentUser()",
+        "membersOf(\"group\")",
+        "now()", "today()",
+        "startOfDay([offset])", "endOfDay([offset])",
+        "startOfWeek([offset])", "endOfWeek([offset])",
+        "startOfMonth([offset])", "endOfMonth([offset])",
+        "startOfYear([offset])", "endOfYear([offset])",
+        "openSprints()", "closedSprints()", "futureSprints()",
+        "unreleasedVersions([project])", "releasedVersions([project])",
+        "earliestUnreleasedVersion([project])", "latestReleasedVersion([project])",
+        "linkedIssues(key[, linkType])", "subtasksOf(key)", "epicIssues(key)",
+        "myOpenIssues()",
+        "violatedCheckpoints([typeName])",
+        "violatedCheckpointsOf(releaseKeyOrId[, typeName])",
+        "checkpointsAtRisk([typeName])",
+        "checkpointsInState(state[, typeName])",
+        "releasePlannedDate() — checkpoint-context only",
+        "checkpointDeadline() — checkpoint-context only"
+      ],
+      "phase2": [
+        "watchedIssues()", "votedIssues()", "lastLogin()"
+      ]
+    }
+  },
+  "dependencies": {
+    "backendModules": [
+      {"name": "search (новый)", "files": [
+        "search.parser.ts", "search.ast.ts", "search.validator.ts",
+        "search.compiler.ts", "search.functions.ts", "search.schema.ts",
+        "search.suggest.ts", "search.service.ts", "search.router.ts"
+      ]},
+      {"name": "saved-filters (новый)", "files": [
+        "saved-filters.dto.ts", "saved-filters.service.ts", "saved-filters.router.ts"
+      ]},
+      {"name": "users", "change": "расширение: preferences JSON + PATCH /users/me/preferences"}
+    ],
+    "frontendComponents": [
+      "pages/SearchPage.tsx",
+      "components/search/JqlEditor.tsx",
+      "components/search/BasicFilterBuilder.tsx",
+      "components/search/FilterModeToggle.tsx",
+      "components/search/SavedFiltersSidebar.tsx",
+      "components/search/SaveFilterModal.tsx",
+      "components/search/FilterShareModal.tsx",
+      "components/search/ColumnConfigurator.tsx",
+      "components/search/ResultsTable.tsx",
+      "components/search/BulkActionsBar.tsx",
+      "components/search/ExportMenu.tsx",
+      "components/search/ValidationErrorBanner.tsx",
+      "store/savedFilters.store.ts",
+      "store/search.store.ts",
+      "api/search.ts",
+      "api/savedFilters.ts"
+    ],
+    "prismaChanges": [
+      "model SavedFilter { ownerId, name, description, jql, visibility, columns JSON, isFavorite, lastUsedAt, useCount }",
+      "model SavedFilterShare { filterId, userId?, groupId?, permission }",
+      "enum FilterVisibility { PRIVATE SHARED PUBLIC }",
+      "enum FilterPermission { READ WRITE }",
+      "User.preferences Json? — дефолтные колонки поиска",
+      "CheckpointType.ttqlCondition String? @db.Text — ADDITIVE к существующему criteria Json",
+      "CheckpointType.conditionMode CheckpointConditionMode @default(STRUCTURED)",
+      "enum CheckpointConditionMode { STRUCTURED TTQL COMBINED }",
+      "ReleaseCheckpoint.ttqlSnapshot String? @db.Text",
+      "ReleaseCheckpoint.conditionModeSnapshot CheckpointConditionMode @default(STRUCTURED)"
+    ],
+    "externalPackages": [
+      "@codemirror/state", "@codemirror/view", "@codemirror/language",
+      "@codemirror/autocomplete", "@codemirror/search",
+      "papaparse (если не установлен — для CSV)"
+    ],
+    "blockers": []
+  },
+  "risks": [
+    {"id": "R1", "risk": "SQL-инъекция через JQL", "probability": "MEDIUM", "impact": "CRITICAL", "mitigation": "Типизированный AST + Prisma.sql tag + fuzz 1000+ cases + security-review"},
+    {"id": "R2", "risk": "Приоритет операторов парсится некорректно", "probability": "HIGH", "impact": "MEDIUM", "mitigation": "EBNF + 80+ snapshot-тестов по JQL-reference"},
+    {"id": "R3", "risk": "Утечка задач через project = SECRET", "probability": "MEDIUM", "impact": "CRITICAL", "mitigation": "Top-level AND projectId IN (accessible) всегда"},
+    {"id": "R4", "risk": "Медленный полнотекстовый поиск", "probability": "HIGH", "impact": "HIGH", "mitigation": "MVP — ILIKE+cap 500 + timeout 5s; Phase 2 — pg_trgm GIN"},
+    {"id": "R5", "risk": "WAS/CHANGED нет истории", "probability": "HIGH", "impact": "LOW", "mitigation": "MVP — NotImplementedError с позицией; Phase 2 — FieldChangeLog"},
+    {"id": "R6", "risk": "Prisma не умеет сложные JSON-операторы", "probability": "MEDIUM", "impact": "MEDIUM", "mitigation": "Prisma.sql raw WHERE для cf + тип-aware ветвление"},
+    {"id": "R7", "risk": "Имя custom-поля неоднозначно между проектами", "probability": "MEDIUM", "impact": "MEDIUM", "mitigation": "Резолв имени при наличии project-scope; иначе warning"},
+    {"id": "R8", "risk": "CodeMirror тяжёлый bundle", "probability": "LOW", "impact": "LOW", "mitigation": "React.lazy + chunk"},
+    {"id": "R9", "risk": "Потеря структуры при Basic↔Advanced", "probability": "MEDIUM", "impact": "LOW", "mitigation": "Advanced→Basic только если AST представим; иначе disable"},
+    {"id": "R10", "risk": "Сломанные ссылки в сохранённых фильтрах (удалённый user/project)", "probability": "HIGH", "impact": "LOW", "mitigation": "Ленивая валидация + warning в результатах"},
+    {"id": "R11", "risk": "PUBLIC-фильтр утечка чувств. данных в JQL-тексте", "probability": "LOW", "impact": "MEDIUM", "mitigation": "Warning в UI; данные не утекают — enforce per-reader scope"},
+    {"id": "R12", "risk": "Bulk actions через кросс-проектную выборку", "probability": "MEDIUM", "impact": "MEDIUM", "mitigation": "Разбиение по проектам + Promise.all + агрегация результатов"},
+    {"id": "R13", "risk": "ORDER BY cf медленный", "probability": "LOW", "impact": "MEDIUM", "mitigation": "MVP — только system-поля; Phase 2 — функциональные индексы"},
+    {"id": "R14", "risk": "Diacritics insensitive отличается от Jira", "probability": "LOW", "impact": "LOW", "mitigation": "MVP — ILIKE; Phase 2 — unaccent extension"},
+    {"id": "R15", "risk": "DDoS дорогими JQL", "probability": "MEDIUM", "impact": "HIGH", "mitigation": "Rate limit 30/min/user + timeout 10s + cap 1000"},
+    {"id": "R16", "risk": "Дорогой TTS-QL в КТ замедляет scheduler", "probability": "MEDIUM", "impact": "HIGH", "mitigation": "Timeout 5s + state=ERROR + violationEvent TTQL_ERROR"},
+    {"id": "R17", "risk": "Изменение TTQL после генерации ломает историю", "probability": "MEDIUM", "impact": "MEDIUM", "mitigation": "ReleaseCheckpoint.ttqlSnapshot freeze"},
+    {"id": "R18", "risk": "now()/today() в условии дают нестабильность между тиками", "probability": "MEDIUM", "impact": "LOW", "mitigation": "Фиксированный now=scheduler.startedAt"},
+    {"id": "R19", "risk": "currentUser() в КТ всегда NULL — путаница", "probability": "HIGH", "impact": "LOW", "mitigation": "Validator WARNING + скрытие из suggester topa + документация"},
+    {"id": "R20", "risk": "Переключение режима стирает данные", "probability": "MEDIUM", "impact": "LOW", "mitigation": "Form-state сохраняет скрытые поля, backend игнорирует неактивные поля"},
+    {"id": "R21", "risk": "Автомиграция structured→TTQL не делается; пользователи ожидают", "probability": "LOW", "impact": "LOW", "mitigation": "Кнопка «Сконвертировать в TTS-QL» one-way + ручная проверка"},
+    {"id": "R22", "risk": "Preview-эндпоинт — вектор resource-abuse", "probability": "MEDIUM", "impact": "MEDIUM", "mitigation": "Rate-limit + timeout + canManageCheckpoints"}
+  ],
+  "functionalRequirements": [
+    "FR-1..33 — см. TTSRH-1.md §6",
+    "FR-20: JIRA-style value suggesters по типу поля (User/Project/Status/Sprint/Release/IssueType/Option/Issue/Enum/Date/Bool/Label/Group) с avatar/dot/icon",
+    "FR-21: Debounce 150ms для dynamic suggester'ов + SWR cache для статичных",
+    "FR-22: Дедупликация уже выбранных значений в IN-списке",
+    "FR-23: Единый ValueSuggesterPopup для Advanced и Basic режимов",
+    "FR-24: CheckpointType.conditionMode = STRUCTURED|TTQL|COMBINED (ADDITIVE к существующему criteria[])",
+    "FR-25: Backward compat — existing КТ поведение не меняется (миграция в STRUCTURED)",
+    "FR-26: ReleaseCheckpoint.ttqlSnapshot + conditionModeSnapshot — freeze на момент генерации",
+    "FR-27: Evaluator TTQL-ветка = one Prisma query (pre-computed passed-set), COMBINED = intersect",
+    "FR-28: КТ-контекст добавляет releasePlannedDate() и checkpointDeadline(); currentUser()=NULL + warning",
+    "FR-29: UI segmented control Режим условия; switch без потери form-state",
+    "FR-30: Preview-panel без сохранения — POST /admin/checkpoint-types/preview",
+    "FR-31: Timeout/compile/runtime error TTQL → state=ERROR + violationEvent(TTQL_ERROR) + UI banner",
+    "FR-32: Иконка режима (S/Q/S+Q) в таблице типов, hover — preview TTQL",
+    "FR-33: /search/validate, /suggest, /schema принимают variant=CHECKPOINT",
+    "FR-34: TTS-QL поддерживает функции/поля для нарушений КТ (violatedCheckpoints/OfRelease/AtRisk/InState + hasCheckpointViolation/checkpointViolationType/checkpointViolationReason) — источник CheckpointViolationEvent.resolvedAt IS NULL и ReleaseCheckpoint.state; скоупится по доступным проектам",
+    "FR-35: Suggester для имён типов КТ и enum CheckpointState"
+  ],
+  "valueSuggesters": {
+    "description": "JIRA-style подсказки значений по типу поля — см. §5.11 TTSRH-1.md",
+    "providers": [
+      {"field": "project", "provider": "ProjectSuggester", "dynamic": true},
+      {"field": "assignee/reporter/creator + cf USER", "provider": "UserSuggester", "dynamic": true, "topFunctions": ["currentUser()"]},
+      {"field": "status", "provider": "StatusSuggester", "dynamic": true, "renderer": "color-dot + category"},
+      {"field": "statusCategory/priority/type/aiStatus/aiAssigneeType", "provider": "EnumSuggester", "dynamic": false},
+      {"field": "sprint", "provider": "SprintSuggester", "dynamic": true, "topFunctions": ["openSprints()", "closedSprints()", "futureSprints()"]},
+      {"field": "release/fixVersion", "provider": "ReleaseSuggester", "dynamic": true, "topFunctions": ["unreleasedVersions()", "latestReleasedVersion()"]},
+      {"field": "parent/epic/key/linkedIssue", "provider": "IssueSuggester", "dynamic": true, "reuses": "searchIssuesGlobal"},
+      {"field": "labels", "provider": "LabelSuggester", "dynamic": true},
+      {"field": "cf SELECT/MULTI_SELECT", "provider": "OptionSuggester", "dynamic": false, "source": "CustomField.options"},
+      {"field": "cf REFERENCE", "provider": "ReferenceSuggester", "delegatesTo": "target type provider"},
+      {"field": "aiEligible/hasChildren", "provider": "BoolSuggester", "dynamic": false},
+      {"field": "due/created/updated/resolvedAt + DATE/DATETIME cf", "provider": "DateSuggester", "sections": ["functions", "relative", "date-picker"]},
+      {"field": "estimatedHours/timeSpent/NUMBER cf", "provider": "NumberSuggester", "dynamic": false},
+      {"field": "summary/description/comment + TEXT cf", "provider": "TextSuggester", "dynamic": false, "source": "recent queries"},
+      {"field": "membersOf(...) argument", "provider": "GroupSuggester", "dynamic": true}
+    ],
+    "caching": {
+      "enum": "client-forever",
+      "project/issueType/status": "SWR 60s",
+      "user/label": "no-cache + debounce 150ms",
+      "sprint/release": "SWR 30s"
+    },
+    "suggestEndpoint": "GET /api/search/suggest?jql=...&cursor=...[&field=...&operator=...&prefix=...]",
+    "response": "{completions: [{kind, label, insert, detail?, icon?, score}], context: {expectedField?, expectedType?, inValueList?}}"
+  },
+  "nonFunctionalRequirements": [
+    {"id": "NFR-1", "metric": "TTFB /search/issues p95 < 400ms на 10K задач"},
+    {"id": "NFR-2", "metric": "TTFB /validate p95 < 100ms"},
+    {"id": "NFR-3", "metric": "TTFB /suggest p95 < 200ms"},
+    {"id": "NFR-4", "metric": "Парсер 1KB ≤ 20ms"},
+    {"id": "NFR-5", "metric": "JqlEditor lazy, +≤160KB gzip"},
+    {"id": "NFR-6", "metric": "Layout адаптивен (>=1280 / >=900 / <900)"},
+    {"id": "NFR-7", "metric": "Chrome 139+, Yandex 25+, Edge 139+, Safari 18+"},
+    {"id": "NFR-8", "metric": "Hard timeout /search/issues 10s, /export 60s"}
+  ],
+  "security": [
+    "SEC-1..8 — см. TTSRH-1.md §6"
+  ],
+  "tests": {
+    "unit": [
+      "Parser ≥ 100 кейсов (escape, unicode, приоритет NOT, глубокая вложенность)",
+      "Compiler матрица ≥ 60 (field × operator)",
+      "Functions — моки даты и сессии"
+    ],
+    "integration": [
+      "/search/issues × 5 ролей × 5 запросов = 25",
+      "RBAC-negative: project = SECRET → 0 results",
+      "SavedFilter CRUD + sharing"
+    ],
+    "fuzz": [
+      "1000 случайных входов, 0 unhandled, 0 500"
+    ],
+    "performance": [
+      "100K задач, p95 < 400ms"
+    ],
+    "e2e": [
+      "search.spec.ts — basic→advanced→save→favorite→share→URL"
+    ],
+    "coverage": {
+      "backend.modules.search": 80,
+      "backend.modules.saved-filters": 75,
+      "frontend.search": 60
+    }
+  },
+  "endpoints": [
+    {"method": "POST", "path": "/api/search/issues"},
+    {"method": "POST", "path": "/api/search/validate"},
+    {"method": "GET",  "path": "/api/search/suggest"},
+    {"method": "POST", "path": "/api/search/export"},
+    {"method": "GET",  "path": "/api/search/schema"},
+    {"method": "GET",  "path": "/api/saved-filters"},
+    {"method": "POST", "path": "/api/saved-filters"},
+    {"method": "GET",  "path": "/api/saved-filters/:id"},
+    {"method": "PATCH","path": "/api/saved-filters/:id"},
+    {"method": "DELETE","path": "/api/saved-filters/:id"},
+    {"method": "POST", "path": "/api/saved-filters/:id/favorite"},
+    {"method": "POST", "path": "/api/saved-filters/:id/share"},
+    {"method": "PATCH","path": "/api/users/me/preferences"},
+    {"method": "POST", "path": "/api/admin/checkpoint-types/preview", "comment": "dry-run eval для отладки TTS-QL условия КТ до сохранения типа"}
+  ],
+  "checkpointConditionModes": {
+    "addedToExisting": "Current CheckpointCriterion[] механизм сохранён полностью и остаётся дефолтом.",
+    "modes": [
+      {"mode": "STRUCTURED", "evaluates": "criteria[] (существующий discriminated union, AND per issue)", "default": true},
+      {"mode": "TTQL", "evaluates": "ttqlCondition (TTS-QL текст, matcher через pre-computed passed-set)"},
+      {"mode": "COMBINED", "evaluates": "criteria[] AND ttqlCondition (intersection passed-sets)"}
+    ],
+    "checkpointContextFunctions": [
+      "releasePlannedDate() — якорь для due ≤ releasePlannedDate() + Nd",
+      "checkpointDeadline() — releasePlannedDate + offsetDays",
+      "currentUser() — resolves to NULL; validator warning"
+    ],
+    "errorHandling": {
+      "timeout": "5s на compile+exec",
+      "onError": "state=ERROR + violationEvent(criterionType=TTQL_ERROR) + UI banner",
+      "snapshot": "ReleaseCheckpoint.ttqlSnapshot/conditionModeSnapshot — freeze в момент генерации"
+    },
+    "backwardCompat": {
+      "migration": "existing CheckpointType → conditionMode='STRUCTURED', ttqlCondition=NULL",
+      "tests": "T-14 проверяет идентичность violationsHash и state после миграции",
+      "ui": "текущие e2e checkpoint-flow тесты остаются зелёными"
+    }
+  },
+  "featureFlag": "FEATURES_ADVANCED_SEARCH",
+  "uxMenu": {
+    "sidebarItem": {
+      "label": "Поиск задач",
+      "path": "/search",
+      "position": "между Projects и submenu Planning",
+      "dataTestId": "nav-search",
+      "icon": "magnifying-glass (inline SVG)",
+      "submenu": "favorite SavedFilters (до 5, сортировка useCount DESC, lastUsedAt DESC)"
+    }
+  },
+  "relatedTasks": [
+    {"key": "TTSRH-2", "title": "Tokenizer + Parser + AST + golden-set"},
+    {"key": "TTSRH-3", "title": "Field registry + Validator + Suggest"},
+    {"key": "TTSRH-4", "title": "Compiler system fields"},
+    {"key": "TTSRH-5", "title": "Compiler custom fields (JSONB raw SQL)"},
+    {"key": "TTSRH-6", "title": "Функции (currentUser/now/sprints/releases/linkedIssues)"},
+    {"key": "TTSRH-7", "title": "Endpoints /search + rate-limit + timeout"},
+    {"key": "TTSRH-8", "title": "SavedFilter CRUD + share"},
+    {"key": "TTSRH-9", "title": "User.preferences + PATCH"},
+    {"key": "TTSRH-10", "title": "Export CSV/XLSX"},
+    {"key": "TTSRH-11", "title": "Fuzz + security-review harness"},
+    {"key": "TTSRH-12", "title": "Frontend SearchPage shell + sidebar"},
+    {"key": "TTSRH-13", "title": "JqlEditor (CodeMirror 6)"},
+    {"key": "TTSRH-14", "title": "Автодополнение + inline errors"},
+    {"key": "TTSRH-15", "title": "BasicFilterBuilder + toggle"},
+    {"key": "TTSRH-16", "title": "SavedFiltersSidebar + save/share modals"},
+    {"key": "TTSRH-17", "title": "ColumnConfigurator (DnD)"},
+    {"key": "TTSRH-18", "title": "ResultsTable + bulk-actions + export UI"},
+    {"key": "TTSRH-19", "title": "URL sync + shortcuts"},
+    {"key": "TTSRH-20", "title": "E2E + perf seed"},
+    {"key": "TTSRH-21", "title": "Документация JQL"},
+    {"key": "TTSRH-22", "title": "Feature flag + cutover"},
+    {"key": "TTSRH-25", "title": "Backend Value Suggesters (13 провайдеров + scope + роутинг /suggest)"},
+    {"key": "TTSRH-26", "title": "Frontend ValueSuggesterPopup + CM6 adapter + Basic chip-popover"},
+    {"key": "TTSRH-27", "title": "Prisma миграция CheckpointType.ttqlCondition/conditionMode + ReleaseCheckpoint snapshot"},
+    {"key": "TTSRH-28", "title": "DTO superRefine + /search/validate?variant=CHECKPOINT"},
+    {"key": "TTSRH-29", "title": "КТ-функции TTS-QL: releasePlannedDate(), checkpointDeadline() + schema variant"},
+    {"key": "TTSRH-30", "title": "checkpoint-engine: TTQL-ветка + COMBINED intersect + violationsHash"},
+    {"key": "TTSRH-31", "title": "Error-handling TTQL (timeout/compile/runtime) → state=ERROR + violationEvent"},
+    {"key": "TTSRH-32", "title": "POST /admin/checkpoint-types/preview (dry-run eval)"},
+    {"key": "TTSRH-33", "title": "Frontend КТ: segmented control Режим условия + иконка в таблице"},
+    {"key": "TTSRH-34", "title": "Frontend КТ: JqlEditor variant=CHECKPOINT"},
+    {"key": "TTSRH-35", "title": "Frontend КТ: Preview-panel (applicable/passed/violated)"},
+    {"key": "TTSRH-36", "title": "Frontend КТ: structured → TTS-QL one-way converter"},
+    {"key": "TTSRH-37", "title": "TTS-QL checkpoint-functions: violatedCheckpoints/OfRelease/AtRisk/InState + поля hasCheckpointViolation/checkpointViolationType/Reason + suggesters + T-20..T-25"},
+    {"key": "TTSRH-23", "title": "(Phase 2) WAS/CHANGED + FieldChangeLog"},
+    {"key": "TTSRH-24", "title": "(Phase 2) PG FTS + pg_trgm + unaccent"}
+  ],
+  "goldensetFile": "docs/tz/TTSRH-1-goldenset.jql"
+}

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1,0 +1,1171 @@
+# ТЗ: TTSRH-1 — Внутренний язык запросов TTS-QL (JQL-совместимый) + страница поиска задач с сохраняемыми фильтрами
+
+---
+
+## 1. Постановка задачи
+
+В системе нет **глобального продвинутого поиска задач**. Текущая функциональность ограничена:
+
+| Где | Что делает | Ограничение |
+|-----|-----------|-------------|
+| [backend/src/modules/issues/issues.router.ts:49](backend/src/modules/issues/issues.router.ts#L49) `GET /issues/search` | Подстрочный поиск по `title` + по `PROJECT-KEY` | Только для виджета связывания задач, 50 записей, без фильтров |
+| [backend/src/modules/issues/issues.router.ts:74](backend/src/modules/issues/issues.router.ts#L74) `GET /projects/:projectId/issues` | Плоский фильтр: `status`/`priority`/`assigneeId`/`sprintId`/`from`/`to`/`search`/`issueTypeConfigId` | Только в рамках одного проекта, только AND, только equals/IN, без OR, без NOT, без кастомных полей, без связей |
+| [frontend/src/pages/ProjectDetailPage.tsx](frontend/src/pages/ProjectDetailPage.tsx) — UI-фильтр | Выпадающие списки | Нельзя сохранить, нельзя разделить с командой, нет глобального вывода |
+
+### Боль пользователя
+
+1. **«Все мои задачи в ревью по трём проектам с приоритетом HIGH»** — приходится открывать каждый проект отдельно и глазами фильтровать.
+2. **«Блокеры на этой неделе по моей команде»** — невозможно сформулировать (нет связей, нет команды, нет OR).
+3. **«Задачи с кастомным полем ‘Story Points > 5’ из активного спринта»** — кастомные поля вообще не участвуют в фильтре.
+4. **Повторный запрос** — фильтр нельзя сохранить; каждый раз кликаешь 6 выпадашек заново.
+5. **Поделиться фильтром** — невозможно (URL не переживает изменения).
+6. **Настроить колонки вывода** — жёсткий набор, нельзя добавить `Due date`, `Estimated` и кастомные поля.
+
+### Цель
+
+1. Реализовать **декларативный язык запросов TTS-QL** (TaskTime Query Language), максимально совместимый с **JQL** (JIRA Query Language) — те же имена операторов, функций, полей, приоритет парсинга. Это сокращает порог входа для команды, знакомой с Jira, и позволяет копировать существующие JQL-фильтры с минимальной адаптацией.
+2. Вынести **поиск в отдельный пункт бокового меню** «Поиск задач» (`/search`), работающий поверх всех доступных пользователю проектов.
+3. Сделать **форму поиска в UX-модели Jira Issue Navigator**:
+   - Два режима: Basic (визуальный конструктор) + Advanced (текстовый TTS-QL с подсветкой и автодополнением).
+   - Результаты — табличный вид с **конфигурируемыми колонками** (вкл. кастомные поля).
+   - **Сохранение фильтров** с именем, описанием, режимами приватности (private / shared-with-users / public), избранным, шарингом по ссылке.
+   - Избранные фильтры — быстрый доступ в левой панели и в сайдбаре (sub-menu).
+
+---
+
+## 2. Текущее состояние
+
+### 2.1 Backend
+
+- [backend/src/modules/issues/issues.service.ts:85-177](backend/src/modules/issues/issues.service.ts#L85-L177) — `listIssues(projectId, filters)` принимает плоский `ListIssuesFilters` с полями `status[]`, `issueTypeConfigId[]`, `priority[]`, `assigneeId`, `sprintId`, `from`/`to` (по `createdAt`), `search` (contains по `title`+`description`). Жёстко завязан на `projectId`.
+- [backend/src/modules/issues/issues.service.ts:179-221](backend/src/modules/issues/issues.service.ts#L179-L221) — `searchIssuesGlobal(q, excludeId, projectIds)` — 50-записный поиск по `title`+`key`, без фильтров, без сортировки.
+- **Нет** модели `SavedFilter`, нет `UserPreferences`, нет столбцовой кастомизации.
+- **Нет** FTS-индексов (Postgres `tsvector`). Поиск по тексту — `contains` с `mode: 'insensitive'` (seq scan при большом объёме).
+- Кастомные поля ([custom_fields](backend/src/prisma/schema.prisma#L658) + [issue_custom_field_values](backend/src/prisma/schema.prisma#L679)) в фильтре **не участвуют**.
+- `IssueLink` (связи) — есть модель, но на фильтрацию не влияет.
+- RBAC-фильтр по доступным проектам реализован в `/issues/search` ([issues.router.ts:57-65](backend/src/modules/issues/issues.router.ts#L57-L65)) — это единственный референсный паттерн, его переиспользовать.
+
+### 2.2 Frontend
+
+- [frontend/src/App.tsx](frontend/src/App.tsx) — роут `/search` отсутствует; нужно добавить новую страницу.
+- [frontend/src/components/layout/Sidebar.tsx](frontend/src/components/layout/Sidebar.tsx) — сайдбар inline-SVG, паттерн копирования пункта понятен (Dashboard/Projects/Time с `data-testid="nav-*"`). Планируется вставить пункт **«Поиск задач»** между «Projects» и submenu «Planning». Sub-menu «Избранные фильтры» — раскрывается при активной странице или открытой submenu (аналог `planning-submenu`).
+- [frontend/src/api/issues.ts:142-147](frontend/src/api/issues.ts#L142-L147) — `searchIssuesGlobal(q, excludeId)` — тонкая обёртка.
+- **Нет** компонентов: `SearchPage`, `JqlEditor`, `BasicFilterBuilder`, `SavedFilterList`, `ColumnConfigurator`, `FilterShareModal`.
+- **Нет** store `savedFilters.store.ts`.
+
+### 2.3 БД / Prisma
+
+- [backend/src/prisma/schema.prisma](backend/src/prisma/schema.prisma) — 54 модели, `Issue` широкий (status, priority, dueDate, estimatedHours, sprintId, releaseId, parentId, assigneeId, creatorId, workflowStatusId, issueTypeConfigId, aiEligible/aiExecutionStatus/aiAssigneeType).
+- Нет модели `SavedFilter`, `FilterShare`, `UserPreferences` — придётся вводить.
+- Нет истории изменения полей (`IssueHistory`/`FieldChangeLog`). Только `AuditLog` — сырой. Это ограничение для JQL-операторов `WAS`/`CHANGED` (см. разделы «Риски» и «Объём»).
+
+---
+
+## 3. Зависимости
+
+### 3.1 Backend модули
+
+- [ ] `search` — **новый модуль** `backend/src/modules/search/`:
+  - `search.parser.ts` — токенизатор + парсер TTS-QL → AST.
+  - `search.ast.ts` — типы AST (Node, Clause, Logical, Function, Literal).
+  - `search.validator.ts` — семантическая валидация (field существует, operator совместим с типом поля, тип литерала подходит).
+  - `search.compiler.ts` — AST → Prisma `Issue.findMany` `where` (+ raw-fragments для JSON-custom-field-value и для сложных текстовых клауз).
+  - `search.functions.ts` — реализация функций (`currentUser()`, `now()`, `startOfDay()`, `openSprints()` и т.д.).
+  - `search.schema.ts` — **реестр полей** (system + dynamically-discovered custom fields).
+  - `search.suggest.ts` — автодополнение (поле/оператор/значение/функция).
+  - `search.service.ts` — высокоуровневая `searchIssues(jql, ctx, pagination, columns?)` и `validate(jql, ctx)` + `suggest(jql, cursorOffset, ctx)`.
+  - `search.router.ts` — роутер (`POST /api/search/issues`, `POST /api/search/validate`, `GET /api/search/suggest`, `POST /api/search/export`).
+- [ ] `saved-filters` — **новый модуль** `backend/src/modules/saved-filters/`:
+  - `saved-filters.dto.ts`, `saved-filters.service.ts`, `saved-filters.router.ts`.
+  - CRUD, share, favorite, subscribe-to-changes (MVP без email-подписки).
+- [ ] `users` — расширение: `GET/PATCH /api/users/me/preferences` для хранения дефолтных колонок и favorite фильтров (`preferences JSON` на `User`).
+
+### 3.2 Frontend компоненты
+
+- [ ] Новый роут `/search` (+ опциональный `/search/saved/:filterId`, `/search?jql=...&view=cards`).
+- [ ] Пункт сайдбара **«Поиск задач»** между «Projects» и «Planning» (иконка — лупа, `data-testid="nav-search"`).
+- [ ] Sub-menu «Избранные фильтры» раскрывается при раскрытии "Поиск задач" или на активной странице поиска (читает фавориты из `savedFilters.store`, до 5 последних).
+- [ ] `frontend/src/pages/SearchPage.tsx` — оболочка, 3-колоночный layout: `SidebarFilters | ResultsArea | DetailPreview (опциональная правая панель)`.
+- [ ] `frontend/src/components/search/` (новая директория):
+  - `JqlEditor.tsx` — поле ввода с подсветкой и автодополнением (CodeMirror 6, расширение `StreamLanguage` с нашими токенами; либо Monaco, либо собственный на `<textarea>` + overlay — выбор в разделе 5.5).
+  - `BasicFilterBuilder.tsx` — визуальные фильтры (chip-add: Project, Type, Status, Priority, Assignee, Sprint, Release, Due, Created, Labels, Custom fields). Каждый chip открывает Popover с поиском значений.
+  - `FilterModeToggle.tsx` — переключатель Basic/Advanced. Basic→Advanced всегда, Advanced→Basic — только если JQL представим в Basic (иначе кнопка задизейблена с тултипом).
+  - `SavedFiltersSidebar.tsx` — «Мои» / «Избранные» / «Общедоступные» / «Поделены со мной» / «Недавние».
+  - `SaveFilterModal.tsx` — имя, описание, visibility (PRIVATE / SHARED / PUBLIC), список users/groups для SHARED.
+  - `FilterShareModal.tsx` — копировать ссылку / изменить visibility / добавить участников.
+  - `ColumnConfigurator.tsx` — drag-n-drop выбор и порядок колонок (включая кастомные поля).
+  - `ResultsTable.tsx` — сортировка через `ORDER BY` в JQL (клик по заголовку — регенерирует JQL).
+  - `ResultsCardsView.tsx` — альтернативный вид (опционально).
+  - `BulkActionsBar.tsx` — массовые операции над выделенными (статус, assignee, sprint, delete) — вызов существующего `bulkUpdateIssues`.
+  - `ExportMenu.tsx` — CSV / XLSX / JSON.
+  - `ValidationErrorBanner.tsx` — показывает позицию ошибки в JQL (line/column + подчёркивание).
+- [ ] `frontend/src/store/savedFilters.store.ts` + `frontend/src/store/search.store.ts` (Zustand, паттерн как существующие).
+- [ ] `frontend/src/api/search.ts` + `frontend/src/api/savedFilters.ts`.
+- [ ] Глобальный шорткат **`/`** → focus на JQL editor (по образцу GitHub); **Ctrl+S / Cmd+S** → сохранить фильтр (если уже назван) или открыть SaveAs.
+
+### 3.3 Prisma / БД
+
+- [ ] Новая модель `SavedFilter`:
+  ```prisma
+  model SavedFilter {
+    id          String             @id @default(uuid())
+    ownerId     String             @map("owner_id")
+    name        String
+    description String?
+    jql         String             @db.Text
+    visibility  FilterVisibility   @default(PRIVATE)
+    columns     Json?              // { fields: string[] }
+    isFavorite  Boolean            @default(false) @map("is_favorite")
+    lastUsedAt  DateTime?          @map("last_used_at")
+    useCount    Int                @default(0) @map("use_count")
+    createdAt   DateTime           @default(now())
+    updatedAt   DateTime           @updatedAt
+    owner       User               @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+    shares      SavedFilterShare[]
+    @@index([ownerId])
+    @@index([visibility])
+    @@map("saved_filters")
+  }
+  enum FilterVisibility { PRIVATE SHARED PUBLIC }
+  model SavedFilterShare {
+    filterId   String
+    userId     String?
+    groupId    String?
+    permission FilterPermission @default(READ)
+    filter     SavedFilter @relation(fields: [filterId], references: [id], onDelete: Cascade)
+    @@id([filterId, userId, groupId])
+  }
+  enum FilterPermission { READ WRITE }
+  ```
+- [ ] Миграция на модель `User.preferences Json?` (или отдельная `UserPreferences` с `userId`-PK) — для хранения дефолтных колонок и недавних фильтров. Паттерн `JSON + версия` из раздела 5.4 TTUI-90.md.
+- [ ] Postgres индекс для текстового поиска (Phase 2, не в MVP — см. Риск R8):
+  ```sql
+  CREATE INDEX issue_title_trgm_idx ON issues USING GIN (title gin_trgm_ops);
+  CREATE INDEX issue_description_trgm_idx ON issues USING GIN (description gin_trgm_ops);
+  ```
+- [ ] Композитные индексы для частых TTS-QL-паттернов (если profiling покажет):
+  ```prisma
+  @@index([projectId, assigneeId, status])   // «assignee = currentUser() AND status = X»
+  @@index([sprintId, status])                // «sprint in openSprints() AND status = X»
+  ```
+
+### 3.4 Внешние пакеты
+
+- **CodeMirror 6** (`@codemirror/state`, `@codemirror/view`, `@codemirror/language`, `@codemirror/autocomplete`, `@codemirror/search`) — для `JqlEditor`. Вес ~120 KB gzip; оправдано, Monaco был бы 1.5 MB.
+- Альтернативно **Lezer** для грамматики (если парсер писать на клиенте для syntax-highlight). MVP — подсветка упрощённая (regex-матчер keywords), полный AST парсится на backend.
+- `papaparse` уже в проекте? — Проверить при реализации; для CSV-экспорта.
+- Парсер — **hand-written recursive descent**, без зависимостей. JQL достаточно прост.
+
+### 3.5 Блокеры
+
+- Нет жёстких блокеров. Модель `SavedFilter` и модуль `search` не зависят друг от друга и могут разрабатываться параллельно после утверждения грамматики (см. разделы 5.1, 5.2).
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| R1 | **SQL-инъекция через JQL** — если хоть один путь компиляции собирает SQL строкой, это catastrophic CVE | MEDIUM | CRITICAL | Парсер возвращает **строго типизированный AST**; компилятор строит Prisma `where` **только через параметризованные вызовы** и `Prisma.sql` tag для raw-фрагментов. Fuzz-тесты в CI на 1000+ случайных query с экранируемыми кавычками, null-байтами, unicode-правосторонними. Security-review обязателен до merge |
+| R2 | Приоритет операторов JQL нетривиален (`AND > OR`, `NOT` — унарный) — парсер может путать группы | HIGH | MEDIUM | Грамматика EBNF в разделе 5.1, unit-тесты на **~80 случаев парсинга** из JQL-reference Atlassian. Тесты проверяют AST-снимки (snapshot tests) |
+| R3 | Задачи без доступа утекают через JQL (`project = "SECRET"`) | MEDIUM | CRITICAL | **Глобальный scope-фильтр** всегда добавляется в compiler на верхнем уровне (AND) — `projectId IN (доступные)`. Пользователь даже после корректного парсинга получит пустой результат. Covered by integration test + security review |
+| R4 | Полнотекстовый поиск без индексов тормозит (~секунды на 100K задач) | HIGH | HIGH | MVP: `ILIKE` с cap результата ≤ 500 + strict timeout 5s. Phase 2: `pg_trgm` GIN-индексы (см. 3.3). В UI — блокирующий сообщ «⚠ Оператор `~` без других фильтров — результат ограничен до N» |
+| R5 | JQL-операторы `WAS`/`CHANGED`/`WAS IN` требуют истории, которой нет (только `AuditLog` без поля-specific) | HIGH | LOW | **MVP — не реализуем** эти операторы. Парсер их принимает, валидатор выдаёт `NotImplementedError` с позицией и подсказкой «Будет в phase 2 при появлении FieldChangeLog». Документация явно перечисляет поддержку |
+| R6 | Кастомные поля — JSON-колонка, Prisma не умеет типизировано фильтровать сложные операторы на JSON | MEDIUM | MEDIUM | Для кастомных полей использовать **`Prisma.sql` raw WHERE** с `JSONB` операторами (`->`, `->>`, `@>`, числовые касты). Компилятор знает тип кастомного поля (NUMBER/DATE/SELECT/MULTI_SELECT/USER/LABEL) и выбирает нужный путь |
+| R7 | Разные пользователи видят разный реестр custom-field-ID (scoping через `FieldSchemaBinding`) — имя `"Story Points"` может быть у двух полей в разных проектах | MEDIUM | MEDIUM | При парсинге имени поля в AST **не резолвим** в ID; резолв — в compiler с учётом `project = X` клаузы. Если поле неоднозначно без scope — warning «Требуется указать `project = ...` до фильтра по "Story Points"» |
+| R8 | CodeMirror 6 + полный редактор выхлопом ≥ 150KB gzip — регрессия initial-load | LOW | LOW | `React.lazy` + `Suspense` на `JqlEditor`; страница `/search` грузит редактор отдельным чанком. Monitoring web-vitals см. [frontend/src/lib/web-vitals.ts](frontend/src/lib/web-vitals.ts) |
+| R9 | Basic↔Advanced mode round-trip — потеря структуры (парные скобки, комментарии) при переключении | MEDIUM | LOW | Basic всегда строит canonical JQL; Advanced→Basic невозможно, если AST содержит что-то, чего нет в Basic (OR, NOT с детьми-группами, custom operators) — кнопка disabled + tooltip |
+| R10 | Сохранённые фильтры ломаются, когда автор удаляет проект/пользователя, на который ссылается (`assignee = "Ivan"`) | HIGH | LOW | **Ленивая валидация** — при выполнении, если ссылаемая сущность не найдена, возвращаем 0 задач + warning `UnknownEntity(field=assignee, value="Ivan")`. UI показывает non-blocking banner в результатах. CRUD фильтра не блокирует сохранение |
+| R11 | Пользователь шарит public-фильтр с `summary ~ "пароль..."` — утечка чувствительных данных через query-text | LOW | MEDIUM | Визуальный warning в Save modal при `visibility=PUBLIC`: «JQL-текст виден всем». Фильтр НЕ даёт доступа к задачам, к которым у читателя нет прав (R3) |
+| R12 | Массовые действия из результатов (`bulkUpdateIssues`) применяются к кросс-проектной выборке — существующий сервис принимает `projectId` | MEDIUM | MEDIUM | Разбивать выделенные задачи по проектам, вызывать bulk-update по каждому проекту в `Promise.all`, агрегировать `{succeeded, failed}`. Atomicity — per-project, НЕ кросс-проектная (документировать) |
+| R13 | `ORDER BY cf["Story Points"]` по JSON-полю — медленно без функционального индекса | LOW | MEDIUM | MVP: разрешить сортировку только по system-полям. Custom-поле sort — Phase 2 с функциональными индексами по конкретным ID |
+| R14 | Разница «diacritics insensitive» (поиск «резюме» найдёт «резюме́»?) — ожидания Jira | LOW | LOW | MVP: обычный `ILIKE` (case-insensitive, без unaccent). Документировать. Phase 2 — `unaccent` extension |
+| R15 | Отсутствие rate-limiting на `POST /search/issues` — DDoS дорогими JQL | MEDIUM | HIGH | Per-user rate limit **30 запросов / минуту** через middleware (паттерн из существующих); hard timeout 10s; cap результат 1000; cap `startAt` 10000 |
+| R16 | Дорогой TTS-QL в КТ замедляет scheduler — backlog оценок | MEDIUM | HIGH | Hard timeout **5s** на compile+exec TTQL-ветки; превышение → `state='ERROR'` + violationEvent `TTQL_ERROR`; scheduler продолжает обработку остальных КТ |
+| R17 | Изменение TTS-QL-текста после генерации снапшота ломает историю | MEDIUM | MEDIUM | `ReleaseCheckpoint.ttqlSnapshot` — **замороженная копия**; evaluator использует snapshot, не живое значение `CheckpointType.ttqlCondition` |
+| R18 | `now()`/`today()` внутри условия дают нестабильный результат между запусками scheduler'а → flap violations | MEDIUM | LOW | Evaluator передаёт фиксированный `now = scheduler.startedAt` одинаковый для всех КТ одного тика |
+| R19 | `currentUser()` в TTQL-условии КТ всегда NULL → логика `assignee = currentUser()` даст всегда false | HIGH | LOW | Валидатор при сохранении WARNING (не ошибка). Документация явно описывает семантику. В suggester — `currentUser()` отсутствует в топе при `variant=CHECKPOINT` |
+| R20 | Пользователь выбрал режим `TTQL`, стёр `criteria`, затем вернулся на `STRUCTURED` — потерял данные | MEDIUM | LOW | Frontend: скрытые поля хранятся в form-state, не стираются; backend Zod не ругается на «лишние» поля в неактивном режиме (они игнорируются при save) |
+| R21 | Existing `CheckpointType` после миграции остаются в режиме `STRUCTURED`, но сотрудники ожидают автоматического переноса в TTQL | LOW | LOW | Миграция **НЕ конвертирует** structured → TTQL автоматически. В UI добавить кнопку «Сконвертировать в TTS-QL» (one-way), которая генерирует эквивалентный JQL и открывает редактор для ручной проверки перед save |
+| R22 | `/admin/checkpoint-types/preview` с произвольным TTQL без сохранения — vector для resource-abuse на любом releaseId | MEDIUM | MEDIUM | Те же rate-limit + timeout, что у `/search/issues`; RBAC — только `canManageCheckpoints` |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Грамматика TTS-QL (EBNF)
+
+```ebnf
+query        ::= or_expr [ "ORDER" "BY" sort_list ]
+or_expr      ::= and_expr { "OR" and_expr }
+and_expr     ::= not_expr { "AND" not_expr }
+not_expr     ::= [ "NOT" ] atom
+atom         ::= "(" query ")" | clause
+clause       ::= field ( cmp_op value
+                       | in_op "(" value_list ")"
+                       | "IS" [ "NOT" ] ("EMPTY" | "NULL")
+                       | history_op hist_value )                  ; history в Phase 2
+
+cmp_op       ::= "=" | "!=" | ">" | ">=" | "<" | "<=" | "~" | "!~"
+in_op        ::= "IN" | "NOT" "IN"
+history_op   ::= "WAS" | "WAS" "NOT" | "WAS" "IN" | "WAS" "NOT" "IN"
+              | "CHANGED"
+              | "CHANGED" ("FROM"|"TO"|"AFTER"|"BEFORE"|"ON"|"DURING"|"BY")
+
+field        ::= IDENT | CUSTOM_FIELD                            ; IDENT — snake/camel/lowercase; CUSTOM_FIELD — cf[UUID] или "имя в кавычках"
+value        ::= literal | function_call
+value_list   ::= value { "," value }
+literal      ::= STRING | NUMBER | DATE_ISO | IDENT | RELATIVE_DATE | "true" | "false" | "EMPTY" | "NULL"
+function_call ::= IDENT "(" [ arg_list ] ")"
+arg_list     ::= value { "," value }
+
+sort_list    ::= sort_item { "," sort_item }
+sort_item    ::= field [ "ASC" | "DESC" ]
+
+STRING         ::= '"' ... '"' | "'" ... "'"                      ; с поддержкой \" \\ \n \t \u{HEX}
+NUMBER         ::= -?\d+(\.\d+)?
+DATE_ISO       ::= "YYYY-MM-DD" | "YYYY-MM-DD HH:MM[:SS]"        ; в строковых кавычках или как литерал
+RELATIVE_DATE  ::= "-"?\d+[dwMyh]                                 ; -1d, 2w, 3M, 1y, 8h
+IDENT          ::= [A-Za-z_][A-Za-z0-9_\-\.]*                     ; case-insensitive для keywords
+CUSTOM_FIELD   ::= "cf" "[" UUID "]" | '"' NAME '"'
+```
+
+**Приоритет:** `( ) > NOT > AND > OR > ORDER BY` (строгий).
+**Регистронезависимость:** ключевые слова (`AND`, `OR`, `IN`, `IS`, `EMPTY`, `ORDER`, `BY`, `ASC`, `DESC`, `NOT`, `WAS`, `CHANGED`) — case-insensitive. Имена полей — case-insensitive.
+**Комментарии:** `-- ...` до конца строки (опционально; полезно в больших сохранённых фильтрах).
+
+### 5.2 Поля TTS-QL — реестр (system)
+
+| Поле | Синонимы | Тип | Операторы | Прим. |
+|------|----------|-----|-----------|-------|
+| `project` | `proj` | Project-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | по `key` или `id` |
+| `key`, `issuekey` | — | Issue-ref | `=`, `!=`, `IN`, `NOT IN` | `PRJ-123` |
+| `summary` | `title` | TEXT | `~`, `!~`, `=`, `!=`, `IS [NOT] EMPTY` | ILIKE |
+| `description` | — | TEXT | `~`, `!~`, `IS [NOT] EMPTY` | |
+| `status` | — | Status-ref | `=`, `!=`, `IN`, `NOT IN`, `CHANGED*`, `WAS*` | имя WorkflowStatus или systemKey (OPEN/IN_PROGRESS/REVIEW/DONE/CANCELLED) |
+| `statusCategory` | `category` | Enum | `=`, `!=`, `IN`, `NOT IN` | `TODO`/`IN_PROGRESS`/`DONE` |
+| `priority` | — | Enum | `=`, `!=`, `IN`, `NOT IN` | CRITICAL/HIGH/MEDIUM/LOW |
+| `type`, `issuetype` | — | Type-ref | `=`, `!=`, `IN`, `NOT IN` | systemKey (TASK/EPIC/…) или UUID |
+| `assignee` | — | User-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | email / id / `currentUser()` |
+| `reporter`, `creator` | — | User-ref | то же | |
+| `sprint` | — | Sprint-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | имя / id / функции |
+| `release`, `fixVersion` | — | Release-ref | то же | |
+| `parent` | — | Issue-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | |
+| `epic` | — | Issue-ref | `=`, `IN` | parent, если type=EPIC |
+| `due`, `dueDate` | — | DATE | `=`, `!=`, `>`, `<`, `>=`, `<=`, `IS [NOT] EMPTY` | + relative: `due <= "7d"` |
+| `created` | — | DATETIME | то же | |
+| `updated` | — | DATETIME | то же | |
+| `resolvedAt` | — | DATETIME | то же | статус переходил в DONE-category |
+| `estimatedHours`, `originalEstimate` | — | NUMBER | `=`, `!=`, `>`, `<`, `>=`, `<=`, `IS [NOT] EMPTY` | |
+| `timeSpent`, `workLog` | — | NUMBER | то же | SUM(TimeLog.hours) |
+| `timeRemaining` | — | NUMBER | то же | estimatedHours − timeSpent |
+| `aiEligible` | — | BOOL | `=` | |
+| `aiStatus` | — | Enum | `=`, `IN` | NOT_STARTED/IN_PROGRESS/DONE/FAILED |
+| `aiAssigneeType` | — | Enum | `=`, `IN` | HUMAN/AGENT/MIXED |
+| `labels`, `label` | — | LIST (custom field) | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | |
+| `comment` | — | TEXT | `~` | поиск по `Comment.content` |
+| `orderIndex` | — | NUMBER | `=`, `>`, `<`, … | |
+| `linkedIssue` | — | Issue-ref | `=`, `IN` | использовать через `linkedIssues()` |
+| `hasChildren` | — | BOOL | `=` | вычисляемое |
+| `hasSubtasks` | — | BOOL | `=` | алиас |
+| `hasCheckpointViolation` | `hasViolation` | BOOL | `=` | `true`, если у задачи есть хоть один активный `CheckpointViolationEvent` (`resolvedAt IS NULL`); быстрый булев фильтр |
+| `checkpointViolationType` | `violationType` | LIST (text) | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | имена типов КТ (из `CheckpointType.name`), по которым задача сейчас нарушает; массив-семантика (IN проверяет хотя бы одно совпадение) |
+| `checkpointViolationReason` | — | TEXT | `~`, `!~` | `CheckpointViolationEvent.reason` (только активные) — полезно для текстовых поисков по причинам |
+
+### 5.3 Кастомные поля
+
+- Синтаксис: `cf[UUID]` или `"Имя поля"` (name lookup).
+- Типы из [CustomFieldType](backend/src/prisma/schema.prisma#L642) маппятся так:
+  - `TEXT`, `TEXTAREA`, `URL` → `~`, `=`, `!=`, `IS [NOT] EMPTY`.
+  - `NUMBER`, `DECIMAL` → все числовые.
+  - `DATE`, `DATETIME` → все временные.
+  - `CHECKBOX` → `=` (true/false).
+  - `SELECT` → `=`, `!=`, `IN`, `NOT IN` (по опции name или id).
+  - `MULTI_SELECT`, `LABEL` → `=`, `!=`, `IN`, `NOT IN` (проверка вхождения в массив).
+  - `USER` → `=`, `!=`, `IN`, `NOT IN`, `currentUser()`.
+  - `REFERENCE` → `=`, `!=`, `IN` (по ID связанной сущности).
+
+### 5.4 Функции (совместимые с JQL)
+
+| Функция | Возвращает | Семантика | Статус |
+|---------|-----------|-----------|--------|
+| `currentUser()` | User | текущий пользователь | MVP |
+| `membersOf("group")` | User[] | члены группы | MVP |
+| `now()` | DATETIME | текущий момент | MVP |
+| `today()` | DATE | сегодня (в TZ пользователя) | MVP |
+| `startOfDay([offset])`, `endOfDay([offset])` | DATETIME | | MVP |
+| `startOfWeek([offset])`, `endOfWeek([offset])` | DATETIME | ISO-неделя | MVP |
+| `startOfMonth([offset])`, `endOfMonth([offset])` | DATETIME | | MVP |
+| `startOfYear([offset])`, `endOfYear([offset])` | DATETIME | | MVP |
+| `openSprints()` | Sprint[] | активные спринты доступных проектов | MVP |
+| `closedSprints()` | Sprint[] | завершённые | MVP |
+| `futureSprints()` | Sprint[] | запланированные | MVP |
+| `unreleasedVersions([project])` | Release[] | unreleased | MVP |
+| `releasedVersions([project])` | Release[] | released | MVP |
+| `earliestUnreleasedVersion([project])` | Release | ближайший unreleased | MVP |
+| `latestReleasedVersion([project])` | Release | последний released | MVP |
+| `linkedIssues(key[, linkType])` | Issue[] | связанные задачи | MVP |
+| `subtasksOf(key)` | Issue[] | дети | MVP |
+| `epicIssues(key)` | Issue[] | задачи под эпиком | MVP |
+| `myOpenIssues()` | shortcut | `assignee = currentUser() AND statusCategory != DONE` | MVP |
+| `violatedCheckpoints([typeName])` | Issue[] | задачи с активными нарушениями КТ (`CheckpointViolationEvent.resolvedAt IS NULL`). Без аргумента — нарушения любого типа; с аргументом — только по типу КТ с заданным `name` (регистр не важен) | MVP |
+| `violatedCheckpointsOf(releaseKeyOrId[, typeName])` | Issue[] | то же, но ограниченное задачами конкретного релиза | MVP |
+| `checkpointsAtRisk([typeName])` | Issue[] | задачи в релизах, где `ReleaseCheckpoint.state IN ('WARNING','OVERDUE','ERROR')`; с необязательным фильтром по типу | MVP |
+| `checkpointsInState(state[, typeName])` | Issue[] | обобщённая — `state ∈ { PENDING, ON_TRACK, WARNING, OVERDUE, ERROR, SATISFIED }` (значения `CheckpointState`) | MVP |
+| `watchedIssues()` | Issue[] | задачи, на которые подписан | Phase 2 (нет модели watchers) |
+| `votedIssues()` | Issue[] | голоса | Phase 2 |
+| `lastLogin()` | DATETIME | | Phase 2 |
+
+**Offset-синтаксис:** `startOfDay("-7d")`, `endOfMonth("1M")`. Единицы: `d`/`w`/`M`/`y`/`h`/`m`.
+
+#### 5.4.1 Компиляция checkpoint-функций
+
+Источник «активного нарушения» — `CheckpointViolationEvent` с `resolvedAt IS NULL` (см. [schema.prisma:1215-1232](backend/src/prisma/schema.prisma#L1215-L1232)), в join с `ReleaseCheckpoint` → `CheckpointType` (для фильтра по `typeName`) и `Release` (для `violatedCheckpointsOf`).
+
+```ts
+// violatedCheckpoints([typeName])
+// → id IN (SELECT cve.issue_id FROM checkpoint_violation_events cve
+//          JOIN release_checkpoints rc ON rc.id = cve.release_checkpoint_id
+//          JOIN checkpoint_types ct ON ct.id = rc.checkpoint_type_id
+//          WHERE cve.resolved_at IS NULL
+//            [AND LOWER(ct.name) = LOWER(:typeName)])
+compileViolatedCheckpoints(typeName?: string): Prisma.Sql {
+  return Prisma.sql`
+    SELECT cve.issue_id FROM checkpoint_violation_events cve
+    JOIN release_checkpoints rc ON rc.id = cve.release_checkpoint_id
+    JOIN checkpoint_types ct ON ct.id = rc.checkpoint_type_id
+    WHERE cve.resolved_at IS NULL
+    ${typeName ? Prisma.sql`AND LOWER(ct.name) = LOWER(${typeName})` : Prisma.empty}
+  `;
+}
+
+// violatedCheckpointsOf(releaseKeyOrId, typeName?) — + join c release + WHERE r.id = :releaseId OR r.name = :key
+// checkpointsAtRisk/checkpointsInState — + WHERE rc.state IN (...) без требования наличия violation (может быть WARNING без violations)
+```
+
+Функции **подставляются в RHS** operator'а `IN` на псевдо-поле `issue` (или можно вообще без LHS-поля — для `violatedCheckpoints()` парсер принимает форму `issue IN violatedCheckpoints()`, совместимую с JQL-синтаксисом). Ради удобства поддерживаем **три эквивалентные формы**:
+
+```sql
+issue IN violatedCheckpoints()
+violatedCheckpoints()                         -- сокращение, парсер оборачивает в issue IN (…)
+hasCheckpointViolation = true                 -- булев-аналог без аргумента
+```
+
+Индексы для быстрой компиляции есть уже сейчас: [checkpoint_violation_events](backend/src/prisma/schema.prisma#L1225-L1230) имеет `@@index([issueId])`, `@@index([resolvedAt])`. Доп. индекс `@@index([resolvedAt, releaseCheckpointId])` — при profiling, если подтвердится замедление на >5K активных violations.
+
+**Scope-фильтр (R3)** применяется на уровне верхнего AND — пользователь увидит нарушения только из доступных ему проектов. Для проектов без доступа результат — пусто.
+
+**Относительные даты в литерале:** `due <= "7d"` — алиас `due <= now() + 7d` (парсер оборачивает).
+
+### 5.5 Архитектура парсера и компилятора
+
+```
+jql text
+  │
+  ▼
+┌────────────┐    ┌───────────┐    ┌────────────────┐    ┌────────────────────┐
+│ Tokenizer  │───▶│  Parser   │───▶│   Validator    │───▶│  Compiler          │
+│  (regex-   │    │ (recursive│    │ (resolve field │    │ (AST → Prisma where│
+│   lexer)   │    │  descent) │    │  + type check) │    │  + raw SQL для CF) │
+└────────────┘    └───────────┘    └────────────────┘    └─────────┬──────────┘
+                                                                    │
+                                                                    ▼
+                                                   prisma.issue.findMany({where, orderBy, ...})
+```
+
+- **Tokenizer**: поддерживает `STRING` с escape, `NUMBER`, `IDENT`, `KEYWORD`, `LPAREN/RPAREN`, `COMMA`, `OP` (`=/!=/>/<=/>=/<=/~/!~`), `RELATIVE_DATE`. Возвращает массив `{type, value, start, end}` — позиции для error reporting.
+- **Parser**: recursive descent. На каждой ноде хранит `span: {start, end}` для инлайн-подчёркивания ошибок в редакторе.
+- **Validator**: семантика — поле существует? тип значения совместим с оператором? функция зарегистрирована? Ошибки накапливает в `errors: ValidationError[]`, не прерывая (для UX автодополнения).
+- **Compiler**: строит Prisma `WhereInput`. Для кастомных полей — `Prisma.sql\`SELECT id FROM issue_custom_field_values WHERE ...\`` с `id IN` под-запросом. Для связей — под-запрос по `IssueLink`. Агрегатные поля (`timeSpent`) — `HAVING`-клауза через `$queryRaw` или материализованное поле. Верхний AND всегда добавляет scope: `projectId IN (:accessibleProjectIds)`.
+
+#### Пример компиляции
+
+Вход:
+```
+project = "TTMP" AND assignee = currentUser() AND status IN (OPEN, IN_PROGRESS)
+  AND priority = HIGH AND due <= "7d"
+  AND "Story Points" > 3
+ORDER BY priority DESC, updated DESC
+```
+
+Выход:
+```ts
+prisma.issue.findMany({
+  where: {
+    AND: [
+      { projectId: { in: accessibleProjectIds } },  // scope
+      { project: { key: 'TTMP' } },
+      { assigneeId: ctx.userId },
+      { OR: [{ status: 'OPEN' }, { status: 'IN_PROGRESS' }] },
+      { priority: 'HIGH' },
+      { dueDate: { lte: addDays(new Date(), 7) } },
+      { id: { in: Prisma.sql`SELECT issue_id FROM issue_custom_field_values
+                             WHERE custom_field_id = ${spId}
+                             AND (value->>'n')::numeric > 3` } }
+    ]
+  },
+  orderBy: [{ priority: 'desc' }, { updatedAt: 'desc' }],
+  skip, take,
+  include: resultIncludeForColumns(columns)
+})
+```
+
+### 5.6 HTTP API
+
+| Метод | Путь | Входные | Выходные | Прим. |
+|-------|------|---------|----------|-------|
+| `POST` | `/api/search/issues` | `{ jql, startAt=0, limit=50 (max 100), columns?: string[] }` | `{ total, startAt, limit, issues: [...], warnings?: [] }` | Выполнение запроса |
+| `POST` | `/api/search/validate` | `{ jql }` | `{ valid, ast?, errors: [{ start, end, code, message, hint? }] }` | Без выполнения |
+| `GET`  | `/api/search/suggest` | `?jql=...&cursor=NN` | `{ completions: [{ label, type, insert, detail? }] }` | Автодополнение |
+| `POST` | `/api/search/export` | `{ jql, format: 'csv'\|'xlsx', columns }` | Stream | Экспорт |
+| `GET`  | `/api/saved-filters` | `?scope=mine\|shared\|public\|favorite` | `SavedFilter[]` | |
+| `POST` | `/api/saved-filters` | `{ name, description, jql, visibility, columns, sharedWith }` | `SavedFilter` | |
+| `GET`  | `/api/saved-filters/:id` | — | `SavedFilter` | |
+| `PATCH`| `/api/saved-filters/:id` | partial | `SavedFilter` | Только owner или SHARED-WRITE |
+| `DELETE`| `/api/saved-filters/:id` | — | 204 | Только owner |
+| `POST` | `/api/saved-filters/:id/favorite` | `{ value: bool }` | `SavedFilter` | |
+| `POST` | `/api/saved-filters/:id/share` | `{ users?: [], groups?: [], permission }` | `SavedFilter` | |
+| `GET`  | `/api/search/schema` | — | `{ fields: [{ name, type, operators, sortable, synonyms }], functions: [...] }` | Для UI-подсказок и Basic builder |
+| `PATCH`| `/api/users/me/preferences` | `{ searchDefaults?: { columns: [], pageSize } }` | `User` | |
+
+### 5.7 UI / UX
+
+#### Страница `/search` — макет
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  [☰] Поиск задач                                         [Export ▾] [Save ▾]│
+├─────────────────────────────────────────────────────────────────────────────┤
+│  [ Basic | Advanced ]   [? JQL help]                                         │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │ project = "TTMP" AND assignee = currentUser() AND status IN (…)     │   │  ← JqlEditor (подсветка, автокомплит)
+│  └──────────────────────────────────────────────────────────────────────┘   │
+│  [▶ Выполнить] (или автозапуск при Enter вне строки)                         │
+├──────────────┬──────────────────────────────────────────────────────────────┤
+│ Мои фильтры  │  Результат: 142 задачи                    [Колонки ⚙] [CSV] │
+│  ★ Мои HIGH  │  ┌─────────────────────────────────────────────────────────┐ │
+│  ★ Ревью     │  │ Key    │ Тип │ Статус │ Приор. │ Assignee │ Due     │ … │ │
+│  Общие       │  ├─────────────────────────────────────────────────────────┤ │
+│    • Релизы  │  │TTMP-12 │ [T] │ OPEN   │ HIGH   │ @gd      │2026-04-25│ … │ │
+│    • UAT     │  │TTMP-42 │ [S] │ REVIEW │ HIGH   │ @gd      │—         │ … │ │
+│  Недавние    │  │…                                                        │ │
+│  Поделены    │  └─────────────────────────────────────────────────────────┘ │
+│  Избранные   │  ◀ 1 2 3 … ▶                                                 │
+└──────────────┴──────────────────────────────────────────────────────────────┘
+```
+
+- **JqlEditor** (CodeMirror 6, lazy-loaded): подсветка токенов (keywords, strings, numbers, functions, идентификаторы полей), inline-ошибки (squiggle + gutter marker), автодополнение (Ctrl+Space / автоматически при наборе):
+  - после `{ничего}` или `AND`/`OR`/`NOT`/`(` — поля;
+  - после поля — операторы, совместимые с его типом;
+  - после оператора — значения (fetch `/suggest`);
+  - после `ORDER BY` — только sortable-поля.
+- **Basic mode**: каждый clause — chip. Клик → Popover с autocomplete значений. Add-chip button → каскадное меню полей, разделённое на категории (Задача / Даты / Пользователи / Планирование / AI / Кастомные).
+- **Save filter**: модалка «Имя», «Описание», «Visibility» (Private / Shared / Public), при Shared — мультиселект пользователей+групп, чекбокс «Сделать избранным».
+- **Save columns**: автоматически в составе фильтра; отдельно — «Сделать колонки дефолтом для меня» → `PATCH /users/me/preferences`.
+- **Bulk actions** (ADMIN/MANAGER, при выделении строк): Assign, Transition, Move to sprint, Delete, Export selected.
+- **URL**: `/search?jql=<url-encoded>&view=table&columns=key,status,assignee,due&page=2`. Обновляется в history на каждое успешное выполнение — можно копировать ссылку.
+- **Shortcuts**: `/` — focus, `Esc` — сброс фокуса, `Ctrl+Enter` — выполнить, `Ctrl+S` — сохранить, `Ctrl+Shift+S` — Save As.
+
+#### Пункт меню в сайдбаре
+
+- Место: между «Projects» и «Planning» (перед submenu Planning).
+- Иконка — лупа (16×16 inline SVG, стиль по соседям).
+- `data-testid="nav-search"`, active-detection `isActive('/search')`.
+- При активной странице поиска под пунктом разворачивается sub-menu «Избранные фильтры» (до 5, отсортированы по `useCount DESC, lastUsedAt DESC`). Клик → `/search/saved/:id`.
+
+### 5.8 Колонки и конфигуратор
+
+- Доступные колонки: все system-поля из 5.2 + все включённые кастомные поля из `CustomField` (`isEnabled=true`).
+- Дефолтный набор: `key, summary, type, status, priority, assignee, sprint, updated`.
+- Конфигуратор (`ColumnConfigurator.tsx`) — два списка: «Доступные» ←→ «Выбранные», drag-n-drop для порядка. Сохранение:
+  - в рамках текущего фильтра — в `SavedFilter.columns`;
+  - как дефолт пользователя — в `User.preferences.searchDefaults.columns`.
+- Сортировка — клик по заголовку колонки переписывает `ORDER BY` в JQL (с сохранением остального).
+
+### 5.9 Безопасность и RBAC
+
+- **Scope-фильтр** (R3): на каждый `POST /search/issues` middleware извлекает `accessibleProjectIds` точно по логике из `issues.router.ts:57-65` и передаёт компилятору как context.
+- **Доступ к SavedFilter**:
+  - `PRIVATE` — только owner.
+  - `SHARED` — owner + entries в `SavedFilterShare`.
+  - `PUBLIC` — все аутентифицированные.
+  - Выполнение PUBLIC-фильтра всё равно использует accessible-projects читающего — никакой пользователь не получит задачи вне своих прав через чужой фильтр.
+- **Write-доступ к SavedFilter**: owner всегда; `SHARED` с `permission=WRITE` — только если явно указано.
+- **Аудит**: создание/удаление/обновление сохранённых фильтров → `AuditLog` запись (существующий middleware `logAudit`).
+- **Rate limit**: 30 запросов/мин на пользователя.
+- **Query-timeout**: 10 секунд на `POST /search/issues`, 2 секунды на `/validate`, 1 секунда на `/suggest`.
+
+### 5.11 Подсказки значений полей (Value Suggesters) — JIRA-style
+
+При наборе JQL после оператора (`=`, `!=`, `IN`, `NOT IN`, `~`) или внутри `(…)` для `IN`-клаузы JqlEditor вызывает `/api/search/suggest` с контекстом `{field, operator, prefix, cursor, scope}` и получает **типизированные предложения со значением для вставки, отображаемой меткой и дополнительным описанием** (email, аватар, цвет статуса). В Basic-builder те же провайдеры используются внутри Popover каждого chip.
+
+Ключевая идея: **реестр провайдеров** — соответствие «field → suggester», где suggester знает, откуда брать значения, как их рендерить и как их сериализовать в JQL-литерал.
+
+| Поле | Suggester | Источник | Представление | Сериализация в JQL |
+|------|-----------|----------|---------------|---------------------|
+| `project` | `ProjectSuggester` | `prisma.project.findMany({where: {id: in accessible}})` | `PRJ — Название` | `PRJ` (key без кавычек) или `"Название"` |
+| `assignee`, `reporter`, `creator` | `UserSuggester` | `prisma.user.findMany({where: { OR: [{email: contains}, {name: contains}], isActive: true }}) LIMIT 20` | avatar + `Имя <email>` | `currentUser()` первой опцией, затем `"email@…"` или `id` |
+| кастомное поле типа `USER` | `UserSuggester` | то же | то же | то же |
+| `status` | `StatusSuggester` | `prisma.workflowStatus.findMany({where: {project: IN scope}})` + systemKeys (OPEN/IN_PROGRESS/…) | dot-цвет + имя + категория | `"Имя статуса"` или `OPEN` |
+| `statusCategory` | `EnumSuggester` | литерал | `TODO / IN_PROGRESS / DONE` | идентификатор без кавычек |
+| `priority` | `EnumSuggester` | литерал | `CRITICAL / HIGH / MEDIUM / LOW` | без кавычек |
+| `type`, `issuetype` | `IssueTypeSuggester` | `prisma.issueTypeConfig.findMany` в scope | icon + имя + systemKey | systemKey или `"Имя"` |
+| `sprint` | `SprintSuggester` | `prisma.sprint.findMany` в scope, **первой строкой — функции** `openSprints()`, `closedSprints()`, `futureSprints()` | state-dot + имя + период | имя в кавычках или ID |
+| `release`, `fixVersion` | `ReleaseSuggester` | `prisma.release.findMany` в scope + функции `unreleasedVersions()`, `latestReleasedVersion()` | state + имя + дата | имя в кавычках или ID |
+| `parent`, `epic`, `key`, `issuekey`, `linkedIssue` | `IssueSuggester` | `searchIssuesGlobal(prefix, accessible)` (переиспользуем) | `PRJ-123 — Title` | `PRJ-123` |
+| `labels`, `label` | `LabelSuggester` | distinct из `IssueCustomFieldValue` по label-полям в scope + auto-complete своих | chip-стиль | `"label"` |
+| кастомное поле `SELECT`/`MULTI_SELECT` | `OptionSuggester` | `CustomField.options` (JSON с опциями поля) | имя опции | имя в кавычках или id |
+| кастомное поле `REFERENCE` | `ReferenceSuggester` | по target-типу поля (issue/user/project) | как соответствующий | как соответствующий |
+| `aiAssigneeType`, `aiStatus` | `EnumSuggester` | литерал | чип | без кавычек |
+| `aiEligible`, `hasChildren` | `BoolSuggester` | `true` / `false` | — | без кавычек |
+| `due`, `created`, `updated`, `resolvedAt` + DATE/DATETIME custom | `DateSuggester` | **три секции**: (1) функции (`now()`, `startOfWeek()`, `endOfMonth("-1M")`), (2) относительные (`"-1d"`, `"-7d"`, `"-1M"`), (3) date-picker для абсолютной | label-с-календарём | функция / `"-7d"` / `"2026-04-18"` |
+| `estimatedHours`, `timeSpent`, `timeRemaining`, `orderIndex` + NUMBER/DECIMAL custom | `NumberSuggester` | история типовых значений + свободный ввод | — | число |
+| `summary`, `description`, `comment` + TEXT/TEXTAREA/URL custom | `TextSuggester` | без autocomplete значений — только шаблоны-кавычки и экранирование; можно предлагать **недавние запросы** пользователя | — | строка в кавычках |
+| `membersOf("…")`-аргумент | `GroupSuggester` | `prisma.userGroup.findMany` | имя группы + счётчик | имя в кавычках |
+| `hasCheckpointViolation` | `BoolSuggester` | литерал | `true` / `false` | без кавычек |
+| `checkpointViolationType` | `CheckpointTypeSuggester` | `prisma.checkpointType.findMany({where:{isActive:true}})` | color-dot + имя + weight | имя в кавычках |
+| `checkpointsAtRisk/checkpointsInState/violatedCheckpoints/violatedCheckpointsOf`-аргументы | те же, что для соответствующих Release/Checkpoint-типов | `ReleaseSuggester` (1-й arg) + `CheckpointTypeSuggester` (2-й) | — | — |
+| `checkpointsInState("…")`-1-й аргумент | `CheckpointStateSuggester` | литерал | цвет-точка + state | `PENDING/ON_TRACK/WARNING/OVERDUE/ERROR/SATISFIED` без кавычек |
+
+**Контракт `/api/search/suggest`** (расширение из §5.6):
+
+```http
+GET /api/search/suggest?jql=<text>&cursor=<offset>
+      [&field=<name>&operator=<op>&prefix=<text>]   # опционально для Basic-mode popover
+```
+
+Ответ:
+```ts
+{
+  completions: Array<{
+    kind: 'field' | 'operator' | 'function' | 'value' | 'keyword';
+    label: string;            // что показать
+    insert: string;           // что вставить (уже экранировано, с кавычками если нужно)
+    detail?: string;          // вторая строка (email, категория, дата)
+    icon?: {
+      kind: 'avatar' | 'color-dot' | 'svg' | 'emoji';
+      value: string;          // url / hex / name
+    };
+    score: number;            // 0..1 для сортировки
+  }>;
+  context: {
+    expectedField?: string;
+    expectedType?: 'USER' | 'DATE' | 'NUMBER' | 'STATUS' | ...;
+    inValueList?: boolean;    // курсор внутри IN (…)
+  };
+}
+```
+
+**Правила выбора suggester'а (алгоритм):**
+1. По курсору в `jql` определяем синтаксическую позицию (после какого токена, ждём ли `value`, `operator`, `field`) — использует тот же парсер в recovery-режиме.
+2. Если ожидается `value`, смотрим предыдущий `field`-токен → находим в `search.schema.ts` тип поля.
+3. Для custom fields — резолвим по имени/UUID (с учётом scope, как в R7).
+4. Если поле — enum/статический список → `EnumSuggester` вернёт константы без сетевого вызова.
+5. Если поле — dynamic (User/Project/Sprint/…) → вызов provider'а с `prefix = текст от последней кавычки/запятой до cursor`, `limit = 20`, `scope = accessibleProjectIds`.
+6. **Fuzzy-ranking**: точное совпадение > startsWith > contains > subsequence; для User — приоритизируем по последнему использованию (джойн по `AuditLog` или отдельное поле `lastInteractedAt`).
+7. Результат всегда содержит **верхние константные предложения** — для User это `currentUser()`, для Sprint — `openSprints()`, для Release — `unreleasedVersions()`.
+8. При `inValueList = true` — **не предлагаем уже выбранные значения** в том же IN-списке (дедупликация).
+
+**Инлайн-ввод в редакторе:**
+- Автоматически открывается при наборе символа после `=`/`!=`/`,`/`(` и при нажатии Ctrl+Space.
+- Debounce **150ms** для dynamic-suggester'ов (User/Issue/Label).
+- Tab / Enter — вставить выбранное (для Enum — без кавычек; для User — с форматом `"email@host"`).
+- Esc — закрыть без вставки.
+- Клавиши ↑/↓ — навигация, Home/End — границы.
+
+**Basic-mode интеграция:**
+- Chip для поля `assignee` открывает Popover, который рендерится тем же компонентом `ValueSuggesterPopup`, что и для Advanced, но с `mode=multi` для IN-clause (чекбоксы) и с preview выбранных chip'ов внизу.
+- ChipBuilder → Advanced сериализация: `assignee IN (currentUser(), "alice@x.com", "bob@x.com")`.
+
+**Кэш:**
+- Enum — client-side forever.
+- Project/IssueType/Status — client-side + SWR 60s.
+- User/Label — debounced fetch, без client-cache (слишком много сущностей).
+- Sprint/Release — SWR 30s (state меняется).
+
+**Типизация редактора** — `@codemirror/autocomplete` extension вызывает `/suggest`, mapping `completions[]` в `CompletionResult` с `apply` (inserts raw) и `info` (detail + icon). Кастомный renderer для avatar/color-dot.
+
+**Тесты:**
+- Unit: для каждого suggester'а — prefix match + сортировка.
+- Integration: `/suggest?field=assignee&prefix=al` возвращает `alice@...` в scope и НЕ возвращает пользователей без общих проектов.
+- E2E: в редакторе набираем `assignee = a`, стрелкой выбираем `alice`, Enter — в строке `assignee = "alice@…"`.
+
+### 5.12 TTS-QL как условие контроля в КТ (Release Checkpoints) — режим ADDITIVE к существующему
+
+Текущая модель условий КТ (см. [TTMP-160](docs/tz/TTMP-160.md), [backend/src/modules/releases/checkpoints/checkpoint.types.ts](backend/src/modules/releases/checkpoints/checkpoint.types.ts)) — **discriminated union `CheckpointCriterion[]`**: `STATUS_IN`, `DUE_BEFORE`, `ASSIGNEE_SET`, `CUSTOM_FIELD_VALUE`, `ALL_SUBTASKS_DONE`, `NO_BLOCKING_LINKS`, AND-комбинируемые и оценивающие **каждую задачу релиза** per-issue через [evaluate-criterion.ts](backend/src/modules/releases/checkpoints/evaluate-criterion.ts). Этот механизм **сохраняется полностью** — формат `criteria Json`, UI [AdminReleaseCheckpointTypesPage](frontend/src/pages/admin/AdminReleaseCheckpointTypesPage.tsx), снимок `ReleaseCheckpoint.criteriaSnapshot`, миграции и евалюатор остаются рабочими без изменений.
+
+**Новое поведение (add-only):** пользователь может дополнительно или альтернативно задать условие в виде **TTS-QL-запроса**. Оба способа сосуществуют, пользователь выбирает удобный — **структурированные `criteria` не убираются**.
+
+#### 5.12.1 Режимы условия
+
+Новое поле `conditionMode` в `CheckpointType`:
+
+| Режим | Что оценивается | Когда использовать |
+|-------|-----------------|--------------------|
+| `STRUCTURED` (default) | Только `criteria[]` — текущий механизм | Простые правила, визуальный редактор, совместимость с существующими КТ |
+| `TTQL` | Только `ttqlCondition: string` | Сложные условия: OR, NOT, вложенные группы, связи (`linkedIssues`), функции дат, кастом-поля через имена |
+| `COMBINED` | `criteria[]` **AND** `ttqlCondition` — задача обязана пройти оба | Базовые правила через UI + точечное ограничение через TTS-QL |
+
+**Миграция совместимости:** все существующие КТ получают `conditionMode = 'STRUCTURED'`, `ttqlCondition = NULL`. Поведение неизменно. DTO/API — новые поля опциональны, старые клиенты не ломаются.
+
+#### 5.12.2 Prisma — изменения модели
+
+```prisma
+model CheckpointType {
+  // ... существующие поля без изменений (criteria Json остаётся)
+  ttqlCondition   String?                  @db.Text @map("ttql_condition")
+  conditionMode   CheckpointConditionMode  @default(STRUCTURED) @map("condition_mode")
+}
+
+enum CheckpointConditionMode { STRUCTURED TTQL COMBINED }
+
+model ReleaseCheckpoint {
+  // criteriaSnapshot Json — остаётся для structured-снапшота
+  ttqlSnapshot        String?  @db.Text @map("ttql_snapshot")    // NEW
+  conditionModeSnapshot CheckpointConditionMode @default(STRUCTURED) @map("condition_mode_snapshot")  // NEW
+}
+```
+
+**Snapshot-логика:** при генерации `ReleaseCheckpoint` из `CheckpointType` копируем **и** `criteria` в `criteriaSnapshot`, **и** `ttqlCondition` в `ttqlSnapshot`, **и** `conditionMode` в `conditionModeSnapshot`. Это сохраняет свойство «изменение типа после генерации не меняет уже поставленные КТ» (текущий инвариант).
+
+#### 5.12.3 Zod DTO — расширение [checkpoint.dto.ts](backend/src/modules/releases/checkpoints/checkpoint.dto.ts)
+
+```ts
+export const createCheckpointTypeDto = z.object({
+  // ... существующие поля без изменений
+  conditionMode: z.enum(['STRUCTURED', 'TTQL', 'COMBINED']).default('STRUCTURED'),
+  criteria: z.array(criterionSchema).max(10).default([]),     // min(1) → ослаблено до default([])
+  ttqlCondition: z.string().max(10000).nullable().optional(),
+}).superRefine((val, ctx) => {
+  const needsStructured = val.conditionMode !== 'TTQL';
+  const needsTtql = val.conditionMode !== 'STRUCTURED';
+  if (needsStructured && val.criteria.length === 0) {
+    ctx.addIssue({ path: ['criteria'], code: 'custom',
+      message: 'Режим STRUCTURED/COMBINED требует хотя бы одно structured-условие' });
+  }
+  if (needsTtql && (!val.ttqlCondition || !val.ttqlCondition.trim())) {
+    ctx.addIssue({ path: ['ttqlCondition'], code: 'custom',
+      message: 'Режим TTQL/COMBINED требует непустой TTS-QL-запрос' });
+  }
+  if (!needsTtql && val.ttqlCondition) {
+    ctx.addIssue({ path: ['ttqlCondition'], code: 'custom',
+      message: 'Режим STRUCTURED несовместим с заполненным ttqlCondition — либо смените режим, либо очистите поле' });
+  }
+});
+```
+
+Дополнительно: на этапе save тип TTS-QL прогоняется через **Validator из §5.5** с предустановленным checkpoint-контекстом (см. 5.12.4). Невалидный JQL → 400 с позицией ошибки.
+
+#### 5.12.4 TTS-QL контекст для КТ — отличия от пользовательского поиска
+
+Evaluator КТ вызывается из scheduler'а без actor'а. Реестр функций и полей **тот же** (см. §5.2 и §5.4), но:
+
+| Функция/поле | Поведение в контексте КТ | Обоснование |
+|--------------|--------------------------|-------------|
+| `currentUser()` | Резолвится в `NULL` → любой `=` возвращает false; валидатор при сохранении выдаёт **WARNING** (не ошибку) | Нет actor'а; не ошибка, т.к. условие может быть корректным (например, `assignee IS NOT EMPTY`) |
+| `now()`, `today()` | Подставляется фиксированное `evaluatedAt` scheduler'а (одно и то же в рамках одной оценки) | Детерминизм результата |
+| `releasePlannedDate()` | **Новая функция**, доступна только в КТ-контексте: возвращает `release.plannedDate` (якорь для `DUE_BEFORE` по аналогии с structured criteria) | Позволяет писать `due <= releasePlannedDate() + 3d` |
+| `checkpointDeadline()` | **Новая функция**, доступна только в КТ-контексте: возвращает `releasePlannedDate + offsetDays` | Для writable-корреляции с дедлайном КТ |
+| Scope-фильтр `projectId IN accessible` | **Не применяется** в evaluator (system-context) — область ограничена проектом релиза автоматически через `release.projectId` | Evaluator запускается от scheduler'а, прав нет; данные всё равно берутся только из проекта релиза |
+| `ORDER BY` | Игнорируется (не влияет на matcher) | Условие КТ — булево, порядок не важен |
+
+Валидатор помечает использование `currentUser()` предупреждением при `conditionMode IN (TTQL, COMBINED)`. Функции `releasePlannedDate()` / `checkpointDeadline()` вне КТ-контекста — ошибка.
+
+#### 5.12.5 Алгоритм evaluator'а — расширение [checkpoint-engine.service.ts](backend/src/modules/releases/checkpoints/checkpoint-engine.service.ts)
+
+```
+evaluateCheckpoint(input):
+  issues = input.issues                              // загружены loader'ом
+  passedStructuredIds = {}
+  passedTtqlIds = {}
+
+  // ветка STRUCTURED (если mode ≠ TTQL) — existing
+  if mode in [STRUCTURED, COMBINED]:
+     for each issue:
+        reasons = []
+        for each criterion in criteriaSnapshot:
+           r = evaluateCriterion(criterion, issue, evalCtx)
+           if r.applicable && !r.passed: reasons.push(r.reason)
+        if reasons.empty: passedStructuredIds.add(issue.id)
+
+  // ветка TTQL (если mode ≠ STRUCTURED) — NEW
+  if mode in [TTQL, COMBINED]:
+     where = compileTtql(ttqlSnapshot, checkpointContext(release, checkpointType, now))
+     applicableIds = [issue.id | issue in issues]
+     matchedIds = prisma.issue.findMany({
+        where: { AND: [ where, { id: { in: applicableIds } } ] },
+        select: { id: true }
+     }).map(r => r.id)
+     passedTtqlIds = Set(matchedIds)
+
+  // пересечение по моду
+  passedFinal = switch mode:
+     STRUCTURED → passedStructuredIds
+     TTQL       → passedTtqlIds
+     COMBINED   → passedStructuredIds ∩ passedTtqlIds
+
+  violations = issues.filter(i => not passedFinal.has(i.id))
+                    .map(i => buildViolation(i, reasonByMode(i)))
+```
+
+- **Единичный DB-вызов** для TTQL-ветки (не per-issue).
+- Timeout 5s на `compileTtql` + `findMany`; превышение → `state=ERROR` для КТ + violationEvent с `criterionType='TTQL_ERROR'` и reason «TTS-QL timeout / compile error / runtime error: …».
+- Ошибка компиляции (после деплоя структура поля изменилась) → `state=ERROR`, в UI — кнопка «Открыть тип и исправить».
+- `violationsHash` считается так же, как сейчас; порядок причин фиксированный: сначала structured-reasons, затем `TTQL_MISMATCH`.
+
+#### 5.12.6 UI — расширение [AdminReleaseCheckpointTypesPage](frontend/src/pages/admin/AdminReleaseCheckpointTypesPage.tsx)
+
+В модалке создания/редактирования типа КТ добавляется **segmented control «Режим условия»**:
+
+```
+┌─ Условие контроля ──────────────────────────────────────────────┐
+│  Режим: ( Structured │ TTQL │ Combined )                        │
+├─────────────────────────────────────────────────────────────────┤
+│  ▾ Structured criteria        [текущий UI, без изменений]       │
+│    (видимо при STRUCTURED и COMBINED; скрыт при TTQL)           │
+│                                                                 │
+│  ▾ TTS-QL условие             [JqlEditor — §5.11/§5.5]          │
+│    (видимо при TTQL и COMBINED; скрыт при STRUCTURED)           │
+│    ┌───────────────────────────────────────────────────────┐   │
+│    │ assignee IS NOT EMPTY AND                             │   │
+│    │   (due IS NOT EMPTY AND due <= releasePlannedDate() ) │   │
+│    │   AND NOT (status = "Blocked")                        │   │
+│    └───────────────────────────────────────────────────────┘   │
+│    ⓘ В контексте КТ доступны функции releasePlannedDate(),     │
+│       checkpointDeadline(). currentUser() = NULL.               │
+│                                                                 │
+│  ▾ Preview (опционально)                                        │
+│    [Выбрать релиз ▾]  → Passed: 42 · Violated: 3                │
+│    Violations: TTMP-15 (не совпал с TTQL), TTMP-22 (…)          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+- Переключение режима **не стирает заполненное**: скрытые поля сохраняются в `form`-state; при смене обратно — восстанавливаются. При save — отправляется только актуальное по режиму (Zod superRefine не пропустит противоречие).
+- `JqlEditor` в режиме «checkpoint» получает `context={ variant: 'CHECKPOINT' }`, `Suggest API` подставляет в автокомплит функции `releasePlannedDate()` / `checkpointDeadline()` и убирает `currentUser()` из топ-функций (с warning-иконкой, если набрал руками).
+- **Preview-панель** (disclosure): выбор тестового релиза → `POST /api/admin/checkpoint-types/:id/preview { releaseId, ttqlCondition?, criteria?, conditionMode? }` возвращает `{ applicable, passed, violated, violations[] }` без сохранения. Полезно при отладке сложного TTQL до сохранения типа.
+- Close-handlers Modal/Drawer вызывают `load()` по [CLAUDE.md](CLAUDE.md)-правилу.
+
+В таблице типов КТ добавляется **значок режима** (S / Q / S+Q) в колонку «Условия», при hover — короткий preview текста TTS-QL.
+
+#### 5.12.7 API — новые и расширенные эндпоинты
+
+| Метод | Путь | Изменение |
+|-------|------|-----------|
+| `POST /api/admin/checkpoint-types` | — | Принимает `conditionMode`, `ttqlCondition` (поля из §5.12.3) |
+| `PATCH /api/admin/checkpoint-types/:id` | — | То же |
+| `GET /api/admin/checkpoint-types` | — | Возвращает новые поля |
+| `POST /api/admin/checkpoint-types/preview` | **NEW** | `{ releaseId, conditionMode, criteria, ttqlCondition }` → `{ applicable, passed, violated, violations[] }` без записи |
+| `POST /api/search/validate` | — | Принимает опциональное `{ variant: 'CHECKPOINT' }` — меняет реестр функций (добавляет `releasePlannedDate()`, `checkpointDeadline()`) |
+| `GET /api/search/suggest` | — | То же — с `variant=CHECKPOINT` suggester возвращает КТ-функции и прячет `currentUser()` из топа |
+| `GET /api/search/schema?variant=CHECKPOINT` | — | Схема доступных функций для текущего контекста |
+
+#### 5.12.8 Совместимость с текущей evaluation-loader инфраструктурой
+
+- Структурные criteria продолжают работать через `EvaluationIssue.customFieldValues: Map<string, unknown>` из [evaluation-loader.service.ts](backend/src/modules/releases/checkpoints/evaluation-loader.service.ts).
+- TTQL-ветка **не использует** `EvaluationIssue` — она ходит напрямую в Prisma через compiled `where`. Это осознанное разделение: loader оптимизирован под per-issue pure evaluation, а TTS-QL-compiler уже умеет строить эффективный SQL с JOIN'ами. Нет дублирования кода.
+- В `COMBINED`-режиме оба пути выполняются параллельно (`Promise.all`), результаты пересекаются в памяти.
+
+#### 5.12.9 Примеры конверсий
+
+**Было (structured):**
+```json
+[
+  { "type": "STATUS_IN", "categories": ["IN_PROGRESS", "DONE"], "issueTypes": ["STORY", "TASK"] },
+  { "type": "ASSIGNEE_SET", "issueTypes": ["STORY", "TASK"] },
+  { "type": "DUE_BEFORE", "days": 3 }
+]
+```
+
+**Эквивалентный TTS-QL:**
+```sql
+(type IN (STORY, TASK) AND statusCategory IN (IN_PROGRESS, DONE) AND assignee IS NOT EMPTY)
+  AND due <= releasePlannedDate() + 3d
+```
+
+**Чего нельзя в structured, но можно в TTQL:**
+```sql
+-- OR + вложенные группы + функция связей
+(priority = CRITICAL OR labels IN ("hotfix"))
+  AND NOT (issue IN linkedIssues(key, "blocks") AND statusCategory != DONE)
+  AND "Story Points" IS NOT EMPTY
+```
+
+### 5.10 Feature flag
+
+Под env-флагом `FEATURES_ADVANCED_SEARCH=true` (дефолт `false` в production до окончания UAT). Паттерн как `FEATURES_DASHBOARD_V2` и `FEATURES_DIRECT_ROLES_DISABLED`. Пункт сайдбара при выключенном флаге — не рендерится.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+
+- [ ] FR-1: Парсер принимает все **JQL-операторы** из раздела 5.1 (кроме `WAS*`/`CHANGED*` — они парсятся, но валидатор выдаёт `NotImplemented` с позицией)
+- [ ] FR-2: Парсер поддерживает **все функции** из 5.4 (MVP-список)
+- [ ] FR-3: Компилятор переводит AST в корректный Prisma-запрос для всех поддержанных операторов × полей из 5.2
+- [ ] FR-4: Кастомные поля всех типов из 3.3 доступны в поиске по имени в кавычках или `cf[UUID]`
+- [ ] FR-5: Верхний AND всегда добавляет `projectId IN (accessible)` (R3)
+- [ ] FR-6: `POST /search/issues` возвращает пагинацию (`{total, startAt, limit, issues}`), лимит ≤ 100, startAt ≤ 10000
+- [ ] FR-7: `POST /search/validate` возвращает структурированный список ошибок со `start`/`end` (для inline-подчёркивания в редакторе)
+- [ ] FR-8: `GET /search/suggest` возвращает контекстные подсказки (поле/оператор/значение/функция) на основе позиции курсора
+- [ ] FR-9: `POST /search/export` — CSV и XLSX, применяет те же права доступа, что и обычный поиск
+- [ ] FR-10: Сохранённые фильтры — CRUD, шаринг (PRIVATE/SHARED/PUBLIC), избранное, счётчик использований
+- [ ] FR-11: Страница `/search` отображается в сайдбаре отдельным пунктом, sub-menu «Избранные фильтры» (до 5)
+- [ ] FR-12: Basic builder покрывает ≥ 80% частых запросов без перехода в Advanced
+- [ ] FR-13: Advanced JQL-editor с подсветкой + автодополнением + inline-ошибками
+- [ ] FR-14: Конфигурация колонок — drag-n-drop, сохраняется в фильтре и/или в user-preferences
+- [ ] FR-15: URL-sharing: `/search?jql=...` — выполнимая ссылка
+- [ ] FR-16: Массовые действия из результатов работают для кросс-проектной выборки (разбиение на `bulkUpdateIssues` по проектам)
+- [ ] FR-17: Глобальный шорткат `/` фокусирует JQL-editor на странице `/search`
+- [ ] FR-18: `Modal`/`Drawer` закрытие (Save filter, Share, Column config) вызывает `load()` страницы-родителя (по [CLAUDE.md](CLAUDE.md))
+- [ ] FR-19: `/search/saved/:filterId` загружает сохранённый фильтр и выполняет его
+- [ ] FR-20: **Value Suggesters по типу поля** (JIRA-style): после `=/!=/IN/,/(` всплывают значения именно для этого поля — пользователи с avatar+email для `assignee/reporter`, проекты с key для `project`, workflow-статусы с цвет-точкой для `status`, спринты с состоянием для `sprint`, релизы с датой для `release`, задачи `PRJ-123 — Title` для `parent/epic/linkedIssue`, опции для `SELECT`/`MULTI_SELECT` кастомных полей, enum-константы для `priority/type/statusCategory/aiStatus`, функции `currentUser()/openSprints()/now()` первыми строками (см. §5.11)
+- [ ] FR-21: Debounced (150ms) dynamic-suggest для User/Issue/Label; кэш/SWR для Project/IssueType/Status/Sprint/Release (см. §5.11)
+- [ ] FR-22: В `IN (…)`-списке уже выбранные значения не предлагаются повторно
+- [ ] FR-23: Basic chip-popover и Advanced autocomplete используют **один и тот же** `ValueSuggesterPopup`-компонент и один backend-эндпоинт, чтобы результаты были идентичны
+- [ ] FR-24: `CheckpointType` поддерживает `conditionMode ∈ {STRUCTURED, TTQL, COMBINED}` и новое поле `ttqlCondition` (§5.12.1–5.12.3). **Существующий механизм `criteria[]` НЕ удаляется и продолжает работать как дефолт.**
+- [ ] FR-25: Все существующие `CheckpointType` после миграции имеют `conditionMode='STRUCTURED'`, `ttqlCondition=NULL`, поведение идентично текущему — backward compat
+- [ ] FR-26: `ReleaseCheckpoint.ttqlSnapshot` + `conditionModeSnapshot` фиксируют TTS-QL-текст и режим в момент генерации; изменение `CheckpointType` после генерации не влияет на уже созданные `ReleaseCheckpoint`
+- [ ] FR-27: Evaluator реализует TTQL-ветку одним Prisma-запросом на КТ (pre-computed passed-set); `COMBINED` пересекает structured-passed и ttql-passed в памяти
+- [ ] FR-28: В контексте КТ TTS-QL поддерживает дополнительные функции `releasePlannedDate()`, `checkpointDeadline()`; `currentUser()` резолвится в NULL + WARNING при сохранении
+- [ ] FR-29: UI модалки `CheckpointType` содержит segmented control «Режим условия» и показывает/скрывает секции structured/TTQL соответственно; заполнение не стирается при переключении
+- [ ] FR-30: Preview-панель — `POST /admin/checkpoint-types/preview { releaseId, ... }` возвращает applicable/passed/violated без записи; доступна в UI до сохранения типа
+- [ ] FR-31: Ошибка компиляции/runtime/timeout TTS-QL-условия в scheduler'е → `ReleaseCheckpoint.state='ERROR'` + violationEvent с `criterionType='TTQL_ERROR'`; UI показывает баннер с кнопкой «Открыть тип и исправить»
+- [ ] FR-32: Таблица типов КТ показывает значок режима (S/Q/S+Q), hover — preview TTS-QL
+- [ ] FR-33: `/search/validate`, `/search/suggest`, `/search/schema` принимают `variant=CHECKPOINT` и возвращают КТ-специфичный реестр функций
+- [ ] FR-34: TTS-QL поддерживает **функции и поля для нарушений КТ** — `violatedCheckpoints([typeName])`, `violatedCheckpointsOf(releaseKeyOrId[, typeName])`, `checkpointsAtRisk([typeName])`, `checkpointsInState(state[, typeName])`, поля `hasCheckpointViolation`, `checkpointViolationType`, `checkpointViolationReason`. Источник — `CheckpointViolationEvent.resolvedAt IS NULL` и `ReleaseCheckpoint.state`. Результаты скоуплены по доступным проектам (R3).
+- [ ] FR-35: Suggester `CheckpointTypeSuggester` подтягивает активные `CheckpointType` с color-dot и weight; `CheckpointStateSuggester` — enum-константы состояний.
+
+### Нефункциональные
+
+- [ ] NFR-1: TTFB `/search/issues` < 400ms (p95) при типичном запросе (5 clauses, limit=50, 10K задач в системе)
+- [ ] NFR-2: TTFB `/search/validate` < 100ms (p95)
+- [ ] NFR-3: TTFB `/search/suggest` < 200ms (p95)
+- [ ] NFR-4: Парсер обрабатывает запрос 1KB за ≤ 20ms
+- [ ] NFR-5: JqlEditor lazy-load, не добавляет > 160KB gzip к initial bundle
+- [ ] NFR-6: Layout страницы адаптивен (≥ 1280px — 3 колонки, ≥ 900px — 2, < 900px — 1 со свёрнутой sidebar)
+- [ ] NFR-7: Совместимость: Chrome 139+, Yandex Browser 25+, Edge 139+, Safari 18+
+- [ ] NFR-8: Hard timeout `/search/issues` — 10s, `/export` — 60s
+
+### Безопасность
+
+- [ ] SEC-1: Scope-фильтр по `accessibleProjectIds` (R3) покрыт unit + integration-тестами для каждой роли (USER/MANAGER/ADMIN/AUDITOR/VIEWER)
+- [ ] SEC-2: Все raw-SQL фрагменты — через `Prisma.sql` tag; fuzz-тест 1000+ JQL со спецсимволами без 500 и без утечки кросс-project
+- [ ] SEC-3: Rate limit 30/min/user; превышение → 429 с `Retry-After`
+- [ ] SEC-4: Hard timeout запроса 10s → 504 gateway-timeout, не 500
+- [ ] SEC-5: `SavedFilter` visibility/permission строго enforced; 403 при чужом PATCH
+- [ ] SEC-6: JSON-схема на вход всех эндпоинтов через Zod
+- [ ] SEC-7: `AuditLog` на create/update/delete/share SavedFilter
+- [ ] SEC-8: PUBLIC SavedFilter — warning в UI, но доступ к задачам не расширяется (R11)
+
+### Тестирование
+
+- [ ] T-1: Unit parser — **≥ 100 кейсов**, включая edge:
+  - экранированные кавычки (`summary ~ "foo \"bar\""`);
+  - пустые строки, unicode;
+  - NOT с приоритетом (`NOT a = 1 AND b = 2` → `(NOT(a=1)) AND (b=2)`);
+  - глубокая вложенность `(((a)))`;
+  - неверный токен возвращает ошибку с позицией
+- [ ] T-2: Unit compiler — per-field × per-operator — **матрица ≥ 60**
+- [ ] T-3: Unit functions — `currentUser`, `startOfWeek(offset)`, `openSprints` с моком даты
+- [ ] T-4: Integration `/search/issues` × 5 ролей × 5 типовых запросов = 25 сценариев
+- [ ] T-5: Integration RBAC — user без доступа к проекту получает 0 задач даже при явном `project = "SECRET"`
+- [ ] T-6: Integration SavedFilter CRUD + sharing
+- [ ] T-7: Fuzz-тест парсера — 1000 случайных входов (включая null-byte, SQL-payload, unicode RTL), 0 unhandled exceptions, 0 500
+- [ ] T-8: Performance — seed 100K задач, assert p95 < 400ms для 5-clause-query
+- [ ] T-9: E2E ([frontend/e2e](frontend/e2e/)): `search.spec.ts` — basic→advanced→save→favorite→share→URL→open in new tab
+- [ ] T-10: Snapshot test Basic builder → canonical JQL
+- [ ] T-11: Integration `/suggest` для каждого suggester'а из §5.11:
+  - `assignee` — prefix возвращает пользователей в scope, вне scope отфильтрованы
+  - `status` — возвращает workflow-статусы + systemKeys, с цветом
+  - `sprint` / `release` — функции (`openSprints()` / `unreleasedVersions()`) первыми
+  - `IN`-дедупликация уже выбранных
+  - кастомное `SELECT` — опции из `CustomField.options`
+- [ ] T-12: E2E: печатаем `assignee = al`, выбираем `alice`, строка становится `assignee = "alice@…"`; печатаем `status IN (`, выбираем 2 статуса — они в списке не повторяются
+- [ ] T-13: Unit evaluator — matrix `conditionMode × issue-data`:
+  - `STRUCTURED` — backward-compat: все существующие тесты зелёные
+  - `TTQL` — задача попала в `where` → passed; не попала → violated с reason «Не соответствует условию TTS-QL»
+  - `COMBINED` — passed = structured ∩ ttql (четыре комбинации SS/SF/FS/FF)
+- [ ] T-14: Integration — миграция данных: существующий сид с `CheckpointType.criteria=[...]` → `conditionMode='STRUCTURED'`, TTQL-ветка не выполняется, `evaluateCheckpoint` возвращает идентичный `violationsHash`
+- [ ] T-15: Integration — `TTQL`-режим с `releasePlannedDate()` + `due <= releasePlannedDate() + 3d` даёт те же passed/violated, что эквивалентный `DUE_BEFORE {days: 3}` structured criterion
+- [ ] T-16: Integration — timeout TTQL-запроса (stub 6s) → `ReleaseCheckpoint.state='ERROR'` + violationEvent с `criterionType='TTQL_ERROR'`
+- [ ] T-17: Integration — невалидный TTS-QL при create/patch `CheckpointType` → 400 с позицией ошибки; сохранение блокируется
+- [ ] T-18: Integration — `POST /admin/checkpoint-types/preview` без `:id` (для нового типа до сохранения) возвращает те же passed/violated, что и evaluator после сохранения
+- [ ] T-19: E2E: админ создаёт тип КТ в режиме TTQL, открывает релиз, видит `state`/violations, переключает тип в `COMBINED`, добавляет structured criterion, видит обновлённый preview после генерации checkpoint'ов
+- [ ] T-20: Integration — `violatedCheckpoints()` без аргументов возвращает **только** задачи с `CheckpointViolationEvent.resolvedAt IS NULL` из доступных проектов; после resolve event'а задача исчезает из выборки
+- [ ] T-21: Integration — `violatedCheckpoints("Go-live")` фильтрует по `CheckpointType.name` без учёта регистра; несуществующее имя → 0 результатов + warning в ответе (не 500)
+- [ ] T-22: Integration — `violatedCheckpointsOf("REL-2.5.0")` принимает как релиз-ключ, так и UUID; фильтрует по `release.id` или `release.name`
+- [ ] T-23: Integration — `checkpointsAtRisk()` возвращает задачи релизов в `WARNING/OVERDUE/ERROR` даже если у самой задачи пока нет violation-event (в отличие от `violatedCheckpoints()`)
+- [ ] T-24: Integration — `hasCheckpointViolation = true` и `issue IN violatedCheckpoints()` эквивалентны (snapshot-тест нормализованного where)
+- [ ] T-25: Integration — scope: пользователь без доступа к проекту релиза не видит задачи через `violatedCheckpoints*`, даже если они нарушают КТ (R3)
+- [ ] Покрытие: backend/modules/search ≥ 80%, saved-filters ≥ 75%, frontend/search ≥ 60%
+
+### Доступность (a11y)
+
+- [ ] A11Y-1: JqlEditor доступен с клавиатуры, умеет ARIA-live для ошибок валидации
+- [ ] A11Y-2: Кнопки filter/sort/column — `<button>` с aria-label
+- [ ] A11Y-3: Модалки Save/Share — focus trap, Esc → close (+ вызов `load()`)
+- [ ] A11Y-4: Контраст выделенных токенов в редакторе ≥ WCAG AA на обеих темах
+
+---
+
+## 7. Критерии приёмки (Definition of Done)
+
+- [ ] Под флагом `FEATURES_ADVANCED_SEARCH=true` в staging: пункт «Поиск задач» появляется в сайдбаре, страница `/search` открывается
+- [ ] Basic builder — можно собрать и выполнить запрос из 5 clauses без написания JQL
+- [ ] Advanced editor — подсветка, автодополнение, inline-ошибки работают для всех полей/операторов из 5.2/5.1
+- [ ] Автодополнение значений (§5.11) возвращает типизированные предложения для всех полей из таблицы suggester'ов, с avatar/цвет-точкой/иконкой, функциями первыми строками, дедупликацией в IN-списке
+- [ ] В модалке `CheckpointType` доступен segmented control «Режим условия» (Structured / TTQL / Combined); переключение не стирает заполненное
+- [ ] Все существующие `CheckpointType` после миграции сохраняют поведение: `violationsHash` и `state` идентичны до/после миграции (T-14)
+- [ ] Эквивалентный TTQL-аналог `DUE_BEFORE{days:3}` даёт те же passed/violated, что structured (T-15)
+- [ ] Timeout 5s в TTQL-ветке → `state='ERROR'` + visible banner с CTA «Открыть тип» (T-16)
+- [ ] Preview-панель КТ работает без сохранения типа (T-18)
+- [ ] E2E: создание TTQL-типа, observation, перевод в COMBINED, regenerate, refreshed violations (T-19)
+- [ ] Структурные criteria **не удалены**: страница-редактор, API, evaluator, миграции, UI-пейдж `AdminReleaseCheckpointTypesPage` текущих возможностей сохраняются; все существующие e2e-тесты checkpoint-flow зелёные
+- [ ] Выполняется ≥ 90% JQL-запросов из приложенного golden-set (`docs/tz/TTSRH-1-goldenset.jql` — ~50 живых запросов команды)
+- [ ] Сохранение фильтра (PRIVATE → SHARED → PUBLIC), избранное, Share, копирование URL — всё работает
+- [ ] Конфигуратор колонок — drag-n-drop, добавление кастомных полей, сохранение в фильтре и в user-preferences
+- [ ] Экспорт CSV/XLSX — respects access + columns
+- [ ] RBAC: негативные тесты (T-5, SEC-1) зелёные
+- [ ] Парсер fuzz-тест (T-7) — 0 unhandled exceptions на 1000 входов
+- [ ] Performance (T-8) — p95 < 400ms на seed 100K
+- [ ] `make test`, `make e2e`, `make lint` — зелёные
+- [ ] [version_history.md](version_history.md) обновлён
+- [ ] Code review пройден
+- [ ] Security review (JQL → SQL injection vector) пройден отдельным approver
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Утверждение грамматики, BNF, golden-set (50 запросов) | 4 |
+| Backend: tokenizer | 4 |
+| Backend: parser (recursive descent) + AST типы | 12 |
+| Backend: validator (field registry, type inference) | 6 |
+| Backend: compiler system-полей | 10 |
+| Backend: compiler custom-полей (raw JSON SQL) | 8 |
+| Backend: functions (currentUser, now, startOfX, sprints, releases, linkedIssues) | 8 |
+| Backend: suggest — позиционный парсер + роутинг на suggester'ы | 6 |
+| Backend: value suggesters (User/Project/Status/Sprint/Release/IssueType/Option/Label/Group/Issue/Enum/Date/Bool) + scope-фильтр | 10 |
+| Backend: endpoint `/search/issues` + pagination + rate-limit + timeout | 4 |
+| Backend: endpoint `/search/validate` | 2 |
+| Backend: endpoint `/search/export` CSV+XLSX | 4 |
+| Backend: модель `SavedFilter` + миграция Prisma + CRUD + share | 8 |
+| Backend: модель `User.preferences` + PATCH | 2 |
+| Backend: fuzz-тест парсера + security-review harness | 4 |
+| Backend: unit/integration тесты (все уровни) | 16 |
+| Frontend: роут + SearchPage shell + layout | 4 |
+| Frontend: `JqlEditor` (CodeMirror 6, подсветка, lazy-load) | 10 |
+| Frontend: `ValueSuggesterPopup` (renderer avatar/dot/icon + keyboard nav + debounce + кэш SWR) | 6 |
+| Frontend: интеграция `ValueSuggesterPopup` в CodeMirror autocomplete (CompletionSource adapter) | 4 |
+| Frontend: интеграция `ValueSuggesterPopup` в BasicFilterBuilder chip-popover | 3 |
+| Backend: Prisma миграция CheckpointType + ReleaseCheckpoint (TTSRH-27) | 3 |
+| Backend: DTO superRefine + validator variant=CHECKPOINT (TTSRH-28) | 4 |
+| Backend: КТ-функции releasePlannedDate / checkpointDeadline + schema variants (TTSRH-29) | 4 |
+| Backend: checkpoint-engine TTQL-ветка + COMBINED intersect + violationsHash (TTSRH-30) | 8 |
+| Backend: error-handling TTQL (timeout/compile/runtime) + state=ERROR + violationEvent (TTSRH-31) | 4 |
+| Backend: /admin/checkpoint-types/preview (TTSRH-32) | 3 |
+| Backend: unit/integration tests T-13..T-18 | 8 |
+| Frontend: КТ segment-mode + show/hide + иконка (TTSRH-33) | 4 |
+| Frontend: КТ JqlEditor variant=CHECKPOINT (TTSRH-34) | 3 |
+| Frontend: КТ Preview-panel (TTSRH-35) | 4 |
+| Frontend: structured→TTQL converter (TTSRH-36) | 4 |
+| E2E: T-19 КТ-TTQL end-to-end сценарий | 3 |
+| Backend: checkpoint-функции TTS-QL (violatedCheckpoints/OfRelease/AtRisk/InState + 3 поля) + suggesters + T-20..T-25 (TTSRH-37) | 8 |
+| Frontend: inline-ошибки (линия/подчёркивание) | 3 |
+| Frontend: `BasicFilterBuilder` | 12 |
+| Frontend: Basic↔Advanced переключение + canonicalizer | 4 |
+| Frontend: `SavedFiltersSidebar` + store | 6 |
+| Frontend: `SaveFilterModal` + `FilterShareModal` | 6 |
+| Frontend: `ColumnConfigurator` (drag-n-drop) | 6 |
+| Frontend: `ResultsTable` + сортировка по клику + пагинация | 5 |
+| Frontend: `BulkActionsBar` + кросс-проектный bulk | 5 |
+| Frontend: `ExportMenu` | 2 |
+| Frontend: sidebar-пункт + favorite submenu | 3 |
+| Frontend: URL sync + deep-linking | 3 |
+| Frontend: shortcuts (`/`, `Ctrl+Enter`, `Ctrl+S`) | 2 |
+| Frontend: unit/component тесты | 8 |
+| E2E (`search.spec.ts`) + screenshot snapshots | 6 |
+| Perf-seed + profiling + composite-index tuning | 4 |
+| Документация: руководство пользователя JQL ([docs/user-manual/jql.md](docs/user-manual/jql.md)), reference операторов/функций | 6 |
+| Code review + фиксы | 8 |
+| Security-review + фиксы | 4 |
+| **Итого** | **278** |
+
+---
+
+## 9. Связанные задачи
+
+**Родитель:** нет (STORY верхнего уровня).
+
+**Дочерние:**
+- TTSRH-2 — Backend: tokenizer + parser TTS-QL + AST + golden-set тесты
+- TTSRH-3 — Backend: field registry + validator + suggest
+- TTSRH-4 — Backend: compiler system-полей (AST → Prisma where)
+- TTSRH-5 — Backend: compiler custom-полей (JSONB raw-SQL)
+- TTSRH-6 — Backend: функции (currentUser/now/openSprints/…)
+- TTSRH-7 — Backend: endpoints `/search/issues`, `/search/validate`, `/search/suggest` + rate-limit + timeout
+- TTSRH-8 — Backend: SavedFilter модель + миграция + CRUD + share
+- TTSRH-9 — Backend: User.preferences + PATCH /users/me/preferences
+- TTSRH-10 — Backend: export CSV/XLSX
+- TTSRH-11 — Backend: fuzz-тесты + security-review harness
+- TTSRH-12 — Frontend: SearchPage shell + роут + сайдбар-пункт + submenu «Избранные»
+- TTSRH-13 — Frontend: JqlEditor (CodeMirror 6, подсветка, lazy-load)
+- TTSRH-14 — Frontend: автодополнение + inline-ошибки
+- TTSRH-15 — Frontend: BasicFilterBuilder + Basic↔Advanced toggle
+- TTSRH-16 — Frontend: SavedFiltersSidebar + save/share модалки + store
+- TTSRH-17 — Frontend: ColumnConfigurator (drag-n-drop)
+- TTSRH-18 — Frontend: ResultsTable + sort-by-click + bulk-actions + ExportMenu
+- TTSRH-19 — Frontend: URL sync + deep linking + shortcuts
+- TTSRH-20 — E2E + perf seed + Lighthouse budget
+- TTSRH-21 — Документация: JQL reference + user manual
+- TTSRH-22 — Feature flag `FEATURES_ADVANCED_SEARCH` + staging-cutover
+- TTSRH-25 — Backend: Value Suggesters (реестр + 13 провайдеров + scope-enforce) + роутинг в `/suggest`
+- TTSRH-26 — Frontend: `ValueSuggesterPopup` + CodeMirror autocomplete adapter + интеграция в BasicFilterBuilder
+- TTSRH-27 — Prisma миграция: `CheckpointType.ttqlCondition`, `CheckpointType.conditionMode`, `ReleaseCheckpoint.ttqlSnapshot`, `ReleaseCheckpoint.conditionModeSnapshot`, backfill существующих строк в `STRUCTURED`
+- TTSRH-28 — Backend: DTO/Zod superRefine для `conditionMode × criteria × ttqlCondition` + `/search/validate?variant=CHECKPOINT`
+- TTSRH-29 — Backend: функции TTS-QL-контекста КТ (`releasePlannedDate()`, `checkpointDeadline()`), валидатор currentUser-warning, поведение scope-фильтра
+- TTSRH-30 — Backend: расширение `checkpoint-engine.service.ts` — TTQL-ветка (compile → Prisma findMany → passed-set), COMBINED-пересечение, `violationsHash` стабилен
+- TTSRH-31 — Backend: обработка ошибок TTQL — timeout 5s, compile-error, runtime-error → `state='ERROR'` + violationEvent `TTQL_ERROR` + UI-баннер
+- TTSRH-32 — Backend: `POST /admin/checkpoint-types/preview` (dry-run для отладки до сохранения)
+- TTSRH-33 — Frontend: segmented control «Режим условия» в `AdminReleaseCheckpointTypesPage`, show/hide секций structured/TTQL без потери form-state, иконка режима в таблице
+- TTSRH-34 — Frontend: интеграция `JqlEditor` в модалку КТ с `variant=CHECKPOINT` (автокомплит КТ-функций, скрытие `currentUser()` из топа, warning-иконка при ручном вводе)
+- TTSRH-35 — Frontend: Preview-панель КТ (выбор релиза → applicable/passed/violated + список violations)
+- TTSRH-36 — Frontend: кнопка «Сконвертировать в TTS-QL» для existing structured-типов (one-way generator → ручная проверка)
+- TTSRH-37 — Backend: checkpoint-функции и поля TTS-QL — `violatedCheckpoints([typeName])`, `violatedCheckpointsOf(release[, typeName])`, `checkpointsAtRisk([typeName])`, `checkpointsInState(state[, typeName])`, поля `hasCheckpointViolation`, `checkpointViolationType`, `checkpointViolationReason`, suggester'ы `CheckpointTypeSuggester` / `CheckpointStateSuggester`, unit + integration тесты T-20..T-25
+- TTSRH-23 — *(Phase 2)* WAS/CHANGED операторы + FieldChangeLog таблица
+- TTSRH-24 — *(Phase 2)* PG full-text + `pg_trgm` индексы + `unaccent`
+
+---
+
+## 10. Иерархия задач
+
+```
+TTSRH-1 (STORY) — Внутренний язык запросов TTS-QL + страница поиска + сохраняемые фильтры
+├── TTSRH-2  (TASK) — Tokenizer + Parser + AST + golden-set
+├── TTSRH-3  (TASK) — Field registry + Validator + Suggest
+├── TTSRH-4  (TASK) — Compiler (system fields → Prisma where)
+├── TTSRH-5  (TASK) — Compiler (custom fields → raw JSONB SQL)
+├── TTSRH-6  (TASK) — Функции (currentUser, now, startOfX, sprints, releases, linkedIssues)
+├── TTSRH-7  (TASK) — Endpoints /search/issues, /validate, /suggest + rate-limit + timeout
+├── TTSRH-8  (TASK) — SavedFilter модель + CRUD + share
+├── TTSRH-9  (TASK) — User.preferences + PATCH
+├── TTSRH-10 (TASK) — Export CSV/XLSX
+├── TTSRH-11 (TASK) — Fuzz-тесты + security-review harness
+├── TTSRH-12 (TASK) — Frontend: SearchPage shell + сайдбар
+├── TTSRH-13 (TASK) — Frontend: JqlEditor (CodeMirror 6)
+├── TTSRH-14 (TASK) — Frontend: автодополнение + inline-ошибки
+├── TTSRH-15 (TASK) — Frontend: BasicFilterBuilder + Basic↔Advanced
+├── TTSRH-16 (TASK) — Frontend: SavedFiltersSidebar + save/share модалки
+├── TTSRH-17 (TASK) — Frontend: ColumnConfigurator
+├── TTSRH-18 (TASK) — Frontend: ResultsTable + bulk-actions + export UI
+├── TTSRH-19 (TASK) — Frontend: URL sync + shortcuts
+├── TTSRH-20 (TASK) — E2E + perf seed + Lighthouse
+├── TTSRH-21 (TASK) — Документация: JQL reference + user manual
+├── TTSRH-22 (TASK) — Feature flag + staging-cutover
+├── TTSRH-25 (TASK) — Backend Value Suggesters (13 провайдеров + scope)
+├── TTSRH-26 (TASK) — Frontend ValueSuggesterPopup + CM6/Basic интеграция
+├── TTSRH-27 (TASK) — Prisma миграция: CheckpointType.ttqlCondition/conditionMode + snapshot
+├── TTSRH-28 (TASK) — DTO superRefine + /search/validate?variant=CHECKPOINT
+├── TTSRH-29 (TASK) — КТ-функции (releasePlannedDate, checkpointDeadline) + context-aware schema
+├── TTSRH-30 (TASK) — checkpoint-engine: TTQL-ветка + COMBINED-пересечение
+├── TTSRH-31 (TASK) — обработка ошибок TTQL (timeout/compile/runtime) → state=ERROR
+├── TTSRH-32 (TASK) — POST /admin/checkpoint-types/preview (dry-run)
+├── TTSRH-33 (TASK) — Frontend КТ: segment-mode + show/hide + иконка в таблице
+├── TTSRH-34 (TASK) — Frontend КТ: JqlEditor variant=CHECKPOINT
+├── TTSRH-35 (TASK) — Frontend КТ: Preview panel (applicable/passed/violated)
+├── TTSRH-36 (TASK) — Frontend КТ: конвертер structured → TTS-QL (one-way, с ручной проверкой)
+├── TTSRH-37 (TASK) — TTS-QL checkpoint-functions: violatedCheckpoints/OfRelease/AtRisk/InState + поля + suggesters + тесты
+├── TTSRH-23 (PHASE-2) — WAS/CHANGED + FieldChangeLog
+└── TTSRH-24 (PHASE-2) — PG full-text + pg_trgm + unaccent
+```
+
+**Порядок выполнения (критический путь):**
+
+1. `TTSRH-2` → `TTSRH-3` → `TTSRH-4` → `TTSRH-6` → `TTSRH-7` (backend-цепочка: без парсера нет ничего)
+2. `TTSRH-5` параллельно с `TTSRH-6` после `TTSRH-4`
+3. `TTSRH-8` / `TTSRH-9` — параллельно, независимы от парсера
+4. `TTSRH-12` → `TTSRH-13` → `TTSRH-14` → `TTSRH-15` → (`TTSRH-16`/`TTSRH-17`/`TTSRH-18` параллельно) → `TTSRH-19`
+5. `TTSRH-11` (fuzz) — сразу после `TTSRH-4` и блокирует merge главной ветки
+6. `TTSRH-10` (export) — после `TTSRH-18`
+7. `TTSRH-20` → `TTSRH-21` → `TTSRH-22` — финал перед cutover
+8. `TTSRH-23`/`TTSRH-24` — Phase 2, не блокируют MVP-релиз
+
+---
+
+## 11. Golden-set JQL (фрагмент, ≈ 20 из 50)
+
+Файл [docs/tz/TTSRH-1-goldenset.jql](docs/tz/TTSRH-1-goldenset.jql) содержит канонические запросы, которые обязаны работать в DoD. Примеры:
+
+```sql
+-- 01: Мои открытые задачи
+assignee = currentUser() AND statusCategory != DONE ORDER BY priority DESC, updated DESC
+
+-- 02: Блокеры в активном спринте
+status = "Blocked" AND sprint in openSprints()
+
+-- 03: Просроченные задачи моей команды
+assignee in membersOf("flow-team-1") AND due < now() AND statusCategory != DONE
+
+-- 04: В ревью у меня дольше 3 дней
+status = "REVIEW" AND assignee = currentUser() AND updated < "-3d"
+
+-- 05: Критичные без оценки
+priority = CRITICAL AND estimatedHours IS EMPTY
+
+-- 06: Задачи по эпику
+epic = "TTMP-10" ORDER BY priority DESC
+
+-- 07: Story Points > 5 в активном спринте
+"Story Points" > 5 AND sprint in openSprints()
+
+-- 08: AI-eligible в AGENT-режиме
+aiEligible = true AND aiAssigneeType = AGENT AND statusCategory != DONE
+
+-- 09: Задачи, созданные на этой неделе
+created >= startOfWeek() AND created < endOfWeek()
+
+-- 10: Незакрытые блокирующие задачи
+issue in linkedIssues("TTMP-42", "blocks") AND statusCategory != DONE
+
+-- 11: Label поиск
+labels in ("backend", "security") AND statusCategory != DONE
+
+-- 12: Без assignee, HIGH и выше
+assignee IS EMPTY AND priority IN (CRITICAL, HIGH)
+
+-- 13: NOT-вложенные
+NOT (status = DONE OR status = CANCELLED) AND assignee = currentUser()
+
+-- 14: Текстовый поиск
+summary ~ "аутентификация" OR description ~ "аутентификация"
+
+-- 15: По релизу
+release = "v2.5.0" AND statusCategory = DONE
+
+-- 16: По нескольким проектам
+project IN (TTMP, TTUI, TTSEC) AND priority = CRITICAL
+
+-- 17: Без спринта, в бэклоге
+sprint IS EMPTY AND status = OPEN AND project = "TTMP"
+
+-- 18: Свежие комментарии
+comment ~ "LGTM" AND updated >= "-1d"
+
+-- 19: Сколько залогировано
+timeSpent > 8 AND assignee = currentUser()
+
+-- 20: Сортировка по сумме дедлайнов
+due IS NOT EMPTY ORDER BY due ASC, priority DESC
+```
+
+---
+
+## 12. Замечания к документации
+
+- [ ] Обновить [docs/user-manual/](docs/user-manual/) разделом «Поиск задач / TTS-QL» с примерами из Golden-set и таблицами операторов/функций.
+- [ ] Обновить [docs/api/reference.md](docs/api/reference.md) эндпоинтами из 5.6.
+- [ ] Обновить [version_history.md](version_history.md) записью о TTSRH-1 в том же коммите, что функциональный код (memory rule).
+- [ ] Добавить в [docs/MCP_GUIDE.html](docs/MCP_GUIDE.html) упоминание `search_issues` MCP-tool, если решим покрыть и MCP (отдельный тикет TTSRH-25, опционально).

--- a/docs/tz/TTUI-90.json
+++ b/docs/tz/TTUI-90.json
@@ -1,0 +1,246 @@
+{
+  "key": "TTUI-90",
+  "title": "Рефакторинг дашборда: role-aware фокусная рабочая область",
+  "generatedAt": "2026-04-18T00:00:00.000Z",
+  "updatedAt": "2026-04-18T12:00:00.000Z",
+  "generatedBy": "claude-code",
+  "source": {
+    "basedOn": "frontend/src/pages/DashboardPage.tsx",
+    "analysedAt": "2026-04-18T00:00:00.000Z",
+    "relatedEpic": "TTMP-160 (Модуль контрольных точек релизов, MVP complete 11/12 PR)"
+  },
+  "issue": {
+    "type": "STORY",
+    "status": "OPEN",
+    "priority": "HIGH",
+    "project": "TTUI",
+    "assignee": null,
+    "creator": "drashkinson@gmail.com",
+    "estimatedHours": 69.5,
+    "description": "Заменить статичный дашборд на role-aware виджетную рабочую область. С учётом готового функционала TTMP-160 добавляются виджеты checkpoints/burndown/releasesAtRisk с переиспользованием существующих компонентов (ReleaseRiskBadge, CheckpointTrafficLight, ReleaseBurndownChart) и API (getMyCheckpointViolations, getBurndown).",
+    "acceptanceCriteria": null
+  },
+  "currentStateIssues": [
+    {"id": "P1", "problem": "Единый layout для всех ролей — админские метрики на экране у обычного пользователя обнулены"},
+    {"id": "P2", "problem": "«+ Новая задача» делает navigate('/projects'), не открывает создание"},
+    {"id": "P3", "problem": "«Сегодня» — декоративный chip без действия"},
+    {"id": "P4", "problem": "«Мои задачи» сортируются по updatedAt, без учёта приоритета/дедлайна"},
+    {"id": "P5", "problem": "N+1 запрос: listIssues(p.id) по каждому проекту в цикле"},
+    {"id": "P6", "problem": "Activity feed без названия сущности и без ссылки"},
+    {"id": "P7", "problem": "Нет focus-виджетов: overdue, due today, in-review-for-me, sprint progress, time week, blocked, checkpoint violations"},
+    {"id": "P8", "problem": "KPI-карточки не кликабельны"},
+    {"id": "P9", "problem": "Нарушение design-system SSOT: hardcoded DARK_C/LIGHT_C вместо design-tokens.ts"},
+    {"id": "P10", "problem": "Пустые состояния без CTA"},
+    {"id": "P11", "problem": "Нет кастомизации / скрытия нерелевантных виджетов"},
+    {"id": "P12", "problem": "Нет адаптивного layout — inline padding, нет breakpoint'ов"},
+    {"id": "P13", "problem": "Нет интеграции с контрольными точками релизов — пользователь не видит своих нарушений КТ на главной"},
+    {"id": "P14", "problem": "Нет диаграммы сгорания активного релиза для USER/MANAGER"},
+    {"id": "P15", "problem": "Нет индикации релизов под угрозой срыва для MANAGER/ADMIN"}
+  ],
+  "userScenarios": {
+    "USER": "5 кликабельных KPI (assigned/overdue/due today/time this week/checkpoint violations) + Focus + MyViolations (reuse CheckpointTrafficLight) + Sprint progress + ReleaseBurndown (primary release, lazy) + Awaiting review + Activity. FAB для создания.",
+    "MANAGER": "Вместо Focus — Team Status; добавить ReleasesAtRisk (risk ≥ MEDIUM с ReleaseRiskBadge), ReleaseBurndown с селектором активных релизов, «скоро дедлайн», «блокеры», прогресс активных спринтов.",
+    "ADMIN": "Дополнительно System KPI + ReleasesAtRisk по всей системе + полный activity feed с CheckpointViolation enrichment."
+  },
+  "reusedFromTTMP160": {
+    "backendEndpoints": [
+      "GET /api/releases/:releaseId/checkpoints",
+      "GET /api/releases/:releaseId/burndown",
+      "GET /api/my-checkpoint-violations",
+      "GET /api/my-checkpoint-violations/count",
+      "GET /api/projects/:projectId/checkpoint-violating-issues"
+    ],
+    "frontendComponents": [
+      "ReleaseRiskBadge",
+      "CheckpointTrafficLight",
+      "ReleaseBurndownChart",
+      "CheckpointsBlock"
+    ],
+    "frontendApis": [
+      "getMyCheckpointViolations",
+      "getMyCheckpointViolationsCount",
+      "getReleaseCheckpoints",
+      "getBurndown"
+    ],
+    "packages": ["recharts (уже установлен TTMP-160 PR-11)"]
+  },
+  "dependencies": {
+    "backendModules": [
+      "dashboard (новый)",
+      "issues (новый эндпоинт /assigned-to-me)",
+      "activity (enrichment, включая CheckpointViolation / ReleaseCheckpoint)",
+      "time (/my-summary)",
+      "sprints (/my-active)",
+      "releases/checkpoints (reuse: getMyCheckpointViolations, getBurndown; новое: releasesAtRisk агрегация в /dashboard/me)",
+      "releases (selectPrimaryRelease для текущего пользователя)"
+    ],
+    "frontendComponents": [
+      "DashboardPage.tsx (переписан)",
+      "components/dashboard/DashboardShell.tsx",
+      "components/dashboard/widgets/WidgetCard.tsx",
+      "components/dashboard/widgets/KpiRow.tsx (+ KPI «Нарушения КТ» с poll 60s)",
+      "components/dashboard/widgets/FocusWidget.tsx",
+      "components/dashboard/widgets/SprintProgressWidget.tsx",
+      "components/dashboard/widgets/AwaitingReviewWidget.tsx",
+      "components/dashboard/widgets/TimeWeekWidget.tsx",
+      "components/dashboard/widgets/ActivityFeedWidget.tsx (+ CheckpointViolation)",
+      "components/dashboard/widgets/TeamStatusWidget.tsx",
+      "components/dashboard/widgets/SystemKpiWidget.tsx",
+      "components/dashboard/widgets/QuickCreateFab.tsx",
+      "components/dashboard/widgets/MyViolationsWidget.tsx (новый, reuse CheckpointTrafficLight)",
+      "components/dashboard/widgets/ReleasesAtRiskWidget.tsx (новый, reuse ReleaseRiskBadge)",
+      "components/dashboard/widgets/ReleaseBurndownWidget.tsx (новый, lazy wrapper над ReleaseBurndownChart)",
+      "store/dashboard.store.ts",
+      "store/user-preferences.store.ts (расширение)",
+      "lib/roles.ts (DASHBOARD_WIDGETS_BY_ROLE с новыми widget ids)",
+      "types/index.ts (DashboardMeResponse с секциями releasesAtRisk/primaryReleaseBurndown/myViolations)"
+    ],
+    "prismaModels": [
+      "User.dashboardLayout Json? (миграция add-column)",
+      "Issue(assigneeId, status) индекс (проверить/добавить)"
+    ],
+    "externalPackages": [],
+    "blockers": []
+  },
+  "risks": [
+    {"id": 1, "description": "Aggregation /dashboard/me становится медленным (6+ параллельных запросов)", "probability": "HIGH", "impact": "p95 > 500ms, деградация TTFB", "mitigation": "Promise.all + Redis cache 30s + invalidation on events; Promise.allSettled с partial: true"},
+    {"id": 2, "description": "Ролевой gate UI/API рассинхронизируется", "probability": "MEDIUM", "impact": "Пустые блоки / 403", "mitigation": "Единый источник DASHBOARD_WIDGETS_BY_ROLE"},
+    {"id": 3, "description": "Activity enrichment N lookups = медленно", "probability": "MEDIUM", "impact": "Feed > 1s", "mitigation": "Batch lookup через groupBy(entityType) + findMany({in: ids})"},
+    {"id": 4, "description": "dashboardLayout JSON-схема эволюционирует — старые данные ломаются", "probability": "LOW", "impact": "Крэш UI", "mitigation": "Версионирование; при mismatch — use defaults"},
+    {"id": 5, "description": "Рефакторинг ломает e2e тесты", "probability": "MEDIUM", "impact": "Красный CI", "mitigation": "Обновить селекторы в том же PR"},
+    {"id": 6, "description": "Новый код продолжает hardcode токены", "probability": "HIGH", "impact": "Drift design system", "mitigation": "grep-check в DoD + pre-push-reviewer"},
+    {"id": 7, "description": "Нет активного спринта у пользователя", "probability": "LOW", "impact": "Пусто", "mitigation": "Empty state c CTA"},
+    {"id": 8, "description": "Новый FAB конфликтует с существующими", "probability": "LOW", "impact": "Двойные кнопки", "mitigation": "Аудит FloatButton"},
+    {"id": 9, "description": "ReleaseBurndownChart тяжёлый (recharts ~90kB gzipped)", "probability": "MEDIUM", "impact": "FCP +200-400ms", "mitigation": "React.lazy + Suspense; skeleton сначала, chart после idle"},
+    {"id": 10, "description": "releasesAtRisk агрегация тяжёлая (N релизов × вычисление риска)", "probability": "MEDIUM", "impact": "+200ms на /dashboard/me", "mitigation": "Читать готовый risk из Redis-кэша TTMP-160 (releaseRisk:{id}); лимит 10 + сортировка на БД"},
+    {"id": 11, "description": "Мои нарушения КТ полагаются на актуальность scheduler'а TTMP-160", "probability": "LOW", "impact": "Stale count", "mitigation": "Использовать готовый countMyViolations; opt: recomputeForRelease при клике"}
+  ],
+  "requirements": {
+    "functional": [
+      "FR-1: Дашборд — один запрос /dashboard/me (burndown lazy отдельно)",
+      "FR-2: KPI кликабельны, ведут в отфильтрованные списки",
+      "FR-3: «Мой фокус» сортирует по priority × overdue × updatedAt, top-10",
+      "FR-4: «Ожидают моего ревью» — задачи REVIEW (reviewer/author)",
+      "FR-5: «Прогресс спринта» — scope + done + days left",
+      "FR-6: «Время на неделе» — сумма + spark-bar по дням",
+      "FR-7: Activity feed — название сущности + ссылка (включая CheckpointViolation/ReleaseCheckpoint)",
+      "FR-8: Role-specific виджеты (Team Status для MANAGER, System KPI для ADMIN)",
+      "FR-9: FAB «+» открывает модалку создания, после закрытия — refresh",
+      "FR-10: Пустые состояния с CTA",
+      "FR-11: Скрытие виджетов persist в User.dashboardLayout",
+      "FR-12: 0 hex-кодов, только tokens.*",
+      "FR-13: При partial: true — non-blocking banner c retry",
+      "FR-14: KPI «Нарушения КТ» для всех ролей, poll 60s через getMyCheckpointViolationsCount",
+      "FR-15: MyViolationsWidget показывает top-5 с CheckpointTrafficLight, дедлайном, именем КТ и релиза",
+      "FR-16: ReleasesAtRiskWidget (MANAGER/ADMIN) сортирует по risk.level DESC × daysLeft ASC; ReleaseRiskBadge + violatedCheckpointsCount",
+      "FR-17: ReleaseBurndownWidget: USER — primaryReleaseBurndown; MANAGER — селектор активных релизов",
+      "FR-18: ReleaseBurndownChart загружается через React.lazy, не блокирует FCP",
+      "FR-19: При отсутствии активных релизов — empty state с CTA «Перейти к релизам»",
+      "FR-20: Событие checkpoint.violation.opened/closed инвалидирует кэш dashboard:me:${userId}"
+    ],
+    "nonFunctional": [
+      "NFR-1: TTFB /dashboard/me < 300ms (p95) при ≤500 assigned",
+      "NFR-2: FCP ≤ 1.2s на 3G Fast (burndown lazy)",
+      "NFR-3: ≤ 2 fetch при входе (dashboard + profile)",
+      "NFR-4: Адаптив: ≥900px — 2 колонки, <900px — 1",
+      "NFR-5: Chrome 139+, Yandex 25+, Edge 139+, Safari 18+",
+      "NFR-6: Cache-hit ratio ≥ 60% (Redis TTL 30s)"
+    ],
+    "security": [
+      "SEC-1: Данные scope'ятся по доступным проектам (RBAC)",
+      "SEC-2: Activity feed фильтруется по доступным проектам",
+      "SEC-3: systemKpi только для ADMIN / super-admin",
+      "SEC-4: dashboardLayout валидируется Zod при PATCH",
+      "SEC-5: releasesAtRisk scope=mine по project membership; scope=all только для SUPER_ADMIN/RELEASE_MANAGER/AUDITOR",
+      "SEC-6: myViolations — reuse service.listMyViolations (scope обеспечен TTMP-160 SEC-7)",
+      "SEC-7: primaryReleaseBurndown — reuse assertReleaseRead TTMP-160"
+    ],
+    "accessibility": [
+      "A11Y-1: KPI — <a>/<button>, не div[role=button]",
+      "A11Y-2: Заголовки виджетов — <h2>, контент — <section aria-labelledby>",
+      "A11Y-3: FAB доступен с клавиатуры",
+      "A11Y-4: Контраст ≥ WCAG AA"
+    ],
+    "testing": [
+      "Unit: focus-score edge cases",
+      "Unit: enrichActivity batch + fallback (+ CheckpointViolation entity)",
+      "Unit: selectPrimaryRelease edge cases",
+      "Integration: /dashboard/me для USER/MANAGER/ADMIN (включая releasesAtRisk / primaryReleaseBurndown / myViolations)",
+      "Integration: /dashboard/me partial degradation",
+      "Integration: invalidation кэша на checkpoint.violation.opened",
+      "E2E: клик по KPI «Нарушения КТ» → страница; ReleasesAtRisk виден только MANAGER/ADMIN; ReleaseBurndownWidget рендерит chart; hide/restore widget persist",
+      "Coverage >= 60%"
+    ]
+  },
+  "acceptanceCriteria": [
+    "Новый дашборд под FEATURES_DASHBOARD_V2 в staging",
+    "Корректно рендерится для USER/MANAGER/ADMIN/VIEWER",
+    "Один API-запрос /dashboard/me (burndown lazy)",
+    "KPI кликабельны, включая KPI «Нарушения КТ»",
+    "FAB + модалка + refresh после закрытия",
+    "Activity feed c названием + ссылкой, включая CheckpointViolation",
+    "MyViolationsWidget показывает top-5 c CheckpointTrafficLight и переходом к задаче",
+    "ReleasesAtRiskWidget c ReleaseRiskBadge виден только MANAGER/ADMIN",
+    "ReleaseBurndownWidget: USER — primary release, MANAGER — селектор; recharts lazy",
+    "0 hex-кодов в новых файлах (grep-check)",
+    "Скрытие виджетов persist",
+    "Мобильный layout одной колонкой без горизонтального скролла",
+    "make test, make e2e, make lint — зелёные",
+    "Lighthouse Performance ≥ 85, Accessibility ≥ 95",
+    "Code review пройден"
+  ],
+  "estimation": {
+    "analysis": 3,
+    "backend": 20.5,
+    "frontend": 33.5,
+    "testing": 8,
+    "tokensMigration": 1,
+    "review": 3,
+    "total": 69.5
+  },
+  "relatedIssues": {
+    "parent": null,
+    "children": [
+      "TTUI-91: Backend: dashboard module + /dashboard/me",
+      "TTUI-92: Backend: /issues/assigned-to-me + index",
+      "TTUI-93: Backend: activity enrichment (+ CheckpointViolation)",
+      "TTUI-94: Backend: User.dashboardLayout + PATCH preferences",
+      "TTUI-95: Frontend: DashboardShell + WidgetCard + grid",
+      "TTUI-96: Frontend: KpiRow (+ KPI «Нарушения КТ»)",
+      "TTUI-97: Frontend: FocusWidget + score",
+      "TTUI-98: Frontend: SprintProgress + TimeWeek widgets",
+      "TTUI-99: Frontend: AwaitingReview + ActivityFeed widgets",
+      "TTUI-100: Frontend: TeamStatus + SystemKpi widgets",
+      "TTUI-101: Frontend: QuickCreateFab + modal + refresh",
+      "TTUI-102: Frontend: customization (hide/restore)",
+      "TTUI-103: Feature flag FEATURES_DASHBOARD_V2 + cutover",
+      "TTUI-104: Tests + Lighthouse",
+      "TTUI-105: Backend: releasesAtRisk + primaryReleaseBurndown + checkpoint invalidation",
+      "TTUI-106: Frontend: MyViolationsWidget (reuse TTMP-160)",
+      "TTUI-107: Frontend: ReleasesAtRiskWidget (reuse ReleaseRiskBadge)",
+      "TTUI-108: Frontend: ReleaseBurndownWidget (lazy wrapper)"
+    ],
+    "blocks": [],
+    "dependsOn": ["TTMP-160 (MVP complete) — reused backend endpoints и UI компоненты"]
+  },
+  "implementationOrder": [
+    "TTUI-91",
+    "TTUI-92",
+    "TTUI-93",
+    "TTUI-105",
+    "TTUI-94",
+    "TTUI-95",
+    "TTUI-96",
+    "TTUI-97",
+    "TTUI-98",
+    "TTUI-99",
+    "TTUI-100",
+    "TTUI-106",
+    "TTUI-107",
+    "TTUI-108",
+    "TTUI-101",
+    "TTUI-102",
+    "TTUI-103",
+    "TTUI-104"
+  ]
+}

--- a/docs/tz/TTUI-90.md
+++ b/docs/tz/TTUI-90.md
@@ -1,0 +1,572 @@
+# ТЗ: TTUI-90 — Рефакторинг дашборда: role-aware фокусная рабочая область
+
+**Дата:** 2026-04-18 (актуализация 2026-04-18 по факту реализации TTMP-160)
+**Тип:** STORY | **Приоритет:** HIGH | **Статус:** OPEN
+**Проект:** Flow Universe UI (TTUI)
+**Автор ТЗ:** Claude Code (auto-generated)
+
+**Связанный EPIC:** [TTMP-160](./TTMP-160.md) — модуль контрольных точек релизов (MVP ✅ complete, 11/12 PR merged). Предоставляет готовые API/компоненты: риск-бейдж, светофор, burndown-чарт, «мои нарушения КТ», матрица КТ. Дашборд **использует их повторно**, а не дублирует.
+
+---
+
+## 1. Постановка задачи
+
+Текущий дашборд ([DashboardPage.tsx](frontend/src/pages/DashboardPage.tsx)) визуально аккуратен, но с UX-стороны выполняет роль «статической витрины метрик», а не рабочего инструмента. Нужно заменить его на **role-aware виджетную рабочую область**, которая в первом экране отвечает на четыре вопроса пользователя после логина:
+
+1. **Что мне делать прямо сейчас?** (фокусные задачи на сегодня/просрочки/ожидающие моего ревью, **мои задачи-нарушители КТ**)
+2. **Как идут мои текущие обязательства?** (активный спринт, **диаграмма сгорания ближайшего релиза**, время за неделю, блокеры)
+3. **Какие релизы под угрозой срыва?** (релизы с risk-level MEDIUM+, просроченные контрольные точки)
+4. **Что изменилось с тех пор, как я последний раз заходил?** (релевантный activity feed с событиями `CheckpointViolation`)
+
+### Проблемы текущей реализации
+
+| # | Проблема | Пример из кода |
+|---|----------|----------------|
+| P1 | Единый layout для всех ролей — админские метрики (счётчик пользователей, общее число time logs) показываются обычному пользователю, где они обнулены | [DashboardPage.tsx:218-220](frontend/src/pages/DashboardPage.tsx#L218-L220) — `adminStats` silently fails для не-админов и остаётся `null` |
+| P2 | Кнопка «+ Новая задача» не создаёт задачу — делает `navigate('/projects')` | [DashboardPage.tsx:248](frontend/src/pages/DashboardPage.tsx#L248) |
+| P3 | «Сегодня» — декоративный chip без действия | [DashboardPage.tsx:240-243](frontend/src/pages/DashboardPage.tsx#L240-L243) |
+| P4 | «Мои задачи» сортируются по `updatedAt` (всплывают закрытые, если их только что обновили), ограничены 5 записями, без учёта приоритета/дедлайна/спринта | [DashboardPage.tsx:192-198](frontend/src/pages/DashboardPage.tsx#L192-L198) |
+| P5 | **N+1 запрос** — для сбора «моих задач» фронт делает `listIssues(p.id, { assigneeId })` по каждому проекту в цикле | [DashboardPage.tsx:189-191](frontend/src/pages/DashboardPage.tsx#L189-L191) |
+| P6 | Activity feed показывает сырой `action` и `entityType` без названия сущности и ссылки — «Иван создал(а) Issue» без возможности перейти | [DashboardPage.tsx:354-369](frontend/src/pages/DashboardPage.tsx#L354-L369) |
+| P7 | Нет фокусных виджетов: «просрочено», «на сегодня», «в ревью ожидают меня», «прогресс спринта», «время на этой неделе», «заблокировано» | — |
+| P8 | KPI-карточки не кликабельны (не переводят в отфильтрованный список) | [DashboardPage.tsx:170-178](frontend/src/pages/DashboardPage.tsx#L170-L178) (компонент `StatCard` без `onClick`) |
+| P9 | **Нарушение design-system SSOT** — hardcoded палитры `DARK_C`/`LIGHT_C` прямо в файле, противоречит [frontend/DESIGN_SYSTEM.md](frontend/DESIGN_SYSTEM.md) (единственный источник — `design-tokens.ts`) | [DashboardPage.tsx:16-51](frontend/src/pages/DashboardPage.tsx#L16-L51) |
+| P10 | Нет пустых состояний с CTA — первый заход в проект без задач показывает «Нет задач» текстом без призыва к действию | [DashboardPage.tsx:301-303](frontend/src/pages/DashboardPage.tsx#L301-L303) |
+| P11 | Нет кастомизации — пользователь не может скрыть нерелевантные виджеты | — |
+| P12 | Нет адаптивного layout — inline-padding `32px`, flex-ряды без breakpoint'ов | [DashboardPage.tsx:226](frontend/src/pages/DashboardPage.tsx#L226) |
+
+### Пользовательские сценарии (после рефакторинга)
+
+**Разработчик (USER) после логина:**
+- Видит приветствие + 5 KPI, каждое кликабельно: «Мне назначено (12)», «Просрочено (2)», «На сегодня (3)», «Залогировано на неделе (14.5h)», **«Нарушения КТ (1)»** (красный pill при count>0, ведёт в `/my-checkpoint-violations`)
+- Ниже — виджет «Мой фокус» — список задач, отсортированных по приоритету × просрочке, со ссылкой, статусом, дедлайном, sprint-tag'ом
+- Виджет **«Мои нарушения контрольных точек»** — задачи-нарушители с указанием КТ, дедлайна, причины (reuse `CheckpointTrafficLight` + ссылка на задачу/релиз)
+- Рядом — «Прогресс активного спринта» (scope bar + дни до конца)
+- **«Диаграмма сгорания ближайшего релиза»** (если пользователь — assignee хотя бы одной задачи в активном релизе) — обёртка над готовым [ReleaseBurndownChart.tsx](frontend/src/components/releases/ReleaseBurndownChart.tsx), metric=issues по умолчанию
+- Ниже — «Ожидают моего ревью» + «Недавние события» (с новым entityType `CheckpointViolation` — ссылка на задачу)
+- FAB «+» открывает модалку быстрого создания задачи
+
+**PM / лид (MANAGER):**
+- Вместо «Мой фокус» доминирует виджет «Команда» — разбивка «В работе / Ревью / Открыто» по его проектам
+- **«Релизы под угрозой»** — список активных релизов с `risk.level ∈ {MEDIUM, HIGH, CRITICAL}`, сортировка по risk DESC × daysLeft ASC; каждая строка — `ReleaseRiskBadge` + название + дата + счётчик нарушенных КТ; клик → `/releases/:id`
+- **«Диаграмма сгорания»** — выпадающий селектор активного релиза + встроенный `ReleaseBurndownChart` с переключателем metric (issues/hours/violations)
+- «Скоро дедлайн» — задачи его проектов с due_date ≤ +3 дня
+- «Блокеры» — задачи со статусом BLOCKED или с `blockedBy` links
+- «Прогресс спринтов» — мини-карточки всех активных спринтов
+
+**Админ (ADMIN):**
+- Дополнительно видит ряд системных KPI («Пользователей», «Проектов», «Time logs»), каждая ведёт в `/admin/*`
+- **«Релизы под угрозой»** — в полном объёме по всей системе, не только по своим проектам
+- Виджет «Последние действия в системе» — полный activity feed с enrichment (включая `CheckpointViolation` события)
+
+---
+
+## 2. Текущее состояние
+
+### Frontend
+- [DashboardPage.tsx](frontend/src/pages/DashboardPage.tsx) (399 строк) — единый монолитный компонент со встроенными токенами, helpers (`avatarGradient`, `timeAgo`, `formatAction`, `greeting`), иконками, StatCard.
+- Используются 2 стора ([projects.store](frontend/src/store/projects.store), [auth.store](frontend/src/store/auth.store)) + theme.store.
+- Вызовы API: `fetchProjects()`, `adminApi.getStats()`, `issuesApi.listIssues(projectId, { assigneeId })` × по одному на проект.
+- Нет компонента «виджет», нет layout-grid, нет персонализации.
+
+### Backend
+- [admin.service.ts](backend/src/modules/admin/admin.service.ts) — `GET /admin/stats` возвращает глобальные счётчики + recentActivity. Эндпоинт рассчитан на ADMIN/MANAGER, не предоставляет personal-scoped данных.
+- [issues.router.ts](backend/src/modules/issues/issues.router.ts) — `listIssues` требует `projectId` в path. Нет эндпоинта «все мои задачи по всем проектам одним запросом».
+- [time.service.ts](backend/src/modules/time/time.service.ts) — агрегаты времени считаются per-project, нет «моё время за период глобально».
+- [sprints.service.ts](backend/src/modules/sprints/sprints.service.ts) — есть `mapSprintWithStats`, но нет «активные спринты, где я участник/assignee».
+- Activity log (`ActivityEntry`) — хранит `entityType` + `entityId`, но не хранит title/snapshot → для ссылки нужен дополнительный join или enrichment.
+
+### Backend: релизы и контрольные точки (готово по TTMP-160)
+- [checkpoints/release-checkpoints.service.ts](backend/src/modules/releases/checkpoints/release-checkpoints.service.ts) — **готово**:
+  - `GET /api/releases/:releaseId/checkpoints` — полный список КТ с `risk: { level, score }`, `violations`, `passedCount`, `applicableCount`
+  - `GET /api/my-checkpoint-violations` — список задач-нарушителей для текущего пользователя (scope по project membership)
+  - `GET /api/my-checkpoint-violations/count` — лёгкий poll-эндпоинт для бейджа (`{ count: number }`)
+  - `GET /api/projects/:projectId/checkpoint-violating-issues` — per-project для MANAGER
+- [checkpoints/burndown.service.ts](backend/src/modules/releases/checkpoints/burndown.service.ts) — **готово**:
+  - `GET /api/releases/:releaseId/burndown?metric=issues|hours|violations&from=&to=` — `{ series[], idealLine[], initial, plannedDate }`
+  - Redis-кэш `burndown:{releaseId}:{metric}:{from}:{to}` TTL 300s
+  - Ежедневный snapshot через `captureSnapshot` (cron по TTMP-160)
+- [checkpoints/release-checkpoints.service.ts](backend/src/modules/releases/checkpoints/release-checkpoints.service.ts) — есть `buildCheckpointsMatrix` (матрица «Задачи × КТ», для будущего «drill-down» из дашборда)
+- **Чего ещё нет в API:** нет «все активные релизы с риском по доступным мне проектам» одним запросом. Нужен новый `GET /api/releases/at-risk?scope=mine|all` (или включить в `/dashboard/me` секцию `releasesAtRisk`).
+
+### Frontend: релизы и контрольные точки (готово по TTMP-160)
+- [components/releases/ReleaseRiskBadge.tsx](frontend/src/components/releases/ReleaseRiskBadge.tsx) — бейдж `LOW/MEDIUM/HIGH/CRITICAL` + numeric score → **переиспользуем** в виджете «Релизы под угрозой»
+- [components/releases/CheckpointTrafficLight.tsx](frontend/src/components/releases/CheckpointTrafficLight.tsx) — светофор `PENDING/OK/VIOLATED` → **переиспользуем** в виджете «Мои нарушения КТ»
+- [components/releases/ReleaseBurndownChart.tsx](frontend/src/components/releases/ReleaseBurndownChart.tsx) — готовый чарт с переключателем metric, recharts → **оборачиваем** в `ReleaseBurndownWidget`, без дублирования логики
+- [components/releases/CheckpointsBlock.tsx](frontend/src/components/releases/CheckpointsBlock.tsx) — блок КТ для страницы релиза (не требуется на дашборде, но используется для навигации)
+- [api/release-checkpoints.ts](frontend/src/api/release-checkpoints.ts) — `getMyCheckpointViolations()`, `getMyCheckpointViolationsCount()`, `getReleaseCheckpoints()` → **используем напрямую** в dashboard widgets
+- [api/release-burndown.ts](frontend/src/api/release-burndown.ts) — `getBurndown()` → **используем в** `ReleaseBurndownWidget`
+- `recharts` уже в `frontend/package.json` (добавлен в TTMP-160 PR-11) — дополнительный bundle не нужен
+
+### Design system
+- [frontend/src/design-tokens.ts](frontend/src/design-tokens.ts) — SSOT токенов (`tokens.dark.*`, `tokens.light.*`, `tokens.radius.*`, `tokens.space.*`).
+- [frontend/src/index.css](frontend/src/index.css) и `tokens.css` — CSS-переменные `var(--*)`.
+- Правило из [DESIGN_SYSTEM.md](frontend/DESIGN_SYSTEM.md): **никаких hex-кодов и px-значений** вне `design-tokens.ts`.
+- Правило из [CLAUDE.md](CLAUDE.md): modal/drawer `onCancel`/`onClose` должны триггерить refresh родителя — применимо к виджету быстрого создания задачи.
+
+---
+
+## 3. Зависимости
+
+### Backend модули
+- [ ] `dashboard` (новый модуль) — агрегатор `GET /api/dashboard/me` (single-call, возвращает всё для текущего пользователя) и `GET /api/dashboard/admin` (опционально, scope=system для ADMIN)
+- [ ] `issues` — новый эндпоинт `GET /api/issues/assigned-to-me` (глобально по всем проектам, с фильтрами status/priority/dueDate/sprintId), индекс на `(assigneeId, status)` если отсутствует
+- [ ] `activity` — enrichment: добавить `entityTitle` и `entityUrl` в `ActivityEntry` ответ, включая **entityType = `CheckpointViolation` / `ReleaseCheckpoint`** (lookup по `entityType` + `entityId`)
+- [ ] `time` — эндпоинт `GET /api/time/my-summary?from=&to=` (суммы по пользователю за период)
+- [ ] `sprints` — эндпоинт `GET /api/sprints/my-active` (активные спринты, где пользователь — assignee задач или участник команды)
+- [ ] `releases/checkpoints` — **используем готовое API**: `getMyCheckpointViolations`, `getMyCheckpointViolationsCount`, `getReleaseCheckpoints`, `getBurndown`. **Дополнительно:** новый эндпоинт `GET /api/releases/at-risk?scope=mine|all&minLevel=MEDIUM&limit=10` — агрегирует активные релизы с риском (фильтр по project membership для `scope=mine`) для виджета «Релизы под угрозой». Альтернатива — включить в `/dashboard/me` секцию `releasesAtRisk` (предпочтительно, чтобы не плодить эндпоинты)
+- [ ] `releases` — при агрегации определить «primary release» для текущего пользователя (ближайший по `plannedDate` релиз, где пользователь — assignee задач) — для `primaryReleaseBurndown` секции
+
+### Frontend компоненты
+- [ ] [DashboardPage.tsx](frontend/src/pages/DashboardPage.tsx) — полный переписан как тонкая оболочка
+- [ ] `components/dashboard/` (новая директория):
+  - [ ] `DashboardShell.tsx` — grid-layout + role gate
+  - [ ] `widgets/FocusWidget.tsx` — «Мой фокус» (приоритизированный список задач)
+  - [ ] `widgets/KpiRow.tsx` — строка кликабельных KPI (включая pill «Нарушения КТ» при count>0)
+  - [ ] `widgets/SprintProgressWidget.tsx` — прогресс активного спринта
+  - [ ] `widgets/AwaitingReviewWidget.tsx` — «Ожидают моего ревью»
+  - [ ] `widgets/TimeWeekWidget.tsx` — «Время за неделю»
+  - [ ] `widgets/ActivityFeedWidget.tsx` — enriched feed c ссылками (включая события `CheckpointViolation`)
+  - [ ] `widgets/TeamStatusWidget.tsx` — для MANAGER
+  - [ ] `widgets/SystemKpiWidget.tsx` — для ADMIN
+  - [ ] `widgets/MyViolationsWidget.tsx` — **новый**: задачи, где пользователь — assignee, нарушающие активные КТ. Переиспользует `CheckpointTrafficLight` + `getMyCheckpointViolations()`
+  - [ ] `widgets/ReleasesAtRiskWidget.tsx` — **новый** (MANAGER/ADMIN): активные релизы с `risk.level ≥ MEDIUM`. Переиспользует `ReleaseRiskBadge` + данные из `/dashboard/me` секции `releasesAtRisk`
+  - [ ] `widgets/ReleaseBurndownWidget.tsx` — **новый**: тонкая обёртка над `ReleaseBurndownChart`. Принимает `releaseId` из `primaryReleaseBurndown` (USER) или из селектора активных релизов (MANAGER). Empty state «Нет активного релиза» с CTA «Перейти к релизам»
+  - [ ] `widgets/QuickCreateFab.tsx` — FAB «+» с модалкой создания задачи
+  - [ ] `widgets/WidgetCard.tsx` — общий wrapper (header + content + empty state + loading)
+- [ ] `store/dashboard.store.ts` — один запрос `/dashboard/me`, кэш в памяти (stale-while-revalidate 60s)
+- [ ] `store/user-preferences.store.ts` — расширить: `dashboardLayout: { hiddenWidgets: string[]; widgetOrder: string[] }`
+- [ ] [frontend/src/types/index.ts](frontend/src/types/index.ts) — типы `DashboardMeResponse`, `WidgetId`, `DashboardLayout`
+
+### Prisma / БД
+- [ ] Поле `dashboardLayout Json?` на модели `User` (или `UserPreferences` если есть) — миграция «add column» без default, read-only при отсутствии
+- [ ] Проверить/добавить индекс `Issue(assigneeId, status)` для быстрого `assigned-to-me`
+
+### Внешние пакеты
+- Используем существующие Ant Design компоненты (`Progress`, `Tag`, `Avatar`, `Empty`, `Skeleton`, `FloatButton`).
+- `recharts` — **уже установлен** (добавлен в TTMP-160 PR-11 для `ReleaseBurndownChart`). Дополнительных пакетов не требуется.
+- Для сеток рассматриваем `react-grid-layout` **только если** в будущем требуется drag-n-drop кастомизация. **MVP — без DnD**, порядок виджетов жёстко задан.
+
+### Блокеры
+- Нет жёстких блокеров. Миграция Prisma и новые эндпоинты выполняются независимо.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Agregation `/dashboard/me` становится «божественным эндпоинтом» и медленным — 6+ параллельных запросов внутри | HIGH | p95 > 500ms, деградация TTFB дашборда | Parallel `Promise.all`, cache Redis TTL 30s (invalidate on issue/time update events). Запросы разбиты: issues-by-me, sprint-active, time-week, activity-recent. Разрешить частичный ответ: если одна из секций упала — вернуть остальное с полем `partial: true` + `errors[]` |
+| 2 | Ролевой gate в UI + в API рассинхронизируется (UI показывает, бэк возвращает 403) | MEDIUM | Пустые блоки, визуальный мусор | Единый источник — `canViewDashboardWidget(widgetId, user)` в [lib/roles.ts](frontend/src/lib/roles.ts); бэк возвращает секции только для доступных ролей, UI рендерит только те ключи, что есть в ответе |
+| 3 | Activity feed enrichment требует N lookups по `entityId` → тормоза | MEDIUM | Медленный feed (>1s) | Lookup батчуется по `entityType` (одна выборка `issues.findMany({ id: { in: ids } })`); при отсутствии сущности — graceful fallback `entityTitle = '#' + entityId` |
+| 4 | `dashboardLayout` JSON схема эволюционирует — старые данные пользователей ломаются | LOW | Крэш UI или сброс настроек | Версионирование (`{ version: 1, hiddenWidgets: [], widgetOrder: [] }`); при несовпадении версии — use defaults, лог предупреждение |
+| 5 | Рефакторинг ломает существующие e2e-тесты | MEDIUM | Красный CI | [frontend/e2e/specs/02-navigation.spec.ts](frontend/e2e/specs/02-navigation.spec.ts) и auth spec проверяют `/dashboard` — обновить селекторы в том же PR |
+| 6 | Старый дашборд содержит hardcoded токены — любой copy-paste продолжит нарушать SSOT | HIGH | Drift design system | Явное правило в новом коде + ESLint rule (если настроен) + pre-push-reviewer chekcs. Все новые компоненты используют `tokens.*` |
+| 7 | `sprintActive` может отсутствовать у пользователя без назначений — виджет схлопывается | LOW | Дашборд выглядит пустым | Fallback: «Нет активного спринта» с CTA «Перейти к спринтам» |
+| 8 | Новый FAB конфликтует с существующими FAB (если есть) | LOW | Двойные кнопки | Аудит `FloatButton` по проекту перед внедрением |
+| 9 | `ReleaseBurndownChart` тяжёлый (recharts ~90kB gzipped) — тянуть на каждом входе в дашборд медленно | MEDIUM | FCP +200-400ms | `React.lazy()` + `Suspense` для `ReleaseBurndownWidget`. Рендерить skeleton сразу, чарт — после idle |
+| 10 | Агрегация `releasesAtRisk` для MANAGER по всем его проектам может быть тяжёлой (N релизов × вычисление риска) | MEDIUM | +200ms на `/dashboard/me` | Читать готовый `risk` из `ReleaseCheckpoint` cache TTMP-160 (Redis `releaseRisk:{id}`), не пересчитывать. Лимит `limit=10` + сортировка на БД |
+| 11 | «Мои нарушения КТ» полагается на актуальность `ReleaseCheckpoint.state` — если scheduler пропустил тик, данные устаревают | LOW | Бейдж показывает stale count | Использовать готовый `countMyViolations` с его TTL; opt: вызвать `recomputeForRelease` только при клике на задачу из widget, не при каждом mount |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Архитектура дашборда
+
+```
+<DashboardShell role={user.role}>
+  <Header greeting, user, quickActions />
+  <KpiRow widgets={role} />                     ← кликабельные карточки
+  <MainGrid>
+    <Column primary>
+      <FocusWidget />                            ← USER
+      <TeamStatusWidget />                       ← MANAGER
+      <AwaitingReviewWidget />
+    </Column>
+    <Column secondary>
+      <SprintProgressWidget />
+      <TimeWeekWidget />
+      <ActivityFeedWidget />
+      <SystemKpiWidget />                        ← ADMIN only
+    </Column>
+  </MainGrid>
+  <QuickCreateFab />
+</DashboardShell>
+```
+
+- **Grid:** CSS Grid `grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr)`, на ширине ≤ 900px — одна колонка.
+- **WidgetCard wrapper:** header (title + actions slot + «свернуть/скрыть») + content + loading skeleton + empty state + error state с retry-кнопкой.
+- **Ролевой gate** в `DashboardShell`: какие widget ID рендерить — читается из `lib/roles.ts`.
+
+### 5.2 Backend: `/dashboard/me`
+
+Новый модуль `backend/src/modules/dashboard/`:
+
+```ts
+// dashboard.dto.ts
+export type DashboardMeResponse = {
+  user: { id; name; role; avatar };
+  kpi: {
+    assignedToMe: number;         // кол-во OPEN+IN_PROGRESS+REVIEW, assigneeId=me
+    overdue: number;              // dueDate < today, не DONE/CANCELLED
+    dueToday: number;             // dueDate = today
+    loggedThisWeek: number;       // сумма hours за ISO week
+    checkpointViolations: number; // TTMP-160: countMyViolations() — красный pill при > 0
+  };
+  focus: Issue[];                 // top-10 «моих» задач, сортировка: priority DESC × overdue × updatedAt DESC
+  awaitingReview: Issue[];        // REVIEW, где я reviewer или author ревью
+  myViolations: IssueViolationSummary[];  // TTMP-160: top-5 из listMyViolations()
+  activeSprint: {
+    sprint: Sprint;
+    totalIssues, doneIssues, inProgressIssues;
+    daysLeft: number;
+  } | null;
+  primaryReleaseBurndown: {       // Только если пользователь — assignee в активном релизе
+    releaseId: string;
+    releaseName: string;
+    plannedDate: string;
+    daysLeft: number;
+    risk: { level: 'LOW'|'MEDIUM'|'HIGH'|'CRITICAL'; score: number };
+    // Сам чарт догружается отдельно через getBurndown(releaseId) — в агрегат не кладём,
+    // чтобы не раздувать ответ (снапшоты могут быть 60+ точек × 3 метрики)
+  } | null;
+  releasesAtRisk: {               // MANAGER/ADMIN only; USER получает [] или поля нет
+    releaseId; releaseName; projectKey; plannedDate; daysLeft;
+    risk: { level; score };
+    violatedCheckpointsCount: number;
+  }[];
+  timeWeek: {
+    totalHours: number;
+    byDay: { date: string; hours: number }[];  // 7 элементов
+  };
+  recentActivity: (ActivityEntry & {
+    entityTitle?: string;
+    entityUrl?: string;
+    // CheckpointViolation события enrich'атся: entityTitle = '{releaseName} / {checkpointName}',
+    // entityUrl = `/releases/{releaseId}#checkpoint-{id}`
+  })[];
+  partial?: boolean;
+  errors?: { section: string; message: string }[];
+};
+```
+
+Эндпоинт — `GET /api/dashboard/me` без параметров. RBAC: любой аутентифицированный.
+
+**Кэш:** Redis, ключ `dashboard:me:${userId}`, TTL 30s. Invalidate при:
+- update/create Issue (assignee), TimeEntry, статус-переходе Issue, close sprint
+- Событии `checkpoint.violation.opened` / `.closed` (подписка на `checkpointEngine.onViolationChange`, TTMP-160)
+- Изменении `release.statusId` или `release.plannedDate` (влияет на `releasesAtRisk` / `primaryReleaseBurndown`)
+
+**Частичный ответ:** обёрнутые в `Promise.allSettled`, rejected секции → `errors[]`, `partial: true`.
+
+### 5.3 Backend: `/issues/assigned-to-me`
+
+```
+GET /api/issues/assigned-to-me?status=OPEN,IN_PROGRESS&limit=50&sort=priority
+```
+
+Фильтры: `status[]`, `priority[]`, `sprintId`, `dueBefore`, `dueAfter`, `limit` (max 100), `sort` (priority|dueDate|updatedAt).
+
+Scope: `WHERE assigneeId = :userId AND project.deletedAt IS NULL`. Индекс: `CREATE INDEX issue_assignee_status_idx ON Issue(assigneeId, status)` если нет.
+
+### 5.4 Backend: enrichment activity feed
+
+В [admin.service.ts](backend/src/modules/admin/admin.service.ts) `getActivity()` — добавить batch lookup:
+
+```ts
+const byType = groupBy(entries, 'entityType');
+const issueIds = byType['Issue']?.map(e => e.entityId) ?? [];
+const issues = issueIds.length
+  ? await prisma.issue.findMany({ where: { id: { in: issueIds } }, select: { id, title, number, project: { select: { key } } } })
+  : [];
+// + аналогично Sprint, Project, Release
+// Enrich entries: entityTitle, entityUrl (например "/issues/{id}")
+```
+
+### 5.5 Frontend: виджеты
+
+**WidgetCard** — единый API:
+```tsx
+<WidgetCard
+  id="focus"
+  title="Мой фокус"
+  actions={<Button size="small">Все задачи →</Button>}
+  loading={!data}
+  empty={data?.length === 0 && <EmptyState cta="Создать задачу" onCta={openCreateModal} />}
+  error={error && <ErrorState onRetry={refetch} />}
+>
+  {children}
+</WidgetCard>
+```
+
+**FocusWidget** — сортировка:
+```ts
+const score = (i: Issue) =>
+  (i.dueDate && new Date(i.dueDate) < new Date() ? 1000 : 0)    // overdue дают +1000
+  + ({ CRITICAL: 400, HIGH: 300, MEDIUM: 200, LOW: 100 }[i.priority] ?? 0)
+  + (i.sprintId === activeSprintId ? 50 : 0)
+  - daysSinceUpdated(i.updatedAt);
+```
+
+**KpiRow** — 5 карточек, каждая — ссылка с `query-params`:
+- «Мне назначено (12)» → `/search?assigneeId=me&status=OPEN,IN_PROGRESS,REVIEW`
+- «Просрочено (2)» → `/search?assigneeId=me&dueBefore=today`
+- «На сегодня (3)» → `/search?assigneeId=me&dueDate=today`
+- «Время на неделе (14.5h)» → `/time?from=weekStart&to=weekEnd&userId=me`
+- **«Нарушения КТ (1)»** — красный pill при `count > 0`, иначе скрыть/серый; клик → `/my-checkpoint-violations` (новая страница или filter view). Данные — `kpi.checkpointViolations`; дополнительно раз в 60s опрашивается `getMyCheckpointViolationsCount()` для live-обновления (уже готовый эндпоинт TTMP-160)
+
+**MyViolationsWidget** — переиспользует готовые `getMyCheckpointViolations()` + `CheckpointTrafficLight`:
+```tsx
+{violations.map(v => (
+  <Row onClick={() => navigate(`/issues/${v.issueId}`)}>
+    <CheckpointTrafficLight state="VIOLATED" isWarning />
+    <IssueKey>{v.issueKey}</IssueKey>
+    <Title>{v.issueTitle}</Title>
+    <Meta>{v.checkpointName} • до {formatDate(v.deadline)}</Meta>
+    <ReleaseBadge>{v.releaseName}</ReleaseBadge>
+  </Row>
+))}
+```
+Empty state: «Нет нарушений контрольных точек 🎉». При наличии кастом-полей из причины — tooltip с `violationReason`.
+
+**ReleasesAtRiskWidget** (MANAGER/ADMIN) — ролевой gate + reuse `ReleaseRiskBadge`:
+```tsx
+{releasesAtRisk.map(r => (
+  <Row onClick={() => navigate(`/releases/${r.releaseId}`)}>
+    <ReleaseRiskBadge level={r.risk.level} score={r.risk.score} />
+    <Name>{r.projectKey} · {r.releaseName}</Name>
+    <Deadline>{r.plannedDate} ({r.daysLeft > 0 ? `${r.daysLeft}д` : 'просрочен'})</Deadline>
+    <ViolationsCount>{r.violatedCheckpointsCount} КТ нарушено</ViolationsCount>
+  </Row>
+))}
+```
+Пустое состояние: «Нет релизов под угрозой — всё по плану ✅».
+
+**ReleaseBurndownWidget** — lazy wrapper:
+```tsx
+const ReleaseBurndownChart = lazy(() => import('../../releases/ReleaseBurndownChart'));
+
+// USER: primaryReleaseBurndown из агрегата
+// MANAGER: Select с активными релизами из releasesAtRisk (+ все активные), dropdown меняет releaseId
+return (
+  <WidgetCard title="Диаграмма сгорания" actions={<ReleaseSelector />}>
+    {!releaseId ? <EmptyState cta="Перейти к релизам" /> : (
+      <Suspense fallback={<Skeleton.Node active style={{ height: 280 }} />}>
+        <ReleaseBurndownChart releaseId={releaseId} canBackfill={isAdmin} />
+      </Suspense>
+    )}
+  </WidgetCard>
+);
+```
+
+**QuickCreateFab** — `<FloatButton type="primary" icon={<PlusOutlined />} onClick={() => setCreateOpen(true)} />`. Модалка закрытия должна триггерить refresh дашборда (правило из CLAUDE.md).
+
+### 5.6 Design system compliance
+
+- Запрещено hex-коды в новых файлах.
+- Все отступы/радиусы — `tokens.space.*`, `tokens.radius.*`.
+- Инлайновые `style` — через `tokens.dark[..]` / `tokens.light[..]` в зависимости от `theme.mode`, либо CSS-классы + `var(--*)`.
+- Иконки — предпочтительно `@ant-design/icons` вместо inline SVG.
+
+### 5.7 Кастомизация (MVP-lite)
+
+- Без drag-n-drop.
+- Каждый виджет имеет «⋮» меню → «Скрыть виджет».
+- Скрытые виджеты хранятся в `User.dashboardLayout.hiddenWidgets: string[]`.
+- Кнопка «Восстановить скрытые виджеты» в правом верхнем углу дашборда, если есть hidden > 0.
+- Persistence: `PATCH /api/users/me/preferences` с `{ dashboardLayout }`.
+
+### 5.8 Ролевой gate
+
+В [lib/roles.ts](frontend/src/lib/roles.ts) добавить:
+```ts
+export const DASHBOARD_WIDGETS_BY_ROLE = {
+  USER:    ['kpi', 'focus', 'myViolations', 'awaitingReview', 'sprintProgress', 'releaseBurndown', 'timeWeek', 'activity'],
+  MANAGER: ['kpi', 'teamStatus', 'releasesAtRisk', 'releaseBurndown', 'sprintProgress', 'myViolations', 'awaitingReview', 'activity', 'timeWeek'],
+  ADMIN:   ['kpi', 'systemKpi', 'releasesAtRisk', 'teamStatus', 'releaseBurndown', 'activity', 'sprintProgress'],
+  VIEWER:  ['kpi', 'releasesAtRisk', 'activity', 'sprintProgress'],
+} as const;
+```
+
+### 5.9 Feature flag
+
+Реализовать под `FEATURES_DASHBOARD_V2` (по аналогии с существующим `FEATURES_DIRECT_ROLES_DISABLED`). Сначала — opt-in через `?dashboard=v2` query-param для QA, затем полный cutover через env.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: Дашборд загружается одним запросом `/dashboard/me` (не более 1 API-вызова для основного контента; `ReleaseBurndownChart` догружается отдельно по клику/mount)
+- [ ] FR-2: KPI-карточки кликабельны и ведут в отфильтрованный список
+- [ ] FR-3: «Мой фокус» сортирует по приоритету × просрочке × давности, top-10
+- [ ] FR-4: «Ожидают моего ревью» показывает задачи REVIEW, где пользователь — reviewer/author
+- [ ] FR-5: «Прогресс спринта» показывает активный спринт пользователя (scope + done + days left)
+- [ ] FR-6: «Время на неделе» — сумма + разбивка по дням (spark-bar)
+- [ ] FR-7: Activity feed содержит кликабельные ссылки на сущность + её название (включая `CheckpointViolation` / `ReleaseCheckpoint`)
+- [ ] FR-8: MANAGER видит дополнительный «Team Status», ADMIN — «System KPI»
+- [ ] FR-9: FAB «+» открывает модалку создания задачи, после закрытия — refresh дашборда
+- [ ] FR-10: Пустые состояния имеют CTA (создать задачу / перейти к спринтам / залогировать время)
+- [ ] FR-11: Виджеты можно скрывать, предпочтения сохраняются per-user
+- [ ] FR-12: Dashboard полностью использует `tokens.*` — 0 hex-кодов
+- [ ] FR-13: При частичном ответе (`partial: true`) показывается non-blocking banner «Часть данных недоступна, попробовать снова»
+- [ ] FR-14: KPI «Нарушения КТ» показывается всем ролям, красный pill при `count > 0`, обновляется раз в 60s через `getMyCheckpointViolationsCount()`
+- [ ] FR-15: Виджет «Мои нарушения КТ» показывает top-5 с `CheckpointTrafficLight`, дедлайном, именем КТ и релиза; клик переводит к задаче
+- [ ] FR-16: Виджет «Релизы под угрозой» (MANAGER/ADMIN) сортирует по `risk.level` DESC, затем `daysLeft` ASC; показывает `ReleaseRiskBadge` + число нарушенных КТ; клик → `/releases/:id`
+- [ ] FR-17: Виджет «Диаграмма сгорания» (USER/MANAGER) оборачивает готовый `ReleaseBurndownChart`; для USER — `primaryReleaseBurndown` автоматически; для MANAGER — селектор активных релизов его проектов
+- [ ] FR-18: `ReleaseBurndownChart` загружается через `React.lazy`, не блокируя FCP
+- [ ] FR-19: При отсутствии активных релизов виджет burndown показывает empty state с CTA «Перейти к релизам»
+- [ ] FR-20: Событие `checkpoint.violation.opened/closed` инвалидирует кэш `dashboard:me:${userId}` для всех assignee затронутой задачи
+
+### Нефункциональные
+- [ ] NFR-1: TTFB `/dashboard/me` < 300ms (p95) при ≤500 задачах у пользователя
+- [ ] NFR-2: First Contentful Paint дашборда ≤ 1.2s на 3G Fast
+- [ ] NFR-3: Кол-во fetch-запросов при входе ≤ 2 (dashboard + profile)
+- [ ] NFR-4: Layout адаптивен: ≥900px — 2 колонки, <900px — 1 колонка
+- [ ] NFR-5: Совместимость: Chrome 139+, Yandex Browser 25+, Edge 139+, Safari 18+
+- [ ] NFR-6: Cache-hit ratio `/dashboard/me` ≥ 60% за час (Redis TTL 30s)
+
+### Безопасность
+- [ ] SEC-1: `/dashboard/me` отдаёт только данные по проектам, к которым у пользователя есть доступ (через RBAC)
+- [ ] SEC-2: Activity feed фильтруется по доступным проектам (не показывать чужие)
+- [ ] SEC-3: ADMIN-секции (`systemKpi`) возвращаются только если `user.isSuperAdmin || user.role === 'ADMIN'`
+- [ ] SEC-4: `dashboardLayout` валидируется Zod при сохранении (не принимать произвольный JSON)
+- [ ] SEC-5: `releasesAtRisk` scope `mine` фильтруется по project membership (TTMP-160 §SEC-2 reuse); `scope=all` только для SUPER_ADMIN / RELEASE_MANAGER / AUDITOR (по `hasAnySystemRole`)
+- [ ] SEC-6: `myViolations` использует готовый `service.listMyViolations(userId, systemRoles)` — scope уже обеспечен TTMP-160 (SEC-7)
+- [ ] SEC-7: `primaryReleaseBurndown` возвращается только если пользователь имеет доступ к проекту релиза (reuse `assertReleaseRead` TTMP-160)
+
+### Тестирование
+- [ ] Unit: `focus-score` функция (edge cases: все одинаковые приоритеты, нет dueDate, нет activeSprint)
+- [ ] Unit: enrichActivity batch lookup (missing entity fallback, `CheckpointViolation` entity)
+- [ ] Unit: `selectPrimaryRelease(userId)` — edge cases (нет релизов, несколько равнозначных, просроченный)
+- [ ] Integration: `/dashboard/me` для USER/MANAGER/ADMIN — ассерты на наличие/отсутствие секций (включая `releasesAtRisk`, `myViolations`, `primaryReleaseBurndown`)
+- [ ] Integration: `/dashboard/me` partial degradation (один из запросов упал)
+- [ ] Integration: кэш `dashboard:me:${userId}` инвалидируется при `checkpoint.violation.opened`
+- [ ] E2E: [frontend/e2e/specs/02-navigation.spec.ts](frontend/e2e/specs/02-navigation.spec.ts) обновить селекторы; новый spec `dashboard-widgets.spec.ts`:
+  - клик по KPI «Нарушения КТ» ведёт на страницу нарушений
+  - виджет «Релизы под угрозой» показан только MANAGER/ADMIN
+  - виджет «Диаграмма сгорания» рендерит chart (recharts) при наличии primary release
+  - скрытие виджета persist после reload
+- [ ] Покрытие >= 60%
+
+### Доступность (a11y)
+- [ ] A11Y-1: Все кликабельные KPI — `<a>` или `<button>` (не `role="button"` на div)
+- [ ] A11Y-2: WidgetCard заголовки — `<h2>`, контент секций — landmark `<section aria-labelledby>`
+- [ ] A11Y-3: FAB доступен с клавиатуры (Tab / Enter)
+- [ ] A11Y-4: Контраст text/bg ≥ WCAG AA (уже обеспечен токенами, но верифицировать)
+
+---
+
+## 7. Критерии приёмки (Definition of Done)
+
+- [ ] Новый дашборд доступен под flag `FEATURES_DASHBOARD_V2=true` в staging
+- [ ] Дашборд рендерится корректно для всех ролей: USER / MANAGER / ADMIN / VIEWER
+- [ ] Один API-запрос `/dashboard/me` загружает все основные секции (burndown chart догружается lazy отдельно)
+- [ ] KPI кликабельны и ведут в правильные фильтрованные списки (включая KPI «Нарушения КТ»)
+- [ ] FAB «+» открывает модалку создания задачи; после закрытия — refresh данных
+- [ ] Activity feed показывает название сущности + ссылку (не сырой `entityType`), включая `CheckpointViolation`
+- [ ] Виджет «Мои нарушения КТ» показывает top-5 с `CheckpointTrafficLight` и переходит к задаче
+- [ ] Виджет «Релизы под угрозой» с `ReleaseRiskBadge` виден только MANAGER/ADMIN
+- [ ] Виджет «Диаграмма сгорания» рендерится: USER — по primary release, MANAGER — с селектором релиза; recharts загружен lazy
+- [ ] 0 hex-кодов в новых файлах (проверяется `grep -E "#[0-9A-Fa-f]{6}" frontend/src/components/dashboard/`)
+- [ ] Виджеты можно скрыть, предпочтения сохраняются между сессиями
+- [ ] Мобильный layout (≤900px) рендерится одной колонкой без горизонтального скролла
+- [ ] Все тесты зелёные (`make test`, `make e2e`)
+- [ ] Lint проходит (`make lint`)
+- [ ] Lighthouse Performance ≥ 85, Accessibility ≥ 95 на странице дашборда
+- [ ] Code review пройден
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Анализ, прототип (Figma / Excalidraw скетчи) | 3 |
+| Backend: модуль `dashboard` + `/dashboard/me` | 6 |
+| Backend: `/issues/assigned-to-me` + индекс | 2 |
+| Backend: activity enrichment (+ CheckpointViolation) | 2.5 |
+| Backend: `/time/my-summary`, `/sprints/my-active` | 3 |
+| Backend: секции `releasesAtRisk` + `primaryReleaseBurndown` + `selectPrimaryRelease` | 3 |
+| Backend: Redis-кэш + invalidation hooks (включая checkpoint.violation events) | 3 |
+| Backend: миграция Prisma `User.dashboardLayout` | 1 |
+| Frontend: `DashboardShell` + grid + responsive | 3 |
+| Frontend: `WidgetCard` wrapper (loading/empty/error/skeleton) | 2 |
+| Frontend: `KpiRow` + кликабельные ссылки (+ KPI «Нарушения КТ» с poll 60s) | 2.5 |
+| Frontend: `FocusWidget` + score-функция | 3 |
+| Frontend: `AwaitingReviewWidget` | 1 |
+| Frontend: `SprintProgressWidget` | 2 |
+| Frontend: `TimeWeekWidget` + spark-bar | 2 |
+| Frontend: `ActivityFeedWidget` (enriched) | 2 |
+| Frontend: `TeamStatusWidget` (MANAGER) | 2 |
+| Frontend: `SystemKpiWidget` (ADMIN) | 1 |
+| Frontend: `MyViolationsWidget` (reuse `CheckpointTrafficLight`) | 2 |
+| Frontend: `ReleasesAtRiskWidget` (reuse `ReleaseRiskBadge`) | 2 |
+| Frontend: `ReleaseBurndownWidget` (lazy wrapper + селектор релиза для MANAGER) | 2.5 |
+| Frontend: `QuickCreateFab` + модалка + refresh | 2 |
+| Frontend: `dashboard.store` + stale-while-revalidate | 2 |
+| Frontend: кастомизация (hide/restore) + persistence | 3 |
+| Frontend: role gate (`lib/roles`) — расширенный с новыми widget ids | 1 |
+| Тесты: unit + integration + e2e (включая checkpoints/burndown сценарии) | 8 |
+| Migration токенов: удаление `DARK_C`/`LIGHT_C` из нового кода | 1 |
+| Code review + фиксы | 3 |
+| **Итого** | **69.5** |
+
+---
+
+## 9. Связанные задачи
+
+- **Родитель:** нет (STORY верхнего уровня)
+- **Дочерние:**
+  - TTUI-91 — Backend: модуль `dashboard` + эндпоинт `/dashboard/me`
+  - TTUI-92 — Backend: `/issues/assigned-to-me` + индекс
+  - TTUI-93 — Backend: activity feed enrichment (title + URL, включая `CheckpointViolation`)
+  - TTUI-94 — Backend: миграция Prisma `User.dashboardLayout` + `PATCH /users/me/preferences`
+  - TTUI-95 — Frontend: `DashboardShell` + `WidgetCard` + grid/responsive
+  - TTUI-96 — Frontend: `KpiRow` виджет (включая KPI «Нарушения КТ» + poll 60s)
+  - TTUI-97 — Frontend: `FocusWidget` + score-функция
+  - TTUI-98 — Frontend: `SprintProgressWidget` + `TimeWeekWidget`
+  - TTUI-99 — Frontend: `AwaitingReviewWidget` + `ActivityFeedWidget`
+  - TTUI-100 — Frontend: `TeamStatusWidget` + `SystemKpiWidget` (role-specific)
+  - TTUI-101 — Frontend: `QuickCreateFab` + модалка + refresh pattern
+  - TTUI-102 — Frontend: кастомизация (hide/restore) + `dashboard.store`
+  - TTUI-103 — Feature flag + cutover `FEATURES_DASHBOARD_V2`
+  - TTUI-104 — E2E + unit тесты + Lighthouse budget
+  - **TTUI-105** — Backend: секции `releasesAtRisk` + `primaryReleaseBurndown` в `/dashboard/me` + selectPrimaryRelease; invalidation на `checkpoint.violation.opened/closed`
+  - **TTUI-106** — Frontend: `MyViolationsWidget` (reuse `CheckpointTrafficLight` + `getMyCheckpointViolations`)
+  - **TTUI-107** — Frontend: `ReleasesAtRiskWidget` (reuse `ReleaseRiskBadge`)
+  - **TTUI-108** — Frontend: `ReleaseBurndownWidget` (lazy-wrapper над `ReleaseBurndownChart` + селектор релиза для MANAGER)
+
+---
+
+## 10. Иерархия задач
+
+```
+TTUI-90 (STORY) — Рефакторинг дашборда: role-aware фокусная рабочая область
+├── TTUI-91  (TASK) — Backend: dashboard module + /dashboard/me
+├── TTUI-92  (TASK) — Backend: /issues/assigned-to-me + index
+├── TTUI-93  (TASK) — Backend: activity enrichment (+ CheckpointViolation)
+├── TTUI-94  (TASK) — Backend: User.dashboardLayout + PATCH preferences
+├── TTUI-105 (TASK) — Backend: releasesAtRisk + primaryReleaseBurndown + checkpoint invalidation
+├── TTUI-95  (TASK) — Frontend: DashboardShell + WidgetCard + grid
+├── TTUI-96  (TASK) — Frontend: KpiRow (+ KPI «Нарушения КТ»)
+├── TTUI-97  (TASK) — Frontend: FocusWidget + score
+├── TTUI-98  (TASK) — Frontend: SprintProgress + TimeWeek widgets
+├── TTUI-99  (TASK) — Frontend: AwaitingReview + ActivityFeed widgets
+├── TTUI-100 (TASK) — Frontend: TeamStatus + SystemKpi widgets
+├── TTUI-106 (TASK) — Frontend: MyViolationsWidget (reuse TTMP-160)
+├── TTUI-107 (TASK) — Frontend: ReleasesAtRiskWidget (reuse ReleaseRiskBadge)
+├── TTUI-108 (TASK) — Frontend: ReleaseBurndownWidget (lazy wrapper)
+├── TTUI-101 (TASK) — Frontend: QuickCreateFab + modal + refresh
+├── TTUI-102 (TASK) — Frontend: customization (hide/restore)
+├── TTUI-103 (TASK) — Feature flag FEATURES_DASHBOARD_V2 + cutover
+└── TTUI-104 (TASK) — Tests (unit + integration + e2e) + Lighthouse
+```
+
+**Рекомендуемый порядок реализации:**
+1. TTUI-91 → TTUI-92 → TTUI-93 → **TTUI-105** (backend data sources first; 105 расширяет агрегат под checkpoints/burndown — не блокирует виджеты, но нужен до 106-108)
+2. TTUI-94 (preferences) — можно параллельно с shell
+3. TTUI-95 (shell) → TTUI-96 (KPI) → TTUI-97–100 + **TTUI-106..108** (виджеты, параллелятся)
+4. TTUI-101 (FAB) → TTUI-102 (customization) → TTUI-103 (feature flag)
+5. TTUI-104 (tests + perf) — финал перед cutover


### PR DESCRIPTION
Чисто-документарный PR: добавляет три ТЗ + JSON-сайдкары, уже упомянутых в `docs/tz/INDEX.md`, но физически отсутствующих в репо.

## Что добавляется

| Файл | Назначение |
|------|------------|
| `docs/tz/TTMP-160.json` | JSON-сайдкар EPIC "Модуль контрольных точек релизов" (12/12 PR merged ✅). Источник для регенерации .md + связь с issueId в TaskTime API. |
| `docs/tz/TTUI-90.md` + `.json` | STORY: рефакторинг дашборда с role-aware фокусной рабочей областью. Переиспользует готовые компоненты из TTMP-160 (risk-badge, светофор, burndown-чарт, мои нарушения, матрица КТ). |
| `docs/tz/TTSRH-1.md` + `.json` | EPIC: внутренний язык запросов TTS-QL (JQL-совместимый) + страница поиска с сохраняемыми фильтрами + TTS-QL-условия в критериях КТ. |
| `docs/tz/TTSRH-1-goldenset.jql` | Golden-set запросов для регрессионного тестирования парсера TTS-QL. |

Документы уже отсылаются из `docs/tz/INDEX.md` (строки добавлены в ходе предыдущих коммитов); этот PR просто подтягивает их содержимое в репозиторий.

## Not changed
- Никаких code-изменений.
- Миграций нет.
- CI изменений нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)