### PR TITLE
feat(search): TTSRH-1 PR-4 — compiler (AST → Prisma + custom-field raw SQL + scope R3)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts tests/search-functions.unit.test.ts tests/search-validator.unit.test.ts",
+    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts tests/search-functions.unit.test.ts tests/search-validator.unit.test.ts tests/search-compiler.unit.test.ts",
     "lint": "eslint src/ --ext .ts",
     "format": "prettier --write 'src/**/*.ts'",
     "mcp": "tsx src/mcp/server.ts"

--- a/backend/src/modules/search/search.compile-context.ts
+++ b/backend/src/modules/search/search.compile-context.ts
@@ -1,0 +1,95 @@
+/**
+ * TTSRH-1 PR-4 — compile context + pre-resolved function outputs.
+ *
+ * The compiler is deliberately DB-agnostic: it consumes `CompileContext` with
+ * everything already resolved (user id, sprint ids, release ids, issue ids from
+ * `linkedIssues(...)` etc.). Async DB look-ups live in `search.function-resolver.ts`.
+ *
+ * This separation makes unit tests fast (no Postgres needed) and keeps the
+ * compiler itself a pure function — easy to audit for the R1 (SQL-injection)
+ * invariant: every identifier, every value, and every enum reaches Prisma
+ * through the typed Prisma input types, never through string concatenation.
+ */
+
+import type { CustomFieldDef } from './search.schema.js';
+import type { QueryVariant } from './search.types.js';
+
+/**
+ * Function call key — canonical, positional serialisation used to dedupe function
+ * calls within an AST. `membersOf("team")` and `membersOf("team")` must share a key;
+ * `membersOf("a")` and `membersOf("b")` must not.
+ *
+ * Format: `<lowercase-name>(<arg1>,<arg2>,...)` where each arg is JSON-stringified
+ * into a stable form (strings quoted, idents as-is). Only applied to function calls
+ * the validator has already accepted — malformed args won't reach here.
+ */
+export type FunctionCallKey = string;
+
+/** Pre-resolved outputs of function calls. Populated by `search.function-resolver.ts`. */
+export interface ResolvedFunctions {
+  /** Current user id — `null` in checkpoint variant (§5.12.4). */
+  currentUserId: string | null;
+  /**
+   * Map from function-call key to resolved value. Shape depends on function:
+   *   - `membersOf("x")` → `string[]` of user ids
+   *   - `openSprints()` → `string[]` of sprint ids
+   *   - `linkedIssues("TTMP-1", "blocks")` → `string[]` of issue ids
+   *   - date helpers are evaluated via `search.functions.evaluatePureDateFn` in the
+   *     compiler itself — no entry needed here.
+   */
+  calls: ReadonlyMap<FunctionCallKey, FunctionCallValue>;
+}
+
+/** A resolved function call: either a scalar or a list of primary-key ids. */
+export type FunctionCallValue =
+  | { kind: 'scalar-id'; id: string | null }     // currentUser() / earliestUnreleasedVersion()
+  | { kind: 'id-list'; ids: readonly string[] }  // openSprints() / linkedIssues()
+  | { kind: 'scalar-datetime'; value: Date }     // only for KT-context functions (Phase 2 wiring)
+  | { kind: 'resolve-failed'; reason: string };  // signals compiler to emit empty-set predicate
+
+/**
+ * Context passed to the compiler. Everything here is deterministic for a given
+ * request — no ambient globals, no mutable state.
+ */
+export interface CompileContext {
+  /**
+   * Project ids the caller may see. The compiler adds `{ projectId: { in: ... } }`
+   * at the top of every query (§5.5 + R3 ТЗ). Empty array = no access → compiler
+   * produces a where-clause that matches nothing.
+   */
+  accessibleProjectIds: readonly string[];
+  /** Custom-field registry (already loaded in the caller, typically via Redis cache). */
+  customFields: readonly CustomFieldDef[];
+  /** Pre-resolved DB-dependent function outputs. */
+  resolved: ResolvedFunctions;
+  /** Anchor `now` for date evaluators. Fixed per request — no Date.now() in compiler. */
+  now: Date;
+  /** `'default'` for user search, `'checkpoint'` for KT conditions. */
+  variant: QueryVariant;
+}
+
+/**
+ * Serialise a function call to its deduping key. Kept deterministic so repeated
+ * references inside one AST hit the same cache entry.
+ */
+export function buildFunctionCallKey(name: string, args: readonly FunctionCallArg[]): FunctionCallKey {
+  const encoded = args.map(encodeArg).join(',');
+  return `${name.toLowerCase()}(${encoded})`;
+}
+
+export type FunctionCallArg =
+  | { kind: 'string'; value: string }
+  | { kind: 'number'; value: number }
+  | { kind: 'ident'; name: string }
+  | { kind: 'bool'; value: boolean }
+  | { kind: 'null' };
+
+function encodeArg(a: FunctionCallArg): string {
+  switch (a.kind) {
+    case 'string': return JSON.stringify(a.value);
+    case 'number': return String(a.value);
+    case 'bool': return String(a.value);
+    case 'null': return 'null';
+    case 'ident': return `#${a.name.toLowerCase()}`;
+  }
+}

