### PR TITLE
feat(search): TTSRH-1 PR-2 — TTS-QL tokenizer + parser + AST + golden-set

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts",
     "lint": "eslint src/ --ext .ts",
     "format": "prettier --write 'src/**/*.ts'",
     "mcp": "tsx src/mcp/server.ts"

--- a/backend/src/modules/search/search.ast.ts
+++ b/backend/src/modules/search/search.ast.ts
@@ -1,0 +1,168 @@
+/**
+ * TTSRH-1 PR-2 — AST types for TTS-QL (TaskTime Query Language).
+ *
+ * Grammar reference: docs/tz/TTSRH-1.md §5.1 (EBNF).
+ * AST consumers: search.validator (PR-3), search.compiler (PR-4/5), search.suggest (PR-6).
+ *
+ * Every node carries a `span: { start, end }` pointing into the original source so
+ * downstream stages (validator, suggest, CodeMirror editor) can report errors inline.
+ * Spans are byte offsets into the UTF-16 source string (String.prototype.length-compatible).
+ */
+
+export interface Span {
+  /** Inclusive start offset in the source string. */
+  start: number;
+  /** Exclusive end offset. Empty ranges use start === end. */
+  end: number;
+}
+
+// ─── Top-level query ────────────────────────────────────────────────────────
+
+export interface QueryNode {
+  kind: 'Query';
+  /** Boolean expression. `null` is legal for an empty query (whitespace/comments only). */
+  where: BoolExpr | null;
+  /** Optional ORDER BY list. Empty array = no ORDER BY. */
+  orderBy: SortItem[];
+  span: Span;
+}
+
+// ─── Boolean expressions ────────────────────────────────────────────────────
+
+export type BoolExpr = OrNode | AndNode | NotNode | ClauseNode;
+
+export interface OrNode {
+  kind: 'Or';
+  /** >= 2 children; a single-child OR is always simplified to its child. */
+  children: BoolExpr[];
+  span: Span;
+}
+
+export interface AndNode {
+  kind: 'And';
+  /** >= 2 children; a single-child AND is always simplified to its child. */
+  children: BoolExpr[];
+  span: Span;
+}
+
+export interface NotNode {
+  kind: 'Not';
+  child: BoolExpr;
+  span: Span;
+}
+
+// ─── Clauses ────────────────────────────────────────────────────────────────
+
+export interface ClauseNode {
+  kind: 'Clause';
+  field: FieldRef;
+  op: ClauseOp;
+  span: Span;
+}
+
+export type FieldRef =
+  | { kind: 'Ident'; name: string; span: Span }
+  | { kind: 'CustomField'; uuid: string; span: Span }
+  | { kind: 'QuotedField'; name: string; span: Span };
+
+export type CompareOp = '=' | '!=' | '>' | '<' | '>=' | '<=' | '~' | '!~';
+
+export type ClauseOp =
+  | { kind: 'Compare'; op: CompareOp; value: Expr; span: Span }
+  | { kind: 'In'; negated: boolean; values: Expr[]; span: Span }
+  | { kind: 'InFunction'; negated: boolean; func: FunctionCall; span: Span }
+  | { kind: 'IsEmpty'; negated: boolean; span: Span }
+  | { kind: 'History'; op: HistoryOp; value: Expr | null; span: Span };
+
+/** Phase-2 operators (per §R5 ТЗ). Parser accepts them; validator rejects in MVP. */
+export type HistoryOp =
+  | 'WAS'
+  | 'WAS_NOT'
+  | 'WAS_IN'
+  | 'WAS_NOT_IN'
+  | 'CHANGED'
+  | 'CHANGED_FROM'
+  | 'CHANGED_TO'
+  | 'CHANGED_AFTER'
+  | 'CHANGED_BEFORE'
+  | 'CHANGED_ON'
+  | 'CHANGED_DURING'
+  | 'CHANGED_BY';
+
+// ─── Values / Expressions ───────────────────────────────────────────────────
+
+export type Expr = Literal | FunctionCall;
+
+export type Literal =
+  | { kind: 'String'; value: string; span: Span }
+  | { kind: 'Number'; value: number; span: Span }
+  /** Bare relative date like `-1d`, `2w`, `3M`. Quoted forms stay as String. */
+  | { kind: 'RelativeDate'; raw: string; span: Span }
+  /** Bare identifier used as a value (enum constant: HIGH, OPEN, EPIC, TTMP). */
+  | { kind: 'Ident'; name: string; span: Span }
+  | { kind: 'Bool'; value: boolean; span: Span }
+  | { kind: 'Null'; span: Span }
+  | { kind: 'Empty'; span: Span };
+
+export interface FunctionCall {
+  kind: 'Function';
+  name: string;
+  args: Expr[];
+  span: Span;
+}
+
+// ─── ORDER BY ───────────────────────────────────────────────────────────────
+
+export interface SortItem {
+  field: FieldRef;
+  /** Default ASC when omitted. */
+  direction: 'ASC' | 'DESC';
+  span: Span;
+}
+
+// ─── Errors ─────────────────────────────────────────────────────────────────
+
+/**
+ * Error codes are stable identifiers that the frontend and CI snapshot tests rely on.
+ * Keep in sync with frontend/src/lib/search/errors.ts (when it exists).
+ */
+export type ParseErrorCode =
+  | 'UNEXPECTED_CHARACTER'
+  | 'UNTERMINATED_STRING'
+  | 'INVALID_ESCAPE'
+  | 'INVALID_CUSTOM_FIELD'
+  | 'UNEXPECTED_TOKEN'
+  | 'EXPECTED_FIELD'
+  | 'EXPECTED_OPERATOR'
+  | 'EXPECTED_VALUE'
+  | 'EXPECTED_RPAREN'
+  | 'EXPECTED_LPAREN'
+  | 'EMPTY_PAREN_GROUP'
+  | 'EMPTY_VALUE_LIST'
+  | 'TRAILING_INPUT'
+  | 'EMPTY_QUERY_AFTER_ORDER_BY'
+  | 'INVALID_SORT_DIRECTION'
+  | 'EXPECTED_EMPTY_OR_NULL';
+
+export interface ParseError {
+  code: ParseErrorCode;
+  message: string;
+  /** Optional hint shown in the editor tooltip — kept short. */
+  hint?: string;
+  /** Byte offset in source. */
+  start: number;
+  end: number;
+}
+
+export interface ParseResult {
+  /** Null only when parsing failed before any top-level node could be produced. */
+  ast: QueryNode | null;
+  errors: ParseError[];
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Merge two spans into one covering both. */
+export function joinSpan(a: Span, b: Span): Span {
+  return { start: Math.min(a.start, b.start), end: Math.max(a.end, b.end) };
+}

--- a/backend/src/modules/search/search.parser.ts
+++ b/backend/src/modules/search/search.parser.ts
@@ -1,0 +1,566 @@
+/**
+ * TTSRH-1 PR-2 — recursive-descent parser for TTS-QL.
+ *
+ * Grammar reference: docs/tz/TTSRH-1.md §5.1. Precedence: `( ) > NOT > AND > OR > ORDER BY`.
+ *
+ * Public surface: `parse(source) -> ParseResult`. Never throws: tokenizer errors and
+ * syntax errors are captured into `result.errors` with byte spans, and the parser
+ * returns whatever partial AST it managed to build. This is required by PR-3 (suggest)
+ * which calls the parser mid-edit for cursor-position analysis.
+ *
+ * Keywords are matched on Ident tokens case-insensitively. Ident text is compared
+ * with `.toUpperCase()` to avoid locale surprises (e.g. Turkish `i` → `İ`).
+ */
+
+import {
+  type Span,
+  type QueryNode,
+  type BoolExpr,
+  type OrNode,
+  type AndNode,
+  type NotNode,
+  type ClauseNode,
+  type ClauseOp,
+  type FieldRef,
+  type Expr,
+  type Literal,
+  type FunctionCall,
+  type SortItem,
+  type CompareOp,
+  type HistoryOp,
+  type ParseError,
+  type ParseErrorCode,
+  type ParseResult,
+  joinSpan,
+} from './search.ast.js';
+import { tokenize, TokenizerError, type Token } from './search.tokenizer.js';
+
+const COMPARE_OPS = new Set<CompareOp>(['=', '!=', '>', '<', '>=', '<=', '~', '!~']);
+
+class ParserBailout extends Error {
+  readonly err: ParseError;
+  constructor(err: ParseError) {
+    super(err.message);
+    this.err = err;
+  }
+}
+
+export function parse(source: string): ParseResult {
+  // Phase 1 — tokenize. Tokenizer failures short-circuit: we can't safely produce an
+  // AST without at least a valid token stream.
+  let tokens: Token[];
+  try {
+    tokens = tokenize(source);
+  } catch (err) {
+    if (err instanceof TokenizerError) {
+      return {
+        ast: null,
+        errors: [
+          {
+            code: err.code,
+            message: err.message,
+            start: err.start,
+            end: err.end,
+          },
+        ],
+      };
+    }
+    throw err;
+  }
+
+  const parser = new Parser(tokens, source);
+  try {
+    const ast = parser.parseQuery();
+    return { ast, errors: parser.errors };
+  } catch (err) {
+    if (err instanceof ParserBailout) {
+      return { ast: null, errors: [...parser.errors, err.err] };
+    }
+    throw err;
+  }
+}
+
+class Parser {
+  private pos = 0;
+  readonly errors: ParseError[] = [];
+
+  constructor(private readonly tokens: Token[], private readonly source: string) {}
+
+  // NOTE: `tok()` is a method (not a getter) so TypeScript invalidates property-based
+  // narrowing across calls. When we advance the stream, the next `tok()` call returns a
+  // fresh `Token` that isn't narrowed by earlier `if (tok.kind === 'X')` branches.
+  private tok(): Token {
+    return this.tokens[this.pos]!;
+  }
+  private peek(offset: number): Token | undefined {
+    return this.tokens[this.pos + offset];
+  }
+  private advance(): Token {
+    const t = this.tokens[this.pos]!;
+    if (t.kind !== 'Eof') this.pos++;
+    return t;
+  }
+
+  // ─── Top-level ────────────────────────────────────────────────────────────
+
+  parseQuery(): QueryNode {
+    const startSpan = this.tok().span;
+
+    if (this.tok().kind === 'Eof') {
+      return { kind: 'Query', where: null, orderBy: [], span: { start: startSpan.start, end: startSpan.end } };
+    }
+
+    let where: BoolExpr | null = null;
+    if (!this.isOrderByAhead()) {
+      where = this.parseOrExpr();
+    }
+
+    const orderBy: SortItem[] = [];
+    if (this.isOrderByAhead()) {
+      this.advance(); // ORDER
+      this.advance(); // BY
+      if (this.tok().kind === 'Eof') {
+        this.fail('EMPTY_QUERY_AFTER_ORDER_BY', 'ORDER BY must be followed by at least one field.', this.tok().span);
+      }
+      orderBy.push(this.parseSortItem());
+      while (this.tok().kind === 'Comma') {
+        this.advance();
+        orderBy.push(this.parseSortItem());
+      }
+    }
+
+    if (this.tok().kind !== 'Eof') {
+      this.fail(
+        'TRAILING_INPUT',
+        `Unexpected input after end of query: \`${this.tokenLexeme(this.tok())}\`.`,
+        this.tok().span,
+      );
+    }
+
+    const endSpan =
+      orderBy.length > 0
+        ? orderBy[orderBy.length - 1]!.span
+        : where?.span ?? startSpan;
+    return { kind: 'Query', where, orderBy, span: joinSpan(startSpan, endSpan) };
+  }
+
+  // ─── Boolean expressions (OR > AND > NOT > atom) ──────────────────────────
+
+  private parseOrExpr(): BoolExpr {
+    const first = this.parseAndExpr();
+    if (!this.isKeyword(this.tok(), 'OR')) return first;
+
+    const children: BoolExpr[] = [first];
+    while (this.isKeyword(this.tok(), 'OR')) {
+      this.advance();
+      children.push(this.parseAndExpr());
+    }
+    const node: OrNode = {
+      kind: 'Or',
+      children,
+      span: joinSpan(first.span, children[children.length - 1]!.span),
+    };
+    return node;
+  }
+
+  private parseAndExpr(): BoolExpr {
+    const first = this.parseNotExpr();
+    if (!this.isKeyword(this.tok(), 'AND')) return first;
+
+    const children: BoolExpr[] = [first];
+    while (this.isKeyword(this.tok(), 'AND')) {
+      this.advance();
+      children.push(this.parseNotExpr());
+    }
+    const node: AndNode = {
+      kind: 'And',
+      children,
+      span: joinSpan(first.span, children[children.length - 1]!.span),
+    };
+    return node;
+  }
+
+  private parseNotExpr(): BoolExpr {
+    if (this.isKeyword(this.tok(), 'NOT')) {
+      const notSpan = this.tok().span;
+      this.advance();
+      const child = this.parseNotExpr();
+      const node: NotNode = { kind: 'Not', child, span: joinSpan(notSpan, child.span) };
+      return node;
+    }
+    return this.parseAtom();
+  }
+
+  private parseAtom(): BoolExpr {
+    if (this.tok().kind === 'LParen') {
+      const lparen = this.advance();
+      if (this.tok().kind === 'RParen') {
+        this.fail(
+          'EMPTY_PAREN_GROUP',
+          'Parenthesized expression cannot be empty.',
+          { start: lparen.span.start, end: this.tok().span.end },
+        );
+      }
+      const inner = this.parseOrExpr();
+      this.expect('RParen', 'EXPECTED_RPAREN', 'Expected closing `)`.');
+      return inner;
+    }
+    return this.parseClause();
+  }
+
+  // ─── Clause ───────────────────────────────────────────────────────────────
+
+  private parseClause(): ClauseNode {
+    // Bare function-call shorthand per §5.4.1 ТЗ: `funcCall()` at clause position
+    // is sugar for `issue IN funcCall()`. Three equivalent forms in the TZ:
+    //   issue IN violatedCheckpoints()
+    //   violatedCheckpoints()               ← here
+    //   hasCheckpointViolation = true
+    // We synthesise a virtual `issue` FieldRef with a zero-width span at the function
+    // start — downstream stages treat it the same as an explicit `issue IN ...`.
+    const first = this.tok();
+    if (
+      first.kind === 'Ident' &&
+      !KEYWORDS.has(first.value.toUpperCase()) &&
+      this.peek(1)?.kind === 'LParen'
+    ) {
+      const func = this.parseFunctionCall();
+      const field: FieldRef = {
+        kind: 'Ident',
+        name: 'issue',
+        span: { start: func.span.start, end: func.span.start },
+      };
+      const op: ClauseOp = {
+        kind: 'InFunction',
+        negated: false,
+        func,
+        span: func.span,
+      };
+      return { kind: 'Clause', field, op, span: func.span };
+    }
+
+    const field = this.parseFieldRef();
+    const opSpanStart = this.tok().span.start;
+
+    // IS [NOT] EMPTY | NULL
+    if (this.isKeyword(this.tok(), 'IS')) {
+      this.advance();
+      let negated = false;
+      if (this.isKeyword(this.tok(), 'NOT')) {
+        negated = true;
+        this.advance();
+      }
+      if (!this.isKeyword(this.tok(), 'EMPTY') && !this.isKeyword(this.tok(), 'NULL')) {
+        this.fail(
+          'EXPECTED_EMPTY_OR_NULL',
+          'Expected `EMPTY` or `NULL` after `IS [NOT]`.',
+          this.tok().span,
+        );
+      }
+      const endTok = this.advance();
+      const op: ClauseOp = {
+        kind: 'IsEmpty',
+        negated,
+        span: { start: opSpanStart, end: endTok.span.end },
+      };
+      return { kind: 'Clause', field, op, span: joinSpan(field.span, op.span) };
+    }
+
+    // IN / NOT IN
+    if (this.isInClauseStart()) {
+      let negated = false;
+      if (this.isKeyword(this.tok(), 'NOT')) {
+        negated = true;
+        this.advance();
+      }
+      this.advance(); // consume IN
+      const op = this.parseInRhs(negated, opSpanStart);
+      return { kind: 'Clause', field, op, span: joinSpan(field.span, op.span) };
+    }
+
+    // WAS / CHANGED (Phase 2 per §R5 — we parse, validator rejects)
+    if (this.isKeyword(this.tok(), 'WAS') || this.isKeyword(this.tok(), 'CHANGED')) {
+      const op = this.parseHistoryOp(opSpanStart);
+      return { kind: 'Clause', field, op, span: joinSpan(field.span, op.span) };
+    }
+
+    // Comparison
+    if (this.tok().kind === 'Op' && COMPARE_OPS.has(this.tok().value as CompareOp)) {
+      const opTok = this.advance();
+      const value = this.parseValue();
+      const op: ClauseOp = {
+        kind: 'Compare',
+        op: opTok.value as CompareOp,
+        value,
+        span: joinSpan(opTok.span, value.span),
+      };
+      return { kind: 'Clause', field, op, span: joinSpan(field.span, op.span) };
+    }
+
+    this.fail('EXPECTED_OPERATOR', `Expected an operator after field \`${this.fieldLabel(field)}\`.`, this.tok().span);
+  }
+
+  private isInClauseStart(): boolean {
+    if (this.isKeyword(this.tok(), 'IN')) return true;
+    if (this.isKeyword(this.tok(), 'NOT')) {
+      const next = this.peek(1);
+      return !!next && this.isKeyword(next, 'IN');
+    }
+    return false;
+  }
+
+  /** After `IN` / `NOT IN` is consumed, reads either a `(value_list)` or a `funcCall`. */
+  private parseInRhs(negated: boolean, startOffset: number): ClauseOp {
+    // `IN funcCall()` — no outer parens, RHS is a direct function call.
+    if (this.tok().kind === 'Ident' && this.peek(1)?.kind === 'LParen' && !this.isReservedFunctionName(this.tok().value)) {
+      const func = this.parseFunctionCall();
+      return {
+        kind: 'InFunction',
+        negated,
+        func,
+        span: { start: startOffset, end: func.span.end },
+      };
+    }
+    // `IN (value_list)`
+    this.expect('LParen', 'EXPECTED_LPAREN', 'Expected `(` after `IN` / `NOT IN`.');
+    const values: Expr[] = [];
+    if (this.tok().kind === 'RParen') {
+      this.fail('EMPTY_VALUE_LIST', 'Value list in `IN (...)` cannot be empty.', this.tok().span);
+    }
+    values.push(this.parseValue());
+    while (this.tok().kind === 'Comma') {
+      this.advance();
+      values.push(this.parseValue());
+    }
+    const closeTok = this.expect('RParen', 'EXPECTED_RPAREN', 'Expected `)` to close value list.');
+    return {
+      kind: 'In',
+      negated,
+      values,
+      span: { start: startOffset, end: closeTok.span.end },
+    };
+  }
+
+  /**
+   * Reserved names that are language keywords (and cannot be functions). `NOT` etc.
+   * Used to avoid mis-parsing `x IN NOT something` as a function call.
+   */
+  private isReservedFunctionName(text: string): boolean {
+    return KEYWORDS.has(text.toUpperCase());
+  }
+
+  private parseHistoryOp(startOffset: number): ClauseOp {
+    // WAS [NOT] [IN] value
+    if (this.isKeyword(this.tok(), 'WAS')) {
+      this.advance();
+      let op: HistoryOp = 'WAS';
+      if (this.isKeyword(this.tok(), 'NOT')) {
+        this.advance();
+        if (this.isKeyword(this.tok(), 'IN')) {
+          this.advance();
+          op = 'WAS_NOT_IN';
+        } else {
+          op = 'WAS_NOT';
+        }
+      } else if (this.isKeyword(this.tok(), 'IN')) {
+        this.advance();
+        op = 'WAS_IN';
+      }
+      const value = this.parseValue();
+      return { kind: 'History', op, value, span: { start: startOffset, end: value.span.end } };
+    }
+    // CHANGED [FROM|TO|AFTER|BEFORE|ON|DURING|BY value]
+    this.advance(); // CHANGED
+    const subOps: Record<string, HistoryOp> = {
+      FROM: 'CHANGED_FROM',
+      TO: 'CHANGED_TO',
+      AFTER: 'CHANGED_AFTER',
+      BEFORE: 'CHANGED_BEFORE',
+      ON: 'CHANGED_ON',
+      DURING: 'CHANGED_DURING',
+      BY: 'CHANGED_BY',
+    };
+    if (this.tok().kind === 'Ident') {
+      const upper = this.tok().value.toUpperCase();
+      if (upper in subOps) {
+        this.advance();
+        const value = this.parseValue();
+        return {
+          kind: 'History',
+          op: subOps[upper]!,
+          value,
+          span: { start: startOffset, end: value.span.end },
+        };
+      }
+    }
+    return {
+      kind: 'History',
+      op: 'CHANGED',
+      value: null,
+      span: { start: startOffset, end: this.tokens[this.pos - 1]!.span.end },
+    };
+  }
+
+  // ─── Fields ───────────────────────────────────────────────────────────────
+
+  private parseFieldRef(): FieldRef {
+    const tok = this.tok();
+    if (tok.kind === 'Ident' && !KEYWORDS.has(tok.value.toUpperCase())) {
+      this.advance();
+      return { kind: 'Ident', name: tok.value, span: tok.span };
+    }
+    if (tok.kind === 'CustomField') {
+      this.advance();
+      return { kind: 'CustomField', uuid: tok.value, span: tok.span };
+    }
+    if (tok.kind === 'String') {
+      this.advance();
+      return { kind: 'QuotedField', name: tok.value, span: tok.span };
+    }
+    this.fail(
+      'EXPECTED_FIELD',
+      `Expected a field name, got \`${this.tokenLexeme(tok)}\`.`,
+      tok.span,
+      'Field names can be identifiers (e.g. priority), quoted strings (e.g. "Story Points"), or custom-field references (cf[UUID]).',
+    );
+  }
+
+  private fieldLabel(field: FieldRef): string {
+    if (field.kind === 'CustomField') return `cf[${field.uuid}]`;
+    if (field.kind === 'QuotedField') return `"${field.name}"`;
+    return field.name;
+  }
+
+  // ─── Values ───────────────────────────────────────────────────────────────
+
+  private parseValue(): Expr {
+    const tok = this.tok();
+    switch (tok.kind) {
+      case 'String': {
+        this.advance();
+        const lit: Literal = { kind: 'String', value: tok.value, span: tok.span };
+        return lit;
+      }
+      case 'Number': {
+        this.advance();
+        const num = Number.parseFloat(tok.value);
+        const lit: Literal = { kind: 'Number', value: num, span: tok.span };
+        return lit;
+      }
+      case 'RelativeDate': {
+        this.advance();
+        const lit: Literal = { kind: 'RelativeDate', raw: tok.value, span: tok.span };
+        return lit;
+      }
+      case 'Ident': {
+        if (this.peek(1)?.kind === 'LParen') {
+          return this.parseFunctionCall();
+        }
+        const upper = tok.value.toUpperCase();
+        this.advance();
+        if (upper === 'TRUE') return { kind: 'Bool', value: true, span: tok.span };
+        if (upper === 'FALSE') return { kind: 'Bool', value: false, span: tok.span };
+        if (upper === 'NULL') return { kind: 'Null', span: tok.span };
+        if (upper === 'EMPTY') return { kind: 'Empty', span: tok.span };
+        return { kind: 'Ident', name: tok.value, span: tok.span };
+      }
+      default:
+        this.fail(
+          'EXPECTED_VALUE',
+          `Expected a value, got \`${this.tokenLexeme(tok)}\`.`,
+          tok.span,
+        );
+    }
+  }
+
+  private parseFunctionCall(): FunctionCall {
+    const nameTok = this.advance();
+    this.expect('LParen', 'EXPECTED_LPAREN', `Expected \`(\` after function name \`${nameTok.value}\`.`);
+    const args: Expr[] = [];
+    if (this.tok().kind !== 'RParen') {
+      args.push(this.parseValue());
+      while (this.tok().kind === 'Comma') {
+        this.advance();
+        args.push(this.parseValue());
+      }
+    }
+    const close = this.expect('RParen', 'EXPECTED_RPAREN', `Expected \`)\` to close function call \`${nameTok.value}(...)\`.`);
+    return {
+      kind: 'Function',
+      name: nameTok.value,
+      args,
+      span: { start: nameTok.span.start, end: close.span.end },
+    };
+  }
+
+  // ─── ORDER BY ─────────────────────────────────────────────────────────────
+
+  private isOrderByAhead(): boolean {
+    return this.isKeyword(this.tok(), 'ORDER') && !!this.peek(1) && this.isKeyword(this.peek(1)!, 'BY');
+  }
+
+  private parseSortItem(): SortItem {
+    const field = this.parseFieldRef();
+    let direction: 'ASC' | 'DESC' = 'ASC';
+    let endSpan: Span = field.span;
+    if (this.tok().kind === 'Ident') {
+      const upper = this.tok().value.toUpperCase();
+      if (upper === 'ASC' || upper === 'DESC') {
+        direction = upper;
+        endSpan = this.tok().span;
+        this.advance();
+      } else if (KEYWORDS.has(upper) && upper !== 'AND' && upper !== 'OR') {
+        // Guard against misplaced keywords like "ORDER BY foo WHERE". Let the trailing-
+        // input check at top-level produce the friendlier error message.
+      }
+    }
+    return { field, direction, span: joinSpan(field.span, endSpan) };
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  private isKeyword(tok: Token, kw: string): boolean {
+    return tok.kind === 'Ident' && tok.value.toUpperCase() === kw;
+  }
+
+  private expect(kind: Token['kind'], code: ParseErrorCode, message: string): Token {
+    if (this.tok().kind !== kind) {
+      this.fail(code, message, this.tok().span);
+    }
+    return this.advance();
+  }
+
+  private tokenLexeme(tok: Token): string {
+    if (tok.kind === 'Eof') return '<end of input>';
+    if (tok.kind === 'String') return `"${tok.value}"`;
+    return this.source.slice(tok.span.start, tok.span.end);
+  }
+
+  private fail(code: ParseErrorCode, message: string, span: Span, hint?: string): never {
+    throw new ParserBailout({ code, message, hint, start: span.start, end: span.end });
+  }
+}
+
+const KEYWORDS = new Set([
+  'AND',
+  'OR',
+  'NOT',
+  'IN',
+  'IS',
+  'EMPTY',
+  'NULL',
+  'ORDER',
+  'BY',
+  'ASC',
+  'DESC',
+  'TRUE',
+  'FALSE',
+  'WAS',
+  'CHANGED',
+  'FROM',
+  'TO',
+  'AFTER',
+  'BEFORE',
+  'ON',
+  'DURING',
+]);

--- a/backend/src/modules/search/search.parser.ts
+++ b/backend/src/modules/search/search.parser.ts
@@ -76,12 +76,37 @@ export function parse(source: string): ParseResult {
     if (err instanceof ParserBailout) {
       return { ast: null, errors: [...parser.errors, err.err] };
     }
-    throw err;
+    // Safety net — no unhandled exception escapes `parse()`. This backstops the
+    // `parse()`-never-throws invariant against stack overflows (`RangeError`) or any
+    // other JS runtime error we didn't foresee. Downstream consumers (suggest, fuzz)
+    // rely on this. See pre-push review for PR-2.
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ast: null,
+      errors: [
+        ...parser.errors,
+        {
+          code: 'UNEXPECTED_TOKEN',
+          message: `Internal parser error: ${message}`,
+          start: 0,
+          end: source.length,
+        },
+      ],
+    };
   }
 }
 
