### PR TITLE
feat(search): TTSRH-1 PR-1 — foundation (Prisma + feature flags + stubs)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -45,6 +45,8 @@ import releaseCheckpointsRouter, {
 } from './modules/releases/checkpoints/release-checkpoints.router.js';
 import checkpointAuditRouter from './modules/releases/checkpoints/audit.router.js';
 import burndownRouter from './modules/releases/checkpoints/burndown.router.js';
+import searchRouter from './modules/search/search.router.js';
+import savedFiltersRouter from './modules/saved-filters/saved-filters.router.js';
 import roleSchemesRouter from './modules/project-role-schemes/project-role-schemes.router.js';
 import userGroupsRouter from './modules/user-groups/user-groups.router.js';
 import userSecurityRouter from './modules/user-security/user-security.router.js';
@@ -166,6 +168,15 @@ export function createApp() {
   app.use('/api/admin/user-groups', userGroupsRouter);
   app.use('/api', userSecurityRouter);
   app.use('/api', workflowEngineRouter);
+
+  // TTSRH-1 PR-1: TTS-QL search + saved filters — mounted only under feature flag.
+  // When disabled, requests to /api/search/* and /api/saved-filters/* fall through to the
+  // 404 handler (Express default), which is what we want for not-yet-cutover features.
+  // See docs/tz/TTSRH-1.md §13.1.
+  if (features.advancedSearch) {
+    app.use('/api', searchRouter);
+    app.use('/api', savedFiltersRouter);
+  }
 
   // Public: project workflow scheme
   app.get('/api/projects/:projectId/workflow-scheme', authenticate, async (req, res, next) => {

--- a/backend/src/modules/saved-filters/saved-filters.router.ts
+++ b/backend/src/modules/saved-filters/saved-filters.router.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express';
+import { authenticate } from '../../shared/middleware/auth.js';
+
+/**
+ * TTSRH-1 PR-1 — stub-роутер для сохранённых фильтров (TTS-QL). Модели SavedFilter /
+ * SavedFilterShare уже мигрированы в этой же ветке, но CRUD-логика поступит в PR-7
+ * (см. §13.5 в docs/tz/TTSRH-1.md). До этого — 501.
+ *
+ * Gate по `features.advancedSearch` — в app.ts.
+ */
+const router = Router();
+router.use(authenticate);
+
+function notImplemented(endpoint: string) {
+  return (_req: unknown, res: { status: (code: number) => { json: (body: unknown) => void } }) => {
+    res.status(501).json({
+      error: 'NOT_IMPLEMENTED',
+      endpoint,
+      message:
+        'Saved-filter endpoints are under development. See docs/tz/TTSRH-1.md — delivered in PR-7.',
+    });
+  };
+}
+
+router.get('/saved-filters', notImplemented('GET /saved-filters'));
+router.post('/saved-filters', notImplemented('POST /saved-filters'));
+router.get('/saved-filters/:id', notImplemented('GET /saved-filters/:id'));
+router.patch('/saved-filters/:id', notImplemented('PATCH /saved-filters/:id'));
+router.delete('/saved-filters/:id', notImplemented('DELETE /saved-filters/:id'));
+router.post('/saved-filters/:id/favorite', notImplemented('POST /saved-filters/:id/favorite'));
+router.post('/saved-filters/:id/share', notImplemented('POST /saved-filters/:id/share'));
+
+export default router;

--- a/backend/src/modules/saved-filters/saved-filters.router.ts
+++ b/backend/src/modules/saved-filters/saved-filters.router.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type Request, type Response } from 'express';
 import { authenticate } from '../../shared/middleware/auth.js';
 
 /**
@@ -12,7 +12,7 @@ const router = Router();
 router.use(authenticate);
 
 function notImplemented(endpoint: string) {
-  return (_req: unknown, res: { status: (code: number) => { json: (body: unknown) => void } }) => {
+  return (_req: Request, res: Response): void => {
     res.status(501).json({
       error: 'NOT_IMPLEMENTED',
       endpoint,

--- a/backend/src/modules/search/search.router.ts
+++ b/backend/src/modules/search/search.router.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type Request, type Response } from 'express';
 import { authenticate } from '../../shared/middleware/auth.js';
 
 /**
@@ -17,7 +17,7 @@ const router = Router();
 router.use(authenticate);
 
 function notImplemented(endpoint: string) {
-  return (_req: unknown, res: { status: (code: number) => { json: (body: unknown) => void } }) => {
+  return (_req: Request, res: Response): void => {
     res.status(501).json({
       error: 'NOT_IMPLEMENTED',
       endpoint,

--- a/backend/src/modules/search/search.router.ts
+++ b/backend/src/modules/search/search.router.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { authenticate } from '../../shared/middleware/auth.js';
+
+/**
+ * TTSRH-1 PR-1 — stub-роутер для TTS-QL-поиска. На этой фазе модуль примонтирован,
+ * но все эндпоинты возвращают 501 Not Implemented. Это позволяет:
+ *   1) проверить на staging, что mount проходит без коллизий путей;
+ *   2) задать публичные контракты путей (см. §5.6 в docs/tz/TTSRH-1.md) до
+ *      появления парсера/компилятора/валидатора;
+ *   3) дать фронту повод «уметь» обрабатывать 501 уже сейчас.
+ *
+ * Фактическая реализация поступит в PR-2..PR-8 (см. §13.4–13.5 ТЗ).
+ * Gate по `features.advancedSearch` происходит в app.ts: при выключенном флаге весь
+ * префикс `/api/search` даёт 404, поэтому здесь делаем только authenticate.
+ */
+const router = Router();
+router.use(authenticate);
+
+function notImplemented(endpoint: string) {
+  return (_req: unknown, res: { status: (code: number) => { json: (body: unknown) => void } }) => {
+    res.status(501).json({
+      error: 'NOT_IMPLEMENTED',
+      endpoint,
+      message:
+        'TTS-QL search endpoints are under development. See docs/tz/TTSRH-1.md — delivered in PR-5..PR-8.',
+    });
+  };
+}
+
+router.post('/search/issues', notImplemented('POST /search/issues'));
+router.post('/search/validate', notImplemented('POST /search/validate'));
+router.get('/search/suggest', notImplemented('GET /search/suggest'));
+router.post('/search/export', notImplemented('POST /search/export'));
+router.get('/search/schema', notImplemented('GET /search/schema'));
+
+export default router;

--- a/backend/src/prisma/migrations/20260423000000_ttsrh_saved_filters/migration.sql
+++ b/backend/src/prisma/migrations/20260423000000_ttsrh_saved_filters/migration.sql
@@ -1,0 +1,72 @@
+-- TTSRH-1 PR-1: Saved filters foundation (TTS-QL)
+
+-- User.preferences — JSON column for per-user UI defaults (search columns, page size, etc.)
+ALTER TABLE "users" ADD COLUMN "preferences" JSONB;
+
+-- Enums
+CREATE TYPE "FilterVisibility" AS ENUM ('PRIVATE', 'SHARED', 'PUBLIC');
+CREATE TYPE "FilterPermission" AS ENUM ('READ', 'WRITE');
+
+-- saved_filters
+CREATE TABLE "saved_filters" (
+    "id"           TEXT NOT NULL,
+    "owner_id"     TEXT NOT NULL,
+    "name"         TEXT NOT NULL,
+    "description"  TEXT,
+    "jql"          TEXT NOT NULL,
+    "visibility"   "FilterVisibility" NOT NULL DEFAULT 'PRIVATE',
+    "columns"      JSONB,
+    "is_favorite"  BOOLEAN NOT NULL DEFAULT false,
+    "last_used_at" TIMESTAMP(3),
+    "use_count"    INTEGER NOT NULL DEFAULT 0,
+    "created_at"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"   TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "saved_filters_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "saved_filters_owner_id_idx" ON "saved_filters"("owner_id");
+CREATE INDEX "saved_filters_visibility_idx" ON "saved_filters"("visibility");
+
+ALTER TABLE "saved_filters"
+    ADD CONSTRAINT "saved_filters_owner_id_fkey"
+    FOREIGN KEY ("owner_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- saved_filter_shares
+CREATE TABLE "saved_filter_shares" (
+    "id"         TEXT NOT NULL,
+    "filter_id"  TEXT NOT NULL,
+    "user_id"    TEXT,
+    "group_id"   TEXT,
+    "permission" "FilterPermission" NOT NULL DEFAULT 'READ',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "saved_filter_shares_pkey" PRIMARY KEY ("id"),
+    -- XOR: exactly one of user_id / group_id must be set. Prisma cannot express this
+    -- declaratively, so we enforce it at the DB level.
+    CONSTRAINT "saved_filter_shares_user_or_group_chk"
+        CHECK (("user_id" IS NOT NULL) <> ("group_id" IS NOT NULL))
+);
+
+CREATE INDEX "saved_filter_shares_filter_id_idx" ON "saved_filter_shares"("filter_id");
+CREATE INDEX "saved_filter_shares_user_id_idx" ON "saved_filter_shares"("user_id");
+CREATE INDEX "saved_filter_shares_group_id_idx" ON "saved_filter_shares"("group_id");
+
+-- Business uniqueness: one share row per (filter, subject). Partial unique indexes
+-- because user_id / group_id are nullable (XOR enforced by the CHECK above).
+CREATE UNIQUE INDEX "saved_filter_shares_filter_id_user_id_key"
+    ON "saved_filter_shares"("filter_id", "user_id")
+    WHERE "group_id" IS NULL;
+CREATE UNIQUE INDEX "saved_filter_shares_filter_id_group_id_key"
+    ON "saved_filter_shares"("filter_id", "group_id")
+    WHERE "user_id" IS NULL;
+
+ALTER TABLE "saved_filter_shares"
+    ADD CONSTRAINT "saved_filter_shares_filter_id_fkey"
+    FOREIGN KEY ("filter_id") REFERENCES "saved_filters"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "saved_filter_shares"
+    ADD CONSTRAINT "saved_filter_shares_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "saved_filter_shares"
+    ADD CONSTRAINT "saved_filter_shares_group_id_fkey"
+    FOREIGN KEY ("group_id") REFERENCES "user_groups"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/src/prisma/migrations/20260423000000_ttsrh_saved_filters/migration.sql
+++ b/backend/src/prisma/migrations/20260423000000_ttsrh_saved_filters/migration.sql
@@ -20,6 +20,7 @@ CREATE TABLE "saved_filters" (
     "last_used_at" TIMESTAMP(3),
     "use_count"    INTEGER NOT NULL DEFAULT 0,
     "created_at"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- updated_at — managed by Prisma @updatedAt; must always be set by ORM on insert/update.
     "updated_at"   TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "saved_filters_pkey" PRIMARY KEY ("id")

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   isActive           Boolean  @default(true) @map("is_active")
   isSystem           Boolean  @default(false) @map("is_system")
   mustChangePassword Boolean  @default(false) @map("must_change_password")
+  preferences        Json?
   createdAt          DateTime @default(now()) @map("created_at")
   updatedAt          DateTime @updatedAt @map("updated_at")
 
@@ -38,6 +39,8 @@ model User {
   groupMemberships           UserGroupMember[]       @relation("GroupMemberUser")
   addedGroupMembers          UserGroupMember[]       @relation("GroupMemberAddedBy")
   checkpointTemplatesCreated CheckpointTemplate[]    @relation("checkpointTemplateCreator")
+  savedFilters               SavedFilter[]           @relation("savedFilterOwner")
+  savedFilterShares          SavedFilterShare[]      @relation("savedFilterShareUser")
 
   @@map("users")
 }
@@ -1075,8 +1078,9 @@ model UserGroup {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
-  members      UserGroupMember[]
-  projectRoles ProjectGroupRole[]
+  members           UserGroupMember[]
+  projectRoles      ProjectGroupRole[]
+  savedFilterShares SavedFilterShare[] @relation("savedFilterShareGroup")
 
   @@index([name])
   @@map("user_groups")
@@ -1252,4 +1256,62 @@ model ReleaseBurndownSnapshot {
   @@index([releaseId])
   @@index([snapshotDate])
   @@map("release_burndown_snapshots")
+}
+
+// ===== TTSRH-1: SAVED FILTERS (TTS-QL) =====
+
+enum FilterVisibility {
+  PRIVATE
+  SHARED
+  PUBLIC
+}
+
+enum FilterPermission {
+  READ
+  WRITE
+}
+
+model SavedFilter {
+  id          String           @id @default(uuid())
+  ownerId     String           @map("owner_id")
+  name        String
+  description String?
+  jql         String           @db.Text
+  visibility  FilterVisibility @default(PRIVATE)
+  columns     Json?
+  isFavorite  Boolean          @default(false) @map("is_favorite")
+  lastUsedAt  DateTime?        @map("last_used_at")
+  useCount    Int              @default(0) @map("use_count")
+  createdAt   DateTime         @default(now()) @map("created_at")
+  updatedAt   DateTime         @updatedAt @map("updated_at")
+
+  owner  User               @relation("savedFilterOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+  shares SavedFilterShare[]
+
+  @@index([ownerId])
+  @@index([visibility])
+  @@map("saved_filters")
+}
+
+model SavedFilterShare {
+  id         String           @id @default(uuid())
+  filterId   String           @map("filter_id")
+  userId     String?          @map("user_id")
+  groupId    String?          @map("group_id")
+  permission FilterPermission @default(READ)
+  createdAt  DateTime         @default(now()) @map("created_at")
+
+  filter SavedFilter @relation(fields: [filterId], references: [id], onDelete: Cascade)
+  user   User?       @relation("savedFilterShareUser", fields: [userId], references: [id], onDelete: Cascade)
+  group  UserGroup?  @relation("savedFilterShareGroup", fields: [groupId], references: [id], onDelete: Cascade)
+
+  // Postgres PK cannot contain nullable columns, so we use a surrogate id. The business
+  // uniqueness (filter × subject) is enforced via two partial unique indexes declared in
+  // the migration SQL — one for (filterId, userId) WHERE groupId IS NULL, one for
+  // (filterId, groupId) WHERE userId IS NULL. A CHECK constraint enforces that exactly
+  // one of userId/groupId is set (XOR).
+  @@index([filterId])
+  @@index([userId])
+  @@index([groupId])
+  @@map("saved_filter_shares")
 }

--- a/backend/src/shared/features.ts
+++ b/backend/src/shared/features.ts
@@ -7,6 +7,8 @@
  *   FEATURES_MCP=true
  *   FEATURES_GITLAB=true
  *   FEATURES_TELEGRAM=true
+ *   FEATURES_ADVANCED_SEARCH=false         # TTSRH-1 cutover flag (TTS-QL + страница поиска)
+ *   FEATURES_CHECKPOINT_TTQL=false         # TTSRH-1 sub-flag: TTQL-ветка evaluator'а КТ
  *   FEATURES_DIRECT_ROLES_DISABLED=false   # TTSEC-2 Phase 4 cutover flag
  *   AI_PROVIDER=anthropic   # anthropic | heuristic
  */
@@ -22,6 +24,11 @@ export const features = {
   mcp: flag('FEATURES_MCP', true),
   gitlab: flag('FEATURES_GITLAB', true),
   telegram: flag('FEATURES_TELEGRAM', false),
+  // TTSRH-1: off by default until UAT cutover (см. §13.1 в docs/tz/TTSRH-1.md).
+  advancedSearch: flag('FEATURES_ADVANCED_SEARCH', false),
+  // TTSRH-1 sub-flag: TTQL-ветка evaluator'а КТ. Отдельно от advancedSearch, чтобы
+  // core-поиск можно было раскатить раньше, не влияя на scheduler КТ (см. PR-16 в §13).
+  checkpointTtql: flag('FEATURES_CHECKPOINT_TTQL', false),
   aiProvider: (process.env.AI_PROVIDER ?? 'heuristic') as 'anthropic' | 'heuristic',
 } as const;
 

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1169,3 +1169,357 @@ due IS NOT EMPTY ORDER BY due ASC, priority DESC
 - [ ] Обновить [docs/api/reference.md](docs/api/reference.md) эндпоинтами из 5.6.
 - [ ] Обновить [version_history.md](version_history.md) записью о TTSRH-1 в том же коммите, что функциональный код (memory rule).
 - [ ] Добавить в [docs/MCP_GUIDE.html](docs/MCP_GUIDE.html) упоминание `search_issues` MCP-tool, если решим покрыть и MCP (отдельный тикет TTSRH-25, опционально).
+
+---
+
+## 13. План реализации (PR / ветки / merge plan)
+
+### 13.1 Стратегия
+
+- **База:** все ветки создаются от свежего `main`, PR-ы мерджатся напрямую в `main` (консистентно с TTMP-160).
+- **Feature flag:** `FEATURES_ADVANCED_SEARCH=false` в production до PR-21 (UAT cutover). Пункт сайдбара, страница `/search` и Admin-секция «TTS-QL в КТ» при выключенном флаге не рендерятся / 404. Бекенд-эндпоинты `/api/search/*` и `/api/saved-filters/*` защищены тем же флагом (middleware → 404) чтобы не предлагать недокументированный API. КТ-TTQL ветка в evaluator'е — отдельный sub-flag `FEATURES_CHECKPOINT_TTQL=false` на случай, если core-поиск выкатим раньше.
+- **Именование веток:** `ttsrh-1/<scope>` (совместимо с `ttmp-160/<scope>`, `ttadm-68/<scope>`).
+- **Имя коммита:** `feat(search): TTSRH-1 — <scope>`, `feat(checkpoints): TTSRH-1 — <scope>`, `chore(search): …` для вспомогательных.
+- **Размер PR:** целимся 400–900 строк diff. PR-10 и PR-15 потенциально крупнее — при 1000+ строк разбиваем на два.
+- **CI:** каждый PR — `make lint`, `make test`, Playwright e2e (кроме PR, не меняющих UI). Начиная с PR-5 CI обязан прогонять fuzz-harness (5 мин, 1000 случайных JQL, 0 unhandled / 0 500).
+- **Staging deploy:** авто-деплой на `main`; smoke-check по чек-листу PR (см. чек-листы в каждой карточке).
+- **Security review gate:** merge PR-5 и PR-16 (анти-инъекция, скоуп, raw SQL в `Prisma.sql`) требует apprоv'а отдельного security-review человека (R1, R3).
+- **Миграции:** каждая Prisma-миграция — отдельный PR (PR-1, PR-15), чтобы `prisma migrate deploy` был проверяем на staging перед follow-up кодом.
+- **Backward compat:** PR-15 **не конвертирует** existing `CheckpointType.criteria` в TTQL — все существующие КТ остаются `conditionMode='STRUCTURED'`, поведение неизменно (R21, FR-25).
+
+### 13.2 DAG зависимостей
+
+```
+PR-1 (schema+flag) ─► PR-2 (parser) ─► PR-3 (validator+schema) ─► PR-4 (compiler) ─► PR-5 (endpoints+fuzz)
+                                                                                      │
+                                                                                      ├─► PR-6 (suggesters backend)
+                                                                                      ├─► PR-7 (SavedFilter API + user prefs)
+                                                                                      └─► PR-8 (export CSV/XLSX)
+
+PR-5 ─► PR-9  (SearchPage shell + sidebar + route)
+PR-6 ─► PR-10 (JqlEditor + highlight + inline errors)
+PR-6 ─► PR-11 (ValueSuggesterPopup + CM6 adapter)
+PR-9+PR-10+PR-11 ─► PR-12 (BasicFilterBuilder + toggle)
+PR-7 ─► PR-13 (SavedFiltersSidebar + modals + store)
+PR-5 ─► PR-14 (ColumnConfigurator + ResultsTable + bulk + export UI + shortcuts)
+
+PR-1 ─► PR-15 (Checkpoint Prisma + DTO + КТ-функции) ─► PR-16 (engine TTQL-ветка + error handling)
+PR-16 ─► PR-17 (/preview + violatedCheckpoints* функции + checkpoint-поля)
+PR-5+PR-15 ─► PR-18 (КТ UI: segment-mode + JqlEditor + Preview panel + mode-icon)
+PR-18 ─► PR-19 (structured→TTQL converter)
+
+PR-12+PR-13+PR-14+PR-17+PR-19 ─► PR-20 (E2E + perf seed + Lighthouse)
+PR-20 ─► PR-21 (docs + feature flag cutover)
+```
+
+Параллелизм: после merge PR-5 — PR-6/PR-7/PR-8 параллельно; после PR-6 — PR-10/PR-11 параллельно; после PR-1 — PR-15 параллельно со всей core-цепочкой (backend КТ не зависит от завершённого frontend поиска).
+
+### 13.3 PR-ы Фазы 0 — Foundation (~6ч)
+
+#### PR-1: Prisma schema + feature flag
+- **Branch:** `ttsrh-1/foundation`
+- **Scope:**
+  - Миграция `YYYYMMDDHHMMSS_ttsrh_saved_filters_and_checkpoint_ttql` — модели `SavedFilter`, `SavedFilterShare`, enum `FilterVisibility`, `FilterPermission`, `User.preferences Json?`. (§3.3)
+  - env-флаги `FEATURES_ADVANCED_SEARCH`, `FEATURES_CHECKPOINT_TTQL` в [shared/config.ts](backend/src/shared/config.ts).
+  - Пустой модуль `backend/src/modules/search/` и `backend/src/modules/saved-filters/` с `search.router.ts`/`saved-filters.router.ts`, возвращающими 404 при выключенном флаге; mount в `app.ts`.
+  - Пустой файл `frontend/src/pages/SearchPage.tsx` (placeholder «Feature disabled»), условный рендер пункта сайдбара (только при флаге).
+  - `prisma generate`, тесты `make test`.
+- **Не включает:** ни грамматики, ни UI, ни CRUD SavedFilter — только инфраструктуру.
+- **Merge-ready check:** миграция применяется/откатывается на чистой БД; при `FEATURES_ADVANCED_SEARCH=true` эндпоинты возвращают 501 (`Not implemented`); пункт сайдбара появляется.
+- **Оценка:** ~6ч.
+
+### 13.4 PR-ы Фазы 1 — TTS-QL Backend Core (~50ч)
+
+#### PR-2: Tokenizer + Parser + AST + golden-set
+- **Branch:** `ttsrh-1/parser`
+- **Scope:** (§5.1, TTSRH-2)
+  - `backend/src/modules/search/search.ast.ts` — типы `Node`, `OrNode`, `AndNode`, `NotNode`, `ClauseNode`, `FunctionCall`, `Literal`, `OrderBy`, `Span`.
+  - `search.tokenizer.ts` — regex-лексер (STRING с escape, NUMBER, IDENT, KEYWORD, OP, RELATIVE_DATE, CUSTOM_FIELD), позиции `{start, end}`.
+  - `search.parser.ts` — recursive descent, приоритет `( > NOT > AND > OR > ORDER BY`; ошибки с позицией (recovery-режим для частичного AST — подготовка к suggest).
+  - Unit: **100+ кейсов** (экранирование, NOT-приоритет, глубокая вложенность, комментарии `--`, unicode, RTL, null-byte) + snapshot-тесты AST.
+  - Golden-set: [docs/tz/TTSRH-1-goldenset.jql](docs/tz/TTSRH-1-goldenset.jql) — все 50 запросов парсятся без ошибок; выделить под это тест-файл `parser-goldenset.test.ts`.
+- **Не включает:** валидатор, компилятор, эндпоинты.
+- **Merge-ready check:** T-1, T-7 (1000-fuzz через базовый harness — 0 unhandled) зелёные; покрытие парсера ≥ 95%.
+- **Оценка:** ~14ч.
+
+#### PR-3: Field registry + Validator + функции + /search/schema
+- **Branch:** `ttsrh-1/validator`
+- **Scope:** (§5.2, §5.4, TTSRH-3, TTSRH-6)
+  - `search.schema.ts` — реестр полей (system из 5.2) + динамическая подгрузка custom fields через `CustomField.findMany({where: {isEnabled: true}})` с кэшем 60с.
+  - `search.functions.ts` — реализация MVP-функций (`currentUser()`, `now()`, `today()`, `startOfDay/Week/Month/Year`, `openSprints()`, `closedSprints()`, `futureSprints()`, `unreleasedVersions()`, `releasedVersions()`, `linkedIssues()`, `subtasksOf()`, `epicIssues()`, `myOpenIssues()`, `membersOf()`).
+  - `search.validator.ts` — ходит по AST, резолвит field↔type, operator↔type-compatibility, function arity/types; возвращает `{valid, errors: [{start, end, code, message, hint?}]}` без прерывания (для UX автокомплита).
+  - `GET /api/search/schema` (`?variant=default`) — структура для UI-подсказок: `{fields: [{name, type, operators, sortable, synonyms}], functions: [...]}`.
+  - `POST /api/search/validate` — stub, делегирует в validator (без выполнения).
+  - Unit T-3 (функции с моком даты), snapshot-тесты validator-ошибок.
+- **Не включает:** компилятор (нет SQL/where), suggest (только schema).
+- **Merge-ready check:** T-3 зелёные; `/search/validate` на 50 golden-set-запросов возвращает `valid: true`; все Phase-2 операторы (`WAS`, `CHANGED`) возвращают `NotImplemented` с позицией.
+- **Оценка:** ~14ч.
+
+#### PR-4: Compiler (system + custom fields → Prisma where)
+- **Branch:** `ttsrh-1/compiler`
+- **Scope:** (§5.5, TTSRH-4, TTSRH-5)
+  - `search.compiler.ts`:
+    - AST → `Prisma.IssueWhereInput` для system-полей.
+    - Custom fields — `Prisma.sql` raw-fragment с JSON-операторами (`->>`, `@>`, числовые касты) в `id IN (SELECT issue_id FROM issue_custom_field_values WHERE ...)`. Диспетчеризация по `CustomFieldType` (§5.3).
+    - **Scope-фильтр на верхнем AND** (R3): `projectId IN (:accessibleProjectIds)` — всегда добавляется компилятором, не парсером. Извлекаем `accessibleProjectIds` тем же паттерном, что `issues.router.ts:57-65` (R3).
+    - Ambiguity-резолв для `"Story Points"` (R7): если без `project = X` и поле есть в нескольких scoped `FieldSchemaBinding` — warning через `warnings[]` в ответе, компилятор выбирает union всех совпадений.
+    - Композитные индексы, обоснованные профайлингом (`@@index([projectId, assigneeId, status])`, `@@index([sprintId, status])`) — в follow-up миграции после perf-seed (PR-20).
+  - Unit T-2 (per-field × per-operator матрица ≥ 60), integration T-5 (RBAC negative — 0 задач при `project = "SECRET"` без доступа).
+  - Property-based тест: fuzzer→parser→validator→compiler не падает на 1000 random inputs (расширение fuzz-harness).
+- **Не включает:** эндпоинты (`/search/issues` пока недоступен), suggest, history-операторы.
+- **Merge-ready check:** T-2, T-5 зелёные; security-review gate — все raw-SQL через `Prisma.sql`; покрытие compiler ≥ 85%.
+- **Оценка:** ~18ч.
+
+#### PR-5: Endpoints + rate-limit + timeout + fuzz-harness
+- **Branch:** `ttsrh-1/endpoints`
+- **Scope:** (§5.6, §5.9, TTSRH-7, TTSRH-11)
+  - `POST /api/search/issues` — pipeline `parse → validate → compile → prisma.findMany` с pagination (`startAt ≤ 10000`, `limit ≤ 100`, total count), scope-фильтр из context.
+  - Rate-limit middleware 30/min/user (паттерн существующих middlewares), hard-timeout 10с (504 gateway-timeout, не 500), cap-результат 500 для «только-текстовых» запросов (R4). Middleware пишет в `AuditLog` medium-debug.
+  - Fuzz-harness `backend/tests/search-fuzz.test.ts`: 1000 случайных JQL (экранируемые кавычки, null-bytes, unicode RTL, SQL-payloads), 0 unhandled, 0 500.
+  - Security-review checklist `docs/security/search-ttql-review.md`: raw-SQL paths, scope-enforcement, rate-limit, timeout, CSRF/CORS.
+  - Integration T-4 (5 ролей × 5 запросов), T-8 (perf на 100K задач — выносится сидер в `backend/tests/fixtures/search-100k.ts`).
+- **Не включает:** `/suggest`, `/export`, SavedFilter.
+- **Merge-ready check:** T-4, T-5, T-7, T-8 зелёные; **security-review approver** подписал; staging под флагом работает для golden-set.
+- **Оценка:** ~10ч.
+
+### 13.5 PR-ы Фазы 2 — Suggest + SavedFilter + Export (~22ч)
+
+#### PR-6: Value Suggesters backend + /search/suggest
+- **Branch:** `ttsrh-1/suggesters`
+- **Scope:** (§5.11, TTSRH-25)
+  - `search.suggest.ts`:
+    - Позиционный парсер (recovery-режим из PR-2): определяет `expectedField | expectedOperator | expectedValue | inValueList`.
+    - Реестр провайдеров: `ProjectSuggester`, `UserSuggester`, `StatusSuggester`, `EnumSuggester`, `IssueTypeSuggester`, `SprintSuggester`, `ReleaseSuggester`, `IssueSuggester`, `LabelSuggester`, `OptionSuggester`, `ReferenceSuggester`, `DateSuggester`, `NumberSuggester`, `TextSuggester`, `BoolSuggester`, `GroupSuggester`.
+    - Scope-фильтр для dynamic-provider'ов (scoped user-set, project-set).
+    - Fuzzy-ranking (exact → startsWith → contains → subsequence); user-suggester приоритизирует по `AuditLog.lastInteractedAt` (или считаем per-request top-50 без истории).
+    - Дедупликация в `IN (…)` (R7).
+  - `GET /api/search/suggest?jql=...&cursor=N[&field=&operator=&prefix=]` — §5.11 контракт.
+  - Integration T-11 (13 suggester'ов × prefix-ранжирование + scope).
+- **Не включает:** frontend-адаптер — он в PR-11.
+- **Merge-ready check:** T-11 зелёные; /suggest p95 < 200ms на seed (NFR-3).
+- **Оценка:** ~10ч.
+
+#### PR-7: SavedFilter CRUD + sharing + favorite + User.preferences
+- **Branch:** `ttsrh-1/saved-filters`
+- **Scope:** (§5.6, TTSRH-8, TTSRH-9)
+  - `saved-filters.dto.ts`, `saved-filters.service.ts`, `saved-filters.router.ts`:
+    - `GET /api/saved-filters?scope=mine|shared|public|favorite`.
+    - `POST /api/saved-filters` с Zod-валидацией visibility/sharedWith.
+    - `GET/PATCH/DELETE /api/saved-filters/:id` (403 на чужое, 200 на SHARED-WRITE).
+    - `POST /api/saved-filters/:id/favorite`, `POST /api/saved-filters/:id/share`.
+    - Инкремент `useCount`/`lastUsedAt` при `GET /:id/execute` (или при фронт-оркестрированном `POST /search/issues` с `savedFilterId=` — выбрать паттерн, зафиксировать в PR).
+    - `AuditLog` на create/update/delete/share (SEC-7).
+  - `users.service.ts` — расширение `GET/PATCH /api/users/me/preferences` для `{searchDefaults: {columns: string[], pageSize: number}}`. JSON-схема с версионированием (паттерн TTUI-90 §5.4).
+  - Integration T-6 (CRUD + sharing + RBAC negative).
+- **Merge-ready check:** T-6 зелёные; SavedFilter PUBLIC + невидимые проекты → 0 задач (SEC-8).
+- **Оценка:** ~8ч.
+
+#### PR-8: Export CSV/XLSX
+- **Branch:** `ttsrh-1/export`
+- **Scope:** (§5.6, TTSRH-10)
+  - `POST /api/search/export { jql, format: 'csv'|'xlsx', columns }` — streaming response, hard-timeout 60с (NFR-8).
+  - `papaparse` для CSV (проверить наличие в deps, иначе добавить), `exceljs` или `xlsx` для XLSX — минимизировать зависимость (можно стримом из JSON).
+  - Respect колонок (включая кастомные поля через JSON-extract).
+  - Integration: negative-test на закрытый проект — строки не попадают в экспорт (SEC-1).
+- **Merge-ready check:** /export для 10K задач укладывается в 60с, респонс 200 OK.
+- **Оценка:** ~4ч.
+
+### 13.6 PR-ы Фазы 3 — Frontend Search Page (~50ч)
+
+#### PR-9: SearchPage shell + route + sidebar + URL sync base
+- **Branch:** `ttsrh-1/frontend-shell`
+- **Scope:** (§5.7, TTSRH-12, частично TTSRH-19)
+  - Роут `/search` + `/search/saved/:filterId` в [App.tsx](frontend/src/App.tsx); условный рендер по флагу.
+  - Пункт сайдбара «Поиск задач» с `data-testid="nav-search"` между «Projects» и «Planning»; иконка-лупа 16×16 SVG (§5.7).
+  - Submenu «Избранные фильтры» — раскрывается при активной странице (до 5, сорт `useCount DESC`, `lastUsedAt DESC`); читает из `savedFilters.store.ts` (пустая реализация в этом PR).
+  - 3-колоночный layout `SidebarFilters | ResultsArea | DetailPreview` (пустые placeholder'ы).
+  - URL-синхронизация: `?jql=<encoded>&view=table&columns=...&page=N` — чтение на mount, запись на каждое успешное выполнение.
+  - `frontend/src/api/search.ts`, `frontend/src/api/savedFilters.ts` (тонкие клиенты для PR-5, PR-6, PR-7).
+- **Merge-ready check:** страница открывается, URL-sync работает на пустом JQL, снэпшот-тест layout.
+- **Оценка:** ~6ч.
+
+#### PR-10: JqlEditor (CodeMirror 6) + inline errors
+- **Branch:** `ttsrh-1/jql-editor`
+- **Scope:** (§5.7, TTSRH-13, TTSRH-14)
+  - `frontend/src/components/search/JqlEditor.tsx` — CodeMirror 6 + `StreamLanguage` с нашими токенами (подсветка keywords/strings/numbers/functions/IDENT), lazy-load через `React.lazy` + `Suspense` (R8, NFR-5 ≤ 160KB gzip).
+  - Добавить deps `@codemirror/state`, `@codemirror/view`, `@codemirror/language`, `@codemirror/autocomplete`, `@codemirror/search` в [frontend/package.json](frontend/package.json).
+  - Inline-errors: подключаем `/search/validate` (debounce 300ms), рендерим `Decoration.mark` squiggle + gutter-marker по `{start, end}`.
+  - ValidationErrorBanner для error-sum.
+  - Shortcut `/` → focus editor (глобально, регистрируется через `window.addEventListener('keydown')` с респектом input-focus); `Ctrl+Enter` → выполнить.
+  - Бандл-аудит в CI: `npx source-map-explorer` на chunk `/search` или Lighthouse budget (NFR-5).
+- **Merge-ready check:** NFR-5 не превышен; a11y A11Y-1 (ARIA-live для ошибок) покрыт.
+- **Оценка:** ~13ч.
+
+#### PR-11: ValueSuggesterPopup + CM6 autocomplete adapter
+- **Branch:** `ttsrh-1/value-suggester`
+- **Scope:** (§5.11, TTSRH-26)
+  - `frontend/src/components/search/ValueSuggesterPopup.tsx` — unified-компонент: renderer по `kind` (avatar/color-dot/svg/emoji), keyboard navigation, debounce 150ms для dynamic-provider'ов, SWR-кэш 60с для Project/IssueType/Status, 30с для Sprint/Release.
+  - CM6 `CompletionSource` adapter, который маппит `/search/suggest` → `CompletionResult` с `apply` (вставка raw) и `info` (detail + icon). Автоматически открывается после `=`/`!=`/`,`/`(` и при Ctrl+Space.
+  - Первый раунд интеграции с BasicFilterBuilder — попап используется в chip-popover (mode=multi для IN-clause).
+  - E2E T-12 (автокомплит assignee+status).
+- **Merge-ready check:** T-12 зелёный; визуальный снапшот popup для 5 suggester'ов.
+- **Оценка:** ~10ч.
+
+#### PR-12: BasicFilterBuilder + Basic↔Advanced toggle
+- **Branch:** `ttsrh-1/basic-builder`
+- **Scope:** (§5.7, TTSRH-15)
+  - `BasicFilterBuilder.tsx` — chip-add с каскадным меню полей (Задача / Даты / Пользователи / Планирование / AI / Кастомные). Каждый chip = popover с `ValueSuggesterPopup`.
+  - Canonicalizer AST → canonical JQL → Basic-chips (и обратно); Advanced→Basic disabled при OR/NOT-с-группами/custom-operators (R9) + tooltip.
+  - `FilterModeToggle.tsx`.
+  - Snapshot T-10 (Basic → canonical JQL).
+- **Merge-ready check:** 80% golden-set-запросов строится в Basic без перехода в Advanced (FR-12).
+- **Оценка:** ~12ч.
+
+#### PR-13: SavedFiltersSidebar + Save/Share modals + store
+- **Branch:** `ttsrh-1/saved-filters-ui`
+- **Scope:** (§5.7, TTSRH-16)
+  - `frontend/src/store/savedFilters.store.ts` (Zustand, паттерн существующих); `search.store.ts` для runtime-состояния.
+  - `SavedFiltersSidebar.tsx` — списки «Мои» / «Избранные» / «Общедоступные» / «Поделены со мной» / «Недавние».
+  - `SaveFilterModal.tsx` — имя/описание/visibility/shared-with; warning при PUBLIC (R11).
+  - `FilterShareModal.tsx` — copy-link, visibility switch, users/groups picker.
+  - **CLAUDE.md правило:** `onCancel`/`onClose` всех модалок вызывают `load()` родительского `SavedFiltersSidebar` (FR-18).
+  - Shortcut `Ctrl+S` → Save (или SaveAs если не назван); `Ctrl+Shift+S` → SaveAs.
+- **Merge-ready check:** E2E create → favorite → share → copy-link.
+- **Оценка:** ~8ч.
+
+#### PR-14: ColumnConfigurator + ResultsTable + bulk + export UI
+- **Branch:** `ttsrh-1/results`
+- **Scope:** (§5.7, §5.8, TTSRH-17, TTSRH-18, остаток TTSRH-19)
+  - `ColumnConfigurator.tsx` — drag-n-drop (react-dnd или нативный HTML5 DnD — выбрать по наличию в deps) двух списков Available/Selected; сохранение в `SavedFilter.columns` или `User.preferences.searchDefaults.columns`.
+  - `ResultsTable.tsx` — Ant Table с virtualized rows при >200, клик по заголовку → перегенерация `ORDER BY` в JQL (canonical re-parse).
+  - `BulkActionsBar.tsx` — разбивает выделенные задачи по `projectId`, вызывает `bulkUpdateIssues` на каждый в `Promise.all`, агрегирует `{succeeded, failed}` (R12).
+  - `ExportMenu.tsx` — вызов `POST /search/export` с текущим `jql` + `columns`.
+  - `/` focus, `Esc` blur, `Ctrl+Enter` — выполнить (часть уже в PR-10; финализируем здесь).
+- **Merge-ready check:** E2E search → sort → выделить 3 → bulk-status; кросс-проектный bulk не валит транзакцию.
+- **Оценка:** ~11ч.
+
+### 13.7 PR-ы Фазы 4 — Checkpoint TTQL Integration (~30ч)
+
+Параллельно с Фазой 3 (зависит только от PR-1 и PR-5).
+
+#### PR-15: Checkpoint Prisma + DTO + КТ-функции + schema variant
+- **Branch:** `ttsrh-1/checkpoint-foundation`
+- **Scope:** (§5.12.1–5.12.4, TTSRH-27, TTSRH-28, TTSRH-29)
+  - Миграция `YYYYMMDDHHMMSS_ttsrh_checkpoint_ttql`: `CheckpointType.ttqlCondition` (Text?), `CheckpointType.conditionMode` (enum default STRUCTURED), `ReleaseCheckpoint.ttqlSnapshot` (Text?), `ReleaseCheckpoint.conditionModeSnapshot` (enum default STRUCTURED). Backfill: все existing рядки получают `STRUCTURED`, `NULL`.
+  - Zod `checkpoint.dto.ts` — `conditionMode`/`ttqlCondition` + `superRefine` для cross-field валидации (§5.12.3).
+  - Функции КТ-контекста в `search.functions.ts`: `releasePlannedDate()`, `checkpointDeadline()` — доступны только при `variant=CHECKPOINT`; вне контекста — validator-ошибка.
+  - `/search/validate?variant=CHECKPOINT`, `/search/schema?variant=CHECKPOINT`, `/search/suggest?variant=CHECKPOINT` — возвращают расширенный реестр.
+  - `currentUser()` в CHECKPOINT-контексте → warning при save (не ошибка) (§5.12.4, R19).
+  - Unit-тесты validator'а по variant; integration T-14 (backward-compat: existing КТ → `violationsHash` не меняется).
+- **Не включает:** engine TTQL-ветку, UI.
+- **Merge-ready check:** T-14 зелёный; миграция идемпотентна.
+- **Оценка:** ~10ч.
+
+#### PR-16: Checkpoint engine TTQL branch + error handling
+- **Branch:** `ttsrh-1/checkpoint-engine`
+- **Scope:** (§5.12.5, TTSRH-30, TTSRH-31)
+  - Расширение [checkpoint-engine.service.ts](backend/src/modules/releases/checkpoints/checkpoint-engine.service.ts) — ветка `TTQL` + `COMBINED` (алгоритм §5.12.5).
+  - **Единичный** `prisma.issue.findMany` с compiled `where` + `{id: {in: applicableIds}}` — не per-issue.
+  - `compileTtql(ttqlSnapshot, checkpointContext)` — `{now: scheduler.startedAt, release, checkpointType}`, детерминистичный `now` на весь тик (R18).
+  - `violationsHash` стабилен (порядок reasons: структурные → `TTQL_MISMATCH`).
+  - Timeout 5с на compile+exec; превышение / compile-error / runtime-error → `ReleaseCheckpoint.state='ERROR'` + `CheckpointViolationEvent` с `criterionType='TTQL_ERROR'`, `reason` из сообщения (R16, FR-31).
+  - **Под флагом `FEATURES_CHECKPOINT_TTQL=false`** в production: ветка TTQL не выполняется, `conditionMode=TTQL/COMBINED` саммится как NOOP (state=OK) до включения флага; чтобы security-review уже merged без ожидания UAT.
+  - Integration T-13, T-14, T-15 (эквивалентность DUE_BEFORE), T-16 (timeout → ERROR).
+  - Security-review gate — RBAC отдельный подписывает (R3 + R16).
+- **Merge-ready check:** T-13..T-16 зелёные; existing КТ-тесты не ломаются (FR-25); security-review.
+- **Оценка:** ~10ч.
+
+#### PR-17: /admin/checkpoint-types/preview + TTS-QL checkpoint-функции/поля
+- **Branch:** `ttsrh-1/checkpoint-search-integration`
+- **Scope:** (§5.2 строки checkpoint-*, §5.4 строки violatedCheckpoints*, §5.12.6, TTSRH-32, TTSRH-37)
+  - `POST /api/admin/checkpoint-types/preview { releaseId, conditionMode, criteria?, ttqlCondition? }` — dry-run, без записи. Тот же rate-limit + timeout + RBAC `canManageCheckpoints` (R22).
+  - Функции в TTS-QL (вне КТ-контекста, доступны обычному поиску!): `violatedCheckpoints([typeName])`, `violatedCheckpointsOf(releaseKeyOrId[, typeName])`, `checkpointsAtRisk([typeName])`, `checkpointsInState(state[, typeName])` (§5.4.1). Scope-фильтр (R3) применяется к результатам.
+  - Поля: `hasCheckpointViolation`, `checkpointViolationType`, `checkpointViolationReason`.
+  - `CheckpointTypeSuggester` (CheckpointType.findMany с color-dot + weight), `CheckpointStateSuggester` (enum).
+  - Индекс `@@index([resolvedAt, releaseCheckpointId])` — if profiling подтверждает (§5.4.1).
+  - Integration T-18, T-20..T-25.
+- **Merge-ready check:** T-18, T-20..T-25 зелёные; `hasCheckpointViolation=true` и `issue IN violatedCheckpoints()` дают одинаковый normalized where (T-24).
+- **Оценка:** ~6ч.
+
+#### PR-18: Frontend КТ — segmented control + JqlEditor + Preview panel + mode-icon
+- **Branch:** `ttsrh-1/checkpoint-admin-ui`
+- **Scope:** (§5.12.6, TTSRH-33, TTSRH-34, TTSRH-35)
+  - В [AdminReleaseCheckpointTypesPage.tsx](frontend/src/pages/admin/AdminReleaseCheckpointTypesPage.tsx):
+    - Segmented control «Режим условия» (Structured / TTQL / Combined).
+    - Show/hide секций структурных criteria / TTQL editor без стирания form-state (R20).
+    - Интеграция `JqlEditor` с `variant=CHECKPOINT` (КТ-функции в автокомплите, `currentUser()` с warning-иконкой).
+    - Preview-панель (disclosure) — выбор релиза → `POST /api/admin/checkpoint-types/preview` → {applicable, passed, violated}.
+    - Иконка режима в таблице типов КТ (S / Q / S+Q), hover — preview TTS-QL.
+    - Баннер при `state=ERROR` с кнопкой «Открыть тип и исправить» (FR-31).
+  - **CLAUDE.md правило** для всех модалок — `onCancel`/`onClose` → `load()`.
+- **Merge-ready check:** E2E T-19 (создать TTQL-тип → видеть violations → перейти в COMBINED → добавить structured → regen → обновлённый preview).
+- **Оценка:** ~11ч.
+
+#### PR-19: Structured → TTQL converter (frontend)
+- **Branch:** `ttsrh-1/checkpoint-converter`
+- **Scope:** (§R21, TTSRH-36)
+  - Кнопка «Сконвертировать в TTS-QL» на existing structured-типах → one-way generator (`criteria[] → canonical JQL`). Открывает TTQL-редактор для **ручной проверки** перед save (не автоматический switch).
+  - Snapshot-тест: каждый тип `CheckpointCriterion` → ожидаемая строка JQL (пример в §5.12.9).
+- **Merge-ready check:** конверсия `[STATUS_IN, ASSIGNEE_SET, DUE_BEFORE]` → ожидаемый канонический JQL; ручное ревью админа требуется (кнопка save не автосохраняется без взаимодействия).
+- **Оценка:** ~3ч.
+
+### 13.8 PR-ы Фазы 5 — Release (~15ч)
+
+#### PR-20: E2E + perf seed + Lighthouse budget
+- **Branch:** `ttsrh-1/e2e-perf`
+- **Scope:** (TTSRH-20)
+  - `frontend/e2e/specs/20-search.spec.ts` — basic→advanced→save→favorite→share→URL→open in new tab + T-9, T-12.
+  - `frontend/e2e/specs/21-checkpoints-ttql.spec.ts` — T-19 (КТ-TTQL end-to-end).
+  - `backend/tests/fixtures/search-seed-100k.ts` — 100K задач seed для perf-теста T-8 (p95 < 400ms).
+  - Lighthouse budget в CI для `/search` (NFR-5 ≤ 160KB gzip lazy-chunk; initial без JqlEditor).
+  - axe-core для A11Y-1..A11Y-4.
+  - Композитные индексы, если profiling подтверждает (§3.3) — отдельная follow-up миграция.
+- **Merge-ready check:** T-8, T-9, T-12, T-19 зелёные; Lighthouse budget не перевышен.
+- **Оценка:** ~9ч.
+
+#### PR-21: Документация + feature flag cutover
+- **Branch:** `ttsrh-1/docs-cutover`
+- **Scope:** (TTSRH-21, TTSRH-22, §12)
+  - [docs/user-manual/jql.md](docs/user-manual/jql.md) — полный reference TTS-QL: §5.1 грамматика, §5.2 поля, §5.4 функции, примеры из golden-set.
+  - [docs/user-manual/search.md](docs/user-manual/search.md) — руководство по странице «Поиск задач», сохранению фильтров, шарингу, колонкам.
+  - [docs/api/reference.md](docs/api/reference.md) — эндпоинты из §5.6 + §5.12.7.
+  - [docs/architecture/backend-modules.md](docs/architecture/backend-modules.md) — модуль `search` и `saved-filters`.
+  - Раздел про КТ-TTQL в `docs/user-manual/checkpoints.md` (существующий файл из TTMP-160).
+  - [version_history.md](version_history.md) — запись о TTSRH-1 (memory rule).
+  - Feature flag cutover: `FEATURES_ADVANCED_SEARCH=true` в staging → UAT → production; `FEATURES_CHECKPOINT_TTQL=true` после отдельного UAT.
+  - Опциональный пункт: MCP-tool `search_issues` — вынести в отдельный follow-up тикет TTSRH-38, **не** в этот PR.
+- **Merge-ready check:** все Definition of Done пункты из §7 зелёные; UAT-чек-лист подписан.
+- **Оценка:** ~6ч.
+
+### 13.9 Итог: список PR
+
+| № | Branch | Scope | Часы | Зависит от | TTSRH-сабтаски |
+|---|--------|-------|------|-----------|----------------|
+| 1 | `ttsrh-1/foundation` | Prisma schema (SavedFilter, User.preferences), feature flags, пустые модули | 6 | — | TTSRH-8 (schema), TTSRH-22 (flag) |
+| 2 | `ttsrh-1/parser` | Tokenizer + Parser + AST + golden-set | 14 | PR-1 | TTSRH-2 |
+| 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 |
+| 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 |
+| 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 |
+| 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 |
+| 7 | `ttsrh-1/saved-filters` | SavedFilter CRUD/share/favorite + User.preferences | 8 | PR-5 | TTSRH-8, TTSRH-9 |
+| 8 | `ttsrh-1/export` | `/search/export` CSV/XLSX | 4 | PR-5 | TTSRH-10 |
+| 9 | `ttsrh-1/frontend-shell` | SearchPage shell + route + sidebar + URL sync | 6 | PR-5 | TTSRH-12, часть TTSRH-19 |
+| 10 | `ttsrh-1/jql-editor` | JqlEditor (CM6) + inline errors + lazy-load | 13 | PR-9 | TTSRH-13, TTSRH-14 |
+| 11 | `ttsrh-1/value-suggester` | ValueSuggesterPopup + CM6 adapter | 10 | PR-6, PR-10 | TTSRH-26 |
+| 12 | `ttsrh-1/basic-builder` | BasicFilterBuilder + Basic↔Advanced toggle | 12 | PR-11 | TTSRH-15 |
+| 13 | `ttsrh-1/saved-filters-ui` | SavedFiltersSidebar + Save/Share modals + store | 8 | PR-7, PR-9 | TTSRH-16 |
+| 14 | `ttsrh-1/results` | ColumnConfigurator + ResultsTable + bulk + ExportMenu + shortcuts | 11 | PR-8, PR-10 | TTSRH-17, TTSRH-18, остаток TTSRH-19 |
+| 15 | `ttsrh-1/checkpoint-foundation` | Checkpoint Prisma + DTO + КТ-функции + variant=CHECKPOINT | 10 | PR-1, PR-3 | TTSRH-27, TTSRH-28, TTSRH-29 |
+| 16 | `ttsrh-1/checkpoint-engine` | Engine TTQL-ветка + COMBINED + error handling | 10 | PR-4, PR-15 | TTSRH-30, TTSRH-31 |
+| 17 | `ttsrh-1/checkpoint-search-integration` | `/preview` + violatedCheckpoints* функции + поля + suggesters | 6 | PR-5, PR-16 | TTSRH-32, TTSRH-37 |
+| 18 | `ttsrh-1/checkpoint-admin-ui` | Segment-mode + JqlEditor КТ + Preview panel + mode-icon | 11 | PR-10, PR-15, PR-17 | TTSRH-33, TTSRH-34, TTSRH-35 |
+| 19 | `ttsrh-1/checkpoint-converter` | Structured → TTQL converter (one-way) | 3 | PR-18 | TTSRH-36 |
+| 20 | `ttsrh-1/e2e-perf` | E2E + perf 100K seed + Lighthouse budget + axe-core | 9 | PR-12, PR-13, PR-14, PR-17, PR-19 | TTSRH-20 |
+| 21 | `ttsrh-1/docs-cutover` | Документация + feature flag cutover | 6 | PR-20 | TTSRH-21, TTSRH-22 |
+| **Итого** | | | **199** | | |
+
+**Дельта к §8 (278ч):** план покрывает ~199ч. Недостающие ~79ч — это (a) code review + фиксы (~8ч per §8), (b) security review + фиксы (~4ч), (c) докуметация JQL полная (~6ч уже в PR-21, ~0ч дополнительно), (d) профайлинг + composite-index tuning (~4ч в PR-20), (e) fuzz-harness extended (~4ч в PR-5); остальное — buffer на unknown unknowns и Phase-2-проникновение. Реалистичный календарный план — 8–10 недель при одном fullstack-разработчике или 5–6 недель при параллельной работе двоих (backend + frontend после PR-5).
+
+### 13.10 Phase 2 (не включена в TTSRH-1)
+
+- **TTSRH-23** — `WAS`/`CHANGED` + модель `FieldChangeLog` — отдельный story-ticket.
+- **TTSRH-24** — `pg_trgm` GIN-индексы + `unaccent` extension + Postgres FTS.
+- **TTSRH-38** — *(опционально)* MCP-tool `search_issues` для Agent SDK consumers.
+
+Phase 2 не блокирует MVP-релиз TTSRH-1.
+

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,7 @@
 VITE_API_URL=/api
+
+# TTSRH-1 cutover flag (TTS-QL + страница поиска). Снапшотится на build-time —
+# для смены значения требуется пересборка frontend-бандла. Держим в синхроне с
+# backend-флагом FEATURES_ADVANCED_SEARCH, иначе фронт увидит пункт меню, но
+# бэкенд вернёт 404 на /api/search/*.
+VITE_FEATURES_ADVANCED_SEARCH=false

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -60,6 +60,8 @@ import SettingsPage from './pages/SettingsPage';
 import LoadingSpinner from './components/common/LoadingSpinner';
 import UatTestsPage from './pages/UatTestsPage';
 import PipelineDashboardPage from './pages/PipelineDashboardPage';
+import SearchPage from './pages/SearchPage';
+import { features as frontendFeatures } from './lib/features';
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuthStore();
@@ -189,6 +191,9 @@ export default function App() {
             <Route path="issues/:id" element={<IssueDetailPage />} />
             <Route path="time" element={<TimePage />} />
             <Route path="teams" element={<TeamsPage />} />
+            {/* TTSRH-1 PR-1: /search mounted only when advanced-search flag is on.
+                When disabled, the <Route path="*"> catch-all below redirects to "/". */}
+            {frontendFeatures.advancedSearch && <Route path="search" element={<SearchPage />} />}
             <Route path="uat" element={<UatTestsPage />} />
             {/*
               TTSEC-2 round 16 — partial revert of round 15's global AdminGate.

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -6,6 +6,7 @@
 import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { canViewCheckpointAudit, hasRequiredRole } from '../../lib/roles';
+import { features as frontendFeatures } from '../../lib/features';
 import type { SystemRoleType, User } from '../../types';
 
 // ─── Design tokens (Paper 1KR-0 dark + computed light) ───────────────────────
@@ -348,6 +349,18 @@ export default function Sidebar({
             </svg>
             <span style={textStyle('/flow-teams')}>Потоковые команды</span>
           </div>
+
+          {/* TTSRH-1 PR-1: «Поиск задач» (/search). Стоит перед Planning-submenu — см. §5.7 ТЗ.
+              Полный sidebar-item с submenu «Избранные фильтры» будет в PR-9. */}
+          {frontendFeatures.advancedSearch && (
+            <div data-testid="nav-search" style={itemStyle('/search')} onClick={() => onNavigate('/search')} onMouseEnter={() => setHovered('/search')} onMouseLeave={() => setHovered(null)}>
+              <svg width="16" height="16" fill="none" viewBox="0 0 16 16" style={{ flexShrink: 0 }}>
+                <circle cx="7" cy="7" r="4.5" stroke={itemColor('/search')} strokeWidth="1.5" />
+                <path d="M10.5 10.5l3 3" stroke={itemColor('/search')} strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+              <span style={textStyle('/search')}>Поиск задач</span>
+            </div>
+          )}
 
           {/* Planning submenu */}
           <div

--- a/frontend/src/lib/features.ts
+++ b/frontend/src/lib/features.ts
@@ -1,0 +1,19 @@
+/**
+ * TTSRH-1: Frontend feature flags for staged UI cutover.
+ *
+ * Pattern mirrors backend/src/shared/features.ts but reads Vite env vars, since
+ * frontend runs in the browser and can't read process.env. Keep names in sync with
+ * backend: `FEATURES_ADVANCED_SEARCH` ↔ `VITE_FEATURES_ADVANCED_SEARCH`.
+ *
+ * Env-vars are snapshotted at build time. Ops flip the flag by rebuilding/redeploying
+ * the frontend bundle — same workflow as VITE_API_URL.
+ */
+function flag(name: string, defaultValue = false): boolean {
+  const val = (import.meta.env as Record<string, string | undefined>)[name];
+  if (val === undefined) return defaultValue;
+  return val.toLowerCase() !== 'false' && val !== '0';
+}
+
+export const features = {
+  advancedSearch: flag('VITE_FEATURES_ADVANCED_SEARCH', false),
+} as const;

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,0 +1,50 @@
+import { useThemeStore } from '../store/theme.store';
+
+/**
+ * TTSRH-1 PR-1 — placeholder-страница «Поиск задач». Роут /search смонтирован условно
+ * в App.tsx под `features.advancedSearch`, поэтому сюда попадают только сборки, где
+ * флаг включён. До merge PR-9 (SearchPage shell) здесь рендерится «под разработкой»-
+ * сообщение, чтобы UAT-стейдж мог проверить факт мaunting и активный-пункт сайдбара.
+ * Полная реализация — §5.7 в docs/tz/TTSRH-1.md и PR-9..PR-14 в §13.6 ТЗ.
+ */
+export default function SearchPage() {
+  const { mode } = useThemeStore();
+  const isLight = mode === 'light';
+  const c = isLight
+    ? { bg: '#F6F8FA', t1: '#1F2328', t3: '#656D76', border: '#D0D7DE' }
+    : { bg: '#080B14', t1: '#E2E8F8', t3: '#8B949E', border: '#21262D' };
+
+  return (
+    <div
+      data-testid="search-page"
+      style={{
+        minHeight: '100%',
+        padding: '32px 24px',
+        fontFamily: '"Inter", system-ui, sans-serif',
+        color: c.t1,
+        background: c.bg,
+      }}
+    >
+      <h1 style={{ fontSize: 22, fontWeight: 600, marginBottom: 8 }}>Поиск задач</h1>
+      <p style={{ fontSize: 14, color: c.t3, marginBottom: 24, maxWidth: 640 }}>
+        Продвинутый поиск с TTS-QL (TaskTime Query Language) — внутренним языком запросов,
+        совместимым с JQL. Страница находится в разработке по тикету TTSRH-1.
+      </p>
+      <div
+        style={{
+          padding: '20px 24px',
+          border: `1px dashed ${c.border}`,
+          borderRadius: 10,
+          maxWidth: 640,
+          fontSize: 13,
+          lineHeight: 1.6,
+          color: c.t3,
+        }}
+      >
+        Готовность: <b style={{ color: c.t1 }}>foundation merged</b>. Редактор TTS-QL,
+        сохранённые фильтры, конструктор Basic и массовые действия появятся в последующих
+        PR — см. <code>docs/tz/TTSRH-1.md §13.6</code>.
+      </div>
+    </div>
+  );
+}

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,56 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.26**
+**Last version: 2.27**
+
+---
+
+## [2.27] [2026-04-20] feat(search): TTSRH-1 PR-1 — foundation для TTS-QL (schema + feature flags)
+
+**PR:** [#100](https://github.com/NovakPAai/tasktime-mvp/pull/100)
+**Ветка:** `ttsrh-1/foundation`
+
+### Что было
+
+Глобального продвинутого поиска по задачам нет — только плоский фильтр по одному проекту в `ProjectDetailPage` и 50-записный `/issues/search` для виджета связывания. JQL-совместимый язык и сохраняемые фильтры отсутствуют (см. §1 и §2 в [docs/tz/TTSRH-1.md](docs/tz/TTSRH-1.md)).
+
+### Что теперь
+
+Заложена инфраструктура TTSRH-1 без продуктового эффекта:
+
+- **Prisma**: добавлены модели `SavedFilter`, `SavedFilterShare` + enums `FilterVisibility`, `FilterPermission`; поле `User.preferences Json?` для будущих UI-дефолтов (колонки, pageSize). Миграция `20260423000000_ttsrh_saved_filters` включает XOR-CHECK и два partial-unique-индекса для shares (user OR group, не оба).
+- **Feature flags**: `FEATURES_ADVANCED_SEARCH` и `FEATURES_CHECKPOINT_TTQL` в [backend/src/shared/features.ts](backend/src/shared/features.ts) (оба `false` по умолчанию). Frontend-зеркало — `VITE_FEATURES_ADVANCED_SEARCH` в [frontend/src/lib/features.ts](frontend/src/lib/features.ts).
+- **Backend-модули**: пустые [backend/src/modules/search/search.router.ts](backend/src/modules/search/search.router.ts) и [backend/src/modules/saved-filters/saved-filters.router.ts](backend/src/modules/saved-filters/saved-filters.router.ts) с эндпоинтами-стабами (501 Not Implemented). Монтируются в [app.ts](backend/src/app.ts) только при включённом `features.advancedSearch`.
+- **Frontend**: роут `/search` + placeholder-страница [SearchPage.tsx](frontend/src/pages/SearchPage.tsx) + пункт сайдбара «Поиск задач» с `data-testid="nav-search"` (SVG-лупа, между Flow Teams и Planning-submenu). Всё под `frontendFeatures.advancedSearch`.
+
+### Изменения
+
+- [backend/src/prisma/schema.prisma](backend/src/prisma/schema.prisma) — модели `SavedFilter`, `SavedFilterShare`, enums, обратные связи в `User` и `UserGroup`.
+- [backend/src/prisma/migrations/20260423000000_ttsrh_saved_filters/migration.sql](backend/src/prisma/migrations/20260423000000_ttsrh_saved_filters/migration.sql) — миграция SQL.
+- [backend/src/shared/features.ts](backend/src/shared/features.ts) — `advancedSearch`, `checkpointTtql` флаги.
+- [backend/src/modules/search/search.router.ts](backend/src/modules/search/search.router.ts), [backend/src/modules/saved-filters/saved-filters.router.ts](backend/src/modules/saved-filters/saved-filters.router.ts) — stub-роутеры.
+- [backend/src/app.ts](backend/src/app.ts) — условный mount.
+- [frontend/src/lib/features.ts](frontend/src/lib/features.ts), [frontend/src/pages/SearchPage.tsx](frontend/src/pages/SearchPage.tsx), [frontend/src/App.tsx](frontend/src/App.tsx), [frontend/src/components/layout/Sidebar.tsx](frontend/src/components/layout/Sidebar.tsx) — route + sidebar-item + placeholder.
+- [docs/tz/TTSRH-1.md](docs/tz/TTSRH-1.md) §13 — план из 21 PR добавлен в ТЗ.
+- [frontend/.env.example](frontend/.env.example) — `VITE_FEATURES_ADVANCED_SEARCH=false`.
+
+### Влияние на prod
+
+При штатной конфигурации (`FEATURES_ADVANCED_SEARCH=false`) — 0 эффекта. Новые таблицы создаются пустыми, эндпоинты `/api/search/*` возвращают 404 (Express fallback), пункт сайдбара не рендерится. Feature flag флипается **с перезапуском контейнера** (backend читает env на import-time; frontend — на build-time).
+
+### Проверки
+
+- `npx prisma validate` — schema valid.
+- `npx prisma generate` — клиент генерируется.
+- Backend `npm run lint` — 0 ошибок, 2 pre-existing warnings (не в новых файлах).
+- Frontend `npm run lint` — 0 ошибок, pre-existing warnings (не в новых файлах).
+- Backend/frontend `npx tsc --noEmit` — зелёные.
+- `npm test` — не запускался локально (требует Postgres); пойдёт в CI.
+- `pre-push-reviewer` — LGTM, 2 medium-фикса применены в follow-up коммите.
+
+---
+
+## [2.26] [2026-04-20] fix: коллизия кэша поиска + утечка фильтров при смене проекта
 
 ---
 


### PR DESCRIPTION
## Summary

TTSRH-1 PR-1 — foundation для TTS-QL. Без продуктового эффекта при дефолтных флагах. Реализация запланирована в PR-2..PR-21 (см. [docs/tz/TTSRH-1.md §13](docs/tz/TTSRH-1.md)).

- **Prisma**: модели `SavedFilter`, `SavedFilterShare` + enums `FilterVisibility`, `FilterPermission`; поле `User.preferences Json?`. Миграция [`20260423000000_ttsrh_saved_filters`](backend/src/prisma/migrations/20260423000000_ttsrh_saved_filters/migration.sql) с `CHECK (userId XOR groupId)` и двумя partial unique-индексами на `saved_filter_shares`.
- **Feature flags**: `FEATURES_ADVANCED_SEARCH`, `FEATURES_CHECKPOINT_TTQL` в [backend/src/shared/features.ts](backend/src/shared/features.ts); зеркало `VITE_FEATURES_ADVANCED_SEARCH` в [frontend/src/lib/features.ts](frontend/src/lib/features.ts). Оба `false` по умолчанию.
- **Backend stubs**: [search.router.ts](backend/src/modules/search/search.router.ts), [saved-filters.router.ts](backend/src/modules/saved-filters/saved-filters.router.ts) — эндпоинты 501 Not Implemented; монтируются в [app.ts](backend/src/app.ts) только при включённом `features.advancedSearch` (иначе 404 через Express fallback).
- **Frontend**: роут `/search` + placeholder [SearchPage.tsx](frontend/src/pages/SearchPage.tsx) + пункт сайдбара «Поиск задач» (`data-testid="nav-search"`, SVG-лупа) — всё под frontend-флагом.

## Operational notes

- **Ops: бэкенд-флаг читается на import-time.** Флип `FEATURES_ADVANCED_SEARCH=true` без рестарта контейнера не даст эффекта (паттерн как у `FEATURES_GITLAB`/`FEATURES_AI`). Для cutover — смена env + перезапуск.
- **Frontend-флаг — build-time.** Флип `VITE_FEATURES_ADVANCED_SEARCH` требует пересборки бандла. Держим backend и frontend синхронно, иначе фронт видит пункт меню, а бэкенд отвечает 404 на `/api/search/*`.
- **`/api/features`** (unauth) теперь отдаёт `advancedSearch` и `checkpointTtql`. Exposure паттерн тот же, что у `gitlab`/`ai`/`mcp`/`telegram`. Если захотим убрать — добавим allowlist в отдельном PR.

## Pre-push review

Прогнал `pre-push-reviewer` перед открытием PR. Summary: 🟠 0 · 🟡 3 · 🔵 2 · ⚪ 5, no blockers.

Medium-фиксы применены в follow-up коммите `chore(search): TTSRH-1 PR-1 — pre-push review fixups`:
- stub-роутеры: `_req: unknown` → стандартные `Request`/`Response` из Express.
- `saved_filters.updated_at` — инлайн-комментарий «managed by Prisma @updatedAt».
- `frontend/.env.example` — добавлен `VITE_FEATURES_ADVANCED_SEARCH=false` с объяснением про build-time snapshot.

Остальные находки (линия длины в Sidebar, отсутствие `@@unique` в Prisma schema для partial-индексов — они не представимы в DSL, выбрано документировать комментарием) — info-level, оставлены как есть.

## Test plan

- [x] `npx prisma validate` — schema valid
- [x] `npx prisma generate` — клиент генерируется
- [x] Backend `npm run lint` — 0 errors, 0 new warnings
- [x] Frontend `npm run lint` — 0 errors, 0 new warnings
- [x] Backend `npx tsc --noEmit` — чистые типы
- [x] Frontend `npx tsc --noEmit` — чистые типы
- [ ] `npm test` — требует Postgres; пойдёт в CI
- [ ] Manual: при `FEATURES_ADVANCED_SEARCH=false` (default) — пункт сайдбара отсутствует, `/api/search/issues` → 404, `/search` → redirect на `/`
- [ ] Manual: при `FEATURES_ADVANCED_SEARCH=true` + `VITE_FEATURES_ADVANCED_SEARCH=true` — появляется пункт сайдбара «Поиск задач», страница `/search` открывает placeholder, `/api/search/issues` → 501
- [ ] Manual: `prisma migrate deploy` применяет миграцию на staging без ошибок; `prisma migrate reset` откатывает чисто; XOR-CHECK блокирует `INSERT ... (user_id, group_id) VALUES (NULL, NULL)` и `VALUES ('u1', 'g1')`

## Плановая дельта

- Текущий прогресс: **PR-1 / 21** по §13.9 ТЗ. После merge разблокируется PR-2 (tokenizer+parser), PR-15 (checkpoint Prisma) и PR-9 (frontend shell) — могут идти параллельно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
