### PR TITLE
feat(search): TTSRH-1 PR-3 — validator + field registry + функции + /search/schema

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts",
+    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts tests/search-functions.unit.test.ts tests/search-validator.unit.test.ts",
     "lint": "eslint src/ --ext .ts",
     "format": "prettier --write 'src/**/*.ts'",
     "mcp": "tsx src/mcp/server.ts"

--- a/backend/src/modules/search/search.functions.ts
+++ b/backend/src/modules/search/search.functions.ts
@@ -1,0 +1,236 @@
+/**
+ * TTSRH-1 PR-3 — function registry for TTS-QL.
+ *
+ * Two responsibilities:
+ *   1. Signature table consumed by the validator (arity, arg types, return type,
+ *      phase). Ambiguous or Phase-2 functions are gated here and surfaced via
+ *      stable error codes.
+ *   2. Pure evaluators for date/time helpers (`now`, `today`, `startOf*`, etc.).
+ *      These run at validate/compile time without hitting the DB and are
+ *      deterministic given a fixed `now`. DB-dependent functions (`currentUser`,
+ *      `openSprints`, …) are registered but return `null` here — compiler
+ *      (PR-4/6) wires their resolution.
+ *
+ * Offset syntax (§5.4 ТЗ): `startOfDay("-7d")`, `endOfMonth("1M")`. Units `d`/`w`/
+ * `M`/`y`/`h`/`m`. An empty/missing offset = 0.
+ */
+
+import type { QueryVariant, TtqlReturnType, FunctionPhase, TtqlType } from './search.types.js';
+
+// ─── Signature ──────────────────────────────────────────────────────────────
+
+export interface FunctionArg {
+  name: string;
+  type: TtqlType | 'OFFSET' | 'ISSUE_KEY' | 'ANY';
+  optional: boolean;
+}
+
+export interface FunctionDef {
+  name: string;
+  args: readonly FunctionArg[];
+  returnType: TtqlReturnType;
+  phase: FunctionPhase;
+  /** `'default'` = user search, `'checkpoint'` = KT condition evaluator (§5.12.4). */
+  availableIn: readonly QueryVariant[];
+  description: string;
+}
+
+/**
+ * MVP function table — see §5.4 ТЗ. Names are stored lowercase; validator compares
+ * case-insensitively. Phase-2 functions are included so the parser can still accept
+ * them; validator emits `PHASE_2_FUNCTION` error with a hint.
+ */
+export const FUNCTION_REGISTRY: readonly FunctionDef[] = [
+  // Identity / user
+  // `currentUser()` is callable in both variants but resolves to NULL in `checkpoint`;
+  // the validator emits a CURRENTUSER_IN_CHECKPOINT warning there per §5.12.4 ТЗ.
+  { name: 'currentuser', args: [], returnType: { kind: 'scalar', type: 'USER' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Текущий пользователь. В контексте КТ резолвится в NULL (R19) — выдаётся warning.' },
+  { name: 'membersof', args: [{ name: 'group', type: 'GROUP', optional: false }], returnType: { kind: 'list', type: 'USER' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Члены указанной группы.' },
+  // Time — pure
+  { name: 'now', args: [], returnType: { kind: 'scalar', type: 'DATETIME' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Текущий момент (в часовом поясе сервера).' },
+  { name: 'today', args: [], returnType: { kind: 'scalar', type: 'DATE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Сегодня на 00:00 (в часовом поясе сервера).' },
+  ...buildStartEndVariants('day', 'DATETIME'),
+  ...buildStartEndVariants('week', 'DATETIME'),
+  ...buildStartEndVariants('month', 'DATETIME'),
+  ...buildStartEndVariants('year', 'DATETIME'),
+  // Sprints
+  { name: 'opensprints', args: [], returnType: { kind: 'list', type: 'SPRINT' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Активные спринты доступных пользователю проектов.' },
+  { name: 'closedsprints', args: [], returnType: { kind: 'list', type: 'SPRINT' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Завершённые спринты.' },
+  { name: 'futuresprints', args: [], returnType: { kind: 'list', type: 'SPRINT' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Запланированные спринты.' },
+  // Releases
+  { name: 'unreleasedversions', args: [{ name: 'project', type: 'PROJECT', optional: true }], returnType: { kind: 'list', type: 'RELEASE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Все ещё не выпущенные релизы.' },
+  { name: 'releasedversions', args: [{ name: 'project', type: 'PROJECT', optional: true }], returnType: { kind: 'list', type: 'RELEASE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Выпущенные релизы.' },
+  { name: 'earliestunreleasedversion', args: [{ name: 'project', type: 'PROJECT', optional: true }], returnType: { kind: 'scalar', type: 'RELEASE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Ближайший unreleased релиз.' },
+  { name: 'latestreleasedversion', args: [{ name: 'project', type: 'PROJECT', optional: true }], returnType: { kind: 'scalar', type: 'RELEASE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Последний released релиз.' },
+  // Issue relations
+  { name: 'linkedissues', args: [{ name: 'key', type: 'ISSUE_KEY', optional: false }, { name: 'linkType', type: 'TEXT', optional: true }], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Задачи, связанные с указанной.' },
+  { name: 'subtasksof', args: [{ name: 'key', type: 'ISSUE_KEY', optional: false }], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Дочерние задачи (подзадачи).' },
+  { name: 'epicissues', args: [{ name: 'key', type: 'ISSUE_KEY', optional: false }], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Задачи, входящие в эпик.' },
+  { name: 'myopenissues', args: [], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'MVP', availableIn: ['default'], description: 'Shortcut: assignee = currentUser() AND statusCategory != DONE.' },
+  // Checkpoint-scoped functions (§5.4 extensions, TTSRH-37). Wire-up in PR-17.
+  { name: 'violatedcheckpoints', args: [{ name: 'typeName', type: 'TEXT', optional: true }], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Задачи с активными нарушениями КТ.' },
+  { name: 'violatedcheckpointsof', args: [{ name: 'releaseKeyOrId', type: 'RELEASE', optional: false }, { name: 'typeName', type: 'TEXT', optional: true }], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Нарушения КТ в конкретном релизе.' },
+  { name: 'checkpointsatrisk', args: [{ name: 'typeName', type: 'TEXT', optional: true }], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Задачи релизов с КТ в состоянии WARNING/OVERDUE/ERROR.' },
+  { name: 'checkpointsinstate', args: [{ name: 'state', type: 'CHECKPOINT_STATE', optional: false }, { name: 'typeName', type: 'TEXT', optional: true }], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Задачи, где КТ находится в заданном состоянии.' },
+  // Checkpoint-context-only (§5.12.4) — wiring in PR-15
+  { name: 'releaseplanneddate', args: [], returnType: { kind: 'scalar', type: 'DATETIME' }, phase: 'MVP', availableIn: ['checkpoint'], description: 'Дата плановой сдачи релиза (только для КТ-условий).' },
+  { name: 'checkpointdeadline', args: [], returnType: { kind: 'scalar', type: 'DATETIME' }, phase: 'MVP', availableIn: ['checkpoint'], description: 'Дедлайн КТ = releasePlannedDate + offsetDays (только для КТ-условий).' },
+  // Phase 2 — parser accepts, validator rejects
+  { name: 'watchedissues', args: [], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'PHASE_2', availableIn: ['default'], description: 'Задачи, на которые я подписан (Phase 2).' },
+  { name: 'votedissues', args: [], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'PHASE_2', availableIn: ['default'], description: 'Голоса (Phase 2).' },
+  { name: 'lastlogin', args: [], returnType: { kind: 'scalar', type: 'DATETIME' }, phase: 'PHASE_2', availableIn: ['default'], description: 'Время последнего входа (Phase 2).' },
+];
+
+function buildStartEndVariants(unit: 'day' | 'week' | 'month' | 'year', rt: TtqlType): FunctionDef[] {
+  const cap = unit[0]!.toUpperCase() + unit.slice(1);
+  return [
+    {
+      name: `startof${unit}`,
+      args: [{ name: 'offset', type: 'OFFSET', optional: true }],
+      returnType: { kind: 'scalar', type: rt },
+      phase: 'MVP',
+      availableIn: ['default', 'checkpoint'],
+      description: `Начало ${cap} с необязательным смещением, напр. startOf${cap}("-1${unit === 'month' ? 'M' : unit[0]}").`,
+    },
+    {
+      name: `endof${unit}`,
+      args: [{ name: 'offset', type: 'OFFSET', optional: true }],
+      returnType: { kind: 'scalar', type: rt },
+      phase: 'MVP',
+      availableIn: ['default', 'checkpoint'],
+      description: `Конец ${cap} с необязательным смещением.`,
+    },
+  ];
+}
+
+const FUNCTION_INDEX: Map<string, FunctionDef> = (() => {
+  const map = new Map<string, FunctionDef>();
+  for (const f of FUNCTION_REGISTRY) map.set(f.name, f);
+  return map;
+})();
+
+export function resolveFunction(name: string): FunctionDef | null {
+  return FUNCTION_INDEX.get(name.toLowerCase()) ?? null;
+}
+
+// ─── Pure evaluators for date/time ──────────────────────────────────────────
+
+export interface EvaluatorContext {
+  /** Anchor time. Caller supplies; scheduler passes `evaluatedAt` for KT variant. */
+  now: Date;
+}
+
+/**
+ * Parse a relative-offset string (`"-7d"`, `"1M"`, `"3h"`) into milliseconds. Months
+ * and years are approximated via calendar arithmetic on the anchor date — caller
+ * passes the anchor and the unit to `applyOffset` to get exact results.
+ */
+export function parseOffset(offset: string): { amount: number; unit: 'd' | 'w' | 'M' | 'y' | 'h' | 'm' } | null {
+  const m = /^(-?\d+)([dwMyhm])$/.exec(offset);
+  if (!m) return null;
+  return { amount: Number.parseInt(m[1]!, 10), unit: m[2] as 'd' | 'w' | 'M' | 'y' | 'h' | 'm' };
+}
+
+/**
+ * Add a parsed offset to an anchor date. Returns a new Date. `M` and `y` use
+ * calendar-aware arithmetic (`setUTCMonth`, `setUTCFullYear`) so "end of next month
+ * from March 30" is correctly May 1st, not "March 30 + 31 days".
+ */
+export function applyOffset(anchor: Date, offset: { amount: number; unit: 'd' | 'w' | 'M' | 'y' | 'h' | 'm' }): Date {
+  const d = new Date(anchor.getTime());
+  switch (offset.unit) {
+    case 'h': d.setUTCHours(d.getUTCHours() + offset.amount); break;
+    case 'm': d.setUTCMinutes(d.getUTCMinutes() + offset.amount); break;
+    case 'd': d.setUTCDate(d.getUTCDate() + offset.amount); break;
+    case 'w': d.setUTCDate(d.getUTCDate() + offset.amount * 7); break;
+    case 'M': d.setUTCMonth(d.getUTCMonth() + offset.amount); break;
+    case 'y': d.setUTCFullYear(d.getUTCFullYear() + offset.amount); break;
+  }
+  return d;
+}
+
+/** Return midnight of the given date (UTC). */
+export function startOfDayUtc(d: Date): Date {
+  const x = new Date(d.getTime());
+  x.setUTCHours(0, 0, 0, 0);
+  return x;
+}
+
+/** Return 23:59:59.999 of the given date (UTC). */
+export function endOfDayUtc(d: Date): Date {
+  const x = new Date(d.getTime());
+  x.setUTCHours(23, 59, 59, 999);
+  return x;
+}
+
+/**
+ * ISO-week start (Monday 00:00 UTC). Matches Jira convention (and is what §5.4 ТЗ
+ * calls out for `startOfWeek([offset])`).
+ */
+export function startOfIsoWeekUtc(d: Date): Date {
+  const x = startOfDayUtc(d);
+  const dow = x.getUTCDay(); // 0 = Sun … 6 = Sat
+  const mondayShift = dow === 0 ? -6 : 1 - dow;
+  x.setUTCDate(x.getUTCDate() + mondayShift);
+  return x;
+}
+
+export function endOfIsoWeekUtc(d: Date): Date {
+  const mon = startOfIsoWeekUtc(d);
+  const sun = new Date(mon.getTime());
+  sun.setUTCDate(sun.getUTCDate() + 6);
+  sun.setUTCHours(23, 59, 59, 999);
+  return sun;
+}
+
+export function startOfMonthUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1, 0, 0, 0, 0));
+}
+
+export function endOfMonthUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0, 23, 59, 59, 999));
+}
+
+export function startOfYearUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), 0, 1, 0, 0, 0, 0));
+}
+
+export function endOfYearUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), 11, 31, 23, 59, 59, 999));
+}
+
+/**
+ * Evaluate a date-only function with optional offset. Returns `null` if the
+ * function isn't one of the pure date helpers. Caller (compiler) should use a
+ * different path for DB-dependent functions. `offset` is pre-parsed; pass `null`
+ * when omitted.
+ */
+export function evaluatePureDateFn(
+  name: string,
+  offset: { amount: number; unit: 'd' | 'w' | 'M' | 'y' | 'h' | 'm' } | null,
+  ctx: EvaluatorContext,
+): Date | null {
+  const lower = name.toLowerCase();
+  const shifted = offset ? applyOffset(ctx.now, offset) : ctx.now;
+  switch (lower) {
+    case 'now': return shifted;
+    case 'today': return startOfDayUtc(shifted);
+    case 'startofday': return startOfDayUtc(shifted);
+    case 'endofday': return endOfDayUtc(shifted);
+    case 'startofweek': return startOfIsoWeekUtc(shifted);
+    case 'endofweek': return endOfIsoWeekUtc(shifted);
+    case 'startofmonth': return startOfMonthUtc(shifted);
+    case 'endofmonth': return endOfMonthUtc(shifted);
+    case 'startofyear': return startOfYearUtc(shifted);
+    case 'endofyear': return endOfYearUtc(shifted);
+    default: return null;
+  }
+}
+
+/**
+ * Iterate the registry filtered by variant. Used by the `/search/schema` endpoint
+ * to expose only the functions legal in the caller's context.
+ */
+export function functionsForVariant(variant: QueryVariant): FunctionDef[] {
+  return FUNCTION_REGISTRY.filter((f) => f.availableIn.includes(variant));
+}

--- a/backend/src/modules/search/search.functions.ts
+++ b/backend/src/modules/search/search.functions.ts
@@ -229,8 +229,12 @@ export function evaluatePureDateFn(
 
 /**
  * Iterate the registry filtered by variant. Used by the `/search/schema` endpoint
- * to expose only the functions legal in the caller's context.
+ * to expose only the functions legal in the caller's context. **Phase-2 functions
+ * are excluded** — they'd only confuse autocomplete (user would pick one and then
+ * hit PHASE_2_FUNCTION at validate-time).
  */
 export function functionsForVariant(variant: QueryVariant): FunctionDef[] {
-  return FUNCTION_REGISTRY.filter((f) => f.availableIn.includes(variant));
+  return FUNCTION_REGISTRY.filter(
+    (f) => f.phase === 'MVP' && f.availableIn.includes(variant),
+  );
 }

--- a/backend/src/modules/search/search.router.ts
+++ b/backend/src/modules/search/search.router.ts
@@ -109,7 +109,17 @@ router.get(
         ],
         functions: functionsForVariant(variant).map((fn) => ({
           name: fn.name,
-          args: fn.args,
+          // Map internal validator-only pseudo-types (OFFSET / ISSUE_KEY / ANY) to
+          // surface types the editor/frontend can render — they're not TTS-QL types.
+          args: fn.args.map((a) => ({
+            name: a.name,
+            type:
+              a.type === 'OFFSET' ? 'TEXT' :
+              a.type === 'ISSUE_KEY' ? 'TEXT' :
+              a.type === 'ANY' ? 'TEXT' :
+              a.type,
+            optional: a.optional,
+          })),
           returnType: fn.returnType,
           phase: fn.phase,
           description: fn.description,

--- a/backend/src/modules/search/search.router.ts
+++ b/backend/src/modules/search/search.router.ts
@@ -1,18 +1,24 @@
 import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
 import { authenticate } from '../../shared/middleware/auth.js';
+import { validate as validateDto } from '../../shared/middleware/validate.js';
+import { parse } from './search.parser.js';
+import { validate as runValidator, createValidatorContext } from './search.validator.js';
+import { SYSTEM_FIELDS } from './search.schema.js';
+import { loadCustomFields } from './search.schema.loader.js';
+import { functionsForVariant } from './search.functions.js';
+import type { QueryVariant } from './search.types.js';
 
 /**
- * TTSRH-1 PR-1 — stub-роутер для TTS-QL-поиска. На этой фазе модуль примонтирован,
- * но все эндпоинты возвращают 501 Not Implemented. Это позволяет:
- *   1) проверить на staging, что mount проходит без коллизий путей;
- *   2) задать публичные контракты путей (см. §5.6 в docs/tz/TTSRH-1.md) до
- *      появления парсера/компилятора/валидатора;
- *   3) дать фронту повод «уметь» обрабатывать 501 уже сейчас.
+ * TTSRH-1 PR-3 — live endpoints for `/search/validate` and `/search/schema`.
  *
- * Фактическая реализация поступит в PR-2..PR-8 (см. §13.4–13.5 ТЗ).
- * Gate по `features.advancedSearch` происходит в app.ts: при выключенном флаге весь
- * префикс `/api/search` даёт 404, поэтому здесь делаем только authenticate.
+ * Still stubbed with 501: `POST /search/issues`, `POST /search/export`,
+ * `GET /search/suggest`. Those come online in PR-5 (issues/export) and PR-6
+ * (suggest).
+ *
+ * Gate by `features.advancedSearch` happens in app.ts — mount is conditional.
  */
+
 const router = Router();
 router.use(authenticate);
 
@@ -22,15 +28,103 @@ function notImplemented(endpoint: string) {
       error: 'NOT_IMPLEMENTED',
       endpoint,
       message:
-        'TTS-QL search endpoints are under development. See docs/tz/TTSRH-1.md — delivered in PR-5..PR-8.',
+        'TTS-QL endpoint is under development. See docs/tz/TTSRH-1.md — delivered in PR-5..PR-8.',
     });
   };
 }
 
+// ─── POST /search/validate ──────────────────────────────────────────────────
+
+const validateDtoSchema = z.object({
+  jql: z.string().max(10_000),
+  variant: z.enum(['default', 'checkpoint']).optional(),
+});
+
+router.post(
+  '/search/validate',
+  validateDto(validateDtoSchema),
+  async (req: Request, res: Response, next): Promise<void> => {
+    try {
+      const { jql, variant } = req.body as z.infer<typeof validateDtoSchema>;
+      const parseResult = parse(jql);
+      if (!parseResult.ast) {
+        res.json({
+          valid: false,
+          errors: parseResult.errors,
+          warnings: [],
+          ast: null,
+        });
+        return;
+      }
+      const customFields = await loadCustomFields();
+      const ctx = createValidatorContext({
+        variant: (variant as QueryVariant | undefined) ?? 'default',
+        customFields,
+      });
+      const result = runValidator(parseResult.ast, ctx);
+      res.json({
+        valid: result.valid && parseResult.errors.length === 0,
+        errors: [...parseResult.errors, ...result.errors],
+        warnings: result.warnings,
+        ast: parseResult.ast,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ─── GET /search/schema ─────────────────────────────────────────────────────
+
+router.get(
+  '/search/schema',
+  async (req: Request, res: Response, next): Promise<void> => {
+    try {
+      const variant = (req.query.variant === 'checkpoint' ? 'checkpoint' : 'default') as QueryVariant;
+      const customFields = await loadCustomFields();
+      res.json({
+        variant,
+        fields: [
+          ...SYSTEM_FIELDS.map((f) => ({
+            name: f.name,
+            label: f.label,
+            type: f.type,
+            synonyms: f.synonyms,
+            operators: f.operators,
+            sortable: f.sortable,
+            custom: false,
+            description: f.description ?? null,
+          })),
+          ...customFields.map((cf) => ({
+            name: cf.name,
+            label: cf.name,
+            type: cf.type,
+            synonyms: [] as string[],
+            operators: cf.operators,
+            sortable: false,
+            custom: true,
+            uuid: cf.id,
+            description: null,
+          })),
+        ],
+        functions: functionsForVariant(variant).map((fn) => ({
+          name: fn.name,
+          args: fn.args,
+          returnType: fn.returnType,
+          phase: fn.phase,
+          description: fn.description,
+        })),
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ─── Still-stubbed endpoints ────────────────────────────────────────────────
+
 router.post('/search/issues', notImplemented('POST /search/issues'));
-router.post('/search/validate', notImplemented('POST /search/validate'));
 router.get('/search/suggest', notImplemented('GET /search/suggest'));
 router.post('/search/export', notImplemented('POST /search/export'));
-router.get('/search/schema', notImplemented('GET /search/schema'));
 
 export default router;

--- a/backend/src/modules/search/search.schema.loader.ts
+++ b/backend/src/modules/search/search.schema.loader.ts
@@ -1,0 +1,41 @@
+/**
+ * TTSRH-1 PR-3 — Prisma + Redis-backed loader for custom fields.
+ *
+ * Kept in a separate module from `search.schema.ts` so that the validator, AST,
+ * and parser — all pure — can be imported without pulling in DB client code.
+ * This matters for unit tests (which don't need Postgres/Redis running).
+ */
+import { prisma } from '../../prisma/client.js';
+import { getCachedJson, setCachedJson } from '../../shared/redis.js';
+import {
+  type CustomFieldDef,
+  customFieldTypeToTtql,
+  operatorsForCustomField,
+} from './search.schema.js';
+
+const CACHE_KEY = 'search:custom-fields:enabled';
+const CACHE_TTL_SECONDS = 60;
+
+/**
+ * Load enabled custom fields (cached 60s). Returns in same shape regardless of cache
+ * hit/miss so validator code doesn't need to branch. When Redis is down we fall
+ * straight through to Prisma — the endpoint stays functional at some latency cost.
+ */
+export async function loadCustomFields(): Promise<CustomFieldDef[]> {
+  const cached = await getCachedJson<CustomFieldDef[]>(CACHE_KEY);
+  if (cached) return cached;
+
+  const rows = await prisma.customField.findMany({
+    where: { isEnabled: true },
+    select: { id: true, name: true, fieldType: true, options: true },
+  });
+  const defs: CustomFieldDef[] = rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    type: customFieldTypeToTtql(r.fieldType),
+    operators: operatorsForCustomField(r.fieldType),
+    options: r.options,
+  }));
+  await setCachedJson(CACHE_KEY, defs, CACHE_TTL_SECONDS);
+  return defs;
+}

--- a/backend/src/modules/search/search.schema.loader.ts
+++ b/backend/src/modules/search/search.schema.loader.ts
@@ -22,7 +22,15 @@ const CACHE_TTL_SECONDS = 60;
  * straight through to Prisma — the endpoint stays functional at some latency cost.
  */
 export async function loadCustomFields(): Promise<CustomFieldDef[]> {
-  const cached = await getCachedJson<CustomFieldDef[]>(CACHE_KEY);
+  // Treat any Redis error (connection refused, READONLY, timeout) as a cache miss.
+  // If we let the exception propagate, a failing Redis would 500 both /search/validate
+  // and /search/schema — not what ops expects from a cache-layer outage.
+  let cached: CustomFieldDef[] | null = null;
+  try {
+    cached = await getCachedJson<CustomFieldDef[]>(CACHE_KEY);
+  } catch {
+    cached = null;
+  }
   if (cached) return cached;
 
   const rows = await prisma.customField.findMany({
@@ -34,8 +42,13 @@ export async function loadCustomFields(): Promise<CustomFieldDef[]> {
     name: r.name,
     type: customFieldTypeToTtql(r.fieldType),
     operators: operatorsForCustomField(r.fieldType),
+    sortable: false, // MVP — see CustomFieldDef.sortable comment
     options: r.options,
   }));
-  await setCachedJson(CACHE_KEY, defs, CACHE_TTL_SECONDS);
+  try {
+    await setCachedJson(CACHE_KEY, defs, CACHE_TTL_SECONDS);
+  } catch {
+    // Redis write failure is non-fatal — we've already computed `defs`.
+  }
   return defs;
 }

--- a/backend/src/modules/search/search.schema.ts
+++ b/backend/src/modules/search/search.schema.ts
@@ -46,7 +46,10 @@ export const SYSTEM_FIELDS: readonly FieldDef[] = [
   { name: 'description', synonyms: [], type: 'TEXT', operators: ['CONTAINS', 'NOT_CONTAINS', 'IS_EMPTY', 'IS_NOT_EMPTY'], sortable: false, label: 'Description' },
   { name: 'comment', synonyms: [], type: 'TEXT', operators: ['CONTAINS'], sortable: false, label: 'Comment' },
   // Status
-  { name: 'status', synonyms: [], type: 'STATUS', operators: [...CMP_REF, 'WAS', 'WAS_NOT', 'WAS_IN', 'WAS_NOT_IN', 'CHANGED'] as readonly TtqlOpKind[], sortable: true, label: 'Status' },
+  // History operators (WAS/WAS_NOT/WAS_IN/WAS_NOT_IN/CHANGED) are syntactically parsed
+  // but currently rejected by the validator with PHASE_2_OPERATOR. Add them back to the
+  // operators array when TTSRH-23 (FieldChangeLog) ships.
+  { name: 'status', synonyms: [], type: 'STATUS', operators: CMP_REF, sortable: true, label: 'Status' },
   { name: 'statuscategory', synonyms: ['category'], type: 'STATUS_CATEGORY', operators: CMP_ENUM, sortable: false, label: 'Status Category' },
   // Priority
   { name: 'priority', synonyms: [], type: 'PRIORITY', operators: CMP_ENUM, sortable: true, label: 'Priority' },
@@ -112,6 +115,13 @@ export interface CustomFieldDef {
   /** TTS-QL type derived from the Prisma `CustomFieldType`. */
   type: TtqlType;
   operators: readonly TtqlOpKind[];
+  /**
+   * MVP: custom fields are never sortable (§R13 ТЗ — sort by JSON-column is too
+   * slow without functional indexes, deferred to Phase 2). The field exists so
+   * validators and the `/search/schema` response treat system and custom fields
+   * with the same shape.
+   */
+  sortable: boolean;
   /** Options for SELECT/MULTI_SELECT — exposed to suggest but not used by validator. */
   options?: unknown;
 }

--- a/backend/src/modules/search/search.schema.ts
+++ b/backend/src/modules/search/search.schema.ts
@@ -1,0 +1,215 @@
+/**
+ * TTSRH-1 PR-3 — field registry for TTS-QL (pure-core).
+ *
+ * Two layers:
+ *   1. System fields: immutable, listed in §5.2 ТЗ. Canonical name + synonyms.
+ *   2. Custom fields: dynamic. The **loader** lives in `search.schema.loader.ts`
+ *      — it depends on Prisma + Redis. Keeping those imports out of this file lets
+ *      the validator + tests run without touching the database layer.
+ *
+ * Lookups are case-insensitive. The registry is read-only from the validator's
+ * perspective — it never mutates.
+ */
+
+import type { CustomFieldType } from '@prisma/client';
+import type { TtqlOpKind, TtqlType } from './search.types.js';
+
+// ─── System field definitions ───────────────────────────────────────────────
+
+export interface FieldDef {
+  /** Canonical lowercase name — what `resolveField` returns. */
+  name: string;
+  type: TtqlType;
+  synonyms: string[];
+  operators: readonly TtqlOpKind[];
+  sortable: boolean;
+  /** Human-readable label for the schema endpoint — shown in chip pickers. */
+  label: string;
+  /** Short description — tooltip material. */
+  description?: string;
+}
+
+const CMP_NUM: readonly TtqlOpKind[] = ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'];
+const CMP_DATE: readonly TtqlOpKind[] = ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'];
+const CMP_REF: readonly TtqlOpKind[] = ['EQ', 'NEQ', 'IN', 'NOT_IN', 'IS_EMPTY', 'IS_NOT_EMPTY'];
+const CMP_ENUM: readonly TtqlOpKind[] = ['EQ', 'NEQ', 'IN', 'NOT_IN'];
+const CMP_TEXT: readonly TtqlOpKind[] = ['CONTAINS', 'NOT_CONTAINS', 'EQ', 'NEQ', 'IS_EMPTY', 'IS_NOT_EMPTY'];
+const CMP_BOOL: readonly TtqlOpKind[] = ['EQ'];
+const CMP_LABEL: readonly TtqlOpKind[] = ['EQ', 'NEQ', 'IN', 'NOT_IN', 'IS_EMPTY', 'IS_NOT_EMPTY'];
+
+export const SYSTEM_FIELDS: readonly FieldDef[] = [
+  // Identity
+  { name: 'project', synonyms: ['proj'], type: 'PROJECT', operators: CMP_REF, sortable: true, label: 'Project', description: 'Проект (по key или id)' },
+  { name: 'key', synonyms: ['issuekey'], type: 'ISSUE', operators: ['EQ', 'NEQ', 'IN', 'NOT_IN'], sortable: true, label: 'Key', description: 'Ключ задачи, напр. TTMP-123' },
+  // Text fields
+  { name: 'summary', synonyms: ['title'], type: 'TEXT', operators: CMP_TEXT, sortable: true, label: 'Summary' },
+  { name: 'description', synonyms: [], type: 'TEXT', operators: ['CONTAINS', 'NOT_CONTAINS', 'IS_EMPTY', 'IS_NOT_EMPTY'], sortable: false, label: 'Description' },
+  { name: 'comment', synonyms: [], type: 'TEXT', operators: ['CONTAINS'], sortable: false, label: 'Comment' },
+  // Status
+  { name: 'status', synonyms: [], type: 'STATUS', operators: [...CMP_REF, 'WAS', 'WAS_NOT', 'WAS_IN', 'WAS_NOT_IN', 'CHANGED'] as readonly TtqlOpKind[], sortable: true, label: 'Status' },
+  { name: 'statuscategory', synonyms: ['category'], type: 'STATUS_CATEGORY', operators: CMP_ENUM, sortable: false, label: 'Status Category' },
+  // Priority
+  { name: 'priority', synonyms: [], type: 'PRIORITY', operators: CMP_ENUM, sortable: true, label: 'Priority' },
+  // Type
+  { name: 'type', synonyms: ['issuetype'], type: 'ISSUE_TYPE', operators: CMP_REF, sortable: true, label: 'Type' },
+  // Users
+  { name: 'assignee', synonyms: [], type: 'USER', operators: CMP_REF, sortable: true, label: 'Assignee' },
+  { name: 'reporter', synonyms: ['creator'], type: 'USER', operators: CMP_REF, sortable: true, label: 'Reporter' },
+  // Planning
+  { name: 'sprint', synonyms: [], type: 'SPRINT', operators: CMP_REF, sortable: true, label: 'Sprint' },
+  { name: 'release', synonyms: ['fixversion'], type: 'RELEASE', operators: CMP_REF, sortable: true, label: 'Release' },
+  // Hierarchy
+  { name: 'parent', synonyms: [], type: 'ISSUE', operators: CMP_REF, sortable: false, label: 'Parent' },
+  { name: 'epic', synonyms: [], type: 'ISSUE', operators: ['EQ', 'IN'], sortable: false, label: 'Epic' },
+  { name: 'haschildren', synonyms: ['hassubtasks'], type: 'BOOL', operators: CMP_BOOL, sortable: false, label: 'Has children' },
+  // Dates
+  { name: 'due', synonyms: ['duedate'], type: 'DATE', operators: CMP_DATE, sortable: true, label: 'Due' },
+  { name: 'created', synonyms: [], type: 'DATETIME', operators: CMP_DATE, sortable: true, label: 'Created' },
+  { name: 'updated', synonyms: [], type: 'DATETIME', operators: CMP_DATE, sortable: true, label: 'Updated' },
+  { name: 'resolvedat', synonyms: [], type: 'DATETIME', operators: CMP_DATE, sortable: true, label: 'Resolved at' },
+  // Estimates / time
+  { name: 'estimatedhours', synonyms: ['originalestimate'], type: 'NUMBER', operators: CMP_NUM, sortable: true, label: 'Estimated hours' },
+  { name: 'timespent', synonyms: ['worklog'], type: 'NUMBER', operators: CMP_NUM, sortable: true, label: 'Time spent' },
+  { name: 'timeremaining', synonyms: [], type: 'NUMBER', operators: CMP_NUM, sortable: true, label: 'Time remaining' },
+  { name: 'orderindex', synonyms: [], type: 'NUMBER', operators: CMP_NUM, sortable: true, label: 'Order index' },
+  // AI flags
+  { name: 'aieligible', synonyms: [], type: 'BOOL', operators: CMP_BOOL, sortable: false, label: 'AI Eligible' },
+  { name: 'aistatus', synonyms: [], type: 'AI_STATUS', operators: CMP_ENUM, sortable: false, label: 'AI Status' },
+  { name: 'aiassigneetype', synonyms: [], type: 'AI_ASSIGNEE_TYPE', operators: CMP_ENUM, sortable: false, label: 'AI Assignee Type' },
+  // Labels / links (special LHS for violatedCheckpoints shorthand — see §5.4.1)
+  { name: 'labels', synonyms: ['label'], type: 'LABEL', operators: CMP_LABEL, sortable: false, label: 'Labels' },
+  { name: 'linkedissue', synonyms: [], type: 'ISSUE', operators: ['EQ', 'IN'], sortable: false, label: 'Linked Issue' },
+  // Pseudo-field `issue` — used by `issue IN funcCall()` and by the bare-function
+  // shorthand rewriter in the parser (§5.4.1 ТЗ). It accepts only IN / NOT IN.
+  { name: 'issue', synonyms: [], type: 'ISSUE', operators: ['IN', 'NOT_IN'], sortable: false, label: 'Issue (for IN funcCall())' },
+  // Checkpoint-related fields (§5.2 extensions, TTSRH-37)
+  { name: 'hascheckpointviolation', synonyms: ['hasviolation'], type: 'BOOL', operators: CMP_BOOL, sortable: false, label: 'Has checkpoint violation' },
+  { name: 'checkpointviolationtype', synonyms: ['violationtype'], type: 'CHECKPOINT_TYPE', operators: CMP_REF, sortable: false, label: 'Violation type' },
+  { name: 'checkpointviolationreason', synonyms: [], type: 'TEXT', operators: ['CONTAINS', 'NOT_CONTAINS'], sortable: false, label: 'Violation reason' },
+];
+
+// ─── Lookup index (case-insensitive, includes synonyms) ─────────────────────
+
+const FIELD_INDEX: Map<string, FieldDef> = (() => {
+  const map = new Map<string, FieldDef>();
+  for (const f of SYSTEM_FIELDS) {
+    map.set(f.name.toLowerCase(), f);
+    for (const syn of f.synonyms) map.set(syn.toLowerCase(), f);
+  }
+  return map;
+})();
+
+/** Case-insensitive system-field lookup. Returns `null` if the name is not a system field. */
+export function resolveSystemField(name: string): FieldDef | null {
+  return FIELD_INDEX.get(name.toLowerCase()) ?? null;
+}
+
+// ─── Custom fields ──────────────────────────────────────────────────────────
+
+export interface CustomFieldDef {
+  id: string;
+  name: string;
+  /** TTS-QL type derived from the Prisma `CustomFieldType`. */
+  type: TtqlType;
+  operators: readonly TtqlOpKind[];
+  /** Options for SELECT/MULTI_SELECT — exposed to suggest but not used by validator. */
+  options?: unknown;
+}
+
+/**
+ * Build a case-insensitive lookup for a batch of custom fields. Resolves BOTH by
+ * canonical name (`"Story Points"` → the field) AND by UUID. When multiple fields
+ * share the same case-insensitive name, resolution returns `'ambiguous'` so the
+ * validator can emit an R7 warning and the compiler can require a scoping clause.
+ */
+export function buildCustomFieldIndex(defs: CustomFieldDef[]): CustomFieldIndex {
+  const byName = new Map<string, CustomFieldDef | 'ambiguous'>();
+  const byId = new Map<string, CustomFieldDef>();
+  for (const def of defs) {
+    byId.set(def.id, def);
+    const key = def.name.toLowerCase();
+    const existing = byName.get(key);
+    if (existing === undefined) {
+      byName.set(key, def);
+    } else if (existing !== 'ambiguous' && existing.id !== def.id) {
+      byName.set(key, 'ambiguous');
+    }
+  }
+  return {
+    resolveByName: (name) => byName.get(name.toLowerCase()) ?? null,
+    resolveById: (id) => byId.get(id) ?? null,
+    all: defs,
+  };
+}
+
+export interface CustomFieldIndex {
+  resolveByName(name: string): CustomFieldDef | 'ambiguous' | null;
+  resolveById(id: string): CustomFieldDef | null;
+  all: readonly CustomFieldDef[];
+}
+
+// ─── Mappers ────────────────────────────────────────────────────────────────
+
+export function customFieldTypeToTtql(ft: CustomFieldType): TtqlType {
+  switch (ft) {
+    case 'TEXT':
+    case 'TEXTAREA':
+    case 'URL':
+      return 'TEXT';
+    case 'NUMBER':
+    case 'DECIMAL':
+      return 'NUMBER';
+    case 'DATE':
+      return 'DATE';
+    case 'DATETIME':
+      return 'DATETIME';
+    case 'CHECKBOX':
+      return 'BOOL';
+    case 'SELECT':
+    case 'MULTI_SELECT':
+      return 'TEXT'; // options matched as strings (case-insensitive); validator doesn't
+                     // enumerate options here — suggest layer handles that
+    case 'LABEL':
+      return 'LABEL';
+    case 'USER':
+      return 'USER';
+    case 'REFERENCE':
+      return 'JSON'; // target-type unknown at this layer; compiler resolves
+    default: {
+      const exhaustive: never = ft;
+      void exhaustive;
+      return 'JSON';
+    }
+  }
+}
+
+export function operatorsForCustomField(ft: CustomFieldType): readonly TtqlOpKind[] {
+  switch (ft) {
+    case 'TEXT':
+    case 'TEXTAREA':
+    case 'URL':
+      return ['CONTAINS', 'NOT_CONTAINS', 'EQ', 'NEQ', 'IS_EMPTY', 'IS_NOT_EMPTY'];
+    case 'NUMBER':
+    case 'DECIMAL':
+      return CMP_NUM;
+    case 'DATE':
+    case 'DATETIME':
+      return CMP_DATE;
+    case 'CHECKBOX':
+      return CMP_BOOL;
+    case 'SELECT':
+      return ['EQ', 'NEQ', 'IN', 'NOT_IN', 'IS_EMPTY', 'IS_NOT_EMPTY'];
+    case 'MULTI_SELECT':
+    case 'LABEL':
+      return CMP_LABEL;
+    case 'USER':
+      return CMP_REF;
+    case 'REFERENCE':
+      return ['EQ', 'NEQ', 'IN', 'IS_EMPTY', 'IS_NOT_EMPTY'];
+    default: {
+      const exhaustive: never = ft;
+      void exhaustive;
+      return ['EQ', 'NEQ'];
+    }
+  }
+}

--- a/backend/src/modules/search/search.types.ts
+++ b/backend/src/modules/search/search.types.ts
@@ -1,0 +1,54 @@
+/**
+ * TTSRH-1 PR-3 — shared type vocabulary for TTS-QL schema, functions, and validator.
+ *
+ * Grammar reference: docs/tz/TTSRH-1.md §5.2 (fields table) + §5.4 (function table).
+ *
+ * `TtqlType` is the semantic type system layered on top of the syntactic AST. The
+ * validator uses it to reject operator/value type mismatches (e.g. `assignee > 5`
+ * compares a User with a Number). Type rules are deliberately coarser than Prisma's
+ * column types — we only need enough precision to catch user mistakes in the editor.
+ */
+
+export type TtqlType =
+  | 'TEXT'
+  | 'NUMBER'
+  | 'DATE'
+  | 'DATETIME'
+  | 'BOOL'
+  | 'USER'
+  | 'PROJECT'
+  | 'ISSUE'
+  | 'SPRINT'
+  | 'RELEASE'
+  | 'STATUS'
+  | 'STATUS_CATEGORY'
+  | 'PRIORITY'
+  | 'ISSUE_TYPE'
+  | 'AI_STATUS'
+  | 'AI_ASSIGNEE_TYPE'
+  | 'CHECKPOINT_STATE'
+  | 'CHECKPOINT_TYPE'
+  | 'LABEL'   // multi-value string tag
+  | 'GROUP'   // user-group name for membersOf() arg
+  | 'JSON';   // opaque custom-field value when type unknown
+
+/** Function-return type: either a scalar or a list (multi-row result). */
+export type TtqlReturnType =
+  | { kind: 'scalar'; type: TtqlType }
+  | { kind: 'list'; type: TtqlType };
+
+/** Operator categories — used both by field definitions and the validator. */
+export type TtqlOpKind =
+  | 'EQ' | 'NEQ'
+  | 'GT' | 'GTE' | 'LT' | 'LTE'
+  | 'CONTAINS' | 'NOT_CONTAINS'  // ~ / !~
+  | 'IN' | 'NOT_IN'
+  | 'IS_EMPTY' | 'IS_NOT_EMPTY'
+  | 'WAS' | 'WAS_NOT' | 'WAS_IN' | 'WAS_NOT_IN'
+  | 'CHANGED';
+
+/** Feature-gate for functions: MVP (implemented now) vs Phase 2 (parser accepts, validator rejects). */
+export type FunctionPhase = 'MVP' | 'PHASE_2';
+
+/** Context variant — user search vs checkpoint-condition evaluation. §5.12.4 ТЗ. */
+export type QueryVariant = 'default' | 'checkpoint';

--- a/backend/src/modules/search/search.validator.ts
+++ b/backend/src/modules/search/search.validator.ts
@@ -1,0 +1,480 @@
+/**
+ * TTSRH-1 PR-3 — semantic validator for TTS-QL AST.
+ *
+ * Responsibilities per §5.5 ТЗ: resolve field references, check operator-to-type
+ * compatibility, check function arity/types, reject Phase-2 operators, and flag
+ * checkpoint-context-only functions when used outside KT.
+ *
+ * Invariant: `validate()` **never throws**. On structural parser errors upstream
+ * we still run the validator on whatever partial AST was produced so the editor
+ * can surface as many issues as possible in one pass. Errors are accumulated —
+ * validation never short-circuits on first failure.
+ *
+ * Error codes are stable and exposed to the frontend via the `/search/validate`
+ * contract. Add new codes to `ValidationErrorCode` and keep the frontend in sync.
+ */
+
+import type {
+  BoolExpr,
+  ClauseNode,
+  ClauseOp,
+  Expr,
+  FieldRef,
+  FunctionCall,
+  Literal,
+  QueryNode,
+  Span,
+} from './search.ast.js';
+import {
+  type CustomFieldDef,
+  type CustomFieldIndex,
+  type FieldDef,
+  buildCustomFieldIndex,
+  resolveSystemField,
+} from './search.schema.js';
+import {
+  type FunctionDef,
+  parseOffset,
+  resolveFunction,
+} from './search.functions.js';
+import type { QueryVariant, TtqlOpKind, TtqlType } from './search.types.js';
+
+// ─── Errors ─────────────────────────────────────────────────────────────────
+
+export type ValidationErrorCode =
+  | 'UNKNOWN_FIELD'
+  | 'UNKNOWN_FUNCTION'
+  | 'OPERATOR_NOT_ALLOWED_FOR_FIELD'
+  | 'VALUE_TYPE_MISMATCH'
+  | 'ARITY_MISMATCH'
+  | 'PHASE_2_OPERATOR'
+  | 'PHASE_2_FUNCTION'
+  | 'FUNCTION_NOT_ALLOWED_IN_CONTEXT'
+  | 'AMBIGUOUS_CUSTOM_FIELD'
+  | 'CUSTOM_FIELD_UUID_UNKNOWN'
+  | 'CURRENTUSER_IN_CHECKPOINT'
+  | 'INVALID_OFFSET_FORMAT';
+
+export type ValidationSeverity = 'error' | 'warning';
+
+export interface ValidationIssue {
+  code: ValidationErrorCode;
+  severity: ValidationSeverity;
+  message: string;
+  hint?: string;
+  start: number;
+  end: number;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationIssue[];
+  warnings: ValidationIssue[];
+}
+
+// ─── Validator context ──────────────────────────────────────────────────────
+
+export interface ValidatorContext {
+  variant: QueryVariant;
+  customFields: readonly CustomFieldDef[];
+}
+
+export function createValidatorContext(input: Partial<ValidatorContext> = {}): ValidatorContext {
+  return {
+    variant: input.variant ?? 'default',
+    customFields: input.customFields ?? [],
+  };
+}
+
+// ─── Entry point ────────────────────────────────────────────────────────────
+
+export function validate(ast: QueryNode, ctx: ValidatorContext): ValidationResult {
+  const v = new Validator(ctx);
+  if (ast.where) v.visitBool(ast.where);
+  for (const s of ast.orderBy) {
+    // ORDER BY resolves fields but doesn't match an operator — just ensure field exists
+    // and is sortable. Non-sortable field → warning, not error (compiler may fall back).
+    const fd = v.resolveField(s.field);
+    if (fd && fd.kind === 'system' && !fd.def.sortable) {
+      v.warn('VALUE_TYPE_MISMATCH', `Field \`${v.fieldLabel(s.field)}\` is not sortable; ORDER BY will be ignored by the compiler.`, s.field.span);
+    }
+  }
+  const errors = v.issues.filter((i) => i.severity === 'error');
+  const warnings = v.issues.filter((i) => i.severity === 'warning');
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+// ─── Implementation ─────────────────────────────────────────────────────────
+
+type ResolvedField =
+  | { kind: 'system'; def: FieldDef; ref: FieldRef }
+  | { kind: 'custom'; def: CustomFieldDef; ref: FieldRef }
+  | { kind: 'unknown'; ref: FieldRef };
+
+class Validator {
+  readonly issues: ValidationIssue[] = [];
+  private readonly customIdx: CustomFieldIndex;
+
+  constructor(private readonly ctx: ValidatorContext) {
+    this.customIdx = buildCustomFieldIndex([...ctx.customFields]);
+  }
+
+  visitBool(node: BoolExpr): void {
+    switch (node.kind) {
+      case 'Or':
+      case 'And':
+        for (const ch of node.children) this.visitBool(ch);
+        return;
+      case 'Not':
+        this.visitBool(node.child);
+        return;
+      case 'Clause':
+        this.visitClause(node);
+        return;
+    }
+  }
+
+  visitClause(c: ClauseNode): void {
+    const resolved = this.resolveField(c.field);
+    this.checkClauseOp(c.op, resolved);
+  }
+
+  // ─── Field resolution ─────────────────────────────────────────────────────
+
+  resolveField(ref: FieldRef): ResolvedField {
+    if (ref.kind === 'CustomField') {
+      const def = this.customIdx.resolveById(ref.uuid);
+      if (!def) {
+        this.err('CUSTOM_FIELD_UUID_UNKNOWN', `Custom field \`cf[${ref.uuid}]\` is not known or disabled.`, ref.span);
+        return { kind: 'unknown', ref };
+      }
+      return { kind: 'custom', def, ref };
+    }
+    if (ref.kind === 'QuotedField') {
+      const sys = resolveSystemField(ref.name);
+      if (sys) return { kind: 'system', def: sys, ref };
+      const hit = this.customIdx.resolveByName(ref.name);
+      if (hit === 'ambiguous') {
+        this.err(
+          'AMBIGUOUS_CUSTOM_FIELD',
+          `Custom field name \`${ref.name}\` is defined more than once; add a scoping \`project = ...\` clause to disambiguate.`,
+          ref.span,
+          'See R7 in docs/tz/TTSRH-1.md — cross-project name collisions must be scoped.',
+        );
+        return { kind: 'unknown', ref };
+      }
+      if (hit) return { kind: 'custom', def: hit, ref };
+      this.err('UNKNOWN_FIELD', `Unknown field \`"${ref.name}"\`.`, ref.span);
+      return { kind: 'unknown', ref };
+    }
+    // Ident
+    const sys = resolveSystemField(ref.name);
+    if (sys) return { kind: 'system', def: sys, ref };
+    this.err('UNKNOWN_FIELD', `Unknown field \`${ref.name}\`.`, ref.span);
+    return { kind: 'unknown', ref };
+  }
+
+  fieldLabel(ref: FieldRef): string {
+    if (ref.kind === 'CustomField') return `cf[${ref.uuid}]`;
+    if (ref.kind === 'QuotedField') return `"${ref.name}"`;
+    return ref.name;
+  }
+
+  // ─── Op / value compatibility ─────────────────────────────────────────────
+
+  checkClauseOp(op: ClauseOp, field: ResolvedField): void {
+    switch (op.kind) {
+      case 'Compare':
+        this.checkOpAllowed(compareToKind(op.op), field, op.span);
+        this.checkValue(op.value, field, op.span);
+        return;
+      case 'In': {
+        this.checkOpAllowed(op.negated ? 'NOT_IN' : 'IN', field, op.span);
+        for (const v of op.values) this.checkValue(v, field, op.span);
+        return;
+      }
+      case 'InFunction': {
+        this.checkOpAllowed(op.negated ? 'NOT_IN' : 'IN', field, op.span);
+        this.checkFunctionCall(op.func, expectedListReturnType(field));
+        return;
+      }
+      case 'IsEmpty':
+        this.checkOpAllowed(op.negated ? 'IS_NOT_EMPTY' : 'IS_EMPTY', field, op.span);
+        return;
+      case 'History':
+        // Phase 2 — parser accepts, we reject with a pointer to documentation.
+        this.err(
+          'PHASE_2_OPERATOR',
+          `History operators (WAS/CHANGED) are not implemented in MVP.`,
+          op.span,
+          'Planned for Phase 2 (TTSRH-23) after FieldChangeLog is added to the schema.',
+        );
+        if (op.value) this.checkValue(op.value, field, op.span);
+    }
+  }
+
+  private checkOpAllowed(wanted: TtqlOpKind, field: ResolvedField, span: Span): void {
+    if (field.kind === 'unknown') return; // already reported
+    const allowed = field.kind === 'system' ? field.def.operators : field.def.operators;
+    if (!allowed.includes(wanted)) {
+      this.err(
+        'OPERATOR_NOT_ALLOWED_FOR_FIELD',
+        `Operator \`${displayOp(wanted)}\` is not allowed for field \`${this.fieldLabel(field.ref)}\`.`,
+        span,
+        `Allowed operators: ${allowed.map(displayOp).join(', ')}.`,
+      );
+    }
+  }
+
+  // ─── Value type checks ────────────────────────────────────────────────────
+
+  private checkValue(expr: Expr, field: ResolvedField, span: Span): void {
+    if (expr.kind === 'Function') {
+      const ret = field.kind === 'unknown' ? undefined : expectedScalarOrListReturnType(field);
+      this.checkFunctionCall(expr, ret);
+      return;
+    }
+    // Literals — coarse compatibility check. Parser accepted the literal; we only
+    // reject pairings that are clearly wrong (e.g. USER = "-7d" relative date).
+    if (field.kind === 'unknown') return;
+    const fieldType = resolvedFieldType(field);
+    if (!literalTypeCompatible(expr, fieldType)) {
+      this.err(
+        'VALUE_TYPE_MISMATCH',
+        `Value ${describeLiteral(expr)} is not compatible with field \`${this.fieldLabel(field.ref)}\` (${fieldType}).`,
+        span,
+      );
+    }
+  }
+
+  // ─── Function-call validation ─────────────────────────────────────────────
+
+  checkFunctionCall(call: FunctionCall, expectedReturnHint?: { kind: 'scalar' | 'list'; type: TtqlType }): void {
+    const def = resolveFunction(call.name);
+    if (!def) {
+      this.err('UNKNOWN_FUNCTION', `Unknown function \`${call.name}()\`.`, call.span);
+      return;
+    }
+    if (def.phase === 'PHASE_2') {
+      this.err(
+        'PHASE_2_FUNCTION',
+        `Function \`${call.name}()\` is Phase-2 and not yet available.`,
+        call.span,
+        def.description,
+      );
+      return;
+    }
+    if (!def.availableIn.includes(this.ctx.variant)) {
+      const where = def.availableIn.join('/') || 'nowhere';
+      this.err(
+        'FUNCTION_NOT_ALLOWED_IN_CONTEXT',
+        `Function \`${call.name}()\` is not available in variant \`${this.ctx.variant}\` (only in ${where}).`,
+        call.span,
+      );
+      return;
+    }
+    this.checkFunctionArity(call, def);
+    this.checkFunctionArgs(call, def);
+    // §5.12.4: warn when currentUser() is used in checkpoint variant — it resolves
+    // to NULL there, making any `= currentUser()` comparison always false.
+    if (this.ctx.variant === 'checkpoint' && def.name === 'currentuser') {
+      this.warn(
+        'CURRENTUSER_IN_CHECKPOINT',
+        '`currentUser()` resolves to NULL in checkpoint context — `assignee = currentUser()` will never match.',
+        call.span,
+        'Use assignee IS NOT EMPTY or a specific email/id instead.',
+      );
+    }
+    // Soft check: if caller expects a specific return shape, verify.
+    if (expectedReturnHint) {
+      if (expectedReturnHint.kind === 'list' && def.returnType.kind === 'scalar') {
+        this.err(
+          'VALUE_TYPE_MISMATCH',
+          `\`${call.name}()\` returns a single ${def.returnType.type} but an IN-clause expects a list.`,
+          call.span,
+        );
+      }
+    }
+  }
+
+  private checkFunctionArity(call: FunctionCall, def: FunctionDef): void {
+    const minArgs = def.args.filter((a) => !a.optional).length;
+    const maxArgs = def.args.length;
+    const got = call.args.length;
+    if (got < minArgs || got > maxArgs) {
+      this.err(
+        'ARITY_MISMATCH',
+        `Function \`${def.name}()\` expects ${minArgs === maxArgs ? `${minArgs}` : `${minArgs}..${maxArgs}`} arguments, got ${got}.`,
+        call.span,
+      );
+    }
+  }
+
+  private checkFunctionArgs(call: FunctionCall, def: FunctionDef): void {
+    const n = Math.min(call.args.length, def.args.length);
+    for (let i = 0; i < n; i++) {
+      const expected = def.args[i]!;
+      const arg = call.args[i]!;
+      if (expected.type === 'OFFSET') {
+        // Offset: either a string like "-7d" or a bare RelativeDate token.
+        if (arg.kind === 'String') {
+          if (!parseOffset(arg.value)) {
+            this.err(
+              'INVALID_OFFSET_FORMAT',
+              `Argument ${i + 1} of \`${def.name}()\` must be an offset like \`"-7d"\`, got \`"${arg.value}"\`.`,
+              arg.span,
+            );
+          }
+        } else if (arg.kind !== 'RelativeDate') {
+          this.err(
+            'VALUE_TYPE_MISMATCH',
+            `Argument ${i + 1} of \`${def.name}()\` must be an offset string (e.g. \`"-7d"\`).`,
+            arg.span,
+          );
+        }
+      } else if (expected.type === 'ISSUE_KEY') {
+        if (arg.kind !== 'String' && arg.kind !== 'Ident') {
+          this.err(
+            'VALUE_TYPE_MISMATCH',
+            `Argument ${i + 1} of \`${def.name}()\` must be an issue key like \`"TTMP-123"\`.`,
+            arg.span,
+          );
+        }
+      } else if (expected.type === 'ANY') {
+        // Accept anything.
+      } else if (arg.kind === 'Function') {
+        // Nested function calls (`membersOf(someFunc())`) — validate the inner call
+        // recursively; type propagation is too coarse to enforce strict match.
+        this.checkFunctionCall(arg);
+      } else {
+        // Literal — loose compatibility only.
+        if (!literalTypeCompatible(arg, expected.type as TtqlType)) {
+          this.err(
+            'VALUE_TYPE_MISMATCH',
+            `Argument ${i + 1} of \`${def.name}()\` should be ${expected.type}, got ${describeLiteral(arg)}.`,
+            arg.span,
+          );
+        }
+      }
+    }
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  private err(code: ValidationErrorCode, message: string, span: Span, hint?: string): void {
+    this.issues.push({ code, severity: 'error', message, hint, start: span.start, end: span.end });
+  }
+
+  warn(code: ValidationErrorCode, message: string, span: Span, hint?: string): void {
+    this.issues.push({ code, severity: 'warning', message, hint, start: span.start, end: span.end });
+  }
+}
+
+// ─── Pure helpers ───────────────────────────────────────────────────────────
+
+function compareToKind(op: string): TtqlOpKind {
+  switch (op) {
+    case '=': return 'EQ';
+    case '!=': return 'NEQ';
+    case '>': return 'GT';
+    case '>=': return 'GTE';
+    case '<': return 'LT';
+    case '<=': return 'LTE';
+    case '~': return 'CONTAINS';
+    case '!~': return 'NOT_CONTAINS';
+    default: return 'EQ';
+  }
+}
+
+function displayOp(kind: TtqlOpKind): string {
+  switch (kind) {
+    case 'EQ': return '=';
+    case 'NEQ': return '!=';
+    case 'GT': return '>';
+    case 'GTE': return '>=';
+    case 'LT': return '<';
+    case 'LTE': return '<=';
+    case 'CONTAINS': return '~';
+    case 'NOT_CONTAINS': return '!~';
+    case 'IN': return 'IN';
+    case 'NOT_IN': return 'NOT IN';
+    case 'IS_EMPTY': return 'IS EMPTY';
+    case 'IS_NOT_EMPTY': return 'IS NOT EMPTY';
+    case 'WAS': return 'WAS';
+    case 'WAS_NOT': return 'WAS NOT';
+    case 'WAS_IN': return 'WAS IN';
+    case 'WAS_NOT_IN': return 'WAS NOT IN';
+    case 'CHANGED': return 'CHANGED';
+  }
+}
+
+function resolvedFieldType(field: ResolvedField & { kind: 'system' | 'custom' }): TtqlType {
+  if (field.kind === 'system') return field.def.type;
+  return field.def.type;
+}
+
+function expectedListReturnType(field: ResolvedField): { kind: 'list'; type: TtqlType } | undefined {
+  if (field.kind === 'unknown') return undefined;
+  return { kind: 'list', type: resolvedFieldType(field) };
+}
+
+function expectedScalarOrListReturnType(field: ResolvedField): { kind: 'scalar' | 'list'; type: TtqlType } | undefined {
+  if (field.kind === 'unknown') return undefined;
+  return { kind: 'scalar', type: resolvedFieldType(field) };
+}
+
+/**
+ * Very coarse type compatibility. We only reject combinations that are ALWAYS
+ * wrong (User field with a Number, etc.). Anything string-like (including bare
+ * idents representing enum constants) is accepted for enum/text-ish types — the
+ * compiler later resolves enum names against actual DB values.
+ */
+function literalTypeCompatible(lit: Literal | FunctionCall, fieldType: TtqlType): boolean {
+  // Null/Empty/Function are always accepted — the compiler handles null semantics
+  // and function return-type resolution downstream.
+  if (lit.kind === 'Null' || lit.kind === 'Empty') return true;
+  if (lit.kind === 'Function') return true;
+  switch (fieldType) {
+    case 'NUMBER':
+      return lit.kind === 'Number';
+    case 'BOOL':
+      return lit.kind === 'Bool';
+    case 'DATE':
+    case 'DATETIME':
+      // Date can be expressed as a quoted ISO string, bare RelativeDate, or a date-
+      // producing function. The validator can't fully check ISO format without a
+      // parser pass — we accept all strings and let the compiler reject invalid ISO.
+      return lit.kind === 'String' || lit.kind === 'RelativeDate';
+    case 'TEXT':
+    case 'JSON':
+    case 'LABEL':
+    case 'STATUS':
+    case 'STATUS_CATEGORY':
+    case 'PRIORITY':
+    case 'ISSUE_TYPE':
+    case 'AI_STATUS':
+    case 'AI_ASSIGNEE_TYPE':
+    case 'CHECKPOINT_STATE':
+    case 'CHECKPOINT_TYPE':
+    case 'USER':
+    case 'PROJECT':
+    case 'ISSUE':
+    case 'SPRINT':
+    case 'RELEASE':
+    case 'GROUP':
+      return lit.kind === 'String' || lit.kind === 'Ident';
+  }
+}
+
+function describeLiteral(lit: Expr): string {
+  switch (lit.kind) {
+    case 'String': return `"${lit.value}"`;
+    case 'Number': return String(lit.value);
+    case 'RelativeDate': return lit.raw;
+    case 'Ident': return lit.name;
+    case 'Bool': return String(lit.value);
+    case 'Null': return 'NULL';
+    case 'Empty': return 'EMPTY';
+    case 'Function': return `${lit.name}(...)`;
+  }
+}

--- a/backend/src/modules/search/search.validator.ts
+++ b/backend/src/modules/search/search.validator.ts
@@ -53,7 +53,8 @@ export type ValidationErrorCode =
   | 'AMBIGUOUS_CUSTOM_FIELD'
   | 'CUSTOM_FIELD_UUID_UNKNOWN'
   | 'CURRENTUSER_IN_CHECKPOINT'
-  | 'INVALID_OFFSET_FORMAT';
+  | 'INVALID_OFFSET_FORMAT'
+  | 'ORDER_BY_NOT_SORTABLE';
 
 export type ValidationSeverity = 'error' | 'warning';
 
@@ -94,9 +95,14 @@ export function validate(ast: QueryNode, ctx: ValidatorContext): ValidationResul
   for (const s of ast.orderBy) {
     // ORDER BY resolves fields but doesn't match an operator — just ensure field exists
     // and is sortable. Non-sortable field → warning, not error (compiler may fall back).
+    // Custom fields are never sortable in MVP (§R13 ТЗ); the check covers both kinds.
     const fd = v.resolveField(s.field);
-    if (fd && fd.kind === 'system' && !fd.def.sortable) {
-      v.warn('VALUE_TYPE_MISMATCH', `Field \`${v.fieldLabel(s.field)}\` is not sortable; ORDER BY will be ignored by the compiler.`, s.field.span);
+    if ((fd.kind === 'system' || fd.kind === 'custom') && !fd.def.sortable) {
+      v.warn(
+        'ORDER_BY_NOT_SORTABLE',
+        `Field \`${v.fieldLabel(s.field)}\` is not sortable; ORDER BY will be ignored by the compiler.`,
+        s.field.span,
+      );
     }
   }
   const errors = v.issues.filter((i) => i.severity === 'error');
@@ -215,7 +221,10 @@ class Validator {
 
   private checkOpAllowed(wanted: TtqlOpKind, field: ResolvedField, span: Span): void {
     if (field.kind === 'unknown') return; // already reported
-    const allowed = field.kind === 'system' ? field.def.operators : field.def.operators;
+    // `FieldDef` (system) and `CustomFieldDef` both expose `.operators`, so a single
+    // access works for both kinds. Don't re-split by `kind` — it creates copy-paste
+    // drift the moment one structure gains an extra permission axis.
+    const allowed = field.def.operators;
     if (!allowed.includes(wanted)) {
       this.err(
         'OPERATOR_NOT_ALLOWED_FOR_FIELD',

--- a/backend/tests/search-functions.unit.test.ts
+++ b/backend/tests/search-functions.unit.test.ts
@@ -1,0 +1,198 @@
+/**
+ * TTSRH-1 PR-3 — unit tests for the TTS-QL function registry and pure date evaluators.
+ *
+ * T-3 in §6 ТЗ ("Unit functions — currentUser, startOfWeek(offset), openSprints with
+ * mocked date") is covered by the pure-evaluator cases below. DB-dependent function
+ * resolution is exercised via integration tests in PR-5.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  applyOffset,
+  endOfDayUtc,
+  endOfIsoWeekUtc,
+  endOfMonthUtc,
+  endOfYearUtc,
+  evaluatePureDateFn,
+  functionsForVariant,
+  parseOffset,
+  resolveFunction,
+  startOfDayUtc,
+  startOfIsoWeekUtc,
+  startOfMonthUtc,
+  startOfYearUtc,
+} from '../src/modules/search/search.functions.js';
+
+// A fixed anchor — Wednesday 2026-04-15 12:34:56.789 UTC — used for every test so
+// week/month arithmetic is deterministic across timezones.
+const ANCHOR = new Date(Date.UTC(2026, 3, 15, 12, 34, 56, 789));
+
+describe('resolveFunction — case-insensitive lookup', () => {
+  it.each([
+    ['currentUser', 'currentuser'],
+    ['CURRENTUSER', 'currentuser'],
+    ['startOfMonth', 'startofmonth'],
+    ['endOfYear', 'endofyear'],
+    ['myOpenIssues', 'myopenissues'],
+  ])('resolves `%s` to `%s`', (input, expected) => {
+    expect(resolveFunction(input)?.name).toBe(expected);
+  });
+
+  it('returns null for unknown function', () => {
+    expect(resolveFunction('bogusFunction')).toBeNull();
+  });
+});
+
+describe('functionsForVariant — context filter', () => {
+  it('default variant excludes checkpoint-only functions', () => {
+    const defaultFns = functionsForVariant('default').map((f) => f.name);
+    expect(defaultFns).not.toContain('releaseplanneddate');
+    expect(defaultFns).not.toContain('checkpointdeadline');
+    expect(defaultFns).toContain('currentuser');
+  });
+
+  it('checkpoint variant excludes user-only functions', () => {
+    const kpFns = functionsForVariant('checkpoint').map((f) => f.name);
+    expect(kpFns).toContain('releaseplanneddate');
+    expect(kpFns).toContain('checkpointdeadline');
+    // currentUser() IS available in checkpoint variant (it resolves to NULL with a
+    // warning per §5.12.4), so the registry includes it there too.
+    // BUT myOpenIssues is user-only.
+    expect(kpFns).not.toContain('myopenissues');
+  });
+
+  it('Phase-2 functions are in the registry but not callable', () => {
+    const watched = resolveFunction('watchedIssues');
+    expect(watched?.phase).toBe('PHASE_2');
+  });
+});
+
+describe('parseOffset', () => {
+  it.each([
+    ['1d', 1, 'd'],
+    ['-7d', -7, 'd'],
+    ['2w', 2, 'w'],
+    ['3M', 3, 'M'],
+    ['-1y', -1, 'y'],
+    ['8h', 8, 'h'],
+    ['15m', 15, 'm'],
+  ])('parses `%s` → %d %s', (src, amount, unit) => {
+    expect(parseOffset(src)).toEqual({ amount, unit });
+  });
+
+  it.each(['', 'notanoffset', '7x', 'd7', '-'])('rejects `%s`', (bad) => {
+    expect(parseOffset(bad)).toBeNull();
+  });
+});
+
+describe('applyOffset — calendar arithmetic', () => {
+  it('adds days', () => {
+    const r = applyOffset(ANCHOR, { amount: 5, unit: 'd' });
+    expect(r.getUTCDate()).toBe(20);
+  });
+
+  it('subtracts days across month boundary', () => {
+    const r = applyOffset(new Date(Date.UTC(2026, 3, 3, 0, 0, 0)), { amount: -5, unit: 'd' });
+    expect(r.getUTCMonth()).toBe(2); // March (0-indexed)
+    expect(r.getUTCDate()).toBe(29);
+  });
+
+  it('adds months (Jan 31 + 1M = Mar 3, because Feb has 28 days)', () => {
+    const r = applyOffset(new Date(Date.UTC(2026, 0, 31)), { amount: 1, unit: 'M' });
+    // JS Date.setMonth normalises to Mar 3 (Feb 31 → Mar 3 in 2026).
+    expect(r.getUTCMonth()).toBe(2);
+  });
+
+  it('adds years', () => {
+    const r = applyOffset(ANCHOR, { amount: 2, unit: 'y' });
+    expect(r.getUTCFullYear()).toBe(2028);
+  });
+
+  it('weeks = 7 days', () => {
+    const r = applyOffset(ANCHOR, { amount: 1, unit: 'w' });
+    expect(r.getUTCDate()).toBe(22);
+  });
+
+  it('hours & minutes', () => {
+    expect(applyOffset(ANCHOR, { amount: 3, unit: 'h' }).getUTCHours()).toBe(15);
+    expect(applyOffset(ANCHOR, { amount: 15, unit: 'm' }).getUTCMinutes()).toBe(49);
+  });
+});
+
+describe('start/end helpers (UTC, deterministic)', () => {
+  it('startOfDayUtc — midnight', () => {
+    expect(startOfDayUtc(ANCHOR).toISOString()).toBe('2026-04-15T00:00:00.000Z');
+  });
+
+  it('endOfDayUtc — 23:59:59.999', () => {
+    expect(endOfDayUtc(ANCHOR).toISOString()).toBe('2026-04-15T23:59:59.999Z');
+  });
+
+  it('startOfIsoWeekUtc — Monday for a Wednesday anchor', () => {
+    // 2026-04-15 is a Wednesday → Monday = 2026-04-13.
+    expect(startOfIsoWeekUtc(ANCHOR).toISOString()).toBe('2026-04-13T00:00:00.000Z');
+  });
+
+  it('startOfIsoWeekUtc — Monday wrap from a Sunday', () => {
+    // 2026-04-19 is a Sunday → Monday = 2026-04-13 (6 days earlier).
+    const sun = new Date(Date.UTC(2026, 3, 19, 10, 0, 0));
+    expect(startOfIsoWeekUtc(sun).toISOString()).toBe('2026-04-13T00:00:00.000Z');
+  });
+
+  it('endOfIsoWeekUtc — Sunday 23:59:59.999', () => {
+    expect(endOfIsoWeekUtc(ANCHOR).toISOString()).toBe('2026-04-19T23:59:59.999Z');
+  });
+
+  it('startOfMonthUtc / endOfMonthUtc', () => {
+    expect(startOfMonthUtc(ANCHOR).toISOString()).toBe('2026-04-01T00:00:00.000Z');
+    expect(endOfMonthUtc(ANCHOR).toISOString()).toBe('2026-04-30T23:59:59.999Z');
+  });
+
+  it('startOfYearUtc / endOfYearUtc', () => {
+    expect(startOfYearUtc(ANCHOR).toISOString()).toBe('2026-01-01T00:00:00.000Z');
+    expect(endOfYearUtc(ANCHOR).toISOString()).toBe('2026-12-31T23:59:59.999Z');
+  });
+});
+
+describe('evaluatePureDateFn — end-to-end', () => {
+  const ctx = { now: ANCHOR };
+
+  it('now() returns anchor', () => {
+    expect(evaluatePureDateFn('now', null, ctx)?.toISOString()).toBe(ANCHOR.toISOString());
+  });
+
+  it('today() returns midnight of anchor', () => {
+    expect(evaluatePureDateFn('today', null, ctx)?.toISOString()).toBe('2026-04-15T00:00:00.000Z');
+  });
+
+  it('startOfWeek("-1w") = Monday of previous week', () => {
+    // Current week Monday = 2026-04-13. Minus 1 week = 2026-04-06.
+    const r = evaluatePureDateFn('startofweek', { amount: -1, unit: 'w' }, ctx);
+    expect(r?.toISOString()).toBe('2026-04-06T00:00:00.000Z');
+  });
+
+  it('endOfMonth("1M") = last day of next month', () => {
+    // Anchor April → +1M = May → last day of May = 2026-05-31 23:59:59.999.
+    const r = evaluatePureDateFn('endofmonth', { amount: 1, unit: 'M' }, ctx);
+    expect(r?.toISOString()).toBe('2026-05-31T23:59:59.999Z');
+  });
+
+  it('startOfMonth("-1M") = first day of previous month', () => {
+    const r = evaluatePureDateFn('startofmonth', { amount: -1, unit: 'M' }, ctx);
+    expect(r?.toISOString()).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('endOfYear() — end of current year', () => {
+    const r = evaluatePureDateFn('endofyear', null, ctx);
+    expect(r?.toISOString()).toBe('2026-12-31T23:59:59.999Z');
+  });
+
+  it('case-insensitive name', () => {
+    const r = evaluatePureDateFn('StArToFdAy', null, ctx);
+    expect(r?.toISOString()).toBe('2026-04-15T00:00:00.000Z');
+  });
+
+  it('returns null for DB-dependent function', () => {
+    expect(evaluatePureDateFn('currentUser', null, ctx)).toBeNull();
+    expect(evaluatePureDateFn('openSprints', null, ctx)).toBeNull();
+  });
+});

--- a/backend/tests/search-validator.unit.test.ts
+++ b/backend/tests/search-validator.unit.test.ts
@@ -1,0 +1,346 @@
+/**
+ * TTSRH-1 PR-3 — unit tests for the TTS-QL semantic validator.
+ *
+ * Covers the full error-code surface (UNKNOWN_FIELD, OPERATOR_NOT_ALLOWED_FOR_FIELD,
+ * VALUE_TYPE_MISMATCH, ARITY_MISMATCH, PHASE_2_OPERATOR, PHASE_2_FUNCTION,
+ * FUNCTION_NOT_ALLOWED_IN_CONTEXT, CURRENTUSER_IN_CHECKPOINT, …) plus the full
+ * golden-set round-trip (parse + validate, zero errors).
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse } from '../src/modules/search/search.parser.js';
+import {
+  createValidatorContext,
+  validate,
+  type ValidationErrorCode,
+  type ValidationResult,
+} from '../src/modules/search/search.validator.js';
+import type { CustomFieldDef } from '../src/modules/search/search.schema.js';
+
+function runValidate(
+  source: string,
+  opts: { variant?: 'default' | 'checkpoint'; customFields?: CustomFieldDef[] } = {},
+): ValidationResult {
+  const { ast, errors: parseErrors } = parse(source);
+  if (!ast) {
+    throw new Error(`Parser failed for \`${source}\`: ${parseErrors.map((e) => e.code).join(', ')}`);
+  }
+  return validate(
+    ast,
+    createValidatorContext({ variant: opts.variant, customFields: opts.customFields ?? [] }),
+  );
+}
+
+function expectCode(result: ValidationResult, code: ValidationErrorCode): void {
+  const all = [...result.errors, ...result.warnings].map((i) => i.code);
+  if (!all.includes(code)) {
+    throw new Error(`expected code ${code}, got: ${all.join(', ') || '<none>'}`);
+  }
+}
+
+// ─── Happy path ─────────────────────────────────────────────────────────────
+
+describe('validator — happy path', () => {
+  it.each([
+    'priority = HIGH',
+    'assignee = currentUser()',
+    'status IN (OPEN, IN_PROGRESS)',
+    'due <= "7d"',
+    'assignee IS NOT EMPTY',
+    'sprint IN openSprints()',
+    'labels in ("backend", "security")',
+    'created >= startOfMonth("-1M")',
+    'hasCheckpointViolation = true',
+    'myOpenIssues()',
+    'issue in violatedCheckpoints()',
+    'statusCategory != DONE ORDER BY priority DESC',
+  ])('%s — valid', (source) => {
+    const r = runValidate(source);
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+});
+
+// ─── Unknown field / function ───────────────────────────────────────────────
+
+describe('validator — unknown symbols', () => {
+  it('unknown field `bogus`', () => {
+    const r = runValidate('bogus = 1');
+    expectCode(r, 'UNKNOWN_FIELD');
+    expect(r.valid).toBe(false);
+  });
+
+  it('unknown quoted field `"No Such Custom Field"`', () => {
+    const r = runValidate('"No Such Custom Field" = 1');
+    expectCode(r, 'UNKNOWN_FIELD');
+  });
+
+  it('unknown function', () => {
+    const r = runValidate('assignee = noSuchFunc()');
+    expectCode(r, 'UNKNOWN_FUNCTION');
+  });
+});
+
+// ─── Operator × field compatibility ─────────────────────────────────────────
+
+describe('validator — operator × field compatibility', () => {
+  it('aieligible (BOOL) does not accept `>`', () => {
+    const r = runValidate('aiEligible > true');
+    expectCode(r, 'OPERATOR_NOT_ALLOWED_FOR_FIELD');
+  });
+
+  it('assignee (USER) does not accept `~`', () => {
+    const r = runValidate('assignee ~ "Ivan"');
+    expectCode(r, 'OPERATOR_NOT_ALLOWED_FOR_FIELD');
+  });
+
+  it('priority (enum) does not accept `>`', () => {
+    const r = runValidate('priority > 5');
+    expectCode(r, 'OPERATOR_NOT_ALLOWED_FOR_FIELD');
+  });
+
+  it('summary (TEXT) accepts `~`', () => {
+    const r = runValidate('summary ~ "аутентификация"');
+    expect(r.valid).toBe(true);
+  });
+});
+
+// ─── Value type compatibility ───────────────────────────────────────────────
+
+describe('validator — value type compatibility', () => {
+  it('NUMBER field rejects string literal', () => {
+    const r = runValidate('estimatedHours = "many"');
+    expectCode(r, 'VALUE_TYPE_MISMATCH');
+  });
+
+  it('DATE field accepts relative-date string', () => {
+    const r = runValidate('due <= "-1d"');
+    expect(r.valid).toBe(true);
+  });
+
+  it('BOOL field rejects string literal', () => {
+    const r = runValidate('aiEligible = "true"');
+    expectCode(r, 'VALUE_TYPE_MISMATCH');
+  });
+
+  it('USER field rejects number literal', () => {
+    const r = runValidate('assignee = 42');
+    expectCode(r, 'VALUE_TYPE_MISMATCH');
+  });
+});
+
+// ─── Function arity / arg types ─────────────────────────────────────────────
+
+describe('validator — function arity and arg types', () => {
+  it('currentUser() with extra arg', () => {
+    const r = runValidate('assignee = currentUser("extra")');
+    expectCode(r, 'ARITY_MISMATCH');
+  });
+
+  it('membersOf() with no arg', () => {
+    const r = runValidate('assignee in membersOf()');
+    expectCode(r, 'ARITY_MISMATCH');
+  });
+
+  it('startOfDay() with invalid offset format', () => {
+    const r = runValidate('created >= startOfDay("not-an-offset")');
+    expectCode(r, 'INVALID_OFFSET_FORMAT');
+  });
+
+  it('startOfDay("-7d") is valid', () => {
+    const r = runValidate('created >= startOfDay("-7d")');
+    expect(r.valid).toBe(true);
+  });
+
+  it('linkedIssues() with no key', () => {
+    const r = runValidate('issue IN linkedIssues()');
+    expectCode(r, 'ARITY_MISMATCH');
+  });
+
+  it('linkedIssues("TTMP-42", "blocks") — valid 2-arg', () => {
+    const r = runValidate('issue in linkedIssues("TTMP-42", "blocks")');
+    expect(r.valid).toBe(true);
+  });
+});
+
+// ─── Phase 2 rejection ──────────────────────────────────────────────────────
+
+describe('validator — Phase-2 features are rejected with clear codes', () => {
+  it('WAS operator → PHASE_2_OPERATOR', () => {
+    const r = runValidate('status WAS "DONE"');
+    expectCode(r, 'PHASE_2_OPERATOR');
+  });
+
+  it('CHANGED → PHASE_2_OPERATOR', () => {
+    const r = runValidate('status CHANGED');
+    expectCode(r, 'PHASE_2_OPERATOR');
+  });
+
+  it('watchedIssues() → PHASE_2_FUNCTION', () => {
+    const r = runValidate('issue in watchedIssues()');
+    expectCode(r, 'PHASE_2_FUNCTION');
+  });
+});
+
+// ─── Checkpoint context ─────────────────────────────────────────────────────
+
+describe('validator — checkpoint variant', () => {
+  it('currentUser() in checkpoint emits warning (not error)', () => {
+    const r = runValidate('assignee = currentUser()', { variant: 'checkpoint' });
+    // Still valid (currentUser IS available in checkpoint, but triggers WARNING).
+    expect(r.valid).toBe(true);
+    expect(r.warnings.map((w) => w.code)).toContain('CURRENTUSER_IN_CHECKPOINT');
+  });
+
+  it('releasePlannedDate() is valid only in checkpoint', () => {
+    expect(runValidate('due <= releasePlannedDate()', { variant: 'checkpoint' }).valid).toBe(true);
+    const r = runValidate('due <= releasePlannedDate()', { variant: 'default' });
+    expectCode(r, 'FUNCTION_NOT_ALLOWED_IN_CONTEXT');
+  });
+
+  it('myOpenIssues() is NOT allowed in checkpoint context', () => {
+    const r = runValidate('myOpenIssues()', { variant: 'checkpoint' });
+    expectCode(r, 'FUNCTION_NOT_ALLOWED_IN_CONTEXT');
+  });
+});
+
+// ─── Custom fields ──────────────────────────────────────────────────────────
+
+describe('validator — custom fields', () => {
+  const storyPoints: CustomFieldDef = {
+    id: '11111111-1111-1111-1111-111111111111',
+    name: 'Story Points',
+    type: 'NUMBER',
+    operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'],
+    options: null,
+  };
+
+  it('resolves quoted custom field by name', () => {
+    const r = runValidate('"Story Points" > 5', { customFields: [storyPoints] });
+    expect(r.valid).toBe(true);
+  });
+
+  it('resolves cf[UUID]', () => {
+    const r = runValidate(
+      `cf[11111111-1111-1111-1111-111111111111] > 5`,
+      { customFields: [storyPoints] },
+    );
+    expect(r.valid).toBe(true);
+  });
+
+  it('unknown custom UUID', () => {
+    const r = runValidate(
+      `cf[22222222-2222-2222-2222-222222222222] > 5`,
+      { customFields: [storyPoints] },
+    );
+    expectCode(r, 'CUSTOM_FIELD_UUID_UNKNOWN');
+  });
+
+  it('ambiguous custom-field name', () => {
+    const a: CustomFieldDef = { ...storyPoints, id: 'aaaaaaaa-1111-1111-1111-111111111111' };
+    const b: CustomFieldDef = { ...storyPoints, id: 'bbbbbbbb-1111-1111-1111-111111111111' };
+    const r = runValidate('"Story Points" > 5', { customFields: [a, b] });
+    expectCode(r, 'AMBIGUOUS_CUSTOM_FIELD');
+  });
+
+  it('custom-field type propagates to value check', () => {
+    const r = runValidate(`"Story Points" = "abc"`, { customFields: [storyPoints] });
+    expectCode(r, 'VALUE_TYPE_MISMATCH');
+  });
+});
+
+// ─── ORDER BY sortable warning ──────────────────────────────────────────────
+
+describe('validator — ORDER BY on non-sortable field', () => {
+  it('description is not sortable — warning', () => {
+    const r = runValidate('x = 1 ORDER BY description');
+    // Validator emits warnings for non-sortable ORDER BY fields; parse still valid.
+    // NB: `x` is unknown → UNKNOWN_FIELD error; we check the warning independently.
+    const codes = [...r.errors, ...r.warnings].map((i) => i.code);
+    expect(codes).toContain('UNKNOWN_FIELD'); // from `x`
+  });
+
+  it('priority IS sortable — no warning', () => {
+    const r = runValidate('priority = HIGH ORDER BY priority');
+    expect(r.warnings).toEqual([]);
+    expect(r.valid).toBe(true);
+  });
+});
+
+// ─── Golden-set round trip ──────────────────────────────────────────────────
+
+interface GoldenQuery {
+  label: string;
+  source: string;
+  startLine: number;
+}
+
+function loadGoldenSet(): GoldenQuery[] {
+  const path = resolve(__dirname, '../../docs/tz/TTSRH-1-goldenset.jql');
+  const text = readFileSync(path, 'utf8');
+  const lines = text.split('\n');
+  const queries: GoldenQuery[] = [];
+  let buf: string[] = [];
+  let bufStartLine = 0;
+  let lastLabel = '';
+  const flush = () => {
+    const source = buf.join('\n').trim();
+    if (source) queries.push({ label: lastLabel, source, startLine: bufStartLine });
+    buf = [];
+    bufStartLine = 0;
+  };
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]!;
+    const line = raw.trim();
+    if (line.startsWith('--')) {
+      flush();
+      const m = line.match(/^--\s*(\d{1,3})\b/);
+      if (m) lastLabel = m[1]!;
+      continue;
+    }
+    if (!line) { flush(); continue; }
+    if (buf.length === 0) bufStartLine = i + 1;
+    buf.push(raw);
+  }
+  flush();
+  return queries;
+}
+
+// Seed a custom-field registry containing every quoted custom-field name used
+// anywhere in the golden set. The validator rejects unknown names as UNKNOWN_FIELD,
+// so we have to introduce them. The cf[UUID] in query #16 is a generic SELECT-style
+// field holding a string, so it gets TEXT-like operators.
+const GOLDEN_CUSTOM_FIELDS: CustomFieldDef[] = [
+  {
+    id: '12345678-1234-1234-1234-123456789abc',
+    name: 'Release Status',
+    type: 'TEXT',
+    operators: ['EQ', 'NEQ', 'IN', 'NOT_IN', 'IS_EMPTY', 'IS_NOT_EMPTY'],
+  },
+  { id: '22222222-2222-2222-2222-222222222201', name: 'Story Points', type: 'NUMBER', operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'] },
+  { id: '22222222-2222-2222-2222-222222222202', name: 'Business Value', type: 'NUMBER', operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'] },
+  { id: '22222222-2222-2222-2222-222222222203', name: 'Effort', type: 'NUMBER', operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'] },
+];
+
+describe('validator — golden-set round trip', () => {
+  const queries = loadGoldenSet();
+
+  it('loaded >= 50 queries', () => {
+    expect(queries.length).toBeGreaterThanOrEqual(50);
+  });
+
+  it.each(queries.map((q) => [q.label || '?', q.source.replace(/\s+/g, ' '), q] as const))(
+    'query #%s: `%s`',
+    (_label, _preview, q) => {
+      const result = runValidate(q.source, { customFields: GOLDEN_CUSTOM_FIELDS });
+      if (!result.valid) {
+        const msg = result.errors
+          .map((e) => `  [${e.code}] ${e.message} at [${e.start}..${e.end}]`)
+          .join('\n');
+        throw new Error(`Golden query #${q.label} (line ${q.startLine}) failed:\n${msg}\nSource: ${q.source}`);
+      }
+      expect(result.valid).toBe(true);
+    },
+  );
+});

--- a/backend/tests/search-validator.unit.test.ts
+++ b/backend/tests/search-validator.unit.test.ts
@@ -213,6 +213,7 @@ describe('validator — custom fields', () => {
     name: 'Story Points',
     type: 'NUMBER',
     operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'],
+    sortable: false,
     options: null,
   };
 
@@ -253,18 +254,29 @@ describe('validator — custom fields', () => {
 // ─── ORDER BY sortable warning ──────────────────────────────────────────────
 
 describe('validator — ORDER BY on non-sortable field', () => {
-  it('description is not sortable — warning', () => {
-    const r = runValidate('x = 1 ORDER BY description');
-    // Validator emits warnings for non-sortable ORDER BY fields; parse still valid.
-    // NB: `x` is unknown → UNKNOWN_FIELD error; we check the warning independently.
-    const codes = [...r.errors, ...r.warnings].map((i) => i.code);
-    expect(codes).toContain('UNKNOWN_FIELD'); // from `x`
+  it('description is not sortable — ORDER_BY_NOT_SORTABLE warning', () => {
+    // Use a known field to isolate the ORDER BY warning from other errors.
+    const r = runValidate('description ~ "text" ORDER BY description');
+    expect(r.valid).toBe(true);
+    expect(r.warnings.map((w) => w.code)).toContain('ORDER_BY_NOT_SORTABLE');
   });
 
   it('priority IS sortable — no warning', () => {
     const r = runValidate('priority = HIGH ORDER BY priority');
     expect(r.warnings).toEqual([]);
     expect(r.valid).toBe(true);
+  });
+
+  it('custom field (always non-sortable in MVP) emits ORDER_BY_NOT_SORTABLE', () => {
+    const cf: CustomFieldDef = {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      name: 'Story Points',
+      type: 'NUMBER',
+      operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'],
+      sortable: false,
+    };
+    const r = runValidate('"Story Points" > 0 ORDER BY "Story Points"', { customFields: [cf] });
+    expect(r.warnings.map((w) => w.code)).toContain('ORDER_BY_NOT_SORTABLE');
   });
 });
 
@@ -317,10 +329,11 @@ const GOLDEN_CUSTOM_FIELDS: CustomFieldDef[] = [
     name: 'Release Status',
     type: 'TEXT',
     operators: ['EQ', 'NEQ', 'IN', 'NOT_IN', 'IS_EMPTY', 'IS_NOT_EMPTY'],
+    sortable: false,
   },
-  { id: '22222222-2222-2222-2222-222222222201', name: 'Story Points', type: 'NUMBER', operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'] },
-  { id: '22222222-2222-2222-2222-222222222202', name: 'Business Value', type: 'NUMBER', operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'] },
-  { id: '22222222-2222-2222-2222-222222222203', name: 'Effort', type: 'NUMBER', operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'] },
+  { id: '22222222-2222-2222-2222-222222222201', name: 'Story Points', type: 'NUMBER', operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'], sortable: false },
+  { id: '22222222-2222-2222-2222-222222222202', name: 'Business Value', type: 'NUMBER', operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'], sortable: false },
+  { id: '22222222-2222-2222-2222-222222222203', name: 'Effort', type: 'NUMBER', operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'], sortable: false },
 ];
 
 describe('validator — golden-set round trip', () => {

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1494,7 +1494,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 |---|--------|-------|------|-----------|----------------|--------|
 | 1 | `ttsrh-1/foundation` | Prisma schema (SavedFilter, User.preferences), feature flags, пустые модули | 6 | — | TTSRH-8 (schema), TTSRH-22 (flag) | 🟢 Merged ([#100](https://github.com/NovakPAai/tasktime-mvp/pull/100)) |
 | 2 | `ttsrh-1/parser` | Tokenizer + Parser + AST + golden-set | 14 | PR-1 | TTSRH-2 | ✅ Done (готов к push после merge PR-1) |
-| 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 | 📋 Планируется |
+| 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 | ✅ Done (готов к push после merge PR-2) |
 | 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 | 📋 Планируется |
 | 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 | 📋 Планируется |
 | 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 | 📋 Планируется |

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1493,7 +1493,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | № | Branch | Scope | Часы | Зависит от | TTSRH-сабтаски | Статус |
 |---|--------|-------|------|-----------|----------------|--------|
 | 1 | `ttsrh-1/foundation` | Prisma schema (SavedFilter, User.preferences), feature flags, пустые модули | 6 | — | TTSRH-8 (schema), TTSRH-22 (flag) | 🟢 Merged ([#100](https://github.com/NovakPAai/tasktime-mvp/pull/100)) |
-| 2 | `ttsrh-1/parser` | Tokenizer + Parser + AST + golden-set | 14 | PR-1 | TTSRH-2 | ✅ Done (готов к push после merge PR-1) |
+| 2 | `ttsrh-1/parser` | Tokenizer + Parser + AST + golden-set | 14 | PR-1 | TTSRH-2 | 🟢 Merged ([#101](https://github.com/NovakPAai/tasktime-mvp/pull/101)) |
 | 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 | ✅ Done (готов к push после merge PR-2) |
 | 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 | 📋 Планируется |
 | 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 | 📋 Планируется |

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,59 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.28**
+**Last version: 2.29**
+
+---
+
+## [2.29] [2026-04-20] feat(search): TTSRH-1 PR-3 — field registry + validator + функции + /search/schema + /search/validate
+
+**PR:** (to be filled after push)
+**Ветка:** `ttsrh-1/validator`
+
+### Что было
+
+После PR-2 был только синтаксический парсер — любой `foo = bar AND bogus = 1` считался корректным. Эндпоинты `/search/validate` и `/search/schema` возвращали 501.
+
+### Что теперь
+
+Добавлен семантический слой поверх AST:
+
+- **`search.types.ts`** — общий словарь типов для TTS-QL: `TtqlType` (16 вариантов: TEXT / NUMBER / DATE / DATETIME / USER / PROJECT / ISSUE / SPRINT / RELEASE / STATUS / STATUS_CATEGORY / PRIORITY / ISSUE_TYPE / AI_STATUS / AI_ASSIGNEE_TYPE / CHECKPOINT_STATE / CHECKPOINT_TYPE / LABEL / GROUP / JSON), `TtqlOpKind` (17 категорий операторов), `TtqlReturnType` (scalar / list), `QueryVariant` (default / checkpoint).
+- **`search.schema.ts`** (pure-core) — реестр из 30+ system-полей из §5.2 ТЗ с label, synonyms, operators, sortable. Индекс для case-insensitive lookup по имени и синонимам. `CustomFieldDef`/`CustomFieldIndex` с detection ambiguous-имён (R7). Мапперы `CustomFieldType → TtqlType` и `→ allowed operators`. **Без импортов Prisma/Redis** — валидатор и тесты переносимы без БД.
+- **`search.schema.loader.ts`** — Prisma+Redis loader для custom fields с 60с кэшем (ключ `search:custom-fields:enabled`). Изолирован от pure-core.
+- **`search.functions.ts`** — реестр из 25 MVP-функций из §5.4 ТЗ: identity (currentUser/membersOf), time (now/today/startOfX/endOfX × 4 единицы), sprints (openSprints/closedSprints/futureSprints), releases (4 функции), relations (linkedIssues/subtasksOf/epicIssues/myOpenIssues), checkpoint-functions (violatedCheckpoints/violatedCheckpointsOf/checkpointsAtRisk/checkpointsInState), checkpoint-context-only (releasePlannedDate/checkpointDeadline). Plus 3 Phase-2 функции (watched/voted/lastLogin) с явным rejection. **Чистые date-эваулюаторы** с offset-syntax `"-7d"/"1M"/"3h"`, calendar-aware month/year арифметика, ISO-week boundaries, UTC-детерминизм.
+- **`search.validator.ts`** — обход AST с накоплением ошибок (не short-circuit). Коды: UNKNOWN_FIELD, UNKNOWN_FUNCTION, OPERATOR_NOT_ALLOWED_FOR_FIELD, VALUE_TYPE_MISMATCH, ARITY_MISMATCH, PHASE_2_OPERATOR, PHASE_2_FUNCTION, FUNCTION_NOT_ALLOWED_IN_CONTEXT, AMBIGUOUS_CUSTOM_FIELD, CUSTOM_FIELD_UUID_UNKNOWN, CURRENTUSER_IN_CHECKPOINT (warning), INVALID_OFFSET_FORMAT. Разделение severity error/warning. `validate()` **никогда не бросает**.
+- **`search.router.ts`** — `POST /search/validate` (Zod-валидация body: `{jql, variant?}`) и `GET /search/schema?variant=default|checkpoint` заменили stubs на реальную реализацию. `POST /search/issues`, `POST /search/export`, `GET /search/suggest` остаются 501 до PR-5/6.
+
+### Тесты (341 passing, +148 к PR-2)
+
+- **`tests/search-functions.unit.test.ts`** (42 кейса) — resolveFunction case-insensitive, functionsForVariant filter, parseOffset/applyOffset calendar arithmetic, start/endOf{Day,Week,Month,Year} UTC-детерминизм (тестируются с anchor 2026-04-15 Wed), evaluatePureDateFn для 10 комбинаций, null для DB-зависимых функций.
+- **`tests/search-validator.unit.test.ts`** (106 кейсов) — happy path (12 запросов), unknown field/function, operator × field compatibility (4 случая), value type compatibility (4), function arity/arg-types (6), Phase-2 rejection (3), checkpoint variant (3, включая currentUser-warning), custom fields (5 — resolution by name/UUID, ambiguous, type propagation), ORDER BY sortable warning, и **golden-set round-trip — все 63 запроса парсятся И валидируются без ошибок**.
+
+### Изменения
+
+- `backend/src/modules/search/search.types.ts` — новый.
+- `backend/src/modules/search/search.schema.ts` — новый (pure).
+- `backend/src/modules/search/search.schema.loader.ts` — новый (Prisma+Redis).
+- `backend/src/modules/search/search.functions.ts` — новый.
+- `backend/src/modules/search/search.validator.ts` — новый.
+- `backend/src/modules/search/search.router.ts` — обновлён (live `/validate` и `/schema`).
+- `backend/tests/search-functions.unit.test.ts` — новый.
+- `backend/tests/search-validator.unit.test.ts` — новый.
+- `backend/package.json` — `test:parser` включает новые тесты.
+- `docs/tz/TTSRH-1.md` §13.9 — статус PR-3 → ✅ Done.
+
+### Влияние на prod
+
+0. Feature flag `FEATURES_ADVANCED_SEARCH=false` по-прежнему активен — эндпоинты под флагом. При включении `POST /api/search/validate` и `GET /api/search/schema` становятся доступны с типизированными ответами для UI-подсказок.
+
+### Проверки
+
+- `npx tsc --noEmit` — чисто
+- `npm run lint` — 0 errors, 0 new warnings
+- `npm run test:parser` — **341 passing** локально без Postgres/Redis
+- Golden-set 63/63 парсится и валидируется без ошибок
+- Pre-push review — в отдельном коммите
 
 ---
 


### PR DESCRIPTION
## Summary

TTSRH-1 PR-3 — семантический validator слой поверх AST из PR-2. `/search/validate` и `/search/schema` теперь живые. Field registry + function registry + type-compatibility checking. **HTTP-эндпоинты под feature flag** `FEATURES_ADVANCED_SEARCH=false` — продакшн не затронут.

- **`search.types.ts`** — общий словарь: `TtqlType` (21 variant), `TtqlOpKind` (17), `TtqlReturnType`, `QueryVariant`.
- **`search.schema.ts`** (pure-core, **0 Prisma/Redis imports**) — 33 system-поля из §5.2 ТЗ с synonyms/operators/sortable. `buildCustomFieldIndex` с R7 ambiguous-detection. Мапперы `CustomFieldType → TtqlType`.
- **`search.schema.loader.ts`** — Prisma+Redis loader (60с кэш) с try/catch на Redis errors — outage деградирует на прямой путь к Prisma, не 500-ит.
- **`search.functions.ts`** — 25 функций §5.4 (identity, time, sprints, releases, relations, 4 checkpoint, 2 KT-context-only, 3 Phase-2). Pure date evaluators: `parseOffset`, `applyOffset` (calendar-aware), `startOf*/endOf*Utc` (ISO-week, детерминизм). `functionsForVariant` фильтрует MVP + variant.
- **`search.validator.ts`** — обход AST с накоплением ошибок (13 стабильных codes). `validate()` никогда не бросает. Warning-уровень для `CURRENTUSER_IN_CHECKPOINT` (§5.12.4) и `ORDER_BY_NOT_SORTABLE` (новый код из pre-push review).
- **`search.router.ts`** — `POST /search/validate` (Zod body) и `GET /search/schema?variant=...` переведены из stub (501) в live. `args` маппятся в client-safe shape (OFFSET/ISSUE_KEY/ANY → TEXT). `POST /search/issues`, `POST /search/export`, `GET /search/suggest` остаются 501 до PR-5/6.

## Тесты — 342 passing (+149 к PR-2)

- **`tests/search-functions.unit.test.ts`** (42) — resolveFunction case-insensitive, functionsForVariant filter, parseOffset/applyOffset calendar arithmetic, start/endOf helpers UTC-детерминизм, evaluatePureDateFn.
- **`tests/search-validator.unit.test.ts`** (107) — happy path, 13 error codes с проверкой, checkpoint variant (включая CURRENTUSER_IN_CHECKPOINT warning), custom fields (resolution, ambiguous, UUID), ORDER_BY_NOT_SORTABLE для system и custom, golden-set round-trip 63/63.

## Pre-push review

Прогнал перед открытием. 🟠 2 · 🟡 4 · 🔵 2. Все применены в follow-up коммите:

- 🟠 `status.operators` — убраны WAS/CHANGED (латентный bug для PR-4 compiler).
- 🟠 `checkOpAllowed` — collapsed dead ternary.
- 🟡 `CustomFieldDef.sortable` обязательное (MVP false по §R13). ORDER BY validator расширен на custom fields.
- 🟡 Новый ValidationErrorCode `ORDER_BY_NOT_SORTABLE` — раньше переиспользовали VALUE_TYPE_MISMATCH, что семантически неверно.
- 🟡 `loadCustomFields` — try/catch на Redis errors.
- 🟡 `/search/schema` — args в client-safe shape.
- 🔵 `functionsForVariant` — добавлен filter phase==='MVP'.

## Test plan

- [x] Backend `npx tsc --noEmit` — чисто
- [x] Backend `npm run lint` — 0 errors, 0 new warnings
- [x] `npm run test:parser` — 342 passing локально без Postgres/Redis
- [x] Golden-set 63/63 parse + validate без ошибок
- [ ] Integration `npm test` в CI — с Postgres/Redis
- [ ] Manual: `POST /api/search/validate` с валидным jql → `{valid: true, errors: [], warnings, ast}`
- [ ] Manual: `POST /api/search/validate` с невалидным jql → правильный code + position
- [ ] Manual: `GET /api/search/schema?variant=default` возвращает fields + functions (без Phase-2)

## Зависимости

- **Зависит от:** PR-2 ([#101](https://github.com/NovakPAai/tasktime-mvp/pull/101)) — merged 🟢.
- **Следующий:** PR-4 (compiler) — AST → Prisma `IssueWhereInput` + custom-fields raw SQL.

## Плановая дельта

- Прогресс: **PR-3 / 21** по §13.9 ТЗ.
- Версия: 2.29 в [version_history.md](version_history.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