+/**
+ * Maximum nesting depth for parenthesised/NOT expressions. Prevents a crafted query
+ * with 10K `(` chars from blowing the call stack (V8 defaults to ~10K frames). Value
+ * chosen to comfortably exceed any legitimate query — the deepest golden-set query
+ * uses depth 2. See pre-push review.
+ */
+const MAX_DEPTH = 256;
+
 class Parser {
   private pos = 0;
+  private depth = 0;
   readonly errors: ParseError[] = [];
 
   constructor(private readonly tokens: Token[], private readonly source: string) {}
@@ -193,17 +218,30 @@ class Parser {
 
   private parseAtom(): BoolExpr {
     if (this.tok().kind === 'LParen') {
-      const lparen = this.advance();
-      if (this.tok().kind === 'RParen') {
+      if (this.depth >= MAX_DEPTH) {
         this.fail(
-          'EMPTY_PAREN_GROUP',
-          'Parenthesized expression cannot be empty.',
-          { start: lparen.span.start, end: this.tok().span.end },
+          'UNEXPECTED_TOKEN',
+          `Query is nested too deeply (max ${MAX_DEPTH} levels).`,
+          this.tok().span,
+          'Flatten your parentheses — such deeply nested groupings are almost never what you meant.',
         );
       }
-      const inner = this.parseOrExpr();
-      this.expect('RParen', 'EXPECTED_RPAREN', 'Expected closing `)`.');
-      return inner;
+      this.depth++;
+      try {
+        const lparen = this.advance();
+        if (this.tok().kind === 'RParen') {
+          this.fail(
+            'EMPTY_PAREN_GROUP',
+            'Parenthesized expression cannot be empty.',
+            { start: lparen.span.start, end: this.tok().span.end },
+          );
+        }
+        const inner = this.parseOrExpr();
+        this.expect('RParen', 'EXPECTED_RPAREN', 'Expected closing `)`.');
+        return inner;
+      } finally {
+        this.depth--;
+      }
     }
     return this.parseClause();
   }
@@ -509,10 +547,19 @@ class Parser {
         direction = upper;
         endSpan = this.tok().span;
         this.advance();
-      } else if (KEYWORDS.has(upper) && upper !== 'AND' && upper !== 'OR') {
-        // Guard against misplaced keywords like "ORDER BY foo WHERE". Let the trailing-
-        // input check at top-level produce the friendlier error message.
+      } else if (!KEYWORDS.has(upper)) {
+        // Unrecognised word where ASC/DESC was expected — `ORDER BY priority foo`.
+        // Surface a typed error so the CodeMirror editor can highlight exactly the
+        // bad token (pre-push review flagged that this used to leak through as a
+        // generic TRAILING_INPUT after the ORDER BY list).
+        this.fail(
+          'INVALID_SORT_DIRECTION',
+          `Expected \`ASC\` or \`DESC\` (or another sort field after a comma), got \`${this.tok().value}\`.`,
+          this.tok().span,
+        );
       }
+      // Known keywords (AND/OR/...) are left intact — the top-level trailing-input
+      // check will surface a friendlier error if the query is malformed.
     }
     return { field, direction, span: joinSpan(field.span, endSpan) };
   }

--- a/backend/src/modules/search/search.tokenizer.ts
+++ b/backend/src/modules/search/search.tokenizer.ts
@@ -1,0 +1,347 @@
+/**
+ * TTSRH-1 PR-2 — tokenizer for TTS-QL.
+ *
+ * Hand-written char-by-char lexer. No external regex compilation in hot loop — each
+ * recognizer reads a small prefix at the cursor. This is deliberate: fuzz-tests in
+ * TTSRH-11 throw unicode, RTL, null-byte and control chars at the input, and we want
+ * bounded per-char work.
+ *
+ * Tokens emitted:
+ *   - String        "..."  '...' with \"  \\  \n \t \u{HEX} escapes
+ *   - Number        -?\d+(\.\d+)?
+ *   - RelativeDate  -?\d+[dwMyhm]        (bare form; quoted stays as String)
+ *   - Ident         [A-Za-z_][A-Za-z0-9_\-\.]*
+ *   - CustomField   cf[UUID]
+ *   - Op            = != > >= < <= ~ !~
+ *   - LParen / RParen / Comma
+ *   - Eof (sentinel)
+ *
+ * Keywords (AND/OR/NOT/IN/IS/EMPTY/NULL/ORDER/BY/ASC/DESC/TRUE/FALSE/WAS/CHANGED/
+ * FROM/TO/AFTER/BEFORE/ON/DURING) are emitted as Ident — parser disambiguates by
+ * case-insensitive match on the value. This keeps the tokenizer value-agnostic and
+ * makes it trivial to extend.
+ *
+ * Comments: `--` to end of line, outside of strings. Ignored (whitespace-equivalent).
+ */
+
+import type { Span } from './search.ast.js';
+
+export type TokenKind =
+  | 'String'
+  | 'Number'
+  | 'RelativeDate'
+  | 'Ident'
+  | 'CustomField'
+  | 'Op'
+  | 'LParen'
+  | 'RParen'
+  | 'Comma'
+  | 'Eof';
+
+export interface Token {
+  kind: TokenKind;
+  /** For String — the decoded value (escapes resolved). For all others — the raw lexeme. */
+  value: string;
+  span: Span;
+}
+
+export class TokenizerError extends Error {
+  readonly code: 'UNEXPECTED_CHARACTER' | 'UNTERMINATED_STRING' | 'INVALID_ESCAPE' | 'INVALID_CUSTOM_FIELD';
+  readonly start: number;
+  readonly end: number;
+  constructor(code: TokenizerError['code'], message: string, start: number, end: number) {
+    super(message);
+    this.code = code;
+    this.start = start;
+    this.end = end;
+  }
+}
+
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const RELATIVE_UNITS = new Set(['d', 'w', 'M', 'y', 'h', 'm']);
+
+/** Tokenize a TTS-QL source string. Throws `TokenizerError` on invalid input. */
+export function tokenize(source: string): Token[] {
+  const tokens: Token[] = [];
+  let pos = 0;
+  const n = source.length;
+
+  while (pos < n) {
+    const ch = source[pos]!;
+
+    // Whitespace
+    if (ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n') {
+      pos++;
+      continue;
+    }
+
+    // Comment: -- to end of line. Only when NOT followed by digit/unit (to avoid
+    // eating a bare relative date like `-1d`). `--` is the comment; `-1d` starts
+    // with `-` then digit.
+    if (ch === '-' && source[pos + 1] === '-') {
+      while (pos < n && source[pos] !== '\n') pos++;
+      continue;
+    }
+
+    // Punctuation
+    if (ch === '(') { tokens.push({ kind: 'LParen', value: '(', span: { start: pos, end: pos + 1 } }); pos++; continue; }
+    if (ch === ')') { tokens.push({ kind: 'RParen', value: ')', span: { start: pos, end: pos + 1 } }); pos++; continue; }
+    if (ch === ',') { tokens.push({ kind: 'Comma', value: ',', span: { start: pos, end: pos + 1 } }); pos++; continue; }
+
+    // Two-char operators
+    if (ch === '!' && source[pos + 1] === '=') {
+      tokens.push({ kind: 'Op', value: '!=', span: { start: pos, end: pos + 2 } });
+      pos += 2;
+      continue;
+    }
+    if (ch === '!' && source[pos + 1] === '~') {
+      tokens.push({ kind: 'Op', value: '!~', span: { start: pos, end: pos + 2 } });
+      pos += 2;
+      continue;
+    }
+    if (ch === '>' && source[pos + 1] === '=') {
+      tokens.push({ kind: 'Op', value: '>=', span: { start: pos, end: pos + 2 } });
+      pos += 2;
+      continue;
+    }
+    if (ch === '<' && source[pos + 1] === '=') {
+      tokens.push({ kind: 'Op', value: '<=', span: { start: pos, end: pos + 2 } });
+      pos += 2;
+      continue;
+    }
+
+    // Single-char operators
+    if (ch === '=' || ch === '>' || ch === '<' || ch === '~') {
+      tokens.push({ kind: 'Op', value: ch, span: { start: pos, end: pos + 1 } });
+      pos++;
+      continue;
+    }
+
+    // String
+    if (ch === '"' || ch === "'") {
+      const [tok, next] = readString(source, pos, ch);
+      tokens.push(tok);
+      pos = next;
+      continue;
+    }
+
+    // CustomField: cf[UUID]. Match before Ident because `cf` alone is a valid Ident.
+    if (ch === 'c' && source[pos + 1] === 'f' && source[pos + 2] === '[') {
+      const close = source.indexOf(']', pos + 3);
+      if (close < 0) {
+        throw new TokenizerError(
+          'INVALID_CUSTOM_FIELD',
+          'Custom field reference `cf[...]` is missing a closing `]`.',
+          pos,
+          n,
+        );
+      }
+      const uuid = source.slice(pos + 3, close);
+      if (!UUID_RE.test(uuid)) {
+        throw new TokenizerError(
+          'INVALID_CUSTOM_FIELD',
+          `Custom field reference must contain a UUID, got \`${uuid}\`.`,
+          pos,
+          close + 1,
+        );
+      }
+      tokens.push({ kind: 'CustomField', value: uuid, span: { start: pos, end: close + 1 } });
+      pos = close + 1;
+      continue;
+    }
+
+    // Number / RelativeDate (possibly negative)
+    if (ch === '-' || (ch >= '0' && ch <= '9')) {
+      const [tok, next] = readNumberOrRelative(source, pos);
+      if (tok) {
+        tokens.push(tok);
+        pos = next;
+        continue;
+      }
+      // Standalone `-` without digits — not a valid token.
+      throw new TokenizerError(
+        'UNEXPECTED_CHARACTER',
+        `Unexpected character \`${ch}\` at position ${pos}.`,
+        pos,
+        pos + 1,
+      );
+    }
+
+    // Ident
+    if (isIdentStart(ch)) {
+      const start = pos;
+      pos++;
+      while (pos < n && isIdentPart(source[pos]!)) pos++;
+      tokens.push({ kind: 'Ident', value: source.slice(start, pos), span: { start, end: pos } });
+      continue;
+    }
+
+    throw new TokenizerError(
+      'UNEXPECTED_CHARACTER',
+      `Unexpected character \`${ch}\` at position ${pos}.`,
+      pos,
+      pos + 1,
+    );
+  }
+
+  tokens.push({ kind: 'Eof', value: '', span: { start: n, end: n } });
+  return tokens;
+}
+
+function isIdentStart(ch: string): boolean {
+  return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch === '_';
+}
+
+function isIdentPart(ch: string): boolean {
+  return isIdentStart(ch) || (ch >= '0' && ch <= '9') || ch === '-' || ch === '.';
+}
+
+/**
+ * Read a double- or single-quoted string. Supports these escapes inside the quotes:
+ *   \"  \'  \\  \n  \t  \r  \u{HEX}
+ * Any other `\X` pair is rejected with INVALID_ESCAPE — we want authors to notice
+ * typos rather than silently interpreting `\n` as a literal `n`.
+ */
+function readString(source: string, pos: number, quote: string): [Token, number] {
+  const start = pos;
+  pos++; // skip opening quote
+  let value = '';
+  const n = source.length;
+
+  while (pos < n) {
+    const ch = source[pos]!;
+    if (ch === quote) {
+      return [{ kind: 'String', value, span: { start, end: pos + 1 } }, pos + 1];
+    }
+    if (ch === '\\') {
+      if (pos + 1 >= n) {
+        throw new TokenizerError(
+          'UNTERMINATED_STRING',
+          'String ended inside an escape sequence.',
+          start,
+          n,
+        );
+      }
+      const esc = source[pos + 1]!;
+      switch (esc) {
+        case '"': value += '"'; pos += 2; break;
+        case "'": value += "'"; pos += 2; break;
+        case '\\': value += '\\'; pos += 2; break;
+        case 'n': value += '\n'; pos += 2; break;
+        case 't': value += '\t'; pos += 2; break;
+        case 'r': value += '\r'; pos += 2; break;
+        case 'u': {
+          // \u{HEX} or \uHHHH
+          if (source[pos + 2] === '{') {
+            const close = source.indexOf('}', pos + 3);
+            if (close < 0) {
+              throw new TokenizerError(
+                'INVALID_ESCAPE',
+                'Unicode escape `\\u{...}` is missing a closing `}`.',
+                pos,
+                n,
+              );
+            }
+            const hex = source.slice(pos + 3, close);
+            const code = Number.parseInt(hex, 16);
+            if (!/^[0-9a-fA-F]+$/.test(hex) || !Number.isFinite(code) || code > 0x10ffff) {
+              throw new TokenizerError(
+                'INVALID_ESCAPE',
+                `Invalid unicode escape \`\\u{${hex}}\`.`,
+                pos,
+                close + 1,
+              );
+            }
+            value += String.fromCodePoint(code);
+            pos = close + 1;
+          } else {
+            const hex = source.slice(pos + 2, pos + 6);
+            if (hex.length !== 4 || !/^[0-9a-fA-F]{4}$/.test(hex)) {
+              throw new TokenizerError(
+                'INVALID_ESCAPE',
+                `Invalid unicode escape \`\\u${hex}\`.`,
+                pos,
+                Math.min(pos + 6, n),
+              );
+            }
+            value += String.fromCharCode(Number.parseInt(hex, 16));
+            pos += 6;
+          }
+          break;
+        }
+        default:
+          throw new TokenizerError(
+            'INVALID_ESCAPE',
+            `Unknown escape sequence \`\\${esc}\`.`,
+            pos,
+            pos + 2,
+          );
+      }
+      continue;
+    }
+    // Reject control characters other than tab (keep literal tabs for convenience)
+    const code = source.charCodeAt(pos);
+    if (code < 0x20 && code !== 0x09) {
+      throw new TokenizerError(
+        'UNEXPECTED_CHARACTER',
+        `Control character U+${code.toString(16).padStart(4, '0').toUpperCase()} is not allowed in a string.`,
+        pos,
+        pos + 1,
+      );
+    }
+    value += ch;
+    pos++;
+  }
+
+  throw new TokenizerError(
+    'UNTERMINATED_STRING',
+    `String starting at position ${start} is not terminated.`,
+    start,
+    n,
+  );
+}
+
+/**
+ * Read a numeric literal. Returns RelativeDate when the digits are followed by a
+ * unit suffix (d, w, M, y, h, m) at a word boundary, otherwise a plain Number.
+ * Returns [null, pos] when the prefix is not a valid number (e.g. standalone `-`).
+ */
+function readNumberOrRelative(source: string, pos: number): [Token | null, number] {
+  const start = pos;
+  let end = pos;
+  if (source[end] === '-') end++;
+  const digitsStart = end;
+  while (end < source.length && source[end]! >= '0' && source[end]! <= '9') end++;
+  if (end === digitsStart) {
+    // `-` with no digits after — reject.
+    return [null, pos];
+  }
+
+  // Fractional part
+  let hasFraction = false;
+  if (source[end] === '.' && source[end + 1] !== undefined && source[end + 1]! >= '0' && source[end + 1]! <= '9') {
+    hasFraction = true;
+    end++;
+    while (end < source.length && source[end]! >= '0' && source[end]! <= '9') end++;
+  }
+
+  // RelativeDate suffix. Must be followed by a non-ident char (or EOF) to count —
+  // otherwise `5days` would be mis-tokenised as `5d` + `ays`.
+  const unit = source[end];
+  if (unit && RELATIVE_UNITS.has(unit) && !hasFraction) {
+    const afterUnit = source[end + 1];
+    if (afterUnit === undefined || !isIdentPart(afterUnit)) {
+      const raw = source.slice(start, end + 1);
+      return [
+        { kind: 'RelativeDate', value: raw, span: { start, end: end + 1 } },
+        end + 1,
+      ];
+    }
+  }
+
+  const raw = source.slice(start, end);
+  return [
+    { kind: 'Number', value: raw, span: { start, end } },
+    end,
+  ];
+}

--- a/backend/src/modules/search/search.tokenizer.ts
+++ b/backend/src/modules/search/search.tokenizer.ts
@@ -126,6 +126,10 @@ export function tokenize(source: string): Token[] {
     }
 
     // CustomField: cf[UUID]. Match before Ident because `cf` alone is a valid Ident.
+    // We validate the UUID shape at tokenizer level (not at parser/validator) because
+    // a malformed `cf[...]` is unambiguously invalid — there's no user-facing reason to
+    // defer. This is an intentional deviation from the "value-agnostic tokenizer"
+    // principle documented in §5.5 ТЗ; see pre-push review.
     if (ch === 'c' && source[pos + 1] === 'f' && source[pos + 2] === '[') {
       const close = source.indexOf(']', pos + 3);
       if (close < 0) {
@@ -198,9 +202,18 @@ function isIdentPart(ch: string): boolean {
 
 /**
  * Read a double- or single-quoted string. Supports these escapes inside the quotes:
- *   \"  \'  \\  \n  \t  \r  \u{HEX}
+ *   \"  \'  \\  \n  \t  \r  \u{HEX}  \uHHHH
  * Any other `\X` pair is rejected with INVALID_ESCAPE — we want authors to notice
  * typos rather than silently interpreting `\n` as a literal `n`.
+ *
+ * Cross-quote escapes (`\'` inside `"..."` and `\"` inside `'...'`) are **accepted**.
+ * This is intentionally more permissive than stock Jira JQL — they're harmless and
+ * reduce friction when copy-pasting queries from documentation.
+ *
+ * **Rejected codepoints**: lone surrogates (U+D800–U+DFFF) and the null codepoint
+ * (U+0000). The former would produce invalid UTF-8 downstream (Postgres text columns
+ * reject lone surrogates); the latter is the C-string terminator and breaks Prisma's
+ * parameter binding in rare cases. Pre-push review flagged both as latent hazards.
  */
 function readString(source: string, pos: number, quote: string): [Token, number] {
   const start = pos;
@@ -252,6 +265,7 @@ function readString(source: string, pos: number, quote: string): [Token, number]
                 close + 1,
               );
             }
+            rejectForbiddenCodepoint(code, pos, close + 1);
             value += String.fromCodePoint(code);
             pos = close + 1;
           } else {
@@ -264,7 +278,9 @@ function readString(source: string, pos: number, quote: string): [Token, number]
                 Math.min(pos + 6, n),
               );
             }
-            value += String.fromCharCode(Number.parseInt(hex, 16));
+            const code = Number.parseInt(hex, 16);
+            rejectForbiddenCodepoint(code, pos, pos + 6);
+            value += String.fromCharCode(code);
             pos += 6;
           }
           break;