--- a/backend/src/modules/search/search.compiler.ts
+++ b/backend/src/modules/search/search.compiler.ts
@@ -1,0 +1,650 @@
+/**
+ * TTSRH-1 PR-4 — pure AST → Prisma compiler for TTS-QL.
+ *
+ * Responsibilities per §5.5 ТЗ:
+ *   - Translate AST clauses to `Prisma.IssueWhereInput`.
+ *   - Add the top-level scope filter `projectId IN (accessibleProjectIds)` (R3).
+ *   - Emit `CustomFieldPredicate` IR for custom-field clauses (executor resolves
+ *     these via raw SQL in `search.custom-field.ts`).
+ *   - Preserve booleans: each AST `Or` / `And` / `Not` becomes a
+ *     `{ OR: [...] }` / `{ AND: [...] }` / `{ NOT: ... }` Prisma node.
+ *   - ORDER BY → `Prisma.IssueOrderByWithRelationInput[]`.
+ *
+ * Security invariant (R1): **no string concatenation of values into SQL.**
+ * System fields go straight into Prisma typed inputs. Custom-field raw SQL lives
+ * in `search.custom-field.ts` and uses `Prisma.sql` exclusively — audited here
+ * at type level: this file must not import `Prisma.sql`.
+ */
+
+import type { Prisma } from '@prisma/client';
+import {
+  type AndNode,
+  type BoolExpr,
+  type ClauseNode,
+  type Expr,
+  type FieldRef,
+  type FunctionCall,
+  type Literal,
+  type NotNode,
+  type OrNode,
+  type QueryNode,
+  type SortItem,
+} from './search.ast.js';
+import type { CompileContext, FunctionCallValue } from './search.compile-context.js';
+import { buildFunctionCallKey, type FunctionCallArg } from './search.compile-context.js';
+import { evaluatePureDateFn, parseOffset } from './search.functions.js';
+import type { CustomFieldDef } from './search.schema.js';
+import { resolveSystemField } from './search.schema.js';
+import type { TtqlType } from './search.types.js';
+import type { CustomFieldPredicate } from './search.custom-field.js';
+import { compileCustomFieldClause } from './search.custom-field.js';
+
+// ─── Result types ───────────────────────────────────────────────────────────
+
+export type CompileIssueCode =
+  | 'UNRESOLVED_FUNCTION'
+  | 'UNRESOLVED_FIELD'
+  | 'UNRESOLVED_VALUE'
+  | 'UNSUPPORTED_OP'
+  | 'AGGREGATE_NOT_SUPPORTED'
+  | 'COMPUTED_FIELD_NOT_SUPPORTED'
+  | 'DATE_PARSE_FAILED';
+
+export interface CompileIssue {
+  code: CompileIssueCode;
+  message: string;
+  hint?: string;
+  /** Not a character offset — references the AST node label since the compiler
+   *  has already consumed the source positions via validator errors. */
+  field?: string;
+}
+
+export interface CompileResult {
+  /**
+   * Typed Prisma where input for system fields + function-resolved predicates.
+   * Already includes the scope filter (R3). Combine with
+   * `{ id: { in: customPredicateResult } }` at execution time.
+   */
+  where: Prisma.IssueWhereInput;
+  orderBy: Prisma.IssueOrderByWithRelationInput[];
+  /**
+   * Custom-field predicates. Each item is an opaque `Prisma.Sql` that, when run
+   * as `$queryRaw`, returns a list of matching `issues.id`. The executor (PR-5)
+   * runs each once, caches, and stitches the result back into `where.AND`.
+   *
+   * Multiple clauses referencing the same CF produce separate predicates — the
+   * compiler doesn't deduplicate, because AND/OR structure depends on boolean
+   * context.
+   */
+  customPredicates: CustomFieldPredicate[];
+  /** Non-fatal warnings (missing enum resolution, degenerate ORDER BY). */
+  warnings: CompileIssue[];
+  /** Fatal — the compiler returns a where-clause that matches nothing. */
+  errors: CompileIssue[];
+}
+
+// ─── Entry point ────────────────────────────────────────────────────────────
+
+/**
+ * Compile a parsed+validated AST to a Prisma query. Never throws — on internal
+ * trouble returns `{ where: { id: 'never' }, errors: [...] }` so downstream DB
+ * work short-circuits cleanly.
+ */
+export function compile(ast: QueryNode, ctx: CompileContext): CompileResult {
+  const builder = new Builder(ctx);
+  const inner = ast.where ? builder.compileBool(ast.where) : null;
+  const scope: Prisma.IssueWhereInput = {
+    projectId: { in: [...ctx.accessibleProjectIds] },
+  };
+  const where: Prisma.IssueWhereInput =
+    inner === null
+      ? scope
+      : { AND: [scope, inner] };
+  const orderBy = ast.orderBy.flatMap((s) => builder.compileSort(s));
+  return {
+    where,
+    orderBy,
+    customPredicates: builder.customPredicates,
+    warnings: builder.warnings,
+    errors: builder.errors,
+  };
+}
+
+// ─── Compiler state ─────────────────────────────────────────────────────────
+
+class Builder {
+  readonly customPredicates: CustomFieldPredicate[] = [];
+  readonly warnings: CompileIssue[] = [];
+  readonly errors: CompileIssue[] = [];
+  private cfCounter = 0;
+
+  constructor(private readonly ctx: CompileContext) {}
+
+  compileBool(node: BoolExpr): Prisma.IssueWhereInput | null {
+    switch (node.kind) {
+      case 'Or': return this.compileOr(node);
+      case 'And': return this.compileAnd(node);
+      case 'Not': return this.compileNot(node);
+      case 'Clause': return this.compileClause(node);
+    }
+  }
+
+  private compileOr(node: OrNode): Prisma.IssueWhereInput {
+    const children = node.children
+      .map((c) => this.compileBool(c))
+      .filter(nonNull);
+    if (children.length === 0) return MATCH_NONE;
+    if (children.length === 1) return children[0]!;
+    return { OR: children };
+  }
+
+  private compileAnd(node: AndNode): Prisma.IssueWhereInput {
+    const children = node.children
+      .map((c) => this.compileBool(c))
+      .filter(nonNull);
+    if (children.length === 0) return MATCH_ALL;
+    if (children.length === 1) return children[0]!;
+    return { AND: children };
+  }
+
+  private compileNot(node: NotNode): Prisma.IssueWhereInput {
+    const child = this.compileBool(node.child);
+    if (!child) return MATCH_ALL;
+    return { NOT: child };
+  }
+
+  // ─── Clause compilation ──────────────────────────────────────────────────
+
+  private compileClause(c: ClauseNode): Prisma.IssueWhereInput | null {
+    // Custom field?
+    const custom = this.resolveCustomField(c.field);
+    if (custom) {
+      return this.compileCustomClause(c, custom);
+    }
+    // System field
+    const systemField = this.resolveSystem(c.field);
+    if (!systemField) {
+      this.errors.push({
+        code: 'UNRESOLVED_FIELD',
+        message: `Field \`${fieldLabel(c.field)}\` is not a system field and no matching custom field was provided.`,
+        field: fieldLabel(c.field),
+      });
+      return MATCH_NONE;
+    }
+    return compileSystemClause(c, systemField, this);
+  }
+
+  private compileCustomClause(c: ClauseNode, cf: CustomFieldDef): Prisma.IssueWhereInput {
+    const alias = `cf_${this.cfCounter++}`;
+    const compiled = compileCustomFieldClause(c, cf, alias, this.ctx, this);
+    if (compiled.errors.length > 0) {
+      this.errors.push(...compiled.errors);
+      return MATCH_NONE;
+    }
+    this.customPredicates.push(compiled.predicate);
+    // Placeholder: at executor time this turns into `{ id: { in: predicateIdSet } }`.
+    // We keep a sentinel `{ id: { in: [alias] } }` so the shape of the where-input
+    // is structurally complete; the executor replaces the alias list with real ids.
+    return { [PLACEHOLDER_KEY]: alias } as unknown as Prisma.IssueWhereInput;
+  }
+
+  // ─── Field resolution helpers ────────────────────────────────────────────
+
+  private resolveCustomField(ref: FieldRef): CustomFieldDef | null {
+    if (ref.kind === 'CustomField') {
+      return this.ctx.customFields.find((f) => f.id === ref.uuid) ?? null;
+    }
+    if (ref.kind === 'QuotedField') {
+      // Prefer system over custom when a quoted name collides (system wins; validator
+      // already warned about ambiguity if any).
+      if (resolveSystemField(ref.name)) return null;
+      const lc = ref.name.toLowerCase();
+      const hits = this.ctx.customFields.filter((f) => f.name.toLowerCase() === lc);
+      return hits.length === 1 ? hits[0]! : null;
+    }
+    return null;
+  }
+
+  private resolveSystem(ref: FieldRef) {
+    if (ref.kind === 'Ident' || ref.kind === 'QuotedField') {
+      return resolveSystemField(ref.kind === 'Ident' ? ref.name : ref.name);
+    }
+    return null;
+  }
+
+  // ─── ORDER BY ────────────────────────────────────────────────────────────
+
+  compileSort(s: SortItem): Prisma.IssueOrderByWithRelationInput[] {
+    const f = this.resolveSystem(s.field);
+    if (!f || !f.sortable) return []; // validator already warned; skip silently here
+    const dir = s.direction.toLowerCase() as 'asc' | 'desc';
+    const col = SYSTEM_FIELD_SORT_COLUMN[f.name];
+    if (!col) return [];
+    return [{ [col]: dir } as Prisma.IssueOrderByWithRelationInput];
+  }
+
+  // ─── Function-call evaluation ────────────────────────────────────────────
+
+  /** Returns a primary-key value for the given function call, or null on failure. */
+  resolveFunctionCall(call: FunctionCall): FunctionCallValue {
+    const lcName = call.name.toLowerCase();
+
+    // Pure date helpers — evaluated directly.
+    if (isPureDateFn(lcName)) {
+      const offsetArg = call.args[0];
+      let offset: ReturnType<typeof parseOffset> | null = null;
+      if (offsetArg) {
+        if (offsetArg.kind === 'String') offset = parseOffset(offsetArg.value);
+        else if (offsetArg.kind === 'RelativeDate') offset = parseOffset(offsetArg.raw);
+      }
+      const value = evaluatePureDateFn(lcName, offset, { now: this.ctx.now });
+      if (!value) {
+        return { kind: 'resolve-failed', reason: `Date function \`${call.name}\` could not be evaluated.` };
+      }
+      return { kind: 'scalar-datetime', value };
+    }
+
+    // currentUser() — compiler variant maps directly to ctx.
+    if (lcName === 'currentuser') {
+      return { kind: 'scalar-id', id: this.ctx.resolved.currentUserId };
+    }
+
+    // Everything else — look up pre-resolved outputs.
+    const key = buildFunctionCallKey(call.name, call.args.map(argToKey));
+    const resolved = this.ctx.resolved.calls.get(key);
+    if (!resolved) {
+      return {
+        kind: 'resolve-failed',
+        reason: `Function \`${call.name}()\` was not pre-resolved — caller must pass it in \`ctx.resolved.calls\`.`,
+      };
+    }
+    return resolved;
+  }
+}
+
+// ─── System-field clause compiler ───────────────────────────────────────────
+
+interface SystemContext {
+  resolveFunctionCall(call: FunctionCall): FunctionCallValue;
+  ctx: CompileContext;
+  warnings: CompileIssue[];
+  errors: CompileIssue[];
+}
+
+function compileSystemClause(
+  c: ClauseNode,
+  field: { name: string; type: TtqlType; sortable: boolean },
+  builder: Builder,
+): Prisma.IssueWhereInput | null {
+  const sysCtx: SystemContext = {
+    resolveFunctionCall: (call) => builder.resolveFunctionCall(call),
+    ctx: (builder as unknown as { ctx: CompileContext }).ctx,
+    warnings: builder.warnings,
+    errors: builder.errors,
+  };
+
+  switch (c.op.kind) {
+    case 'Compare':
+      return compileCompare(field, c.op.op, c.op.value, sysCtx);
+    case 'In':
+      return compileIn(field, c.op.negated, c.op.values, sysCtx);
+    case 'InFunction':
+      return compileInFunction(field, c.op.negated, c.op.func, sysCtx);
+    case 'IsEmpty':
+      return compileIsEmpty(field, c.op.negated);
+    case 'History':
+      // Validator already rejected these. Defensive: compile as match-none so the
+      // query stays structurally valid even if someone skips the validator.
+      builder.errors.push({ code: 'UNSUPPORTED_OP', message: 'History operators (WAS/CHANGED) are not supported by the compiler yet.' });
+      return MATCH_NONE;
+  }
+}
+
+// ─── Compare ────────────────────────────────────────────────────────────────
+
+function compileCompare(
+  field: { name: string; type: TtqlType },
+  op: string,
+  valueExpr: Expr,
+  ctx: SystemContext,
+): Prisma.IssueWhereInput {
+  const col = SYSTEM_FIELD_COLUMN[field.name];
+  if (!col) {
+    ctx.errors.push({ code: 'UNRESOLVED_FIELD', message: `No Prisma column mapping for \`${field.name}\`.`, field: field.name });
+    return MATCH_NONE;
+  }
+
+  const value = evaluateValue(valueExpr, field.type, ctx);
+  if (value.kind === 'error') {
+    ctx.errors.push({ code: 'UNRESOLVED_VALUE', message: value.message, field: field.name });
+    return MATCH_NONE;
+  }
+
+  // Text fields with `~` / `!~`
+  if (op === '~' || op === '!~') {
+    if (value.kind !== 'string') {
+      ctx.errors.push({ code: 'UNRESOLVED_VALUE', message: `Operator \`${op}\` expects a string, got ${value.kind}.`, field: field.name });
+      return MATCH_NONE;
+    }
+    // Slice to 200 chars to align with the Redis-key limit in issues.service.ts — a
+    // defense against absurdly long predicates bloating the query plan.
+    const predicate = {
+      contains: value.value.slice(0, 200),
+      mode: 'insensitive' as const,
+    };
+    const where = wrapColumn(col, predicate);
+    return op === '~' ? where : { NOT: where };
+  }
+
+  // Comparisons
+  const comparator = toPrismaComparator(op);
+  if (!comparator) {
+    ctx.errors.push({ code: 'UNSUPPORTED_OP', message: `Unknown comparator ${op}.`, field: field.name });
+    return MATCH_NONE;
+  }
+
+  // EQ / NEQ can produce `{ col: value }` or `{ col: { not: value } }`
+  const rhs = valueKindToPrisma(value, field.type, ctx);
+  if (rhs === null) return MATCH_NONE;
+
+  if (comparator === 'eq') return wrapColumn(col, rhs);
+  if (comparator === 'neq') return wrapColumn(col, { not: rhs });
+
+  // Range comparators — a generic `{ [op]: value }` filter. Prisma's IntFilter /
+  // DateTimeFilter / DecimalFilter all accept this shape, so a single cast into
+  // `IssueWhereInput` is safe across all numeric/date columns.
+  return wrapColumn(col, { [comparator]: rhs });
+}
+
+// ─── IN ─────────────────────────────────────────────────────────────────────
+
+function compileIn(
+  field: { name: string; type: TtqlType },
+  negated: boolean,
+  values: Expr[],
+  ctx: SystemContext,
+): Prisma.IssueWhereInput {
+  const col = SYSTEM_FIELD_COLUMN[field.name];
+  if (!col) {
+    ctx.errors.push({ code: 'UNRESOLVED_FIELD', message: `No column for \`${field.name}\`.`, field: field.name });
+    return MATCH_NONE;
+  }
+  const resolved = values.map((v) => evaluateValue(v, field.type, ctx));
+  const erroring = resolved.filter((r) => r.kind === 'error');
+  if (erroring.length > 0) {
+    for (const e of erroring) {
+      if (e.kind === 'error') ctx.errors.push({ code: 'UNRESOLVED_VALUE', message: e.message, field: field.name });
+    }
+    return MATCH_NONE;
+  }
+
+  const primitives = resolved.flatMap((r) => flattenResolvedValue(r));
+  if (primitives.length === 0) return MATCH_NONE;
+
+  const where = wrapColumn(col, { in: primitives });
+  return negated ? { NOT: where } : where;
+}
+
+function compileInFunction(
+  field: { name: string; type: TtqlType },
+  negated: boolean,
+  func: FunctionCall,
+  ctx: SystemContext,
+): Prisma.IssueWhereInput {
+  const col = SYSTEM_FIELD_COLUMN[field.name];
+  if (!col) {
+    ctx.errors.push({ code: 'UNRESOLVED_FIELD', message: `No column for \`${field.name}\`.`, field: field.name });
+    return MATCH_NONE;
+  }
+  const resolved = ctx.resolveFunctionCall(func);
+  if (resolved.kind === 'resolve-failed') {
+    ctx.errors.push({ code: 'UNRESOLVED_FUNCTION', message: resolved.reason, field: func.name });
+    return MATCH_NONE;
+  }
+  const ids = resolved.kind === 'id-list' ? resolved.ids : resolved.kind === 'scalar-id' && resolved.id ? [resolved.id] : [];
+  if (ids.length === 0) return negated ? MATCH_ALL : MATCH_NONE;
+  const where = wrapColumn(col, { in: [...ids] });
+  return negated ? { NOT: where } : where;
+}
+
+// ─── IS [NOT] EMPTY ─────────────────────────────────────────────────────────
+
+function compileIsEmpty(field: { name: string; type: TtqlType }, negated: boolean): Prisma.IssueWhereInput {
+  const col = SYSTEM_FIELD_COLUMN[field.name];
+  if (!col) return MATCH_NONE;
+  const rhs = negated ? { not: null } : null;
+  return wrapColumn(col, rhs);
+}
+
+// ─── Value evaluator ────────────────────────────────────────────────────────
+
+/**
+ * Evaluator output. Distinguishes raw value kinds so we can map to the correct
+ * Prisma filter family (numeric vs date vs string vs boolean).
+ */
+export type EvaluatedValue =
+  | { kind: 'string'; value: string }
+  | { kind: 'number'; value: number }
+  | { kind: 'datetime'; value: Date }
+  | { kind: 'bool'; value: boolean }
+  | { kind: 'null' }
+  | { kind: 'id-list'; ids: readonly string[] }       // function result, multi-id
+  | { kind: 'scalar-id'; id: string | null }          // function result, single id
+  | { kind: 'error'; message: string };
+
+function evaluateValue(expr: Expr, fieldType: TtqlType, ctx: SystemContext): EvaluatedValue {
+  if (expr.kind === 'Function') {
+    const fn = ctx.resolveFunctionCall(expr);
+    switch (fn.kind) {
+      case 'scalar-id':
+        return { kind: 'scalar-id', id: fn.id };
+      case 'id-list':
+        return { kind: 'id-list', ids: fn.ids };
+      case 'scalar-datetime':
+        return { kind: 'datetime', value: fn.value };
+      case 'resolve-failed':
+        return { kind: 'error', message: fn.reason };
+    }
+  }
+  return literalToValue(expr, fieldType, ctx);
+}
+
+function literalToValue(lit: Literal, fieldType: TtqlType, ctx: SystemContext): EvaluatedValue {
+  switch (lit.kind) {
+    case 'Null':
+    case 'Empty':
+      return { kind: 'null' };
+    case 'Bool':
+      return { kind: 'bool', value: lit.value };
+    case 'Number':
+      return { kind: 'number', value: lit.value };
+    case 'String':
+      // DATE/DATETIME: string might be an ISO date, a "-7d" relative offset, or a
+      // date-ish token. Try ISO first, then offset-from-now.
+      if (fieldType === 'DATE' || fieldType === 'DATETIME') {
+        const parsed = parseDateString(lit.value, ctx.ctx.now);
+        if (parsed) return { kind: 'datetime', value: parsed };
+        return { kind: 'error', message: `Cannot parse \`"${lit.value}"\` as a date.` };
+      }
+      return { kind: 'string', value: lit.value };
+    case 'RelativeDate': {
+      const parsed = parseRelativeDate(lit.raw, ctx.ctx.now);
+      if (parsed) return { kind: 'datetime', value: parsed };
+      return { kind: 'error', message: `Cannot parse relative date \`${lit.raw}\`.` };
+    }
+    case 'Ident':
+      return { kind: 'string', value: lit.name };
+  }
+}
+
+function parseDateString(value: string, now: Date): Date | null {
+  // Check for relative-date format first: `7d`, `-7d`, `2w` etc.
+  const relative = parseRelativeDate(value, now);
+  if (relative) return relative;
+  const asDate = new Date(value);
+  if (Number.isFinite(asDate.getTime())) return asDate;
+  return null;
+}
+
+function parseRelativeDate(raw: string, now: Date): Date | null {
+  const offset = parseOffset(raw);
+  if (!offset) return null;
+  const d = new Date(now.getTime());
+  switch (offset.unit) {
+    case 'h': d.setUTCHours(d.getUTCHours() + offset.amount); break;
+    case 'm': d.setUTCMinutes(d.getUTCMinutes() + offset.amount); break;
+    case 'd': d.setUTCDate(d.getUTCDate() + offset.amount); break;
+    case 'w': d.setUTCDate(d.getUTCDate() + offset.amount * 7); break;
+    case 'M': d.setUTCMonth(d.getUTCMonth() + offset.amount); break;
+    case 'y': d.setUTCFullYear(d.getUTCFullYear() + offset.amount); break;
+  }
+  return d;
+}
+
+/**
+ * Convert an `EvaluatedValue` to a Prisma-compatible primitive (string / number /
+ * Date / boolean / null) for use as the RHS of EQ/NEQ/range comparators.
+ */
+function valueKindToPrisma(value: EvaluatedValue, fieldType: TtqlType, ctx: SystemContext): unknown {
+  switch (value.kind) {
+    case 'null': return null;
+    case 'string':
+      // STATUS / PRIORITY / TYPE — may need enum mapping. For MVP, pass the upper-
+      // case string value directly; Prisma's String filter will match.
+      if (fieldType === 'PRIORITY' || fieldType === 'AI_STATUS' || fieldType === 'AI_ASSIGNEE_TYPE' || fieldType === 'STATUS_CATEGORY') {
+        return value.value.toUpperCase();
+      }
+      return value.value;
+    case 'number': return value.value;
+    case 'bool': return value.value;
+    case 'datetime': return value.value;
+    case 'scalar-id': return value.id;
+    case 'id-list':
+      ctx.errors.push({ code: 'UNRESOLVED_VALUE', message: 'A list value was used where a scalar was expected.' });
+      return null;
+    case 'error': return null;
+  }
+}
+
+function flattenResolvedValue(v: EvaluatedValue): (string | number | Date | boolean | null)[] {
+  switch (v.kind) {
+    case 'null': return [null];
+    case 'string': return [v.value];
+    case 'number': return [v.value];
+    case 'bool': return [v.value];
+    case 'datetime': return [v.value];
+    case 'scalar-id': return v.id ? [v.id] : [];
+    case 'id-list': return [...v.ids];
+    case 'error': return [];
+  }
+}
+
+// ─── Prisma column map (system fields → Issue columns) ──────────────────────
+
+/**
+ * Map a TTS-QL system-field canonical name to a Prisma `IssueWhereInput` key.
+ * Kept as a plain object for easy audit — every entry here is a non-derived,
+ * directly-queryable column on the `issues` table. Derived fields (timeSpent,
+ * timeRemaining, hasChildren) are deferred to PR-5 via raw SQL.
+ */
+const SYSTEM_FIELD_COLUMN: Record<string, string> = {
+  project: 'projectId',
+  key: 'id',
+  summary: 'title',
+  description: 'description',
+  status: 'status',
+  priority: 'priority',
+  type: 'issueTypeConfigId',
+  assignee: 'assigneeId',
+  reporter: 'creatorId',
+  sprint: 'sprintId',
+  release: 'releaseId',
+  parent: 'parentId',
+  epic: 'parentId',
+  due: 'dueDate',
+  created: 'createdAt',
+  updated: 'updatedAt',
+  estimatedhours: 'estimatedHours',
+  orderindex: 'orderIndex',
+  aieligible: 'aiEligible',
+  aistatus: 'aiExecutionStatus',
+  aiassigneetype: 'aiAssigneeType',
+  issue: 'id',
+};
+
+const SYSTEM_FIELD_SORT_COLUMN: Record<string, string> = {
+  project: 'projectId',
+  key: 'id',
+  summary: 'title',
+  status: 'status',
+  priority: 'priority',
+  type: 'issueTypeConfigId',
+  assignee: 'assigneeId',
+  reporter: 'creatorId',
+  sprint: 'sprintId',
+  release: 'releaseId',
+  due: 'dueDate',
+  created: 'createdAt',
+  updated: 'updatedAt',
+  estimatedhours: 'estimatedHours',
+  orderindex: 'orderIndex',
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const MATCH_NONE: Prisma.IssueWhereInput = { id: { in: [] } };
+const MATCH_ALL: Prisma.IssueWhereInput = {};
+export const PLACEHOLDER_KEY = '__ttql_custom_predicate__';
+
+function wrapColumn(col: string, predicate: unknown): Prisma.IssueWhereInput {
+  // The compiler intentionally widens predicate types to `unknown` here — by the
+  // time we reach this helper, `col` is one of the audited `SYSTEM_FIELD_COLUMN`
+  // keys (a static, non-user-driven set) and `predicate` is a Prisma-shaped filter
+  // produced by typed paths above. Prisma validates at runtime; strict static
+  // typing would require a giant per-column switch for marginal benefit.
+  return { [col]: predicate } as Prisma.IssueWhereInput;
+}
+
+function toPrismaComparator(op: string): 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | null {
+  switch (op) {
+    case '=': return 'eq';
+    case '!=': return 'neq';
+    case '>': return 'gt';
+    case '>=': return 'gte';
+    case '<': return 'lt';
+    case '<=': return 'lte';
+    default: return null;
+  }
+}
+
+function isPureDateFn(lcName: string): boolean {
+  return (
+    lcName === 'now' ||
+    lcName === 'today' ||
+    lcName.startsWith('startof') ||
+    lcName.startsWith('endof')
+  );
+}
+
+function argToKey(e: Expr): FunctionCallArg {
+  switch (e.kind) {
+    case 'String': return { kind: 'string', value: e.value };
+    case 'Number': return { kind: 'number', value: e.value };
+    case 'Bool':   return { kind: 'bool', value: e.value };
+    case 'Null':
+    case 'Empty':  return { kind: 'null' };
+    case 'Ident':  return { kind: 'ident', name: e.name };
+    case 'RelativeDate': return { kind: 'string', value: e.raw };
+    case 'Function': return { kind: 'string', value: `${e.name}(...)` };
+  }
+}
+
+function fieldLabel(ref: FieldRef): string {
+  if (ref.kind === 'CustomField') return `cf[${ref.uuid}]`;
+  if (ref.kind === 'QuotedField') return `"${ref.name}"`;
+  return ref.name;
+}
+
+function nonNull<T>(x: T | null): x is T {
+  return x !== null;
+}

--- a/backend/src/modules/search/search.compiler.ts
+++ b/backend/src/modules/search/search.compiler.ts
@@ -596,6 +596,23 @@ const MATCH_NONE: Prisma.IssueWhereInput = { id: { in: [] } };
 const MATCH_ALL: Prisma.IssueWhereInput = {};
 export const PLACEHOLDER_KEY = '__ttql_custom_predicate__';
 
+/**
+ * Assert that the given `where` contains no unresolved custom-field placeholders.
+ * Callable from the executor (PR-5) as a development-time guard — if PR-5's
+ * substitution logic has a wiring gap, Prisma would either silently ignore the
+ * unknown key (dropping the CF predicate — a correctness bug) or throw at
+ * runtime; this assertion catches the mistake loudly at test time instead.
+ */
+export function assertNoUnresolvedPlaceholders(where: Prisma.IssueWhereInput): void {
+  const serialised = JSON.stringify(where);
+  if (serialised.includes(PLACEHOLDER_KEY)) {
+    throw new Error(
+      `BUG: unresolved TTS-QL custom-field placeholder in where-input (\`${PLACEHOLDER_KEY}\`). ` +
+        `Executor must substitute every CustomFieldPredicate alias before querying Prisma.`,
+    );
+  }
+}
+
 function wrapColumn(col: string, predicate: unknown): Prisma.IssueWhereInput {
   // The compiler intentionally widens predicate types to `unknown` here — by the
   // time we reach this helper, `col` is one of the audited `SYSTEM_FIELD_COLUMN`

--- a/backend/src/modules/search/search.custom-field.ts
+++ b/backend/src/modules/search/search.custom-field.ts
@@ -59,8 +59,8 @@ export function compileCustomFieldClause(
   builder: FunctionResolver,
 ): CustomClauseCompiled {
   const errors: CompileIssue[] = [];
-  const empty = (reason: string): CustomClauseCompiled => {
-    errors.push({ code: 'UNRESOLVED_VALUE', message: reason, field: cf.name });
+  const empty = (reason: string, code: CompileIssue['code'] = 'UNRESOLVED_VALUE'): CustomClauseCompiled => {
+    errors.push({ code, message: reason, field: cf.name });
     return {
       predicate: {
         alias,
@@ -139,20 +139,38 @@ function buildCompareSql(
   }
 
   // For LABEL / MULTI_SELECT — EQ / NEQ checks membership in the JSON array.
+  // Storage format per issue-custom-fields.service.ts: `{ "v": ["tag1", "tag2"] }`.
+  // The containment operator `@>` must descend into `value->'v'` — applying it on
+  // the outer wrapper `{ "v": [...] }` against a bare string would always be false.
   if ((cf.fieldType === 'LABEL' || cf.fieldType === 'MULTI_SELECT') && (op === '=' || op === '!=')) {
-    const containment = Prisma.sql`icfv.value @> to_jsonb(${value}::text)`;
+    const containment = Prisma.sql`(icfv.value->'v') @> to_jsonb(${value}::text)`;
     const body = op === '=' ? containment : Prisma.sql`NOT (${containment})`;
     return selectWhere(cf.id, body);
   }
 
-  // Default: comparator on typed body.
+  // Default: comparator on typed body. `COMPARATOR_SQL` is a constant map of
+  // `Prisma.Sql` so we never call `Prisma.raw()` on user-adjacent input (R1).
   const body = valueTypedForCompare(cf.fieldType, value);
   if (!body) return null;
-  const comparator = sqlComparator(op);
-  if (!comparator) return null;
-  const filter = Prisma.sql`${body} ${Prisma.raw(comparator)} ${value}`;
+  const comparatorSql = COMPARATOR_SQL[op];
+  if (!comparatorSql) return null;
+  const filter = Prisma.sql`${body} ${comparatorSql} ${value}`;
   return selectWhere(cf.id, filter);
 }
+
+/**
+ * Whitelist of SQL comparator operators. Typed as `Prisma.Sql` so interpolation
+ * into `Prisma.sql\`...\`` templates is safe — no `Prisma.raw()` call site exists
+ * in this module, eliminating an R1 audit surface.
+ */
+const COMPARATOR_SQL: Record<string, Prisma.Sql> = {
+  '=':  Prisma.sql`=`,
+  '!=': Prisma.sql`<>`,
+  '>':  Prisma.sql`>`,
+  '>=': Prisma.sql`>=`,
+  '<':  Prisma.sql`<`,
+  '<=': Prisma.sql`<=`,
+};
 
 function buildInSql(
   cf: CustomFieldDef,
@@ -167,8 +185,9 @@ function buildInSql(
     resolved.push(r);
   }
   // LABEL/MULTI_SELECT — match if any of the values is contained in the array.
+  // See buildCompareSql for the `value->'v'` descent rationale.
   if (cf.fieldType === 'LABEL' || cf.fieldType === 'MULTI_SELECT') {
-    const orParts = resolved.map((v) => Prisma.sql`icfv.value @> to_jsonb(${v as string}::text)`);
+    const orParts = resolved.map((v) => Prisma.sql`(icfv.value->'v') @> to_jsonb(${v as string}::text)`);
     const joined = Prisma.join(orParts, ' OR ');
     return selectWhere(cf.id, joined);
   }
@@ -228,18 +247,6 @@ function valueTypedForCompare(ft: CustomFieldType, sample: unknown): Prisma.Sql 
   }
 }
 
-function sqlComparator(op: string): string | null {
-  switch (op) {
-    case '=': return '=';
-    case '!=': return '<>';
-    case '>': return '>';
-    case '>=': return '>=';
-    case '<': return '<';
-    case '<=': return '<=';
-    default: return null;
-  }
-}
-
 function selectWhere(cfId: string, filter: Prisma.Sql): Prisma.Sql {
   return Prisma.sql`SELECT icfv.issue_id FROM issue_custom_field_values icfv WHERE icfv.custom_field_id = ${cfId}::uuid AND (${filter})`;
 }
@@ -265,8 +272,11 @@ function literalToSqlValue(expr: Expr, ft: CustomFieldType, builder: FunctionRes
       }
       return expr.value;
     case 'RelativeDate': {
-      // Not supported directly on custom-field values in MVP (compiler lacks `now`
-      // here). Caller should switch to `startOfDay("-7d")` or explicit ISO date.
+      // Deliberately not supported in MVP on custom-field values. The compiler
+      // doesn't thread `now` into this module yet; switching CF clauses to
+      // `startOfDay("-7d")` or an explicit ISO date is the recommended fix. The
+      // caller surfaces a DATE_PARSE_FAILED error instead of silently matching
+      // nothing.
       return undefined;
     }
     case 'Ident':

--- a/backend/src/modules/search/search.custom-field.ts
+++ b/backend/src/modules/search/search.custom-field.ts
@@ -1,0 +1,275 @@
+/**
+ * TTSRH-1 PR-4 — custom-field clause compiler.
+ *
+ * Custom-field values live in `issue_custom_field_values.value` (JSONB). Prisma
+ * can't express JSON comparisons typed-fully, so we emit parameterised `Prisma.sql`
+ * fragments that the executor runs via `$queryRaw` to get matching `issue_id`s,
+ * then stitches into the parent query via `{ id: { in: ... } }`.
+ *
+ * Security invariant (R1): every value reaches the SQL through `${...}` Prisma
+ * interpolation, which quotes with PG-native escape rules. **No string concat of
+ * user input.** Custom-field IDs are UUIDs from `ctx.customFields[].id` — also
+ * parameterised, never interpolated.
+ */
+
+import { Prisma, type CustomFieldType } from '@prisma/client';
+import type { ClauseNode, Expr, FunctionCall } from './search.ast.js';
+import type { CompileContext, FunctionCallValue } from './search.compile-context.js';
+import type { CustomFieldDef } from './search.schema.js';
+import type { CompileIssue } from './search.compiler.js';
+
+/**
+ * Intermediate representation of a custom-field predicate. The executor (PR-5)
+ * interprets these: runs `rawSql` with `$queryRaw`, gets a list of `issue_id`s,
+ * and replaces `{ __ttql_custom_predicate__: alias }` placeholders in the
+ * Prisma where-input with `{ id: { in: theseIds } }`.
+ */
+export interface CustomFieldPredicate {
+  alias: string;
+  customFieldId: string;
+  /** If true, executor wraps the id-set in `{ NOT: { id: { in: ... } } }`. */
+  negated: boolean;
+  /** Ready-to-execute `SELECT issue_id FROM issue_custom_field_values WHERE ...`. */
+  rawSql: Prisma.Sql;
+}
+
+export interface CustomClauseCompiled {
+  predicate: CustomFieldPredicate;
+  errors: CompileIssue[];
+}
+
+/**
+ * Compile a single clause whose LHS is a custom field into a `Prisma.Sql`
+ * fragment. Returns a predicate + any non-fatal errors (fatal errors produce an
+ * empty predicate that matches nothing).
+ */
+/**
+ * Function-call resolver interface. Typed as a small shape to avoid a circular
+ * import with `search.compiler.ts` (where the concrete resolver lives).
+ */
+export interface FunctionResolver {
+  resolveFunctionCall(fn: FunctionCall): FunctionCallValue;
+}
+
+export function compileCustomFieldClause(
+  c: ClauseNode,
+  cf: CustomFieldDef,
+  alias: string,
+  ctx: CompileContext,
+  builder: FunctionResolver,
+): CustomClauseCompiled {
+  const errors: CompileIssue[] = [];
+  const empty = (reason: string): CustomClauseCompiled => {
+    errors.push({ code: 'UNRESOLVED_VALUE', message: reason, field: cf.name });
+    return {
+      predicate: {
+        alias,
+        customFieldId: cf.id,
+        negated: false,
+        rawSql: Prisma.sql`SELECT NULL::text WHERE FALSE`,
+      },
+      errors,
+    };
+  };
+
+  switch (c.op.kind) {
+    case 'Compare': {
+      const sql = buildCompareSql(cf, c.op.op, c.op.value, builder);
+      if (!sql) return empty(`Cannot compile ${c.op.op} on custom field \`${cf.name}\`.`);
+      return wrap(sql, alias, cf.id, false, errors);
+    }
+    case 'In': {
+      const sql = buildInSql(cf, c.op.values, builder);
+      if (!sql) return empty(`Cannot compile IN on custom field \`${cf.name}\`.`);
+      return wrap(sql, alias, cf.id, c.op.negated, errors);
+    }
+    case 'InFunction': {
+      // cf IN funcCall() — not a real-world pattern for custom fields in MVP.
+      return empty(`IN funcCall() on a custom field is not supported in MVP.`);
+    }
+    case 'IsEmpty': {
+      // IS EMPTY = there is no row in issue_custom_field_values for this CF.
+      // We compile this as a positive SELECT that returns all issues WITHOUT a row
+      // for this CF. Negation is applied by the executor.
+      const sql = c.op.negated
+        ? Prisma.sql`SELECT icfv.issue_id FROM issue_custom_field_values icfv WHERE icfv.custom_field_id = ${cf.id}::uuid`
+        : Prisma.sql`SELECT i.id AS issue_id FROM issues i WHERE NOT EXISTS (SELECT 1 FROM issue_custom_field_values icfv WHERE icfv.issue_id = i.id AND icfv.custom_field_id = ${cf.id}::uuid)`;
+      return wrap(sql, alias, cf.id, false, errors); // negation already baked in
+    }
+    case 'History':
+      return empty(`History operators (WAS/CHANGED) are not yet supported on custom fields.`);
+  }
+  // Unreachable — all ClauseOp kinds are covered above. TypeScript's exhaustiveness
+  // check prevents new kinds from silently falling through.
+  return empty(`Unhandled custom-field clause.`);
+}
+
+// CompileContext may be needed later for timezone/locale-aware operations; keep
+// the import alive even though the current builders don't consume it.
+void ({} as CompileContext);
+
+function wrap(rawSql: Prisma.Sql, alias: string, cfId: string, negated: boolean, errors: CompileIssue[]): CustomClauseCompiled {
+  return {
+    predicate: { alias, customFieldId: cfId, negated, rawSql },
+    errors,
+  };
+}
+
+// ─── Per-op SQL builders ────────────────────────────────────────────────────
+
+function buildCompareSql(
+  cf: CustomFieldDef,
+  op: string,
+  valueExpr: Expr,
+  builder: FunctionResolver,
+): Prisma.Sql | null {
+  // Resolve value into a SQL-embeddable form.
+  const value = literalToSqlValue(valueExpr, cf.fieldType, builder);
+  if (value === null) return null;
+
+  // `~` / `!~` — string contains (case-insensitive) on JSON-extracted text.
+  if (op === '~' || op === '!~') {
+    if (typeof value !== 'string') return null;
+    const like = Prisma.sql`${'%' + value.slice(0, 200) + '%'}`;
+    const body = valueJsonText(cf.fieldType);
+    const filter = op === '~'
+      ? Prisma.sql`${body} ILIKE ${like}`
+      : Prisma.sql`(${body} IS NULL OR ${body} NOT ILIKE ${like})`;
+    return selectWhere(cf.id, filter);
+  }
+
+  // For LABEL / MULTI_SELECT — EQ / NEQ checks membership in the JSON array.
+  if ((cf.fieldType === 'LABEL' || cf.fieldType === 'MULTI_SELECT') && (op === '=' || op === '!=')) {
+    const containment = Prisma.sql`icfv.value @> to_jsonb(${value}::text)`;
+    const body = op === '=' ? containment : Prisma.sql`NOT (${containment})`;
+    return selectWhere(cf.id, body);
+  }
+
+  // Default: comparator on typed body.
+  const body = valueTypedForCompare(cf.fieldType, value);
+  if (!body) return null;
+  const comparator = sqlComparator(op);
+  if (!comparator) return null;
+  const filter = Prisma.sql`${body} ${Prisma.raw(comparator)} ${value}`;
+  return selectWhere(cf.id, filter);
+}
+
+function buildInSql(
+  cf: CustomFieldDef,
+  values: Expr[],
+  builder: FunctionResolver,
+): Prisma.Sql | null {
+  if (values.length === 0) return null;
+  const resolved: unknown[] = [];
+  for (const v of values) {
+    const r = literalToSqlValue(v, cf.fieldType, builder);
+    if (r === null) return null;
+    resolved.push(r);
+  }
+  // LABEL/MULTI_SELECT — match if any of the values is contained in the array.
+  if (cf.fieldType === 'LABEL' || cf.fieldType === 'MULTI_SELECT') {
+    const orParts = resolved.map((v) => Prisma.sql`icfv.value @> to_jsonb(${v as string}::text)`);
+    const joined = Prisma.join(orParts, ' OR ');
+    return selectWhere(cf.id, joined);
+  }
+  const body = valueTypedForCompare(cf.fieldType, resolved[0]);
+  if (!body) return null;
+  const filter = Prisma.sql`${body} IN (${Prisma.join(resolved)})`;
+  return selectWhere(cf.id, filter);
+}
+
+// ─── JSON-extract helpers ───────────────────────────────────────────────────
+
+/** Text extraction for `~` / `!~`. Always uses ->>'v' or falls back to text(value). */
+function valueJsonText(ft: CustomFieldType): Prisma.Sql {
+  switch (ft) {
+    case 'TEXT':
+    case 'TEXTAREA':
+    case 'URL':
+      return Prisma.sql`(icfv.value->>'v')`;
+    case 'SELECT':
+      return Prisma.sql`(icfv.value->>'v')`;
+    default:
+      return Prisma.sql`(icfv.value::text)`;
+  }
+}
+
+/**
+ * Typed JSON extraction for comparator predicates. Returns the correct cast so
+ * `=`, `>` etc. use PG's native ordering for the data type.
+ */
+function valueTypedForCompare(ft: CustomFieldType, sample: unknown): Prisma.Sql | null {
+  switch (ft) {
+    case 'TEXT':
+    case 'TEXTAREA':
+    case 'URL':
+    case 'SELECT':
+      if (typeof sample !== 'string') return null;
+      return Prisma.sql`(icfv.value->>'v')`;
+    case 'NUMBER':
+    case 'DECIMAL':
+      if (typeof sample !== 'number') return null;
+      return Prisma.sql`((icfv.value->>'n')::numeric)`;
+    case 'DATE':
+      if (!(sample instanceof Date)) return null;
+      return Prisma.sql`((icfv.value->>'d')::date)`;
+    case 'DATETIME':
+      if (!(sample instanceof Date)) return null;
+      return Prisma.sql`((icfv.value->>'d')::timestamp)`;
+    case 'CHECKBOX':
+      if (typeof sample !== 'boolean') return null;
+      return Prisma.sql`((icfv.value->>'b')::boolean)`;
+    case 'USER':
+    case 'REFERENCE':
+      if (typeof sample !== 'string') return null;
+      return Prisma.sql`(icfv.value->>'v')`;
+    default:
+      return null;
+  }
+}
+
+function sqlComparator(op: string): string | null {
+  switch (op) {
+    case '=': return '=';
+    case '!=': return '<>';
+    case '>': return '>';
+    case '>=': return '>=';
+    case '<': return '<';
+    case '<=': return '<=';
+    default: return null;
+  }
+}
+
+function selectWhere(cfId: string, filter: Prisma.Sql): Prisma.Sql {
+  return Prisma.sql`SELECT icfv.issue_id FROM issue_custom_field_values icfv WHERE icfv.custom_field_id = ${cfId}::uuid AND (${filter})`;
+}
+
+// ─── Value conversion from AST ──────────────────────────────────────────────
+
+function literalToSqlValue(expr: Expr, ft: CustomFieldType, builder: FunctionResolver): string | number | Date | boolean | null | undefined {
+  if (expr.kind === 'Function') {
+    const r = builder.resolveFunctionCall(expr);
+    if (r.kind === 'scalar-id') return r.id ?? undefined;
+    if (r.kind === 'scalar-datetime') return r.value;
+    // id-list and resolve-failed → not a scalar, caller rejects.
+    return undefined;
+  }
+  switch (expr.kind) {
+    case 'Null': case 'Empty': return null;
+    case 'Bool': return expr.value;
+    case 'Number': return expr.value;
+    case 'String':
+      if (ft === 'DATE' || ft === 'DATETIME') {
+        const d = new Date(expr.value);
+        return Number.isFinite(d.getTime()) ? d : undefined;
+      }
+      return expr.value;
+    case 'RelativeDate': {
+      // Not supported directly on custom-field values in MVP (compiler lacks `now`
+      // here). Caller should switch to `startOfDay("-7d")` or explicit ISO date.
+      return undefined;
+    }
+    case 'Ident':
+      return expr.name;
+  }
+}

--- a/backend/src/modules/search/search.function-resolver.ts
+++ b/backend/src/modules/search/search.function-resolver.ts
@@ -1,0 +1,347 @@
+/**
+ * TTSRH-1 PR-4 — DB-wired function resolver.
+ *
+ * Walks an AST, collects every DB-dependent function call, de-duplicates by
+ * canonical key, and runs one Prisma query per unique call to get the resulting
+ * id set (or scalar id). Pure date functions (now, today, startOfX, endOfX) are
+ * evaluated by the compiler directly — not here.
+ *
+ * Caller (PR-5 `search.service.ts`) passes the returned `ResolvedFunctions` into
+ * the compiler via `CompileContext.resolved`.
+ */
+
+import { prisma } from '../../prisma/client.js';
+import type {
+  BoolExpr,
+  Expr,
+  FunctionCall,
+  QueryNode,
+} from './search.ast.js';
+import {
+  buildFunctionCallKey,
+  type FunctionCallKey,
+  type FunctionCallArg,
+  type FunctionCallValue,
+  type ResolvedFunctions,
+} from './search.compile-context.js';
+
+export interface FunctionResolverContext {
+  userId: string | null;
+  accessibleProjectIds: readonly string[];
+  now: Date;
+  /**
+   * When `variant === 'checkpoint'`, `currentUserId` resolves to `null` (§5.12.4
+   * ТЗ) and user-only shortcuts like `myOpenIssues()` should not appear (validator
+   * rejects them pre-compile).
+   */
+  variant: 'default' | 'checkpoint';
+}
+
+/**
+ * Walk the AST and collect unique function-call signatures (name + args). Used
+ * to batch DB queries — if the same call appears 5 times in a query, we resolve
+ * it once.
+ */
+export function collectFunctionCalls(ast: QueryNode): Map<FunctionCallKey, FunctionCall> {
+  const out = new Map<FunctionCallKey, FunctionCall>();
+  const visitBool = (n: BoolExpr) => {
+    switch (n.kind) {
+      case 'And':
+      case 'Or':
+        n.children.forEach(visitBool);
+        return;
+      case 'Not':
+        visitBool(n.child);
+        return;
+      case 'Clause': {
+        switch (n.op.kind) {
+          case 'Compare':
+            visitExpr(n.op.value);
+            return;
+          case 'In':
+            n.op.values.forEach(visitExpr);
+            return;
+          case 'InFunction':
+            collectCall(n.op.func);
+            // Function args themselves may contain nested calls.
+            n.op.func.args.forEach(visitExpr);
+            return;
+          case 'IsEmpty':
+          case 'History':
+            return;
+        }
+      }
+    }
+  };
+  const visitExpr = (e: Expr) => {
+    if (e.kind === 'Function') {
+      collectCall(e);
+      e.args.forEach(visitExpr);
+    }
+  };
+  const collectCall = (c: FunctionCall) => {
+    const key = buildFunctionCallKey(c.name, c.args.map(argToKey));
+    if (!out.has(key)) out.set(key, c);
+  };
+
+  if (ast.where) visitBool(ast.where);
+  for (const s of ast.orderBy) {
+    // ORDER BY has only FieldRef — no function calls. Nothing to collect.
+    void s;
+  }
+  return out;
+}
+
+function argToKey(e: Expr): FunctionCallArg {
+  switch (e.kind) {
+    case 'String': return { kind: 'string', value: e.value };
+    case 'Number': return { kind: 'number', value: e.value };
+    case 'Bool':   return { kind: 'bool', value: e.value };
+    case 'Null':
+    case 'Empty':  return { kind: 'null' };
+    case 'Ident':  return { kind: 'ident', name: e.name };
+    case 'RelativeDate': return { kind: 'string', value: e.raw };
+    case 'Function': return { kind: 'string', value: `${e.name}(...)` };
+  }
+}
+
+/**
+ * Resolve every DB-dependent function call from the AST into actual id sets.
+ * Returns a `ResolvedFunctions` suitable to feed the compiler. Functions that
+ * aren't DB-dependent (pure date helpers, currentUser) are handled here or in
+ * compiler; we only hit Prisma for dynamic ones.
+ */
+export async function resolveFunctions(
+  ast: QueryNode,
+  fnCtx: FunctionResolverContext,
+): Promise<ResolvedFunctions> {
+  const calls = collectFunctionCalls(ast);
+  const resolved = new Map<FunctionCallKey, FunctionCallValue>();
+
+  for (const [key, call] of calls) {
+    const lc = call.name.toLowerCase();
+    // Pure functions are evaluated by the compiler — skip DB query here.
+    if (PURE_DATE_FNS.has(lc) || lc === 'currentuser') continue;
+
+    const value = await resolveOne(call, fnCtx);
+    resolved.set(key, value);
+  }
+
+  return {
+    currentUserId: fnCtx.variant === 'checkpoint' ? null : fnCtx.userId,
+    calls: resolved,
+  };
+}
+
+const PURE_DATE_FNS = new Set([
+  'now',
+  'today',
+  'startofday', 'endofday',
+  'startofweek', 'endofweek',
+  'startofmonth', 'endofmonth',
+  'startofyear', 'endofyear',
+]);
+
+async function resolveOne(call: FunctionCall, ctx: FunctionResolverContext): Promise<FunctionCallValue> {
+  const lc = call.name.toLowerCase();
+  try {
+    switch (lc) {
+      case 'membersof': return await resolveMembersOf(call);
+      case 'opensprints': return await resolveSprintsByState('ACTIVE', ctx);
+      case 'closedsprints': return await resolveSprintsByState('CLOSED', ctx);
+      case 'futuresprints': return await resolveSprintsByState('PLANNED', ctx);
+      case 'unreleasedversions': return await resolveReleases(call, 'unreleased', ctx);
+      case 'releasedversions': return await resolveReleases(call, 'released', ctx);
+      case 'earliestunreleasedversion': return await resolveEarliestUnreleased(call, ctx);
+      case 'latestreleasedversion': return await resolveLatestReleased(call, ctx);
+      case 'linkedissues': return await resolveLinkedIssues(call, ctx);
+      case 'subtasksof': return await resolveSubtasksOf(call, ctx);
+      case 'epicissues': return await resolveEpicIssues(call, ctx);
+      case 'myopenissues': return await resolveMyOpenIssues(ctx);
+      default:
+        return { kind: 'resolve-failed', reason: `Function \`${call.name}()\` resolver not implemented.` };
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { kind: 'resolve-failed', reason: `Resolving \`${call.name}()\` failed: ${msg}` };
+  }
+}
+
+// ─── Per-function resolvers ─────────────────────────────────────────────────
+
+async function resolveMembersOf(call: FunctionCall): Promise<FunctionCallValue> {
+  const groupName = stringArg(call, 0);
+  if (!groupName) return { kind: 'resolve-failed', reason: '`membersOf()` requires a group name argument.' };
+  const group = await prisma.userGroup.findFirst({
+    where: { name: groupName },
+    select: {
+      members: { select: { userId: true } },
+    },
+  });
+  if (!group) return { kind: 'id-list', ids: [] };
+  return { kind: 'id-list', ids: group.members.map((m) => m.userId) };
+}
+
+async function resolveSprintsByState(
+  state: 'PLANNED' | 'ACTIVE' | 'CLOSED',
+  ctx: FunctionResolverContext,
+): Promise<FunctionCallValue> {
+  const sprints = await prisma.sprint.findMany({
+    where: {
+      state,
+      projectId: { in: [...ctx.accessibleProjectIds] },
+    },
+    select: { id: true },
+  });
+  return { kind: 'id-list', ids: sprints.map((s) => s.id) };
+}
+
+async function resolveReleases(
+  call: FunctionCall,
+  mode: 'unreleased' | 'released',
+  ctx: FunctionResolverContext,
+): Promise<FunctionCallValue> {
+  const projectKey = stringArg(call, 0);
+  const project = projectKey
+    ? await prisma.project.findFirst({ where: { key: projectKey }, select: { id: true } })
+    : null;
+  if (projectKey && !project) return { kind: 'id-list', ids: [] };
+  // No `isReleased` column on `Release`. We treat `releaseDate <= now` as "released"
+  // and everything else as unreleased, mirroring the convention used by the release
+  // workflow engine. If a project later adds a terminal-state boolean, switch to that.
+  const scope = project ? { projectId: project.id } : { projectId: { in: [...ctx.accessibleProjectIds] } };
+  const releases = await prisma.release.findMany({
+    where: mode === 'released'
+      ? { AND: [scope, { releaseDate: { not: null } }, { releaseDate: { lte: ctx.now } }] }
+      : { AND: [scope, { OR: [{ releaseDate: null }, { releaseDate: { gt: ctx.now } }] }] },
+    select: { id: true },
+  });
+  return { kind: 'id-list', ids: releases.map((r) => r.id) };
+}
+
+async function resolveEarliestUnreleased(
+  call: FunctionCall,
+  ctx: FunctionResolverContext,
+): Promise<FunctionCallValue> {
+  const projectKey = stringArg(call, 0);
+  const project = projectKey
+    ? await prisma.project.findFirst({ where: { key: projectKey }, select: { id: true } })
+    : null;
+  if (projectKey && !project) return { kind: 'scalar-id', id: null };
+  const scope = project ? { projectId: project.id } : { projectId: { in: [...ctx.accessibleProjectIds] } };
+  const release = await prisma.release.findFirst({
+    where: { AND: [scope, { OR: [{ releaseDate: null }, { releaseDate: { gt: ctx.now } }] }] },
+    orderBy: { plannedDate: 'asc' },
+    select: { id: true },
+  });
+  return { kind: 'scalar-id', id: release?.id ?? null };
+}
+
+async function resolveLatestReleased(
+  call: FunctionCall,
+  ctx: FunctionResolverContext,
+): Promise<FunctionCallValue> {
+  const projectKey = stringArg(call, 0);
+  const project = projectKey
+    ? await prisma.project.findFirst({ where: { key: projectKey }, select: { id: true } })
+    : null;
+  if (projectKey && !project) return { kind: 'scalar-id', id: null };
+  const scope = project ? { projectId: project.id } : { projectId: { in: [...ctx.accessibleProjectIds] } };
+  const release = await prisma.release.findFirst({
+    where: { AND: [scope, { releaseDate: { not: null } }, { releaseDate: { lte: ctx.now } }] },
+    orderBy: { releaseDate: 'desc' },
+    select: { id: true },
+  });
+  return { kind: 'scalar-id', id: release?.id ?? null };
+}
+
+async function resolveLinkedIssues(call: FunctionCall, ctx: FunctionResolverContext): Promise<FunctionCallValue> {
+  const key = stringArg(call, 0);
+  if (!key) return { kind: 'resolve-failed', reason: '`linkedIssues()` requires an issue-key argument.' };
+  const linkTypeName = stringArg(call, 1);
+  const source = await findIssueByKey(key, ctx);
+  if (!source) return { kind: 'id-list', ids: [] };
+  // `IssueLink.linkType` is a FK relation to `IssueLinkType`, not a scalar — filter
+  // via the relation's `name`. Unknown link-type names produce an empty set, not an
+  // error (matches how Jira silently ignores unrecognised link kinds).
+  const links = await prisma.issueLink.findMany({
+    where: {
+      OR: [{ sourceIssueId: source.id }, { targetIssueId: source.id }],
+      ...(linkTypeName ? { linkType: { name: linkTypeName } } : {}),
+    },
+    select: { sourceIssueId: true, targetIssueId: true },
+  });
+  const ids = new Set<string>();
+  for (const l of links) {
+    if (l.sourceIssueId !== source.id) ids.add(l.sourceIssueId);
+    if (l.targetIssueId !== source.id) ids.add(l.targetIssueId);
+  }
+  return { kind: 'id-list', ids: [...ids] };
+}
+
+async function resolveSubtasksOf(call: FunctionCall, ctx: FunctionResolverContext): Promise<FunctionCallValue> {
+  const key = stringArg(call, 0);
+  if (!key) return { kind: 'resolve-failed', reason: '`subtasksOf()` requires an issue-key argument.' };
+  const parent = await findIssueByKey(key, ctx);
+  if (!parent) return { kind: 'id-list', ids: [] };
+  const subtasks = await prisma.issue.findMany({
+    where: { parentId: parent.id },
+    select: { id: true },
+  });
+  return { kind: 'id-list', ids: subtasks.map((i) => i.id) };
+}
+
+async function resolveEpicIssues(call: FunctionCall, ctx: FunctionResolverContext): Promise<FunctionCallValue> {
+  const key = stringArg(call, 0);
+  if (!key) return { kind: 'resolve-failed', reason: '`epicIssues()` requires an issue-key argument.' };
+  const epic = await findIssueByKey(key, ctx);
+  if (!epic) return { kind: 'id-list', ids: [] };
+  const issues = await prisma.issue.findMany({
+    where: { parentId: epic.id },
+    select: { id: true },
+  });
+  return { kind: 'id-list', ids: issues.map((i) => i.id) };
+}
+
+async function resolveMyOpenIssues(ctx: FunctionResolverContext): Promise<FunctionCallValue> {
+  if (!ctx.userId) return { kind: 'id-list', ids: [] };
+  const issues = await prisma.issue.findMany({
+    where: {
+      assigneeId: ctx.userId,
+      status: { not: 'DONE' },
+      projectId: { in: [...ctx.accessibleProjectIds] },
+    },
+    select: { id: true },
+  });
+  return { kind: 'id-list', ids: issues.map((i) => i.id) };
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function stringArg(call: FunctionCall, i: number): string | null {
+  const a = call.args[i];
+  if (!a) return null;
+  if (a.kind === 'String') return a.value;
+  if (a.kind === 'Ident') return a.name;
+  return null;
+}
+
+/**
+ * Resolve an issue by its `PROJECTKEY-NUMBER` identifier. Scoped to the caller's
+ * accessible projects — a user cannot reference issues from projects they don't
+ * see (R3 ТЗ).
+ */
+async function findIssueByKey(key: string, ctx: FunctionResolverContext): Promise<{ id: string } | null> {
+  const m = /^([A-Z][A-Z0-9]*)-(\d+)$/.exec(key.trim());
+  if (!m) return null;
+  const [, projectKey, numStr] = m;
+  const project = await prisma.project.findFirst({
+    where: { key: projectKey, id: { in: [...ctx.accessibleProjectIds] } },
+    select: { id: true },
+  });
+  if (!project) return null;
+  return prisma.issue.findFirst({
+    where: { projectId: project.id, number: Number.parseInt(numStr!, 10) },
+    select: { id: true },
+  });
+}

--- a/backend/src/modules/search/search.function-resolver.ts
+++ b/backend/src/modules/search/search.function-resolver.ts
@@ -10,6 +10,7 @@
  * the compiler via `CompileContext.resolved`.
  */
 
+import { IssueStatus } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import type {
   BoolExpr,
@@ -116,15 +117,19 @@ export async function resolveFunctions(
   fnCtx: FunctionResolverContext,
 ): Promise<ResolvedFunctions> {
   const calls = collectFunctionCalls(ast);
-  const resolved = new Map<FunctionCallKey, FunctionCallValue>();
 
-  for (const [key, call] of calls) {
+  // Parallelise independent DB lookups — a typical saved filter can reference
+  // 3-5 functions; serial awaits here add 3-5× latency for no reason. Prisma's
+  // connection pool (default 10) handles the concurrency comfortably.
+  const dbEntries = [...calls.entries()].filter(([, call]) => {
     const lc = call.name.toLowerCase();
-    // Pure functions are evaluated by the compiler — skip DB query here.
-    if (PURE_DATE_FNS.has(lc) || lc === 'currentuser') continue;
+    return !PURE_DATE_FNS.has(lc) && lc !== 'currentuser';
+  });
+  const values = await Promise.all(dbEntries.map(([, call]) => resolveOne(call, fnCtx)));
 
-    const value = await resolveOne(call, fnCtx);
-    resolved.set(key, value);
+  const resolved = new Map<FunctionCallKey, FunctionCallValue>();
+  for (let i = 0; i < dbEntries.length; i++) {
+    resolved.set(dbEntries[i]![0], values[i]!);
   }
 
   return {
@@ -172,8 +177,11 @@ async function resolveOne(call: FunctionCall, ctx: FunctionResolverContext): Pro
 async function resolveMembersOf(call: FunctionCall): Promise<FunctionCallValue> {
   const groupName = stringArg(call, 0);
   if (!groupName) return { kind: 'resolve-failed', reason: '`membersOf()` requires a group name argument.' };
+  // Case-insensitive match — `buildFunctionCallKey` serialises args verbatim, so
+  // `membersOf("Team")` and `membersOf("team")` have distinct cache keys. Doing the
+  // DB lookup case-insensitively still gives both the same resolved id-list.
   const group = await prisma.userGroup.findFirst({
-    where: { name: groupName },
+    where: { name: { equals: groupName, mode: 'insensitive' } },
     select: {
       members: { select: { userId: true } },
     },
@@ -271,36 +279,62 @@ async function resolveLinkedIssues(call: FunctionCall, ctx: FunctionResolverCont
     },
     select: { sourceIssueId: true, targetIssueId: true },
   });
-  const ids = new Set<string>();
+  const candidateIds = new Set<string>();
   for (const l of links) {
-    if (l.sourceIssueId !== source.id) ids.add(l.sourceIssueId);
-    if (l.targetIssueId !== source.id) ids.add(l.targetIssueId);
+    if (l.sourceIssueId !== source.id) candidateIds.add(l.sourceIssueId);
+    if (l.targetIssueId !== source.id) candidateIds.add(l.targetIssueId);
   }
-  return { kind: 'id-list', ids: [...ids] };
+  if (candidateIds.size === 0) return { kind: 'id-list', ids: [] };
+  // Defense in depth (R3): even though the top-level compiler adds
+  // `projectId IN accessibleProjectIds` to every query — which strips any
+  // cross-project link targets from the final result — we also scope the
+  // resolver's id-list so ids from inaccessible projects never even leave this
+  // function. Any future executor that logs, traces, or bounds id-sets won't
+  // leak uuids the caller shouldn't see.
+  const scoped = await prisma.issue.findMany({
+    where: {
+      id: { in: [...candidateIds] },
+      projectId: { in: [...ctx.accessibleProjectIds] },
+    },
+    select: { id: true },
+  });
+  return { kind: 'id-list', ids: scoped.map((i) => i.id) };
+}
+
+/**
+ * `subtasksOf(key)` and `epicIssues(key)` are structurally identical — both look up
+ * children of the given issue via `parentId`. The schema's ALLOWED_PARENT_KEYS
+ * already enforces that only SUBTASKs have STORY/TASK parents, and only STORY/TASK/
+ * BUG have EPIC parents — so `subtasksOf(storyKey)` returns its subtasks and
+ * `epicIssues(epicKey)` returns its stories/tasks/bugs. We keep both functions
+ * rather than a single generic `childrenOf` because the JQL vocabulary distinguishes
+ * them and users expect the familiar Jira names.
+ */
+async function resolveChildrenOf(
+  call: FunctionCall,
+  ctx: FunctionResolverContext,
+  functionName: string,
+): Promise<FunctionCallValue> {
+  const key = stringArg(call, 0);
+  if (!key) return { kind: 'resolve-failed', reason: `\`${functionName}()\` requires an issue-key argument.` };
+  const parent = await findIssueByKey(key, ctx);
+  if (!parent) return { kind: 'id-list', ids: [] };
+  const children = await prisma.issue.findMany({
+    where: {
+      parentId: parent.id,
+      projectId: { in: [...ctx.accessibleProjectIds] },
+    },
+    select: { id: true },
+  });
+  return { kind: 'id-list', ids: children.map((i) => i.id) };
 }
 
 async function resolveSubtasksOf(call: FunctionCall, ctx: FunctionResolverContext): Promise<FunctionCallValue> {
-  const key = stringArg(call, 0);
-  if (!key) return { kind: 'resolve-failed', reason: '`subtasksOf()` requires an issue-key argument.' };
-  const parent = await findIssueByKey(key, ctx);
-  if (!parent) return { kind: 'id-list', ids: [] };
-  const subtasks = await prisma.issue.findMany({
-    where: { parentId: parent.id },
-    select: { id: true },
-  });
-  return { kind: 'id-list', ids: subtasks.map((i) => i.id) };
+  return resolveChildrenOf(call, ctx, 'subtasksOf');
 }
 
 async function resolveEpicIssues(call: FunctionCall, ctx: FunctionResolverContext): Promise<FunctionCallValue> {
-  const key = stringArg(call, 0);
-  if (!key) return { kind: 'resolve-failed', reason: '`epicIssues()` requires an issue-key argument.' };
-  const epic = await findIssueByKey(key, ctx);
-  if (!epic) return { kind: 'id-list', ids: [] };
-  const issues = await prisma.issue.findMany({
-    where: { parentId: epic.id },
-    select: { id: true },
-  });
-  return { kind: 'id-list', ids: issues.map((i) => i.id) };
+  return resolveChildrenOf(call, ctx, 'epicIssues');
 }
 
 async function resolveMyOpenIssues(ctx: FunctionResolverContext): Promise<FunctionCallValue> {
@@ -308,7 +342,7 @@ async function resolveMyOpenIssues(ctx: FunctionResolverContext): Promise<Functi
   const issues = await prisma.issue.findMany({
     where: {
       assigneeId: ctx.userId,
-      status: { not: 'DONE' },
+      status: { not: IssueStatus.DONE },
       projectId: { in: [...ctx.accessibleProjectIds] },
     },
     select: { id: true },

--- a/backend/src/modules/search/search.schema.loader.ts
+++ b/backend/src/modules/search/search.schema.loader.ts
@@ -41,6 +41,7 @@ export async function loadCustomFields(): Promise<CustomFieldDef[]> {
     id: r.id,
     name: r.name,
     type: customFieldTypeToTtql(r.fieldType),
+    fieldType: r.fieldType,
     operators: operatorsForCustomField(r.fieldType),
     sortable: false, // MVP — see CustomFieldDef.sortable comment
     options: r.options,

--- a/backend/src/modules/search/search.schema.ts
+++ b/backend/src/modules/search/search.schema.ts
@@ -112,8 +112,14 @@ export function resolveSystemField(name: string): FieldDef | null {
 export interface CustomFieldDef {
   id: string;
   name: string;
-  /** TTS-QL type derived from the Prisma `CustomFieldType`. */
+  /** TTS-QL type derived from the Prisma `CustomFieldType` — used by the validator. */
   type: TtqlType;
+  /**
+   * Original Prisma `CustomFieldType` — retained so the compiler (PR-4) can pick
+   * the correct JSON extraction / cast when building raw SQL. `MULTI_SELECT` vs
+   * `LABEL` collapse to the same `TtqlType` but differ in storage encoding.
+   */
+  fieldType: CustomFieldType;
   operators: readonly TtqlOpKind[];
   /**
    * MVP: custom fields are never sortable (§R13 ТЗ — sort by JSON-column is too

--- a/backend/tests/search-compiler.unit.test.ts
+++ b/backend/tests/search-compiler.unit.test.ts
@@ -1,0 +1,411 @@
+/**
+ * TTSRH-1 PR-4 — unit tests for the pure TTS-QL compiler.
+ *
+ * Covers T-2 from §6 ТЗ: per-field × per-operator matrix with 60+ cases, plus
+ * scope-filter (R3), boolean precedence, function-result splicing, and custom-
+ * field predicate emission. All tests run without a database — function values
+ * and custom fields are injected via the `CompileContext`.
+ */
+import { describe, expect, it } from 'vitest';
+import { parse } from '../src/modules/search/search.parser.js';
+import { compile, type CompileResult } from '../src/modules/search/search.compiler.js';
+import type { CompileContext, ResolvedFunctions } from '../src/modules/search/search.compile-context.js';
+import { buildFunctionCallKey } from '../src/modules/search/search.compile-context.js';
+import type { CustomFieldDef } from '../src/modules/search/search.schema.js';
+
+const ANCHOR = new Date(Date.UTC(2026, 3, 15, 12, 0, 0, 0));
+const PROJECTS: readonly string[] = ['proj-a', 'proj-b', 'proj-c'];
+
+// Default context with no function resolutions — good for pure-field tests.
+function makeCtx(overrides: Partial<CompileContext> = {}): CompileContext {
+  return {
+    accessibleProjectIds: PROJECTS,
+    customFields: [],
+    resolved: { currentUserId: 'user-1', calls: new Map() },
+    now: ANCHOR,
+    variant: 'default',
+    ...overrides,
+  };
+}
+
+function compileFromSource(src: string, ctx?: CompileContext): CompileResult {
+  const { ast, errors } = parse(src);
+  if (!ast) throw new Error(`Parser failed for \`${src}\`: ${errors.map((e) => e.code).join(',')}`);
+  return compile(ast, ctx ?? makeCtx());
+}
+
+function topScope(result: CompileResult): unknown {
+  const where = result.where as Record<string, unknown>;
+  if (Array.isArray(where.AND)) return where.AND[0];
+  return where;
+}
+
+function innerWhere(result: CompileResult): unknown {
+  const where = result.where as Record<string, unknown>;
+  if (Array.isArray(where.AND)) return where.AND[1];
+  return null;
+}
+
+// ─── Scope filter (R3) ──────────────────────────────────────────────────────
+
+describe('compiler — scope filter (R3)', () => {
+  it('empty query produces the scope filter and nothing else', () => {
+    const r = compileFromSource('');
+    expect(r.where).toEqual({ projectId: { in: [...PROJECTS] } });
+  });
+
+  it('scope filter is always the top-level AND prefix', () => {
+    const r = compileFromSource('priority = HIGH');
+    expect(topScope(r)).toEqual({ projectId: { in: [...PROJECTS] } });
+  });
+
+  it('no accessible projects → scope is empty; query matches nothing', () => {
+    const r = compileFromSource('priority = HIGH', makeCtx({ accessibleProjectIds: [] }));
+    expect(topScope(r)).toEqual({ projectId: { in: [] } });
+  });
+});
+
+// ─── Compare operators (system fields) ─────────────────────────────────────
+
+describe('compiler — compare operators on system fields', () => {
+  it.each([
+    ['priority = HIGH', { priority: 'HIGH' }],
+    ['priority != HIGH', { priority: { not: 'HIGH' } }],
+    ['status = OPEN', { status: 'OPEN' }],
+    ['type = EPIC', { issueTypeConfigId: 'EPIC' }],
+  ])('%s → %j', (src, expected) => {
+    const r = compileFromSource(src);
+    expect(innerWhere(r)).toEqual(expected);
+  });
+
+  it.each([
+    ['estimatedHours = 5', { estimatedHours: 5 }],
+    ['estimatedHours != 5', { estimatedHours: { not: 5 } }],
+    ['estimatedHours > 5', { estimatedHours: { gt: 5 } }],
+    ['estimatedHours >= 5', { estimatedHours: { gte: 5 } }],
+    ['estimatedHours < 5', { estimatedHours: { lt: 5 } }],
+    ['estimatedHours <= 5', { estimatedHours: { lte: 5 } }],
+    ['orderIndex > 100', { orderIndex: { gt: 100 } }],
+  ])('numeric compare: %s', (src, expected) => {
+    const r = compileFromSource(src);
+    expect(innerWhere(r)).toEqual(expected);
+  });
+
+  it.each([
+    ['due >= "2026-01-01"', 'dueDate', 'gte'],
+    ['created < "2026-06-01"', 'createdAt', 'lt'],
+  ])('date compare: %s uses Prisma filter on %s', (src, col, op) => {
+    const r = compileFromSource(src);
+    const inner = innerWhere(r) as Record<string, unknown>;
+    expect(inner).toHaveProperty(col);
+    const filter = inner[col] as Record<string, unknown>;
+    expect(filter).toHaveProperty(op);
+    expect(filter[op]).toBeInstanceOf(Date);
+  });
+
+  it.each([
+    ['summary ~ "hello"', 'title', 'contains', 'hello'],
+    ['summary !~ "hello"', 'title', 'contains', 'hello'],
+    ['description ~ "world"', 'description', 'contains', 'world'],
+  ])('text contains: %s', (src, col, key, val) => {
+    const r = compileFromSource(src);
+    let inner = innerWhere(r) as Record<string, unknown>;
+    if (typeof inner === 'object' && 'NOT' in inner) inner = inner.NOT as Record<string, unknown>;
+    const filter = inner[col] as Record<string, unknown>;
+    expect(filter[key]).toBe(val);
+    expect(filter['mode']).toBe('insensitive');
+  });
+});
+
+// ─── IN / NOT IN ────────────────────────────────────────────────────────────
+
+describe('compiler — IN / NOT IN', () => {
+  it('IN with idents', () => {
+    const r = compileFromSource('status IN (OPEN, IN_PROGRESS)');
+    expect(innerWhere(r)).toEqual({ status: { in: ['OPEN', 'IN_PROGRESS'] } });
+  });
+
+  it('NOT IN', () => {
+    const r = compileFromSource('status NOT IN (DONE, CANCELLED)');
+    expect(innerWhere(r)).toEqual({ NOT: { status: { in: ['DONE', 'CANCELLED'] } } });
+  });
+
+  it('IN with strings', () => {
+    const r = compileFromSource('priority IN ("HIGH", "CRITICAL")');
+    expect(innerWhere(r)).toEqual({ priority: { in: ['HIGH', 'CRITICAL'] } });
+  });
+});
+
+// ─── IS EMPTY / IS NOT EMPTY ────────────────────────────────────────────────
+
+describe('compiler — IS EMPTY / IS NOT EMPTY', () => {
+  it.each([
+    ['assignee IS EMPTY', { assigneeId: null }],
+    ['assignee IS NOT EMPTY', { assigneeId: { not: null } }],
+    ['due IS EMPTY', { dueDate: null }],
+    ['sprint IS NOT NULL', { sprintId: { not: null } }],
+  ])('%s', (src, expected) => {
+    const r = compileFromSource(src);
+    expect(innerWhere(r)).toEqual(expected);
+  });
+});
+
+// ─── Boolean operators ──────────────────────────────────────────────────────
+
+describe('compiler — boolean structure', () => {
+  it('AND produces Prisma AND', () => {
+    const r = compileFromSource('priority = HIGH AND status = OPEN');
+    const inner = innerWhere(r) as Record<string, unknown>;
+    expect(inner).toHaveProperty('AND');
+    expect((inner.AND as unknown[]).length).toBe(2);
+  });
+
+  it('OR produces Prisma OR', () => {
+    const r = compileFromSource('priority = HIGH OR priority = CRITICAL');
+    const inner = innerWhere(r) as Record<string, unknown>;
+    expect(inner).toHaveProperty('OR');
+  });
+
+  it('NOT wraps child', () => {
+    const r = compileFromSource('NOT status = DONE');
+    const inner = innerWhere(r) as Record<string, unknown>;
+    expect(inner).toHaveProperty('NOT');
+    expect(inner.NOT).toEqual({ status: 'DONE' });
+  });
+
+  it('precedence: NOT a = 1 AND b = 2', () => {
+    const r = compileFromSource('NOT priority = HIGH AND status = OPEN');
+    const inner = innerWhere(r) as Record<string, unknown>;
+    expect(inner.AND).toHaveLength(2);
+    expect((inner.AND as Record<string, unknown>[])[0]).toHaveProperty('NOT');
+  });
+
+  it('parens override: NOT (a OR b)', () => {
+    const r = compileFromSource('NOT (status = DONE OR status = CANCELLED)');
+    const inner = innerWhere(r) as Record<string, unknown>;
+    expect(inner).toHaveProperty('NOT');
+    const child = inner.NOT as Record<string, unknown>;
+    expect(child).toHaveProperty('OR');
+  });
+});
+
+// ─── Function values ────────────────────────────────────────────────────────
+
+describe('compiler — function values', () => {
+  it('currentUser() maps to ctx.resolved.currentUserId', () => {
+    const r = compileFromSource('assignee = currentUser()');
+    expect(innerWhere(r)).toEqual({ assigneeId: 'user-1' });
+  });
+
+  it('pure date: due <= startOfDay("-7d")', () => {
+    const r = compileFromSource('due <= startOfDay("-7d")');
+    const inner = innerWhere(r) as Record<string, { lte: Date }>;
+    expect(inner.dueDate.lte).toBeInstanceOf(Date);
+    const expected = new Date(ANCHOR);
+    expected.setUTCDate(expected.getUTCDate() - 7);
+    expected.setUTCHours(0, 0, 0, 0);
+    expect(inner.dueDate.lte.toISOString()).toBe(expected.toISOString());
+  });
+
+  it('relative date literal: updated >= "-1d"', () => {
+    const r = compileFromSource('updated >= "-1d"');
+    const inner = innerWhere(r) as Record<string, { gte: Date }>;
+    const expected = new Date(ANCHOR);
+    expected.setUTCDate(expected.getUTCDate() - 1);
+    expect(inner.updatedAt.gte.toISOString()).toBe(expected.toISOString());
+  });
+
+  it('sprint IN openSprints() with pre-resolved ids', () => {
+    const resolved: ResolvedFunctions = {
+      currentUserId: 'user-1',
+      calls: new Map([[buildFunctionCallKey('opensprints', []), { kind: 'id-list', ids: ['s1', 's2'] }]]),
+    };
+    const r = compileFromSource('sprint IN openSprints()', makeCtx({ resolved }));
+    expect(innerWhere(r)).toEqual({ sprintId: { in: ['s1', 's2'] } });
+  });
+
+  it('empty id-list → MATCH_NONE', () => {
+    const resolved: ResolvedFunctions = {
+      currentUserId: 'user-1',
+      calls: new Map([[buildFunctionCallKey('opensprints', []), { kind: 'id-list', ids: [] }]]),
+    };
+    const r = compileFromSource('sprint IN openSprints()', makeCtx({ resolved }));
+    expect(innerWhere(r)).toEqual({ id: { in: [] } });
+  });
+
+  it('unresolved function → error + MATCH_NONE', () => {
+    const r = compileFromSource('sprint IN futureSprints()'); // ctx has no resolution
+    expect(r.errors.length).toBeGreaterThan(0);
+    expect(r.errors[0]!.code).toBe('UNRESOLVED_FUNCTION');
+    expect(innerWhere(r)).toEqual({ id: { in: [] } });
+  });
+});
+
+// ─── ORDER BY ───────────────────────────────────────────────────────────────
+
+describe('compiler — ORDER BY', () => {
+  it('single DESC', () => {
+    const r = compileFromSource('priority = HIGH ORDER BY priority DESC');
+    expect(r.orderBy).toEqual([{ priority: 'desc' }]);
+  });
+
+  it('multiple', () => {
+    const r = compileFromSource('x = 1 ORDER BY priority DESC, updated ASC');
+    // `x = 1` is an unknown system field → compiler emits UNRESOLVED_FIELD error,
+    // but ORDER BY still compiles (it's parsed independently).
+    expect(r.orderBy).toEqual([{ priority: 'desc' }, { updatedAt: 'asc' }]);
+  });
+
+  it('non-sortable field is silently dropped (validator already warned)', () => {
+    const r = compileFromSource('description ~ "x" ORDER BY description');
+    expect(r.orderBy).toEqual([]);
+  });
+});
+
+// ─── Custom fields ──────────────────────────────────────────────────────────
+
+describe('compiler — custom fields', () => {
+  const storyPoints: CustomFieldDef = {
+    id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    name: 'Story Points',
+    type: 'NUMBER',
+    fieldType: 'NUMBER',
+    operators: ['EQ', 'NEQ', 'GT', 'GTE', 'LT', 'LTE', 'IS_EMPTY', 'IS_NOT_EMPTY'],
+    sortable: false,
+  };
+
+  const releaseStatus: CustomFieldDef = {
+    id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    name: 'Release Status',
+    type: 'TEXT',
+    fieldType: 'TEXT',
+    operators: ['EQ', 'NEQ', 'CONTAINS', 'NOT_CONTAINS', 'IS_EMPTY', 'IS_NOT_EMPTY'],
+    sortable: false,
+  };
+
+  it('resolves by quoted name and produces a predicate', () => {
+    const r = compileFromSource('"Story Points" > 5', makeCtx({ customFields: [storyPoints] }));
+    expect(r.customPredicates).toHaveLength(1);
+    const pred = r.customPredicates[0]!;
+    expect(pred.customFieldId).toBe(storyPoints.id);
+    expect(pred.negated).toBe(false);
+    // The raw SQL should mention the CF id via parameterised `::uuid` cast.
+    const { sql } = pred.rawSql;
+    expect(sql).toMatch(/issue_custom_field_values/);
+    expect(sql).toMatch(/::uuid/);
+    expect(sql).toMatch(/::numeric/);
+  });
+
+  it('resolves by cf[UUID]', () => {
+    const r = compileFromSource(
+      `cf[aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa] = 5`,
+      makeCtx({ customFields: [storyPoints] }),
+    );
+    expect(r.customPredicates).toHaveLength(1);
+    expect(r.customPredicates[0]!.customFieldId).toBe(storyPoints.id);
+  });
+
+  it('IN (list) produces a single IN predicate', () => {
+    const r = compileFromSource(
+      `"Story Points" IN (3, 5, 8)`,
+      makeCtx({ customFields: [storyPoints] }),
+    );
+    expect(r.customPredicates).toHaveLength(1);
+  });
+
+  it('NOT IN sets the negated flag', () => {
+    const r = compileFromSource(
+      `"Story Points" NOT IN (3, 5, 8)`,
+      makeCtx({ customFields: [storyPoints] }),
+    );
+    expect(r.customPredicates[0]!.negated).toBe(true);
+  });
+
+  it('text ~ emits ILIKE', () => {
+    const r = compileFromSource(
+      `"Release Status" ~ "done"`,
+      makeCtx({ customFields: [releaseStatus] }),
+    );
+    expect(r.customPredicates).toHaveLength(1);
+    expect(r.customPredicates[0]!.rawSql.sql).toMatch(/ILIKE/);
+  });
+
+  it('IS EMPTY emits NOT EXISTS form', () => {
+    const r = compileFromSource(
+      `"Story Points" IS EMPTY`,
+      makeCtx({ customFields: [storyPoints] }),
+    );
+    expect(r.customPredicates[0]!.rawSql.sql).toMatch(/NOT EXISTS/);
+  });
+
+  it('unknown cf[UUID] produces an UNRESOLVED_FIELD error', () => {
+    const r = compileFromSource(
+      `cf[99999999-9999-9999-9999-999999999999] = 5`,
+      makeCtx({ customFields: [storyPoints] }),
+    );
+    expect(r.errors[0]?.code).toBe('UNRESOLVED_FIELD');
+  });
+});
+
+// ─── Error paths ────────────────────────────────────────────────────────────
+
+describe('compiler — error paths', () => {
+  it('unknown field → UNRESOLVED_FIELD + MATCH_NONE', () => {
+    const r = compileFromSource('bogusField = 1');
+    expect(r.errors[0]?.code).toBe('UNRESOLVED_FIELD');
+    expect(innerWhere(r)).toEqual({ id: { in: [] } });
+  });
+
+  it('never throws on structural corner cases', () => {
+    // The compiler must be robust on any AST the parser produces. Round-trip a
+    // handful of edge cases through the full pipeline.
+    for (const src of [
+      '',
+      'NOT NOT priority = HIGH',
+      '(((priority = HIGH)))',
+      'status IN (OPEN) OR (priority = HIGH AND due IS NOT EMPTY)',
+    ]) {
+      expect(() => compileFromSource(src)).not.toThrow();
+    }
+  });
+});
+
+// ─── Property-based: fuzz parse → compile ───────────────────────────────────
+
+function mulberry32(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+describe('compiler — property-based fuzz', () => {
+  it('500 random parseable queries compile without throwing', () => {
+    const rng = mulberry32(0xdecaf);
+    const fields = ['priority', 'status', 'assignee', 'due', 'estimatedHours', 'summary', 'description'];
+    const ops = ['=', '!=', '>', '<', '>=', '<='];
+    const values = ['HIGH', 'OPEN', 'CRITICAL', '"text"', '5', '"2026-01-01"', 'currentUser()'];
+    const pick = <T>(arr: readonly T[]) => arr[Math.floor(rng() * arr.length)]!;
+
+    let failures = 0;
+    for (let i = 0; i < 500; i++) {
+      const clauseCount = 1 + Math.floor(rng() * 4);
+      const clauses: string[] = [];
+      for (let k = 0; k < clauseCount; k++) {
+        clauses.push(`${pick(fields)} ${pick(ops)} ${pick(values)}`);
+      }
+      const connective = rng() < 0.5 ? ' AND ' : ' OR ';
+      const src = clauses.join(connective);
+      try {
+        compileFromSource(src);
+      } catch {
+        failures++;
+      }
+    }
+    expect(failures).toBe(0);
+  });
+});

--- a/backend/tests/search-compiler.unit.test.ts
+++ b/backend/tests/search-compiler.unit.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { parse } from '../src/modules/search/search.parser.js';
-import { compile, type CompileResult } from '../src/modules/search/search.compiler.js';
+import { assertNoUnresolvedPlaceholders, compile, PLACEHOLDER_KEY, type CompileResult } from '../src/modules/search/search.compiler.js';
 import type { CompileContext, ResolvedFunctions } from '../src/modules/search/search.compile-context.js';
 import { buildFunctionCallKey } from '../src/modules/search/search.compile-context.js';
 import type { CustomFieldDef } from '../src/modules/search/search.schema.js';
@@ -344,6 +344,47 @@ describe('compiler — custom fields', () => {
       makeCtx({ customFields: [storyPoints] }),
     );
     expect(r.errors[0]?.code).toBe('UNRESOLVED_FIELD');
+  });
+
+  // Pre-push review found a silent bug: `value @> to_jsonb(text)` on the outer
+  // wrapper `{ "v": [...] }` is always false. The fix descends into `value->'v'`.
+  it('LABEL/MULTI_SELECT: JSON containment uses `value->\'v\'`, not outer wrapper', () => {
+    const labelField: CustomFieldDef = {
+      id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      name: 'Priority Tags',
+      type: 'LABEL',
+      fieldType: 'LABEL',
+      operators: ['EQ', 'NEQ', 'IN', 'NOT_IN', 'IS_EMPTY', 'IS_NOT_EMPTY'],
+      sortable: false,
+    };
+    // `=` path
+    const eq = compileFromSource(
+      `"Priority Tags" = "bug"`,
+      makeCtx({ customFields: [labelField] }),
+    );
+    expect(eq.customPredicates[0]!.rawSql.sql).toMatch(/value->'v'[^@]*@>/);
+    // `IN` path
+    const inRes = compileFromSource(
+      `"Priority Tags" IN ("bug", "hotfix")`,
+      makeCtx({ customFields: [labelField] }),
+    );
+    expect(inRes.customPredicates[0]!.rawSql.sql).toMatch(/value->'v'[^@]*@>/);
+  });
+});
+
+// ─── Placeholder guard ──────────────────────────────────────────────────────
+
+describe('compiler — assertNoUnresolvedPlaceholders', () => {
+  it('throws when the placeholder key leaks to Prisma', () => {
+    expect(() =>
+      assertNoUnresolvedPlaceholders({ [PLACEHOLDER_KEY]: 'cf_0' } as unknown as Parameters<typeof assertNoUnresolvedPlaceholders>[0]),
+    ).toThrow(/unresolved TTS-QL custom-field placeholder/);
+  });
+
+  it('passes for a substituted where-input', () => {
+    expect(() =>
+      assertNoUnresolvedPlaceholders({ id: { in: ['issue-a', 'issue-b'] } }),
+    ).not.toThrow();
   });
 });
 

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1495,7 +1495,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 1 | `ttsrh-1/foundation` | Prisma schema (SavedFilter, User.preferences), feature flags, пустые модули | 6 | — | TTSRH-8 (schema), TTSRH-22 (flag) | 🟢 Merged ([#100](https://github.com/NovakPAai/tasktime-mvp/pull/100)) |
 | 2 | `ttsrh-1/parser` | Tokenizer + Parser + AST + golden-set | 14 | PR-1 | TTSRH-2 | 🟢 Merged ([#101](https://github.com/NovakPAai/tasktime-mvp/pull/101)) |
 | 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 | ✅ Done (готов к push после merge PR-2) |
-| 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 | 📋 Планируется |
+| 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 | ✅ Done (готов к push после merge PR-3) |
 | 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 | 📋 Планируется |
 | 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 | 📋 Планируется |
 | 7 | `ttsrh-1/saved-filters` | SavedFilter CRUD/share/favorite + User.preferences | 8 | PR-5 | TTSRH-8, TTSRH-9 | 📋 Планируется |

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1494,7 +1494,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 |---|--------|-------|------|-----------|----------------|--------|
 | 1 | `ttsrh-1/foundation` | Prisma schema (SavedFilter, User.preferences), feature flags, пустые модули | 6 | — | TTSRH-8 (schema), TTSRH-22 (flag) | 🟢 Merged ([#100](https://github.com/NovakPAai/tasktime-mvp/pull/100)) |
 | 2 | `ttsrh-1/parser` | Tokenizer + Parser + AST + golden-set | 14 | PR-1 | TTSRH-2 | 🟢 Merged ([#101](https://github.com/NovakPAai/tasktime-mvp/pull/101)) |
-| 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 | ✅ Done (готов к push после merge PR-2) |
+| 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 | 🟢 Merged ([#102](https://github.com/NovakPAai/tasktime-mvp/pull/102)) |
 | 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 | ✅ Done (готов к push после merge PR-3) |
 | 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 | 📋 Планируется |
 | 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 | 📋 Планируется |

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,66 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.29**
+**Last version: 2.30**
+
+---
+
+## [2.30] [2026-04-20] feat(search): TTSRH-1 PR-4 — compiler (AST → Prisma + custom-field raw SQL + scope R3)
+
+**PR:** (to be filled after push)
+**Ветка:** `ttsrh-1/compiler`
+
+### Что было
+
+После PR-3 был validator, но ничего не умело превратить AST в Prisma-запрос. `/search/issues` оставался 501.
+
+### Что теперь
+
+Готов pure compiler AST → `Prisma.IssueWhereInput` с полной поддержкой system-полей, custom-полей через raw SQL, pre-resolved function-ов, и scope-фильтра.
+
+- **`search.compile-context.ts`** — `CompileContext` (accessibleProjectIds, customFields, resolved, now, variant), `FunctionCallKey` canonical serialisation, `FunctionCallValue` (scalar-id / id-list / scalar-datetime / resolve-failed). `buildFunctionCallKey(name, args)` дедупит повторяющиеся вызовы в одном AST.
+- **`search.compiler.ts`** (pure, no Prisma runtime — только types) — `compile(ast, ctx) → CompileResult { where, orderBy, customPredicates, warnings, errors }`. Visitor обходит Or/And/Not/Clause, каждая clause переводится в Prisma-предикат. Scope-фильтр `projectId IN accessibleProjectIds` добавляется как `AND[0]` всегда (R3). Функции в значениях резолвятся через `ctx.resolved.calls` — компилятор сам не хитит БД. Pure date helpers (now/today/startOfX/endOfX) вычисляются через `evaluatePureDateFn`. `compile()` никогда не бросает — на внутренних ошибках возвращает `MATCH_NONE`.
+- **`search.custom-field.ts`** — custom-field clauses компилируются в `Prisma.sql` фрагменты (`SELECT issue_id FROM issue_custom_field_values WHERE ...`). Диспетчеризация по `CustomFieldType`: TEXT/TEXTAREA/URL → `value->>'v'`, NUMBER/DECIMAL → `(value->>'n')::numeric`, DATE → `(value->>'d')::date`, CHECKBOX → `(value->>'b')::boolean`, LABEL/MULTI_SELECT → `value @> to_jsonb(?::text)` (array containment). **Все значения через `${...}` Prisma interpolation — 0 string-concat, R1-safe.** IS EMPTY компилируется в `NOT EXISTS` sub-query.
+- **`search.function-resolver.ts`** — DB-wired layer. `collectFunctionCalls(ast)` вытаскивает уникальные вызовы по canonical-key; `resolveFunctions(ast, ctx)` queries Prisma по одному разу на уникальный вызов. Реализовано 11 DB-зависимых функций: membersOf, openSprints/closedSprints/futureSprints, unreleasedVersions/releasedVersions, earliestUnreleased/latestReleased, linkedIssues, subtasksOf, epicIssues, myOpenIssues. Ошибки резолва → `resolve-failed` с reason, компилятор эмитит `UNRESOLVED_FUNCTION` и MATCH_NONE.
+
+### Тесты (392 passing, +50 к PR-3)
+
+- **`tests/search-compiler.unit.test.ts`** (50 кейсов) — **T-2 per-field×per-operator матрица**:
+  - Scope R3 (3 кейса): empty query, always first in AND, empty projects → match none.
+  - Compare operators (4+7+2+3 = 16 кейсов): string equality/inequality, numeric compare <=, >=, >, <, =, !=, date compare с Prisma filter, text ~/!~ с `mode: 'insensitive'`.
+  - IN/NOT IN (3).
+  - IS EMPTY/IS NOT EMPTY/IS NULL/IS NOT NULL (4).
+  - Boolean structure (5): AND, OR, NOT, precedence, parens.
+  - Function values (5): currentUser mapping, pure date, relative date, pre-resolved id-list, empty id-list → MATCH_NONE, unresolved → error.
+  - ORDER BY (3).
+  - Custom fields (7): resolve by name/UUID, IN, NOT IN, text ~, IS EMPTY, unknown UUID.
+  - Error paths (2).
+  - **Property-based fuzz** (1): 500 random parseable queries compile без throw.
+
+### Изменения
+
+- `backend/src/modules/search/search.compile-context.ts` — новый.
+- `backend/src/modules/search/search.compiler.ts` — новый.
+- `backend/src/modules/search/search.custom-field.ts` — новый.
+- `backend/src/modules/search/search.function-resolver.ts` — новый.
+- `backend/src/modules/search/search.schema.ts` — `CustomFieldDef.fieldType` добавлен.
+- `backend/src/modules/search/search.schema.loader.ts` — заполняет `fieldType` из Prisma.
+- `backend/tests/search-compiler.unit.test.ts` — новый.
+- `backend/package.json` — `test:parser` включает compiler-тест.
+- `docs/tz/TTSRH-1.md` §13.9 — статус PR-4 → ✅ Done.
+
+### Влияние на prod
+
+0. Без feature-flag cutover — compiler ещё не подключен к `/search/issues` (это PR-5). Существующие эндпоинты не затронуты.
+
+### Проверки
+
+- `npx tsc --noEmit` — чисто
+- `npm run lint` — 0 errors, 0 new warnings
+- `npm run test:parser` — **392 passing** локально без Postgres
+- **R1 проверен**: весь raw SQL в custom-field.ts через `Prisma.sql` template с `${...}` interpolation — 0 string concat.
+- **R3 проверен**: scope-фильтр всегда `AND[0]` (тест `scope filter is always the top-level AND prefix`).
+- Golden-set 63/63 parse + validate без изменений.
 
 ---
 


### PR DESCRIPTION
## Summary

TTSRH-1 PR-4 — pure AST → `Prisma.IssueWhereInput` компилятор с полной поддержкой system-полей, custom-fields через raw JSON-SQL, pre-resolved функций и обязательного scope-фильтра (R3 ТЗ).

- **`search.compile-context.ts`** — `CompileContext`, canonical `FunctionCallKey`, `FunctionCallValue` union (scalar-id / id-list / scalar-datetime / resolve-failed).
- **`search.compiler.ts`** (pure, type-only Prisma import) — `compile(ast, ctx): CompileResult`. Scope-фильтр `projectId IN accessibleProjectIds` — **всегда AND[0]** (R3). Pure date helpers через `evaluatePureDateFn`. Function values pre-resolved через `ctx.resolved.calls`. `compile()` никогда не бросает.
- **`search.custom-field.ts`** — raw SQL для custom-field clauses через `Prisma.sql`: TEXT → `value->>'v'`, NUMBER → `(value->>'n')::numeric`, DATE → `(value->>'d')::date`, CHECKBOX → `(value->>'b')::boolean`, LABEL/MULTI_SELECT → `(value->'v') @> to_jsonb(?::text)`. **Все значения через `${...}` — 0 string-concat**. `COMPARATOR_SQL` map типа `Record<string, Prisma.Sql>` исключает `Prisma.raw()` — R1 audit-surface ноль.
- **`search.function-resolver.ts`** — DB-wired layer. 11 функций (membersOf/open-closed-future Sprints/un-released Versions/earliestUnreleased/latestReleased/linkedIssues/subtasksOf/epicIssues/myOpenIssues). `Promise.all` для параллельного резолва. `findIssueByKey` и linkedIssues scope'ятся по accessible projects (defense-in-depth).
- **`search.schema.ts`** — `CustomFieldDef.fieldType` добавлен для JSON-диспетчеризации.
- **`search.compiler.ts`** — exported `assertNoUnresolvedPlaceholders(where)` guard для PR-5 executor.

## Тесты — 395 passing (+53 к PR-3)

- **`tests/search-compiler.unit.test.ts`** (53 кейса) — T-2 per-field×per-operator матрица:
  - Scope R3 (3): empty query, always AND[0], empty projects → match none.
  - Compare operators 16 кейсов (string/number/date/text).
  - IN / NOT IN (3), IS EMPTY (4), boolean precedence (5).
  - Function values (5): currentUser, pure date, relative date, pre-resolved id-list, unresolved → error.
  - ORDER BY (3).
  - Custom fields (8): by name, by UUID, IN, NOT IN, text ~, IS EMPTY, unknown UUID, **LABEL/MULTI_SELECT JSON path**.
  - Error paths (2).
  - **Property-based fuzz**: 500 random parseable queries компилируются без throw.
  - `assertNoUnresolvedPlaceholders` guard (2 кейса).

## Pre-push review

Прогнал перед открытием. Summary: 🟠 3 · 🟡 4 · 🔵 2. Все применены в follow-up коммите:

- 🟠 **LABEL/MULTI_SELECT silent bug**: `@> to_jsonb(text)` на outer wrapper `{"v":[...]}` всегда false. Фикс: descend в `value->'v'`. Без фикса `labels = "bug"` возвращал бы 0 задач в prod.
- 🟠 **`Prisma.raw(comparator)` убран** — заменён `COMPARATOR_SQL` constants map. R1 audit-surface сокращён.
- 🟠 **`membersOf` case-insensitive**: раньше `"Team"` и `"team"` давали разные cache keys и silent-match нулевую группу.
- 🟡 **`resolveFunctions` переведён на `Promise.all`** — для 5+ функций latency падает 5×.
- 🟡 **`linkedIssues` scope-filter в resolver** — defense-in-depth поверх compiler AND[0].
- 🟡 **`assertNoUnresolvedPlaceholders`** exported — catches wiring gaps в PR-5 executor.
- 🟡 RelativeDate в CF: JSDoc-note про рекомендацию `startOfDay("-7d")`.
- 🔵 `subtasksOf` / `epicIssues`: консолидированы в `resolveChildrenOf` + scope-filter.
- 🔵 `myOpenIssues`: `IssueStatus.DONE` enum вместо hardcoded 'DONE'.

## Test plan

- [x] Backend `npx tsc --noEmit` — чисто
- [x] Backend `npm run lint` — 0 errors, 0 new warnings
- [x] `npm run test:parser` — 395 passing локально без Postgres
- [x] R1 audit: весь raw SQL через `Prisma.sql` с `${...}` interpolation; ноль `Prisma.raw()`
- [x] R3 audit: scope filter всегда AND[0], покрыто тестом
- [ ] Integration `npm test` в CI — с Postgres

## Зависимости

- **Зависит от:** PR-3 ([#102](https://github.com/NovakPAai/tasktime-mvp/pull/102)) — merged 🟢.
- **Следующий:** PR-5 (endpoints) — `POST /search/issues` + executor для custom-field placeholder + rate-limit + timeout + fuzz-harness.

## Плановая дельта

- Прогресс: **PR-4 / 21** по §13.9 ТЗ.
- Версия: 2.30 в [version_history.md](version_history.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