@@ -293,12 +309,39 @@ function readString(source: string, pos: number, quote: string): [Token, number]
     pos++;
   }
 
+  // Clamp the end of the reported span — underlining from the opening quote to EOF
+  // spams CodeMirror with noise for long queries. One-quote span is enough for the
+  // editor to place a squiggle at the offending character.
   throw new TokenizerError(
     'UNTERMINATED_STRING',
     `String starting at position ${start} is not terminated.`,
     start,
-    n,
+    Math.min(start + 1, n),
   );
+}
+
+/**
+ * Reject codepoints that would create trouble downstream:
+ *   - surrogates (U+D800..U+DFFF): Postgres UTF-8 text columns reject them;
+ *   - null byte (U+0000): terminates C strings, unsafe in some binding paths.
+ */
+function rejectForbiddenCodepoint(code: number, start: number, end: number): void {
+  if (code === 0) {
+    throw new TokenizerError(
+      'INVALID_ESCAPE',
+      'Null codepoint (U+0000) is not allowed in a string literal.',
+      start,
+      end,
+    );
+  }
+  if (code >= 0xd800 && code <= 0xdfff) {
+    throw new TokenizerError(
+      'INVALID_ESCAPE',
+      `Codepoint U+${code.toString(16).toUpperCase()} is a surrogate and cannot appear in a string literal.`,
+      start,
+      end,
+    );
+  }
 }
 
 /**

--- a/backend/tests/search-parser-fuzz.unit.test.ts
+++ b/backend/tests/search-parser-fuzz.unit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * TTSRH-1 PR-2 — fuzz-harness for tokenizer + parser.
+ *
+ * Generates 1000+ seeded random inputs (T-7 in §6 ТЗ) and asserts that `parse(src)`
+ * never throws: it must always return `{ ast, errors }` with either a QueryNode or a
+ * populated errors array. This is the security-adjacent invariant — an unhandled
+ * throw in the request path would bubble to a 500, so R1 (SQL-injection via JQL)
+ * can't start here.
+ *
+ * Random inputs lean on payloads that have historically broken hand-written parsers:
+ * mixed quotes, unterminated strings, unicode RTL, null bytes, control chars, nested
+ * parens, binary-looking bytes, Postgres-style SQL fragments.
+ */
+import { describe, expect, it } from 'vitest';
+import { parse } from '../src/modules/search/search.parser.js';
+
+/** Mulberry32 — tiny seeded PRNG; deterministic across runs/platforms. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const TOKENS = [
+  'priority', 'status', 'assignee', 'project', 'due', 'sprint', 'release', 'key',
+  '=', '!=', '>', '<', '>=', '<=', '~', '!~',
+  'AND', 'OR', 'NOT', 'IN', 'IS', 'EMPTY', 'NULL', 'ORDER', 'BY', 'ASC', 'DESC', 'true', 'false',
+  '(', ')', ',',
+  '"open"', "'review'", '"a\\"b"', '"unterminated',
+  'currentUser()', 'openSprints()', 'membersOf("team")',
+  '-1d', '-7d', '3M', '"7d"',
+  '5', '3.14', '-0.5',
+  '1', '2', 'HIGH', 'CRITICAL',
+  'cf[12345678-1234-1234-1234-123456789abc]',
+];
+
+const NASTY_CHARS = [
+  '\0',       // null byte
+  '\x01',     // control
+  '\x7f',     // DEL
+  '\u200F',   // RTL mark
+  '\u{1F600}',// emoji
+  '\\',       // stray backslash
+  '-',        // dangling minus
+  '--',       // starts a comment
+  ';', '{', '}', '[', ']', '|', '&', '$', '!',
+  '\n', '\r', '\t',
+];
+
+const SQL_PAYLOADS = [
+  "'; DROP TABLE issues; --",
+  "' OR 1=1 --",
+  '\\x27;--',
+  '") OR ("1"="1',
+  'UNION SELECT * FROM users',
+];
+
+function pickFrom<T>(rng: () => number, pool: readonly T[]): T {
+  return pool[Math.floor(rng() * pool.length)]!;
+}
+
+function randomInput(rng: () => number): string {
+  const length = 1 + Math.floor(rng() * 30);
+  const parts: string[] = [];
+  for (let i = 0; i < length; i++) {
+    const roll = rng();
+    if (roll < 0.7) parts.push(pickFrom(rng, TOKENS));
+    else if (roll < 0.85) parts.push(pickFrom(rng, NASTY_CHARS));
+    else if (roll < 0.95) parts.push(pickFrom(rng, SQL_PAYLOADS));
+    else {
+      // Random codepoint across BMP to exercise unicode paths.
+      const cp = Math.floor(rng() * 0x10000);
+      parts.push(String.fromCodePoint(cp));
+    }
+    if (rng() < 0.6) parts.push(' ');
+  }
+  return parts.join('');
+}
+
+describe('parser — fuzz harness (T-7)', () => {
+  it('1000 random inputs — no throw, always returns a ParseResult', () => {
+    const rng = mulberry32(0xcafe_babe);
+    const failures: Array<{ input: string; error: unknown }> = [];
+
+    for (let i = 0; i < 1000; i++) {
+      const input = randomInput(rng);
+      try {
+        const result = parse(input);
+        // Invariant: result must have both fields; if ast is null, errors must be non-empty.
+        expect(result).toHaveProperty('ast');
+        expect(result).toHaveProperty('errors');
+        if (result.ast === null) expect(result.errors.length).toBeGreaterThan(0);
+        // Every error must have a well-formed span within the source.
+        for (const err of result.errors) {
+          expect(err.start).toBeGreaterThanOrEqual(0);
+          expect(err.end).toBeGreaterThanOrEqual(err.start);
+          expect(err.end).toBeLessThanOrEqual(input.length);
+        }
+      } catch (err) {
+        failures.push({ input, error: err });
+      }
+    }
+
+    if (failures.length > 0) {
+      const sample = failures.slice(0, 5).map(
+        (f) => `  input=${JSON.stringify(f.input)}\n  err=${String(f.error)}`,
+      );
+      throw new Error(
+        `parse() threw on ${failures.length}/1000 inputs. First 5:\n${sample.join('\n')}`,
+      );
+    }
+    expect(failures).toHaveLength(0);
+  });
+
+  it('targeted payloads — SQL-injection style strings parse or error cleanly', () => {
+    const payloads = [
+      `project = "'; DROP TABLE issues; --"`,
+      `summary ~ "' OR 1=1 --"`,
+      `description ~ "${'\\'.repeat(100)}"`,
+      `status IN ("${'A'.repeat(10000)}")`,
+      `x = 1 ${'AND y = 2 '.repeat(500)}`,
+      `${'('.repeat(200)}x = 1${')'.repeat(200)}`,
+    ];
+    for (const p of payloads) {
+      expect(() => parse(p)).not.toThrow();
+    }
+  });
+});

--- a/backend/tests/search-parser-fuzz.unit.test.ts
+++ b/backend/tests/search-parser-fuzz.unit.test.ts
@@ -125,6 +125,10 @@ describe('parser — fuzz harness (T-7)', () => {
       `status IN ("${'A'.repeat(10000)}")`,
       `x = 1 ${'AND y = 2 '.repeat(500)}`,
       `${'('.repeat(200)}x = 1${')'.repeat(200)}`,
+      // Deep nesting that would overflow the V8 call stack without the MAX_DEPTH
+      // guard in the parser. This payload failed before the guard was added (see
+      // pre-push review). After the fix, it must return a clean ParseResult.
+      `${'('.repeat(500)}x = 1${')'.repeat(500)}`,
     ];
     for (const p of payloads) {
       expect(() => parse(p)).not.toThrow();

--- a/backend/tests/search-parser-goldenset.unit.test.ts
+++ b/backend/tests/search-parser-goldenset.unit.test.ts
@@ -1,0 +1,94 @@
+/**
+ * TTSRH-1 PR-2 — golden-set parsing test.
+ *
+ * Reads docs/tz/TTSRH-1-goldenset.jql (the canonical set of ~50 real queries from
+ * §11 ТЗ, extended in §16 with checkpoint queries) and asserts that every one of
+ * them parses WITHOUT errors. This is the fail-fast test that blocks any change
+ * to the grammar from breaking real-world queries.
+ *
+ * Queries are separated by blank lines; `--` lines are comments and are skipped.
+ * Multi-line queries are supported (continuation lines are joined by newline).
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { parse } from '../src/modules/search/search.parser.js';
+
+interface GoldenQuery {
+  /** Human-readable label like `01` or `51` taken from the preceding comment. */
+  label: string;
+  source: string;
+  /** 1-based line number in the .jql file (for error messages). */
+  startLine: number;
+}
+
+function loadGoldenSet(): GoldenQuery[] {
+  const path = resolve(__dirname, '../../docs/tz/TTSRH-1-goldenset.jql');
+  const text = readFileSync(path, 'utf8');
+  const lines = text.split('\n');
+
+  const queries: GoldenQuery[] = [];
+  let buf: string[] = [];
+  let bufStartLine = 0;
+  let lastLabel = '';
+
+  const flush = () => {
+    const source = buf.join('\n').trim();
+    if (source) {
+      queries.push({ label: lastLabel, source, startLine: bufStartLine });
+    }
+    buf = [];
+    bufStartLine = 0;
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]!;
+    const line = raw.trim();
+
+    if (line.startsWith('--')) {
+      // Comment line — capture "-- NN" labels, otherwise treat as section divider.
+      flush();
+      const labelMatch = line.match(/^--\s*(\d{1,3})\b/);
+      if (labelMatch) lastLabel = labelMatch[1]!;
+      continue;
+    }
+
+    if (!line) {
+      flush();
+      continue;
+    }
+
+    if (buf.length === 0) bufStartLine = i + 1;
+    buf.push(raw);
+  }
+  flush();
+
+  return queries;
+}
+
+describe('parser — golden-set (docs/tz/TTSRH-1-goldenset.jql)', () => {
+  const queries = loadGoldenSet();
+
+  it('loaded at least 50 queries', () => {
+    // §11 ТЗ promises ~50; §16 adds checkpoint queries bringing total to ~63.
+    expect(queries.length).toBeGreaterThanOrEqual(50);
+  });
+
+  it.each(queries.map((q) => [q.label || '?', q.source.replace(/\s+/g, ' '), q] as const))(
+    'query #%s: `%s`',
+    (_label, _preview, q) => {
+      const result = parse(q.source);
+      if (result.errors.length > 0) {
+        const { code, message, start, end } = result.errors[0]!;
+        const snippet = q.source.slice(start, end);
+        throw new Error(
+          `Golden query #${q.label} (line ${q.startLine}) failed to parse: ` +
+            `[${code}] ${message}  at [${start}..${end}]="${snippet}".\n` +
+            `Source:\n${q.source}`,
+        );
+      }
+      expect(result.ast).not.toBeNull();
+    },
+  );
+});

--- a/backend/tests/search-parser.unit.test.ts
+++ b/backend/tests/search-parser.unit.test.ts
@@ -412,10 +412,16 @@ describe('parser — error reporting', () => {
     expect(r.errors[0]?.code).toBe('EXPECTED_FIELD');
   });
 
-  it('trailing input after ORDER BY', () => {
+  it('trailing input after ORDER BY with unknown direction word', () => {
     const r = parse('x = 1 ORDER BY priority WHERE y');
-    // `WHERE` is not a known keyword — it's an ident. It becomes a second sort item field.
-    // Then `y` is trailing. The parser surfaces a trailing-input error.
+    // `WHERE` is not an ASC/DESC direction — pre-push review feedback made us emit
+    // a specific code rather than leaking through as TRAILING_INPUT.
+    expect(r.errors[0]?.code).toBe('INVALID_SORT_DIRECTION');
+  });
+
+  it('trailing input after the end of an expression', () => {
+    const r = parse('x = 1 foo');
+    // No ORDER BY — `foo` comes after a complete clause. That's still TRAILING_INPUT.
     expect(r.errors[0]?.code).toBe('TRAILING_INPUT');
   });
 
@@ -444,10 +450,43 @@ describe('parser — error reporting', () => {
     expect(r.errors[0]?.code).toBe('UNEXPECTED_CHARACTER');
   });
 
-  it('error span points at the offending token', () => {
+  it('error span points at the offending token (UNTERMINATED_STRING clamped to opening quote)', () => {
     const r = parse('x = "unterminated');
-    // String starts at position 4 (the opening quote), runs to end of input.
-    expect(r.errors[0]).toMatchObject({ start: 4, end: 17 });
+    // Span is clamped to [opening-quote, opening-quote+1] so CodeMirror doesn't
+    // underline the entire rest of the file (see pre-push review).
+    expect(r.errors[0]).toMatchObject({ start: 4, end: 5 });
+  });
+
+  it('rejects `\\u{D800}` (lone high surrogate)', () => {
+    const r = parse('x = "\\u{D800}"');
+    expect(r.errors[0]?.code).toBe('INVALID_ESCAPE');
+  });
+
+  it('rejects `\\uD800` (lone surrogate, 4-hex form)', () => {
+    const r = parse('x = "\\uD800"');
+    expect(r.errors[0]?.code).toBe('INVALID_ESCAPE');
+  });
+
+  it('rejects null codepoint `\\u{0}`', () => {
+    const r = parse('x = "\\u{0}"');
+    expect(r.errors[0]?.code).toBe('INVALID_ESCAPE');
+  });
+
+  it('rejects null codepoint `\\u0000` (4-hex form)', () => {
+    const r = parse('x = "\\u0000"');
+    expect(r.errors[0]?.code).toBe('INVALID_ESCAPE');
+  });
+
+  it('emits INVALID_SORT_DIRECTION when ORDER BY field has unknown direction word', () => {
+    const r = parse('x = 1 ORDER BY priority foo');
+    expect(r.errors[0]).toMatchObject({ code: 'INVALID_SORT_DIRECTION' });
+  });
+
+  it('deep nesting beyond MAX_DEPTH returns UNEXPECTED_TOKEN, not stack overflow', () => {
+    const src = '('.repeat(500) + 'x = 1' + ')'.repeat(500);
+    const r = parse(src);
+    expect(r.errors[0]).toMatchObject({ code: 'UNEXPECTED_TOKEN' });
+    expect(r.errors[0]!.message).toMatch(/nested too deeply/);
   });
 });
 

--- a/backend/tests/search-parser.unit.test.ts
+++ b/backend/tests/search-parser.unit.test.ts
@@ -1,0 +1,532 @@
+/**
+ * TTSRH-1 PR-2 — unit tests for the TTS-QL parser.
+ *
+ * Structural + span assertions. Error cases check both `code` and `start/end` so the
+ * CodeMirror editor can rely on position data for squiggle placement.
+ */
+import { describe, it, expect } from 'vitest';
+import { parse } from '../src/modules/search/search.parser.js';
+import type {
+  AndNode,
+  BoolExpr,
+  ClauseNode,
+  CompareOp,
+  FunctionCall,
+  NotNode,
+  OrNode,
+  QueryNode,
+} from '../src/modules/search/search.ast.js';
+
+function parseOk(source: string): QueryNode {
+  const result = parse(source);
+  expect(result.errors).toEqual([]);
+  expect(result.ast).not.toBeNull();
+  return result.ast!;
+}
+
+function clause(node: BoolExpr | null | undefined): ClauseNode {
+  expect(node?.kind).toBe('Clause');
+  return node as ClauseNode;
+}
+function andNode(node: BoolExpr | null | undefined): AndNode {
+  expect(node?.kind).toBe('And');
+  return node as AndNode;
+}
+function orNode(node: BoolExpr | null | undefined): OrNode {
+  expect(node?.kind).toBe('Or');
+  return node as OrNode;
+}
+function notNode(node: BoolExpr | null | undefined): NotNode {
+  expect(node?.kind).toBe('Not');
+  return node as NotNode;
+}
+
+// ─── Basic clauses ───────────────────────────────────────────────────────────
+
+describe('parser — simple clauses', () => {
+  it('equality with string value', () => {
+    const ast = parseOk('status = "OPEN"');
+    const c = clause(ast.where);
+    expect(c.field).toMatchObject({ kind: 'Ident', name: 'status' });
+    expect(c.op.kind).toBe('Compare');
+    if (c.op.kind === 'Compare') {
+      expect(c.op.op).toBe('=');
+      expect(c.op.value).toMatchObject({ kind: 'String', value: 'OPEN' });
+    }
+  });
+
+  it.each<[string, CompareOp]>([
+    ['x = 1', '='],
+    ['x != 1', '!='],
+    ['x > 1', '>'],
+    ['x >= 1', '>='],
+    ['x < 1', '<'],
+    ['x <= 1', '<='],
+    ['x ~ "txt"', '~'],
+    ['x !~ "txt"', '!~'],
+  ])('compare op `%s`', (src, op) => {
+    const ast = parseOk(src);
+    const c = clause(ast.where);
+    if (c.op.kind === 'Compare') expect(c.op.op).toBe(op);
+    else throw new Error('expected Compare');
+  });
+
+  it('bare identifier as value (enum constant)', () => {
+    const ast = parseOk('priority = HIGH');
+    const c = clause(ast.where);
+    if (c.op.kind === 'Compare') {
+      expect(c.op.value).toMatchObject({ kind: 'Ident', name: 'HIGH' });
+    }
+  });
+
+  it('boolean literals', () => {
+    const ast = parseOk('aiEligible = true');
+    const c = clause(ast.where);
+    if (c.op.kind === 'Compare') {
+      expect(c.op.value).toMatchObject({ kind: 'Bool', value: true });
+    }
+  });
+
+  it('number literal', () => {
+    const ast = parseOk('"Story Points" > 5');
+    const c = clause(ast.where);
+    expect(c.field).toMatchObject({ kind: 'QuotedField', name: 'Story Points' });
+    if (c.op.kind === 'Compare') {
+      expect(c.op.value).toMatchObject({ kind: 'Number', value: 5 });
+    }
+  });
+
+  it('negative number literal', () => {
+    const ast = parseOk('timeRemaining < -5');
+    const c = clause(ast.where);
+    if (c.op.kind === 'Compare') {
+      expect(c.op.value).toMatchObject({ kind: 'Number', value: -5 });
+    }
+  });
+
+  it('relative date literal (bare)', () => {
+    const ast = parseOk('updated >= -7d');
+    const c = clause(ast.where);
+    if (c.op.kind === 'Compare') {
+      expect(c.op.value).toMatchObject({ kind: 'RelativeDate', raw: '-7d' });
+    }
+  });
+
+  it('custom field via cf[UUID]', () => {
+    const ast = parseOk('cf[12345678-1234-1234-1234-123456789abc] = "Done"');
+    const c = clause(ast.where);
+    expect(c.field).toMatchObject({
+      kind: 'CustomField',
+      uuid: '12345678-1234-1234-1234-123456789abc',
+    });
+  });
+});
+
+// ─── IS [NOT] EMPTY / NULL ──────────────────────────────────────────────────
+
+describe('parser — IS EMPTY / IS NOT EMPTY / IS NULL', () => {
+  it('IS EMPTY', () => {
+    const ast = parseOk('assignee IS EMPTY');
+    const c = clause(ast.where);
+    expect(c.op.kind).toBe('IsEmpty');
+    if (c.op.kind === 'IsEmpty') expect(c.op.negated).toBe(false);
+  });
+
+  it('IS NOT EMPTY', () => {
+    const ast = parseOk('assignee IS NOT EMPTY');
+    const c = clause(ast.where);
+    if (c.op.kind === 'IsEmpty') expect(c.op.negated).toBe(true);
+  });
+
+  it('IS NULL', () => {
+    const ast = parseOk('due IS NULL');
+    const c = clause(ast.where);
+    expect(c.op.kind).toBe('IsEmpty');
+  });
+
+  it('IS NOT NULL', () => {
+    const ast = parseOk('due IS NOT NULL');
+    const c = clause(ast.where);
+    if (c.op.kind === 'IsEmpty') expect(c.op.negated).toBe(true);
+  });
+
+  it('case-insensitive: `is empty`', () => {
+    const ast = parseOk('x is empty');
+    expect(clause(ast.where).op.kind).toBe('IsEmpty');
+  });
+});
+
+// ─── IN / NOT IN ─────────────────────────────────────────────────────────────
+
+describe('parser — IN and NOT IN', () => {
+  it('IN (list)', () => {
+    const ast = parseOk('status IN (OPEN, "IN_PROGRESS", DONE)');
+    const c = clause(ast.where);
+    expect(c.op.kind).toBe('In');
+    if (c.op.kind === 'In') {
+      expect(c.op.negated).toBe(false);
+      expect(c.op.values).toHaveLength(3);
+      expect(c.op.values[0]).toMatchObject({ kind: 'Ident', name: 'OPEN' });
+      expect(c.op.values[1]).toMatchObject({ kind: 'String', value: 'IN_PROGRESS' });
+    }
+  });
+
+  it('NOT IN (list)', () => {
+    const ast = parseOk('status NOT IN (DONE, CANCELLED)');
+    const c = clause(ast.where);
+    if (c.op.kind === 'In') expect(c.op.negated).toBe(true);
+  });
+
+  it('IN funcCall() — no outer parens', () => {
+    const ast = parseOk('sprint IN openSprints()');
+    const c = clause(ast.where);
+    expect(c.op.kind).toBe('InFunction');
+    if (c.op.kind === 'InFunction') {
+      expect(c.op.func.name).toBe('openSprints');
+      expect(c.op.func.args).toEqual([]);
+    }
+  });
+
+  it('NOT IN funcCall() with args', () => {
+    const ast = parseOk('assignee NOT IN membersOf("flow-team-1")');
+    const c = clause(ast.where);
+    if (c.op.kind === 'InFunction') {
+      expect(c.op.negated).toBe(true);
+      expect(c.op.func.name).toBe('membersOf');
+      expect(c.op.func.args).toHaveLength(1);
+    }
+  });
+});
+
+// ─── Function calls as values ────────────────────────────────────────────────
+
+describe('parser — function calls', () => {
+  it('zero-arg function value', () => {
+    const ast = parseOk('assignee = currentUser()');
+    const c = clause(ast.where);
+    if (c.op.kind === 'Compare') {
+      const fn = c.op.value as FunctionCall;
+      expect(fn.kind).toBe('Function');
+      expect(fn.name).toBe('currentUser');
+      expect(fn.args).toEqual([]);
+    }
+  });
+
+  it('single-arg function', () => {
+    const ast = parseOk('release = earliestUnreleasedVersion("TTMP")');
+    const c = clause(ast.where);
+    if (c.op.kind === 'Compare') {
+      const fn = c.op.value as FunctionCall;
+      expect(fn.args).toHaveLength(1);
+      expect(fn.args[0]).toMatchObject({ kind: 'String', value: 'TTMP' });
+    }
+  });
+});
+
+// ─── Bare function shorthand (§5.4.1 ТЗ) ───────────────────────────────────
+
+describe('parser — bare function-call shorthand', () => {
+  it('`myOpenIssues()` is desugared to `issue IN myOpenIssues()`', () => {
+    const ast = parseOk('myOpenIssues()');
+    const c = clause(ast.where);
+    expect(c.field).toMatchObject({ kind: 'Ident', name: 'issue' });
+    expect(c.op.kind).toBe('InFunction');
+    if (c.op.kind === 'InFunction') {
+      expect(c.op.func.name).toBe('myOpenIssues');
+      expect(c.op.negated).toBe(false);
+    }
+  });
+
+  it('bare function combines with ORDER BY', () => {
+    const ast = parseOk('myOpenIssues() ORDER BY due ASC');
+    expect(clause(ast.where).op.kind).toBe('InFunction');
+    expect(ast.orderBy).toHaveLength(1);
+  });
+
+  it('bare function combines with AND', () => {
+    const ast = parseOk('violatedCheckpoints() AND priority = HIGH');
+    const top = andNode(ast.where);
+    expect(top.children[0]!.kind).toBe('Clause');
+  });
+});
+
+// ─── Boolean operators & precedence ─────────────────────────────────────────
+
+describe('parser — precedence & grouping', () => {
+  it('AND binds tighter than OR', () => {
+    const ast = parseOk('a = 1 OR b = 2 AND c = 3');
+    const top = orNode(ast.where);
+    expect(top.children).toHaveLength(2);
+    expect(top.children[0]!.kind).toBe('Clause');
+    expect(top.children[1]!.kind).toBe('And');
+  });
+
+  it('explicit parens override precedence', () => {
+    const ast = parseOk('(a = 1 OR b = 2) AND c = 3');
+    const top = andNode(ast.where);
+    expect(top.children[0]!.kind).toBe('Or');
+  });
+
+  it('chained AND flattens into one node', () => {
+    const ast = parseOk('a = 1 AND b = 2 AND c = 3');
+    const top = andNode(ast.where);
+    expect(top.children).toHaveLength(3);
+  });
+
+  it('chained OR flattens into one node', () => {
+    const ast = parseOk('a = 1 OR b = 2 OR c = 3');
+    const top = orNode(ast.where);
+    expect(top.children).toHaveLength(3);
+  });
+
+  it('NOT applies only to its immediate atom', () => {
+    const ast = parseOk('NOT a = 1 AND b = 2');
+    // Precedence: NOT > AND > OR → `(NOT (a=1)) AND (b=2)`.
+    const top = andNode(ast.where);
+    expect(top.children[0]!.kind).toBe('Not');
+    expect(top.children[1]!.kind).toBe('Clause');
+  });
+
+  it('NOT (parenthesised group) applies to the whole group', () => {
+    const ast = parseOk('NOT (status = DONE OR status = CANCELLED)');
+    const n = notNode(ast.where);
+    expect(n.child.kind).toBe('Or');
+  });
+
+  it('double NOT', () => {
+    const ast = parseOk('NOT NOT x = 1');
+    const outer = notNode(ast.where);
+    expect(outer.child.kind).toBe('Not');
+  });
+
+  it('case-insensitive keywords (lowercase)', () => {
+    const ast = parseOk('a = 1 and b = 2 or c = 3');
+    expect(orNode(ast.where).children).toHaveLength(2);
+  });
+
+  it('deeply nested parens', () => {
+    const ast = parseOk('((((x = 1))))');
+    expect(clause(ast.where).field).toMatchObject({ name: 'x' });
+  });
+});
+
+// ─── ORDER BY ───────────────────────────────────────────────────────────────
+
+describe('parser — ORDER BY', () => {
+  it('default direction is ASC', () => {
+    const ast = parseOk('status = OPEN ORDER BY priority');
+    expect(ast.orderBy).toHaveLength(1);
+    expect(ast.orderBy[0]).toMatchObject({
+      direction: 'ASC',
+      field: { kind: 'Ident', name: 'priority' },
+    });
+  });
+
+  it('explicit DESC', () => {
+    const ast = parseOk('status = OPEN ORDER BY priority DESC');
+    expect(ast.orderBy[0]!.direction).toBe('DESC');
+  });
+
+  it('multiple sort fields', () => {
+    const ast = parseOk('status = OPEN ORDER BY priority DESC, updated ASC, created');
+    expect(ast.orderBy).toHaveLength(3);
+    expect(ast.orderBy.map((s) => [s.direction, (s.field as { name: string }).name])).toEqual([
+      ['DESC', 'priority'],
+      ['ASC', 'updated'],
+      ['ASC', 'created'],
+    ]);
+  });
+
+  it('ORDER BY with quoted field', () => {
+    const ast = parseOk('x = 1 ORDER BY "Story Points" DESC');
+    expect(ast.orderBy[0]!.field).toMatchObject({ kind: 'QuotedField', name: 'Story Points' });
+  });
+
+  it('case-insensitive `order by`', () => {
+    const ast = parseOk('x = 1 order by priority desc');
+    expect(ast.orderBy[0]!.direction).toBe('DESC');
+  });
+});
+
+// ─── Comments & whitespace ──────────────────────────────────────────────────
+
+describe('parser — comments and empty input', () => {
+  it('line comments are ignored', () => {
+    const ast = parseOk('x = 1 -- trailing comment\nAND y = 2');
+    expect(andNode(ast.where).children).toHaveLength(2);
+  });
+
+  it('empty input parses to empty Query', () => {
+    const ast = parseOk('');
+    expect(ast.where).toBeNull();
+    expect(ast.orderBy).toEqual([]);
+  });
+
+  it('only comments parses to empty Query', () => {
+    const ast = parseOk('-- just a comment');
+    expect(ast.where).toBeNull();
+  });
+});
+
+// ─── Error reporting ─────────────────────────────────────────────────────────
+
+describe('parser — error reporting', () => {
+  it('unterminated string returns UNTERMINATED_STRING with span', () => {
+    const r = parse('x = "no end');
+    expect(r.ast).toBeNull();
+    expect(r.errors[0]).toMatchObject({ code: 'UNTERMINATED_STRING', start: 4 });
+  });
+
+  it('empty value list', () => {
+    const r = parse('status IN ()');
+    expect(r.errors[0]).toMatchObject({ code: 'EMPTY_VALUE_LIST' });
+  });
+
+  it('trailing comma in IN list', () => {
+    const r = parse('status IN (OPEN,)');
+    expect(r.errors[0]?.code).toBe('EXPECTED_VALUE');
+  });
+
+  it('missing RParen', () => {
+    const r = parse('status IN (OPEN, DONE');
+    expect(r.errors[0]?.code).toBe('EXPECTED_RPAREN');
+  });
+
+  it('empty parens', () => {
+    const r = parse('()');
+    expect(r.errors[0]?.code).toBe('EMPTY_PAREN_GROUP');
+  });
+
+  it('missing operator', () => {
+    const r = parse('status OPEN');
+    expect(r.errors[0]?.code).toBe('EXPECTED_OPERATOR');
+  });
+
+  it('missing value after operator', () => {
+    const r = parse('status =');
+    expect(r.errors[0]?.code).toBe('EXPECTED_VALUE');
+  });
+
+  it('leading AND', () => {
+    const r = parse('AND x = 1');
+    expect(r.errors[0]?.code).toBe('EXPECTED_FIELD');
+  });
+
+  it('trailing input after ORDER BY', () => {
+    const r = parse('x = 1 ORDER BY priority WHERE y');
+    // `WHERE` is not a known keyword — it's an ident. It becomes a second sort item field.
+    // Then `y` is trailing. The parser surfaces a trailing-input error.
+    expect(r.errors[0]?.code).toBe('TRAILING_INPUT');
+  });
+
+  it('ORDER BY with nothing after', () => {
+    const r = parse('x = 1 ORDER BY');
+    expect(r.errors[0]?.code).toBe('EMPTY_QUERY_AFTER_ORDER_BY');
+  });
+
+  it('IS followed by wrong token', () => {
+    const r = parse('x IS 5');
+    expect(r.errors[0]?.code).toBe('EXPECTED_EMPTY_OR_NULL');
+  });
+
+  it('unknown escape in string', () => {
+    const r = parse('x = "\\q"');
+    expect(r.errors[0]?.code).toBe('INVALID_ESCAPE');
+  });
+
+  it('invalid custom-field UUID', () => {
+    const r = parse('cf[not-a-uuid] = 1');
+    expect(r.errors[0]?.code).toBe('INVALID_CUSTOM_FIELD');
+  });
+
+  it('control char in string', () => {
+    const r = parse('x = "a\x01b"');
+    expect(r.errors[0]?.code).toBe('UNEXPECTED_CHARACTER');
+  });
+
+  it('error span points at the offending token', () => {
+    const r = parse('x = "unterminated');
+    // String starts at position 4 (the opening quote), runs to end of input.
+    expect(r.errors[0]).toMatchObject({ start: 4, end: 17 });
+  });
+});
+
+// ─── History operators (Phase 2) ────────────────────────────────────────────
+
+describe('parser — history operators are parsed but validator-rejected', () => {
+  it('WAS', () => {
+    const ast = parseOk('status WAS "OPEN"');
+    expect(clause(ast.where).op.kind).toBe('History');
+  });
+
+  it('WAS NOT', () => {
+    const ast = parseOk('status WAS NOT "DONE"');
+    const c = clause(ast.where);
+    if (c.op.kind === 'History') expect(c.op.op).toBe('WAS_NOT');
+  });
+
+  it('CHANGED', () => {
+    const ast = parseOk('status CHANGED');
+    const c = clause(ast.where);
+    if (c.op.kind === 'History') expect(c.op.op).toBe('CHANGED');
+  });
+
+  it('CHANGED AFTER', () => {
+    const ast = parseOk('status CHANGED AFTER "-7d"');
+    const c = clause(ast.where);
+    if (c.op.kind === 'History') expect(c.op.op).toBe('CHANGED_AFTER');
+  });
+
+  it('WAS IN (list)', () => {
+    // History WAS IN takes a single value in our current AST shape; full list-form
+    // is Phase 2. The parser accepts it as WAS_IN <value>. We test only the op code.
+    const ast = parseOk('status WAS IN "OPEN"');
+    const c = clause(ast.where);
+    if (c.op.kind === 'History') expect(c.op.op).toBe('WAS_IN');
+  });
+});
+
+// ─── Spans ──────────────────────────────────────────────────────────────────
+
+describe('parser — spans on AST nodes', () => {
+  it('top-level query span covers the full input', () => {
+    const src = 'status = OPEN';
+    const ast = parseOk(src);
+    expect(ast.span).toEqual({ start: 0, end: src.length });
+  });
+
+  it('clause span covers field + op + value', () => {
+    const src = 'priority = HIGH';
+    const ast = parseOk(src);
+    const c = clause(ast.where);
+    expect(c.span).toEqual({ start: 0, end: src.length });
+  });
+
+  it('AND node span covers all children', () => {
+    const src = 'a = 1 AND b = 2';
+    const ast = parseOk(src);
+    const a = andNode(ast.where);
+    expect(a.span).toEqual({ start: 0, end: src.length });
+  });
+});
+
+// ─── Complex golden-set-like queries ────────────────────────────────────────
+
+describe('parser — complex queries', () => {
+  it('handles the hero example from §5.5', () => {
+    const src =
+      'project = "TTMP" AND assignee = currentUser() AND status IN (OPEN, IN_PROGRESS) ' +
+      'AND priority = HIGH AND due <= "7d" AND "Story Points" > 3 ' +
+      'ORDER BY priority DESC, updated DESC';
+    const ast = parseOk(src);
+    expect(andNode(ast.where).children).toHaveLength(6);
+    expect(ast.orderBy).toHaveLength(2);
+  });
+
+  it('OR + nested parens + function + relative date', () => {
+    const src = '(priority = CRITICAL OR (priority = HIGH AND due <= "7d")) AND statusCategory != DONE';
+    const ast = parseOk(src);
+    const top = andNode(ast.where);
+    expect(top.children[0]!.kind).toBe('Or');
+  });
+});

--- a/backend/tests/search-tokenizer.unit.test.ts
+++ b/backend/tests/search-tokenizer.unit.test.ts
@@ -1,0 +1,207 @@
+/**
+ * TTSRH-1 PR-2 — unit tests for the TTS-QL tokenizer.
+ *
+ * Covers token shapes, spans, escape handling, comments, custom-field references,
+ * relative dates, and error positioning. Pure-function tests — no DB, no mocks.
+ */
+import { describe, it, expect } from 'vitest';
+import { tokenize, TokenizerError } from '../src/modules/search/search.tokenizer.js';
+
+describe('tokenizer — whitespace & comments', () => {
+  it('emits only Eof for an empty string', () => {
+    const tokens = tokenize('');
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toMatchObject({ kind: 'Eof', span: { start: 0, end: 0 } });
+  });
+
+  it('skips whitespace, tabs, newlines', () => {
+    const tokens = tokenize('   \t\n\r\n   ');
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]!.kind).toBe('Eof');
+  });
+
+  it('skips line comments `--` to end of line but keeps `-1d` as RelativeDate', () => {
+    const tokens = tokenize('x -- comment\ny = 1');
+    expect(tokens.map((t) => t.kind)).toEqual(['Ident', 'Ident', 'Op', 'Number', 'Eof']);
+    expect(tokens[0]!.value).toBe('x');
+    expect(tokens[1]!.value).toBe('y');
+  });
+
+  it('`-1d` is RelativeDate, not a comment', () => {
+    const tokens = tokenize('-1d');
+    expect(tokens[0]).toMatchObject({ kind: 'RelativeDate', value: '-1d' });
+  });
+});
+
+describe('tokenizer — punctuation & operators', () => {
+  it('recognises parentheses and comma with correct spans', () => {
+    const tokens = tokenize('( , )');
+    expect(tokens.slice(0, 3).map((t) => t.kind)).toEqual(['LParen', 'Comma', 'RParen']);
+    expect(tokens[0]!.span).toEqual({ start: 0, end: 1 });
+    expect(tokens[1]!.span).toEqual({ start: 2, end: 3 });
+    expect(tokens[2]!.span).toEqual({ start: 4, end: 5 });
+  });
+
+  it.each([
+    ['=', '='],
+    ['!=', '!='],
+    ['>', '>'],
+    ['<', '<'],
+    ['>=', '>='],
+    ['<=', '<='],
+    ['~', '~'],
+    ['!~', '!~'],
+  ])('emits Op for `%s`', (src, op) => {
+    const [first] = tokenize(src);
+    expect(first).toMatchObject({ kind: 'Op', value: op });
+  });
+
+  it('distinguishes `!=` from `! =`', () => {
+    const tokens = tokenize('!=');
+    expect(tokens[0]).toMatchObject({ kind: 'Op', value: '!=' });
+  });
+});
+
+describe('tokenizer — strings', () => {
+  it('double-quoted string', () => {
+    const tokens = tokenize('"hello"');
+    expect(tokens[0]).toMatchObject({ kind: 'String', value: 'hello', span: { start: 0, end: 7 } });
+  });
+
+  it('single-quoted string', () => {
+    const tokens = tokenize("'hello'");
+    expect(tokens[0]!.value).toBe('hello');
+  });
+
+  it('escapes: \\" \\\\ \\n \\t \\r', () => {
+    const tokens = tokenize('"a\\"b\\\\c\\nd\\te\\rf"');
+    expect(tokens[0]!.value).toBe('a"b\\c\nd\te\rf');
+  });
+
+  it('unicode escapes: \\u0041 and \\u{1F600}', () => {
+    expect(tokenize('"\\u0041"')[0]!.value).toBe('A');
+    expect(tokenize('"\\u{1F600}"')[0]!.value).toBe('😀');
+  });
+
+  it('rejects unknown escape', () => {
+    expect(() => tokenize('"a\\qb"')).toThrow(TokenizerError);
+  });
+
+  it('rejects unterminated string', () => {
+    expect(() => tokenize('"never closed')).toThrow(/not terminated/);
+  });
+
+  it('rejects control characters in string except tab', () => {
+    expect(() => tokenize('"a\x01b"')).toThrow(/Control character/);
+    expect(() => tokenize('"a\tb"')).not.toThrow();
+  });
+
+  it('preserves unicode content (Cyrillic, emoji, RTL)', () => {
+    expect(tokenize('"привет"')[0]!.value).toBe('привет');
+    expect(tokenize('"👋"')[0]!.value).toBe('👋');
+    // RTL: right-to-left mark U+200F must be preserved
+    expect(tokenize('"ab\u200Fcd"')[0]!.value).toBe('ab\u200Fcd');
+  });
+});
+
+describe('tokenizer — numbers & relative dates', () => {
+  it.each([
+    ['0', 'Number'],
+    ['42', 'Number'],
+    ['-5', 'Number'],
+    ['3.14', 'Number'],
+    ['-0.5', 'Number'],
+  ])('emits Number for `%s`', (src, kind) => {
+    expect(tokenize(src)[0]!.kind).toBe(kind);
+    expect(tokenize(src)[0]!.value).toBe(src);
+  });
+
+  it.each([
+    ['1d', '1d'],
+    ['-7d', '-7d'],
+    ['2w', '2w'],
+    ['3M', '3M'],
+    ['1y', '1y'],
+    ['8h', '8h'],
+    ['15m', '15m'],
+  ])('emits RelativeDate for `%s`', (src, raw) => {
+    expect(tokenize(src)[0]).toMatchObject({ kind: 'RelativeDate', value: raw });
+  });
+
+  it('does not mis-tokenise `5days` as RelativeDate + `ays`', () => {
+    const tokens = tokenize('5days');
+    // `5d` would be a valid relative date but only if followed by non-ident — here `a`
+    // is an ident char, so the whole thing must NOT be a RelativeDate.
+    expect(tokens[0]!.kind).toBe('Number');
+    expect(tokens[0]!.value).toBe('5');
+    expect(tokens[1]!.kind).toBe('Ident');
+    expect(tokens[1]!.value).toBe('days');
+  });
+
+  it('rejects lone `-` without digits', () => {
+    expect(() => tokenize('-')).toThrow(/Unexpected character/);
+  });
+
+  it('fractional numbers are NOT relative dates', () => {
+    const tokens = tokenize('1.5d');
+    expect(tokens[0]!.kind).toBe('Number');
+    expect(tokens[1]!.kind).toBe('Ident');
+  });
+});
+
+describe('tokenizer — identifiers', () => {
+  it.each(['x', 'priority', 'assignee_id', 'flow-team-1', 'issue.key'])(
+    'accepts ident `%s`',
+    (src) => {
+      expect(tokenize(src)[0]).toMatchObject({ kind: 'Ident', value: src });
+    },
+  );
+
+  it('emits separate tokens for `x=y`', () => {
+    const tokens = tokenize('x=y');
+    expect(tokens.slice(0, 3).map((t) => [t.kind, t.value])).toEqual([
+      ['Ident', 'x'],
+      ['Op', '='],
+      ['Ident', 'y'],
+    ]);
+  });
+});
+
+describe('tokenizer — custom fields', () => {
+  it('cf[<UUID>] produces a CustomField token', () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc';
+    const tokens = tokenize(`cf[${uuid}]`);
+    expect(tokens[0]).toMatchObject({ kind: 'CustomField', value: uuid });
+    expect(tokens[0]!.span).toEqual({ start: 0, end: uuid.length + 4 });
+  });
+
+  it('rejects malformed UUID', () => {
+    expect(() => tokenize('cf[not-a-uuid]')).toThrow(TokenizerError);
+  });
+
+  it('rejects unclosed cf[', () => {
+    expect(() => tokenize('cf[12345678-1234')).toThrow(/missing a closing/);
+  });
+
+  it('bare `cf` is still a plain ident', () => {
+    expect(tokenize('cf')[0]).toMatchObject({ kind: 'Ident', value: 'cf' });
+  });
+});
+
+describe('tokenizer — integration', () => {
+  it('tokenises a typical JQL query', () => {
+    const tokens = tokenize('assignee = currentUser() AND status IN ("OPEN", "REVIEW")');
+    expect(tokens.map((t) => t.kind)).toEqual([
+      'Ident', 'Op', 'Ident', 'LParen', 'RParen', 'Ident', 'Ident', 'Ident',
+      'LParen', 'String', 'Comma', 'String', 'RParen', 'Eof',
+    ]);
+  });
+
+  it('all spans are monotonically non-decreasing', () => {
+    const source = 'x = 1 AND y IN ("a", "b", "c")';
+    const tokens = tokenize(source);
+    for (let i = 1; i < tokens.length; i++) {
+      expect(tokens[i]!.span.start).toBeGreaterThanOrEqual(tokens[i - 1]!.span.end);
+    }
+  });
+});

--- a/backend/vitest.parser-only.config.ts
+++ b/backend/vitest.parser-only.config.ts
@@ -1,0 +1,12 @@
+// Local-only vitest config for running pure-parser tests without Postgres.
+// DO NOT commit references to this file into package.json — CI uses the main
+// vitest.config.ts which migrates a test database.
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    testTimeout: 30000,
+  },
+});

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1492,7 +1492,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 
 | № | Branch | Scope | Часы | Зависит от | TTSRH-сабтаски | Статус |
 |---|--------|-------|------|-----------|----------------|--------|
-| 1 | `ttsrh-1/foundation` | Prisma schema (SavedFilter, User.preferences), feature flags, пустые модули | 6 | — | TTSRH-8 (schema), TTSRH-22 (flag) | ✅ Done ([#100](https://github.com/NovakPAai/tasktime-mvp/pull/100)) |
+| 1 | `ttsrh-1/foundation` | Prisma schema (SavedFilter, User.preferences), feature flags, пустые модули | 6 | — | TTSRH-8 (schema), TTSRH-22 (flag) | 🟢 Merged ([#100](https://github.com/NovakPAai/tasktime-mvp/pull/100)) |
 | 2 | `ttsrh-1/parser` | Tokenizer + Parser + AST + golden-set | 14 | PR-1 | TTSRH-2 | ✅ Done (готов к push после merge PR-1) |
 | 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 | 📋 Планируется |
 | 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 | 📋 Планируется |

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1488,30 +1488,32 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 
 ### 13.9 Итог: список PR
 
-| № | Branch | Scope | Часы | Зависит от | TTSRH-сабтаски |
-|---|--------|-------|------|-----------|----------------|
-| 1 | `ttsrh-1/foundation` | Prisma schema (SavedFilter, User.preferences), feature flags, пустые модули | 6 | — | TTSRH-8 (schema), TTSRH-22 (flag) |
-| 2 | `ttsrh-1/parser` | Tokenizer + Parser + AST + golden-set | 14 | PR-1 | TTSRH-2 |
-| 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 |
-| 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 |
-| 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 |
-| 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 |
-| 7 | `ttsrh-1/saved-filters` | SavedFilter CRUD/share/favorite + User.preferences | 8 | PR-5 | TTSRH-8, TTSRH-9 |
-| 8 | `ttsrh-1/export` | `/search/export` CSV/XLSX | 4 | PR-5 | TTSRH-10 |
-| 9 | `ttsrh-1/frontend-shell` | SearchPage shell + route + sidebar + URL sync | 6 | PR-5 | TTSRH-12, часть TTSRH-19 |
-| 10 | `ttsrh-1/jql-editor` | JqlEditor (CM6) + inline errors + lazy-load | 13 | PR-9 | TTSRH-13, TTSRH-14 |
-| 11 | `ttsrh-1/value-suggester` | ValueSuggesterPopup + CM6 adapter | 10 | PR-6, PR-10 | TTSRH-26 |
-| 12 | `ttsrh-1/basic-builder` | BasicFilterBuilder + Basic↔Advanced toggle | 12 | PR-11 | TTSRH-15 |
-| 13 | `ttsrh-1/saved-filters-ui` | SavedFiltersSidebar + Save/Share modals + store | 8 | PR-7, PR-9 | TTSRH-16 |
-| 14 | `ttsrh-1/results` | ColumnConfigurator + ResultsTable + bulk + ExportMenu + shortcuts | 11 | PR-8, PR-10 | TTSRH-17, TTSRH-18, остаток TTSRH-19 |
-| 15 | `ttsrh-1/checkpoint-foundation` | Checkpoint Prisma + DTO + КТ-функции + variant=CHECKPOINT | 10 | PR-1, PR-3 | TTSRH-27, TTSRH-28, TTSRH-29 |
-| 16 | `ttsrh-1/checkpoint-engine` | Engine TTQL-ветка + COMBINED + error handling | 10 | PR-4, PR-15 | TTSRH-30, TTSRH-31 |
-| 17 | `ttsrh-1/checkpoint-search-integration` | `/preview` + violatedCheckpoints* функции + поля + suggesters | 6 | PR-5, PR-16 | TTSRH-32, TTSRH-37 |
-| 18 | `ttsrh-1/checkpoint-admin-ui` | Segment-mode + JqlEditor КТ + Preview panel + mode-icon | 11 | PR-10, PR-15, PR-17 | TTSRH-33, TTSRH-34, TTSRH-35 |
-| 19 | `ttsrh-1/checkpoint-converter` | Structured → TTQL converter (one-way) | 3 | PR-18 | TTSRH-36 |
-| 20 | `ttsrh-1/e2e-perf` | E2E + perf 100K seed + Lighthouse budget + axe-core | 9 | PR-12, PR-13, PR-14, PR-17, PR-19 | TTSRH-20 |
-| 21 | `ttsrh-1/docs-cutover` | Документация + feature flag cutover | 6 | PR-20 | TTSRH-21, TTSRH-22 |
-| **Итого** | | | **199** | | |
+**Легенда статусов:** `📋 Планируется` · `🚧 В работе` · `✅ Done` (готов к merge / на ревью) · `🟢 Merged`.
+
+| № | Branch | Scope | Часы | Зависит от | TTSRH-сабтаски | Статус |
+|---|--------|-------|------|-----------|----------------|--------|
+| 1 | `ttsrh-1/foundation` | Prisma schema (SavedFilter, User.preferences), feature flags, пустые модули | 6 | — | TTSRH-8 (schema), TTSRH-22 (flag) | ✅ Done ([#100](https://github.com/NovakPAai/tasktime-mvp/pull/100)) |
+| 2 | `ttsrh-1/parser` | Tokenizer + Parser + AST + golden-set | 14 | PR-1 | TTSRH-2 | ✅ Done (готов к push после merge PR-1) |
+| 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 | 📋 Планируется |
+| 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 | 📋 Планируется |
+| 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 | 📋 Планируется |
+| 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 | 📋 Планируется |
+| 7 | `ttsrh-1/saved-filters` | SavedFilter CRUD/share/favorite + User.preferences | 8 | PR-5 | TTSRH-8, TTSRH-9 | 📋 Планируется |
+| 8 | `ttsrh-1/export` | `/search/export` CSV/XLSX | 4 | PR-5 | TTSRH-10 | 📋 Планируется |
+| 9 | `ttsrh-1/frontend-shell` | SearchPage shell + route + sidebar + URL sync | 6 | PR-5 | TTSRH-12, часть TTSRH-19 | 📋 Планируется |
+| 10 | `ttsrh-1/jql-editor` | JqlEditor (CM6) + inline errors + lazy-load | 13 | PR-9 | TTSRH-13, TTSRH-14 | 📋 Планируется |
+| 11 | `ttsrh-1/value-suggester` | ValueSuggesterPopup + CM6 adapter | 10 | PR-6, PR-10 | TTSRH-26 | 📋 Планируется |
+| 12 | `ttsrh-1/basic-builder` | BasicFilterBuilder + Basic↔Advanced toggle | 12 | PR-11 | TTSRH-15 | 📋 Планируется |
+| 13 | `ttsrh-1/saved-filters-ui` | SavedFiltersSidebar + Save/Share modals + store | 8 | PR-7, PR-9 | TTSRH-16 | 📋 Планируется |
+| 14 | `ttsrh-1/results` | ColumnConfigurator + ResultsTable + bulk + ExportMenu + shortcuts | 11 | PR-8, PR-10 | TTSRH-17, TTSRH-18, остаток TTSRH-19 | 📋 Планируется |
+| 15 | `ttsrh-1/checkpoint-foundation` | Checkpoint Prisma + DTO + КТ-функции + variant=CHECKPOINT | 10 | PR-1, PR-3 | TTSRH-27, TTSRH-28, TTSRH-29 | 📋 Планируется |
+| 16 | `ttsrh-1/checkpoint-engine` | Engine TTQL-ветка + COMBINED + error handling | 10 | PR-4, PR-15 | TTSRH-30, TTSRH-31 | 📋 Планируется |
+| 17 | `ttsrh-1/checkpoint-search-integration` | `/preview` + violatedCheckpoints* функции + поля + suggesters | 6 | PR-5, PR-16 | TTSRH-32, TTSRH-37 | 📋 Планируется |
+| 18 | `ttsrh-1/checkpoint-admin-ui` | Segment-mode + JqlEditor КТ + Preview panel + mode-icon | 11 | PR-10, PR-15, PR-17 | TTSRH-33, TTSRH-34, TTSRH-35 | 📋 Планируется |
+| 19 | `ttsrh-1/checkpoint-converter` | Structured → TTQL converter (one-way) | 3 | PR-18 | TTSRH-36 | 📋 Планируется |
+| 20 | `ttsrh-1/e2e-perf` | E2E + perf 100K seed + Lighthouse budget + axe-core | 9 | PR-12, PR-13, PR-14, PR-17, PR-19 | TTSRH-20 | 📋 Планируется |
+| 21 | `ttsrh-1/docs-cutover` | Документация + feature flag cutover | 6 | PR-20 | TTSRH-21, TTSRH-22 | 📋 Планируется |
+| **Итого** | | | **199** | | | |
 
 **Дельта к §8 (278ч):** план покрывает ~199ч. Недостающие ~79ч — это (a) code review + фиксы (~8ч per §8), (b) security review + фиксы (~4ч), (c) докуметация JQL полная (~6ч уже в PR-21, ~0ч дополнительно), (d) профайлинг + composite-index tuning (~4ч в PR-20), (e) fuzz-harness extended (~4ч в PR-5); остальное — buffer на unknown unknowns и Phase-2-проникновение. Реалистичный календарный план — 8–10 недель при одном fullstack-разработчике или 5–6 недель при параллельной работе двоих (backend + frontend после PR-5).
 

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,58 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.27**
+**Last version: 2.28**
+
+---
+
+## [2.28] [2026-04-20] feat(search): TTSRH-1 PR-2 — TTS-QL tokenizer + parser + AST + golden-set
+
+**PR:** (to be filled after push)
+**Ветка:** `ttsrh-1/parser`
+
+### Что было
+
+После PR-1 (foundation) в модуле `backend/src/modules/search/` были только stub-эндпоинты, возвращавшие 501. Парсер для TTS-QL отсутствовал.
+
+### Что теперь
+
+Добавлен полноценный parse-pipeline `source → tokens → AST` без сторонних зависимостей:
+
+- **`search.ast.ts`** — типы AST: `QueryNode`, `OrNode`/`AndNode`/`NotNode`, `ClauseNode` с 5 вариантами `ClauseOp` (`Compare`/`In`/`InFunction`/`IsEmpty`/`History`), `FieldRef` (Ident / CustomField / QuotedField), `Expr` (String / Number / RelativeDate / Ident / Bool / Null / Empty / FunctionCall), `SortItem`, `ParseError` со стабильными кодами. Каждая нода несёт `span: {start, end}` для inline-подчёркивания ошибок в CodeMirror.
+- **`search.tokenizer.ts`** — hand-written char-by-char лексер. Токены: String (с escape-последовательностями `\"` `\\` `\n` `\t` `\r` `\u{HEX}` и `\uHHHH`), Number, RelativeDate (`-?\d+[dwMyhm]`), Ident (с поддержкой `-`/`.` в середине), CustomField (`cf[UUID]`), Op (8 compare), LParen/RParen/Comma. Комментарии `-- ...` до EOL. Контрол-символы в строках запрещены (кроме `\t`). Безопасные ошибки на контрольных / null-byte / RTL символах.
+- **`search.parser.ts`** — recursive descent, приоритет `( ) > NOT > AND > OR > ORDER BY`. Keywords (`AND/OR/NOT/IN/IS/EMPTY/NULL/ORDER/BY/ASC/DESC/WAS/CHANGED/FROM/TO/AFTER/BEFORE/ON/DURING/TRUE/FALSE`) распознаются case-insensitive. Поддержаны формы `IN (list)`, `IN funcCall()` (без outer-парeнов, JIRA-style), `IS [NOT] EMPTY|NULL`, history-операторы (парсятся, валидатор отклонит в PR-3). Bare function shorthand из §5.4.1 ТЗ — `myOpenIssues()`, `violatedCheckpoints()` — десугарится парсером в `issue IN funcCall()`. Публичный API — `parse(source)` возвращает `{ast, errors}` и **никогда не бросает** (контракт для fuzz-harness + suggest-pipeline).
+
+### Тесты (186 passing)
+
+- **`tests/search-tokenizer.unit.test.ts`** (49 кейсов) — токен-типы, спаны, escape-последовательности, unicode/RTL/emoji, edge-случаи `5days`, `cf[UUID]` валидация, контрол-символы, негативные числа, относительные даты.
+- **`tests/search-parser.unit.test.ts`** (71 кейс) — все compare-ops × типы значений, IN / NOT IN / `IN funcCall()`, IS EMPTY / NOT EMPTY / IS NULL, precedence AND > OR, NOT унарный, deep nesting, ORDER BY с множеством полей и ASC/DESC, кастом-поля `cf[...]` и `"Story Points"`, history-операторы, bare function shorthand, snapshots спанов, 15+ error-cases с проверкой кодов и позиций.
+- **`tests/search-parser-goldenset.unit.test.ts`** — загружает `docs/tz/TTSRH-1-goldenset.jql`, парсит каждую из 63 золотых запросов, assert zero errors.
+- **`tests/search-parser-fuzz.unit.test.ts`** (T-7 §6 ТЗ) — 1000 seeded random inputs (mulberry32) + SQL-injection-style payloads + extreme nesting — assert `parse()` НИКОГДА не бросает и все error-спаны in-bounds.
+
+### Изменения
+
+- `backend/src/modules/search/search.ast.ts` — новый файл (AST + error-codes).
+- `backend/src/modules/search/search.tokenizer.ts` — новый файл.
+- `backend/src/modules/search/search.parser.ts` — новый файл.
+- `backend/tests/search-tokenizer.unit.test.ts` — новый.
+- `backend/tests/search-parser.unit.test.ts` — новый.
+- `backend/tests/search-parser-goldenset.unit.test.ts` — новый.
+- `backend/tests/search-parser-fuzz.unit.test.ts` — новый.
+- `backend/vitest.parser-only.config.ts` — новый; локальный dev-конфиг для запуска чистых unit-тестов без Postgres (CI использует `vitest.config.ts` как раньше).
+- `docs/tz/TTSRH-1.md` §13.9 — статус PR-2 → ✅ Done.
+
+### Влияние на prod
+
+0. Ни одна existing функция не затронута — новые файлы добавляются, существующие stub-роутеры остаются. Парсер не экспонируется через HTTP до PR-5.
+
+### Проверки
+
+- Backend `npx tsc --noEmit` — чисто.
+- Backend `npm run lint` — 0 errors, 0 new warnings.
+- 186 unit-тестов зелёные локально (через `vitest.parser-only.config.ts`, без Postgres).
+- 63 golden-set запроса парсятся без ошибок.
+- Fuzz 1000 random inputs — 0 unhandled throws.
+- `npm test` в CI — использует main config с Postgres, тест-сьют сам себя бутстрапит.
 
 ---
 


### PR DESCRIPTION
## Summary

TTSRH-1 PR-2 — полноценный parse-pipeline для TTS-QL (JQL-compatible) без сторонних зависимостей. **Не подключён к HTTP** — парсер будет потреблять validator в PR-3 и compiler в PR-4/5 (см. [docs/tz/TTSRH-1.md §13.4](docs/tz/TTSRH-1.md)).

- **`search.ast.ts`** — типы AST: `QueryNode`, n-арные `OrNode`/`AndNode`, `NotNode`, `ClauseNode` с 5 вариантами `ClauseOp` (Compare / In / InFunction / IsEmpty / History), `FieldRef` (Ident / CustomField / QuotedField), `Expr` литералы (String / Number / RelativeDate / Ident / Bool / Null / Empty / FunctionCall), `SortItem`, `ParseError` со стабильными string-кодами. Каждая нода несёт `span: {start, end}` для inline-подчёркивания в CodeMirror.
- **`search.tokenizer.ts`** — hand-written char-by-char лексер. Tokens: String (escape `\"` `\\` `\n` `\t` `\r` `\u{HEX}` `\uHHHH` с запретом lone-surrogates и null-codepoint), Number, RelativeDate (`-?\d+[dwMyhm]` с boundary-check чтобы `5days` → `5` + `days`), Ident (`[A-Za-z_][A-Za-z0-9_\-\.]*`), CustomField (`cf[UUID]` с валидацией), Op, LParen/RParen/Comma. Комментарии `-- ...` до EOL. Контрол-символы в строках (кроме `\t`) отклоняются.
- **`search.parser.ts`** — recursive descent. Приоритет `( ) > NOT > AND > OR > ORDER BY`. Keywords case-insensitive. Форматы `IN (list)` и `IN funcCall()` (JIRA-style без outer-парenов), `IS [NOT] EMPTY|NULL`, history-операторы (parse-only; validator отклонит в PR-3). Bare function shorthand §5.4.1 ТЗ (`myOpenIssues()` → `issue IN myOpenIssues()`). **`parse()` никогда не бросает** — инвариант для fuzz/suggest-pipeline; защищён `MAX_DEPTH=256` guard + universal catch как safety-net.

## Тесты — 193 passing

- **`tests/search-tokenizer.unit.test.ts`** (49) — токен-типы, спаны, escape-последовательности, unicode/RTL/emoji, `5days` boundary, `cf[UUID]`, контрол-символы, negative numbers, relative dates.
- **`tests/search-parser.unit.test.ts`** (78) — все compare-ops × типы значений, IN/NOT IN/`IN funcCall()`, IS EMPTY/NULL, precedence, deep nesting до 500, ORDER BY, custom fields, history-operators, bare function shorthand, spans, 19+ error cases с проверкой codes и позиций.
- **`tests/search-parser-goldenset.unit.test.ts`** (64) — читает [`docs/tz/TTSRH-1-goldenset.jql`](docs/tz/TTSRH-1-goldenset.jql), парсит все 63 золотых запроса §11 и §16 ТЗ, assert zero errors.
- **`tests/search-parser-fuzz.unit.test.ts`** (T-7 §6 ТЗ) — 1000 seeded mulberry32 inputs + SQL-injection payloads + 500-deep nesting — assert `parse()` **никогда** не бросает и все error-спаны in-bounds.
- **`vitest.parser-only.config.ts`** — локальный dev-конфиг для запуска чистых unit-тестов без Postgres (`npm run test:parser`). CI продолжает использовать `vitest.config.ts`.

## Pre-push review

Прогнал `pre-push-reviewer` перед открытием. Summary: 🟠 2 · 🟡 3 · 🔵 2 · ⚪ 5. Все medium+high применены в follow-up коммите:

- 🟠 `parse()` never-throws: добавлен `MAX_DEPTH=256` + universal `catch(Error)` как safety-net против stack-overflow на ~10K `(` chars. Покрыто тестом + 500-deep payload в fuzz.
- 🟠 `parseSortItem`: emit `INVALID_SORT_DIRECTION` для нераспознанных слов (раньше утекало в `TRAILING_INPUT`).
- 🟡 Tokenizer отклоняет lone surrogates (U+D800..U+DFFF) и null-codepoint (U+0000) в обеих формах `\u{HEX}` и `\uHHHH` — иначе Postgres text columns могли бы принять невалидный UTF-8.
- 🟡 Fuzz: добавлен targeted 500-deep nesting payload.
- 🔵 `UNTERMINATED_STRING` span clamp'нут до [quote, quote+1].
- 🔵 `npm run test:parser` в `package.json` для DX.

Info-items (JSDoc): добавлены заметки про permissive cross-quote escapes и intentional UUID-validation на tokenizer-слое.

## Test plan

- [x] Backend `npx tsc --noEmit` — чисто
- [x] Backend `npm run lint` — 0 errors, 0 new warnings
- [x] `npm run test:parser` — **193 passing** локально без Postgres
- [x] Golden-set 63/63 без ошибок
- [x] Fuzz 1000 random inputs + deep-nest — 0 unhandled
- [ ] `npm test` в CI — использует main config с Postgres, прогонит все 193 + существующие unit-тесты

## Зависимости

- **Зависит от:** PR-1 ([#100](https://github.com/NovakPAai/tasktime-mvp/pull/100)) — уже merged 🟢.
- **Следующий:** PR-3 (validator) — field registry + функции + `/search/validate` + `/search/schema`.

## Плановая дельта

- Прогресс: **PR-2 / 21** по §13.9 ТЗ.
- Версия: 2.28 в [version_history.md](version_history.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
