### PR TITLE
feat(search): TTSRH-1 PR-6 — Value Suggesters backend + GET /search/suggest

### DIFF
--- a/.claude/commands/implement-tz.md
+++ b/.claude/commands/implement-tz.md
@@ -1,0 +1,152 @@
+---
+description: Реализовать большое ТЗ по циклу с PR-ами, pre-push review, merge-кaденсом и автоматическим CI-мониторингом
+---
+
+# /implement-tz — Реализация большого ТЗ циклом PR'ов
+
+**Триггер:** `/implement-tz <ключ-ТЗ>` или `Реализуй ТЗ <ключ>`.
+
+Пример: `Реализуй ТЗ TTSRH-1` — прочитать `docs/tz/TTSRH-1.md`, декомпозировать на PR'ы, реализовать каждый PR в одном и том же цикле, автоматически мерджить зелёные PR-ы.
+
+## Правила игры
+
+- **Один PR — один атомарный кусок функциональности.** 400–900 LoC diff максимум. Если больше — делим на два PR.
+- **Каждый PR проходит полный цикл**, описанный ниже. Никаких срезаний углов.
+- **Статусы в ТЗ обновляются на каждом шаге:** 📋 Планируется → 🚧 В работе → ✅ Done → 🟢 Merged.
+- **CI мониторится асинхронно** через `ScheduleWakeup` (780s ~ 13 мин). Не зацикливаемся на polling.
+- **Pre-push review обязателен ДО push'а.** Apply 🟠/🟡-фиксы в follow-up коммит.
+- **Cycle continues** пока не merged последний PR эпика.
+
+## Декомпозиция (выполняется один раз в начале)
+
+1. **Прочитать ТЗ** `docs/tz/<KEY>.md` полностью (через `ctx_read` / chunks если >80K).
+2. **Составить план PR'ов** со всеми секциями:
+   - `13.1 Стратегия` (branch naming `<key-lowercase>/<scope>`, feature flag если нужен, size budget, CI-требования, security-review gate)
+   - `13.2 DAG зависимостей` (ASCII)
+   - `13.3–13.N PR-ы по фазам` — каждая карточка: Branch, Scope (с файлами), Не включает, Merge-ready check, Оценка.
+   - `13.N+1 Итог: таблица PR | № | Branch | Scope | Часы | Зависимости | Сабтаски | Статус |` (с легендой: 📋 Планируется · 🚧 В работе · ✅ Done · 🟢 Merged).
+3. **Записать план как §13** в том же `docs/tz/<KEY>.md`.
+4. **Commit** декомпозиции отдельно: `docs(tz): <KEY> — план реализации (§13)`.
+
+## Цикл одного PR (повторить для каждой карточки §13.3+)
+
+### 1. Подготовка ветки
+- **Обновить todo-лист** через `TodoWrite`: все шаги ниже как отдельные задачи.
+- **Pop stash** с `.claude/settings.json` если есть (он не должен попадать в коммит).
+- **`git checkout -b <branch>`** от предыдущей PR-ветки (чтобы иметь уже реализованные абстракции) или от `main` (первый PR).
+- **Обновить статус в ТЗ:** 📋 → 🚧 В работе.
+
+### 2. Исследование
+- **Прочитать** существующие файлы, которые будут затронуты (через `ctx_read`).
+- **Grep** паттерны: как ранее делались похожие модули, типы Prisma, middlewares, exports.
+- **Не дублировать** утилиты, которые уже есть в `shared/`.
+
+### 3. Имплементация
+- **Пишем production-код** сначала. Комментарии только про **почему**, не про **что** (см. CLAUDE.md).
+- **Каждый новый файл** начинается с JSDoc-блока: TTSRH ссылка, что делает, публичный API, инварианты (never-throw, R1/R3/R15).
+- **Zod-DTO** на всех HTTP-входах. `authenticate` middleware на приватных эндпоинтах.
+- **Feature-flag gate** в app.ts если требуется (обновить `features.ts` + `VITE_*` зеркало).
+- **После каждого файла** запускать `tsc --noEmit` для раннего обнаружения type-ошибок.
+
+### 4. Тесты
+- **Pure-unit-тесты** для каждого нового pure-модуля. Добавить в `package.json:test:parser` если работают без Postgres.
+- **Property-based fuzz** для hot paths (парсер, компилятор) — seeded `mulberry32`, 500-1000 итераций, adversarial payloads включить.
+- **Coverage target:** 80%+ для нового кода.
+- **Integration-тесты** (требующие Postgres) пишем, но не запускаем локально — CI проверит.
+
+### 5. Документация
+- **`version_history.md`** — запись с новой версией (инкремент). Формат: «Что было → Что теперь → Изменения → Влияние на prod → Проверки».
+- **`docs/tz/<KEY>.md` §13.N`** — статус PR → ✅ Done (готов к push после merge предыдущего).
+- **CLAUDE.md правила** на модалки/refresh — применить если задача фронтовая.
+
+### 6. Проверки локально
+- `npx tsc --noEmit` — зелёный.
+- `npm run lint` — 0 errors, 0 новых warnings.
+- `npm run test:parser` (или эквивалент pure-unit) — все зелёные.
+- Manual smoke если есть UI/endpoint — отметить в PR description что проверено.
+
+### 7. Коммит локально (ещё не push!)
+- **Staging целевых файлов** через `git add <path> <path>...` — **никогда** `git add .` или `-A`. Явно исключать `.claude/settings.json`, `.claude/scheduled_tasks.lock`.
+- **Сообщение коммита** в heredoc → tmp-файл → `git commit -F`. Zsh ломает heredoc в inline.
+- **Формат:**
+  ```
+  feat(<scope>): <KEY> PR-<N> — <summary>
+
+  <body: что, почему, коротко>
+
+  См. docs/tz/<KEY>.md §13.N PR-<N>.
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  ```
+
+### 8. Pre-push review (обязательно!)
+- **`Agent(subagent_type: pre-push-reviewer, prompt: <detailed diff summary>)`**.
+- Prompt агенту включает: все файлы с кратким описанием, локальные проверки, **перечисление зон риска** (R1/R3/R15/RBAC/race conditions/SQL-injection/etc).
+- Агент возвращает список находок с приоритетами 🟠 🟡 🔵 ⚪.
+
+### 9. Apply фиксы
+- **🟠 + 🟡 обязательно** — это потенциальные баги.
+- **🔵 оптимизация** — применяем если не больше 5 минут.
+- **⚪ nitpick** — на усмотрение.
+- Для каждой находки: fix + unit-тест закрывающий кейс (если применимо).
+- Коммит follow-up: `chore(<scope>): <KEY> PR-<N> — pre-push review fixups`.
+
+### 10. Мониторинг CI предыдущего PR
+- **`gh pr view <prev-PR> --json state,mergeStateStatus,statusCheckRollup`** — проверить состояние.
+- **Если всё зелёное** — `gh pr merge <prev-PR> --squash --delete-branch`.
+- **Обновить статус в ТЗ** на 🟢 Merged. Commit: `docs(tz): <KEY> — PR-<N> merged, статус 🟢`.
+
+### 11. Rebase на свежий main
+- **Stash settings.json**: `git stash push -m "settings" -- .claude/settings.json`.
+- **`git fetch origin main && git rebase origin/main`**.
+- **При конфликтах на уже-squash-merged PR'ов** — `git rebase --skip` для каждого их коммита (содержимое уже upstream).
+- **Reprогнать** tsc + test:parser после rebase.
+
+### 12. Push + Open PR
+- `git push -u origin <branch>`.
+- **PR body в tmp-файле** (heredoc ломается в zsh).
+- **Формат body:** Summary (bullets), Pre-push review counts, Test plan (чекбоксы), Зависимости, Плановая дельта.
+- `gh pr create --base main --head <branch> --title "<type>(<scope>): <KEY> PR-<N> — <summary>" --body-file /tmp/<key>-pr<N>-body.md`.
+
+### 13. Schedule auto-check
+- **`ScheduleWakeup`** через 780s (~13 мин, типичное время backend CI): `"проверь состояние CI PR-<N> (#<num>), если всё зелёное — merge"`.
+
+## Что сохранить между циклами
+
+- **Полное покрытие §13 в ТЗ** — статусы PR'ов.
+- **Тесты всех предыдущих PR** остаются зелёными. Регрессий нет.
+- **`test:parser` npm-script** актуален — включает все новые unit-файлы.
+- **`version_history.md`** — запись на каждый PR, инкрементальный version.
+
+## Anti-patterns (НЕ делать)
+
+- ❌ Push без pre-push review.
+- ❌ `git add .` или `-A` — захватит settings.json.
+- ❌ Merge PR без CI зелёного (даже AI Review — дождаться).
+- ❌ Скипать тесты потому что «Postgres не на локали» — написать и надеяться на CI.
+- ❌ Массивные PR'ы 2000+ LoC — разбивать.
+- ❌ Пропускать обновление `version_history.md` — это правило в CLAUDE.md.
+- ❌ Обновлять статус PR в ТЗ на Merged ДО фактического merge.
+- ❌ Polling CI через `sleep` в цикле — использовать `ScheduleWakeup`.
+
+## Что делать, когда `ScheduleWakeup` триггерит проверку
+
+1. Проверить PR, который просит prompt (но он может быть устаревшим — один из предыдущих уже merged).
+2. Проверить **актуальный открытый PR** в эпике.
+3. Если CI зелёный — merge + обновить статус.
+4. Если красный — прочитать логи failed job, починить, push fix, re-schedule.
+5. Если pending — ScheduleWakeup ещё раз на 300s.
+
+## Когда цикл завершён
+
+- Все PR'ы эпика имеют статус 🟢 Merged в §13.
+- Последний PR (обычно docs-cutover + feature-flag flip) включает финальный UAT.
+- Итоговое сообщение пользователю: «эпик <KEY> завершён, N PR'ов merged, feature-flag flipped».
+
+---
+
+## Ссылки
+
+- Пример работы цикла: эпик [TTSRH-1](docs/tz/TTSRH-1.md) — PR-1..PR-5.
+- Memory-rule: `/Users/georgydubovik/.claude/projects/-Users-georgydubovik-tasktime-mvp/memory/feedback_version_history.md` — обязательное обновление `version_history.md`.
+- Pre-push reviewer агент: `.claude/agents/pre-push-reviewer.md`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts tests/search-functions.unit.test.ts tests/search-validator.unit.test.ts tests/search-compiler.unit.test.ts tests/search-pipeline-fuzz.unit.test.ts",
+    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts tests/search-functions.unit.test.ts tests/search-validator.unit.test.ts tests/search-compiler.unit.test.ts tests/search-pipeline-fuzz.unit.test.ts tests/search-suggest.unit.test.ts",
     "lint": "eslint src/ --ext .ts",
     "format": "prettier --write 'src/**/*.ts'",
     "mcp": "tsx src/mcp/server.ts"

--- a/backend/src/modules/search/search.router.ts
+++ b/backend/src/modules/search/search.router.ts
@@ -237,8 +237,23 @@ async function resolveAccessibleProjectIds(req: AuthRequest): Promise<Accessible
 
 // ─── GET /search/suggest ────────────────────────────────────────────────────
 
+const suggestQuerySchema = z.object({
+  jql: z.string().max(10_000).optional(),
+  cursor: z.string().optional(),
+  field: z.string().max(200).optional(),
+  operator: z.string().max(20).optional(),
+  prefix: z.string().max(200).optional(),
+  variant: z.enum(['default', 'checkpoint']).optional(),
+});
+
 router.get(
   '/search/suggest',
+  // Autocomplete is called on every keystroke (editor debounces 150ms on the
+  // frontend), but spam-protect anyway — 30 req/min caps an abusive client at
+  // one request every 2s, still usable by a real user typing at ~10 chars/s
+  // after debounce applies.
+  searchRateLimit,
+  validateDto(suggestQuerySchema, 'query'),
   async (req: Request, res: Response, next): Promise<void> => {
     try {
       const auth = req as AuthRequest;
@@ -247,12 +262,12 @@ router.get(
         return;
       }
       const { projectIds } = await resolveAccessibleProjectIds(auth);
-      const { jql = '', cursor: cursorRaw, field, operator, prefix, variant } =
-        req.query as Record<string, string | undefined>;
+      const { jql, cursor: cursorRaw, field, operator, prefix, variant } =
+        req.query as z.infer<typeof suggestQuerySchema>;
       const cursor = Number.parseInt(cursorRaw ?? '0', 10);
       const customFields = await loadCustomFields();
       const result = await suggest(
-        typeof jql === 'string' ? jql.slice(0, 10_000) : '',
+        jql ?? '',
         Number.isFinite(cursor) ? cursor : 0,
         {
           userId: auth.user.userId,

--- a/backend/src/modules/search/search.router.ts
+++ b/backend/src/modules/search/search.router.ts
@@ -12,6 +12,7 @@ import { loadCustomFields } from './search.schema.loader.js';
 import { functionsForVariant } from './search.functions.js';
 import { searchIssues } from './search.service.js';
 import { searchRateLimit } from './search.rate-limit.js';
+import { suggest } from './search.suggest.js';
 import type { QueryVariant } from './search.types.js';
 
 /**
@@ -234,9 +235,44 @@ async function resolveAccessibleProjectIds(req: AuthRequest): Promise<Accessible
   };
 }
 
+// ─── GET /search/suggest ────────────────────────────────────────────────────
+
+router.get(
+  '/search/suggest',
+  async (req: Request, res: Response, next): Promise<void> => {
+    try {
+      const auth = req as AuthRequest;
+      if (!auth.user) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+      const { projectIds } = await resolveAccessibleProjectIds(auth);
+      const { jql = '', cursor: cursorRaw, field, operator, prefix, variant } =
+        req.query as Record<string, string | undefined>;
+      const cursor = Number.parseInt(cursorRaw ?? '0', 10);
+      const customFields = await loadCustomFields();
+      const result = await suggest(
+        typeof jql === 'string' ? jql.slice(0, 10_000) : '',
+        Number.isFinite(cursor) ? cursor : 0,
+        {
+          userId: auth.user.userId,
+          accessibleProjectIds: projectIds,
+          variant: (variant === 'checkpoint' ? 'checkpoint' : 'default') as QueryVariant,
+          field,
+          operator,
+          prefix,
+        },
+        customFields,
+      );
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // ─── Still-stubbed endpoints ────────────────────────────────────────────────
 
-router.get('/search/suggest', notImplemented('GET /search/suggest'));
 router.post('/search/export', notImplemented('POST /search/export'));
 
 export default router;

--- a/backend/src/modules/search/search.suggest.position.ts
+++ b/backend/src/modules/search/search.suggest.position.ts
@@ -1,0 +1,259 @@
+/**
+ * TTSRH-1 PR-6 — position analyser for the TTS-QL suggest pipeline.
+ *
+ * Given the raw JQL text and a cursor offset, determine what the user is trying
+ * to type: a field? an operator? a value? a function name? The parser recovers
+ * gracefully from incomplete input, so this module walks the tokenizer output
+ * up to the cursor position and applies heuristic rules.
+ *
+ * The heuristics match the §5.11 ТЗ contract — callers expect:
+ *   - After `{nothing}` / `AND` / `OR` / `NOT` / `(` → **field**.
+ *   - After a field → **operator** compatible with its type.
+ *   - After an operator (`=`/`!=`/`>`/`<`/`IN`/`IS`) → **value**.
+ *   - After `,` inside `IN (…)` → **value**, and dedupe picked values.
+ *   - After `ORDER BY` → **field** (sortable only — enforced in suggester).
+ *
+ * We fail open: if the input is irrecoverable, we return `{ expected: 'field' }`
+ * so the editor still shows something useful.
+ */
+
+import { resolveSystemField } from './search.schema.js';
+import { tokenize, type Token } from './search.tokenizer.js';
+import type { PositionContext } from './search.suggest.types.js';
+
+const BOOLEAN_CONTINUATION = new Set(['AND', 'OR', 'NOT']);
+const IN_OPS = new Set(['IN', 'NOT']); // "NOT IN" handled specially via lookahead
+
+/**
+ * Analyse `source` with a cursor at byte offset `cursor`. Returns a
+ * `PositionContext` describing what kind of completion is expected and the
+ * prefix the user has typed so far.
+ */
+export function analysePosition(source: string, cursor: number): PositionContext {
+  // Guard — cursor out of bounds normalises to end.
+  const pos = Math.max(0, Math.min(cursor, source.length));
+  const before = source.slice(0, pos);
+
+  // Tokenize the text up to the cursor. On tokenizer errors (e.g. unterminated
+  // string), fall back to treating everything as "field expected with empty
+  // prefix" — editor experience degrades gracefully.
+  let tokens: Token[];
+  try {
+    tokens = tokenize(before);
+  } catch {
+    return emptyField();
+  }
+
+  // Strip trailing Eof token for easier last-token access.
+  const real = tokens.filter((t) => t.kind !== 'Eof');
+  if (real.length === 0) return emptyField();
+
+  // Compute the "prefix" — characters from the start of the last ident/string
+  // to the cursor. If the cursor is inside whitespace, prefix is empty.
+  const prefix = extractPrefix(source, pos, real);
+
+  // If the cursor touches the end of an *editable* token (ident/string/number/
+  // relative-date/custom-field), treat that token as being typed and analyse
+  // the context before it. Structural delimiters (`(`, `,`, `)`, operators,
+  // `=`) are not edited in place, so we keep them as context.
+  const lastToken = real[real.length - 1]!;
+  const editableKinds = new Set(['Ident', 'String', 'Number', 'RelativeDate', 'CustomField']);
+  const editingLastToken = pos === lastToken.span.end && editableKinds.has(lastToken.kind);
+  const effectiveTokens = editingLastToken ? real.slice(0, -1) : real;
+
+  if (effectiveTokens.length === 0) return withPrefix(emptyField(), prefix);
+
+  return analyseAfterTokens(effectiveTokens, prefix);
+}
+
+// ─── Heuristics ─────────────────────────────────────────────────────────────
+
+function analyseAfterTokens(tokens: readonly Token[], prefix: string): PositionContext {
+  const last = tokens[tokens.length - 1]!;
+
+  // Case 1 — inside an IN value list. Check FIRST, so `(` after `IN` is not
+  // mis-classified as a grouping boundary.
+  const inListCtx = detectInList(tokens);
+  if (inListCtx) {
+    return {
+      expected: 'value',
+      prefix,
+      field: inListCtx.field,
+      operator: 'IN',
+      inValueList: true,
+      pickedValues: inListCtx.picked,
+    };
+  }
+
+  // Case 2 — after a boolean connective / grouping paren / NOT: expect field.
+  if (isBooleanBoundary(last)) {
+    return { expected: 'field', prefix, inValueList: false, pickedValues: [] };
+  }
+
+  // Case 3 — after `ORDER BY` or a comma inside sort list.
+  if (isAfterOrderBy(tokens)) {
+    return { expected: 'field', prefix, inValueList: false, pickedValues: [] };
+  }
+
+  // Case 4 — after a field (next token is a comparison op or expected op).
+  const fieldThenOp = detectFieldThenOp(tokens);
+  if (fieldThenOp) {
+    return {
+      expected: 'value',
+      prefix,
+      field: fieldThenOp.field,
+      operator: fieldThenOp.op,
+      inValueList: false,
+      pickedValues: [],
+    };
+  }
+
+  // Case 5 — field just named, next expected is operator.
+  if (last.kind === 'Ident' && isLikelyField(last.value)) {
+    return {
+      expected: 'operator',
+      prefix,
+      field: last.value.toLowerCase(),
+      inValueList: false,
+      pickedValues: [],
+    };
+  }
+
+  // Case 6 — fallback: field.
+  return { expected: 'field', prefix, inValueList: false, pickedValues: [] };
+}
+
+function isBooleanBoundary(t: Token): boolean {
+  if (t.kind === 'LParen') return true;
+  if (t.kind === 'Ident' && BOOLEAN_CONTINUATION.has(t.value.toUpperCase())) return true;
+  return false;
+}
+
+/**
+ * Look back through tokens to see if we're inside an `IN (...)` list.
+ * Returns the field name and the values already picked (for dedup).
+ */
+function detectInList(tokens: readonly Token[]): { field: string; picked: readonly string[] } | null {
+  // Find the closest unmatched LParen working backwards.
+  let depth = 0;
+  let lparenIdx = -1;
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const t = tokens[i]!;
+    if (t.kind === 'RParen') depth++;
+    else if (t.kind === 'LParen') {
+      if (depth === 0) {
+        lparenIdx = i;
+        break;
+      }
+      depth--;
+    }
+  }
+  if (lparenIdx < 1) return null;
+
+  // Check what's before the LParen — must be IN or NOT IN.
+  const prev = tokens[lparenIdx - 1];
+  if (!prev || prev.kind !== 'Ident') return null;
+  if (prev.value.toUpperCase() !== 'IN') return null;
+
+  // Find field: prev-prev ident (skipping over NOT).
+  let fieldIdx = lparenIdx - 2;
+  if (fieldIdx >= 0 && tokens[fieldIdx]!.kind === 'Ident' && tokens[fieldIdx]!.value.toUpperCase() === 'NOT') {
+    fieldIdx--;
+  }
+  if (fieldIdx < 0) return null;
+  const fieldTok = tokens[fieldIdx]!;
+  if (fieldTok.kind !== 'Ident' && fieldTok.kind !== 'String' && fieldTok.kind !== 'CustomField') return null;
+
+  // Collect picked values inside the list (String/Number/Ident tokens separated
+  // by commas).
+  const picked: string[] = [];
+  for (let i = lparenIdx + 1; i < tokens.length; i++) {
+    const t = tokens[i]!;
+    if (t.kind === 'String' || t.kind === 'Number' || t.kind === 'Ident') {
+      picked.push(t.value);
+    }
+  }
+
+  return {
+    field:
+      fieldTok.kind === 'Ident'
+        ? fieldTok.value.toLowerCase()
+        : fieldTok.kind === 'String'
+          ? fieldTok.value
+          : fieldTok.value,
+    picked,
+  };
+}
+
+function isAfterOrderBy(tokens: readonly Token[]): boolean {
+  const last = tokens[tokens.length - 1]!;
+  if (last.kind === 'Comma' || (last.kind === 'Ident' && last.value.toUpperCase() === 'BY')) {
+    // Also confirm `ORDER BY` preceded this region.
+    for (let i = tokens.length - 1; i >= 0; i--) {
+      if (tokens[i]!.kind === 'Ident' && tokens[i]!.value.toUpperCase() === 'ORDER') return true;
+    }
+  }
+  return false;
+}
+
+function detectFieldThenOp(tokens: readonly Token[]): { field: string; op: string } | null {
+  if (tokens.length < 2) return null;
+  const last = tokens[tokens.length - 1]!;
+  const prev = tokens[tokens.length - 2]!;
+  // Case: `priority =` → expect value.
+  if (last.kind === 'Op' && (prev.kind === 'Ident' || prev.kind === 'CustomField' || prev.kind === 'String')) {
+    return {
+      field: fieldName(prev),
+      op: last.value,
+    };
+  }
+  // Case: `assignee IN` → expect value (without outer paren — bare `IN` case).
+  if (last.kind === 'Ident' && last.value.toUpperCase() === 'IN' && (prev.kind === 'Ident' || prev.kind === 'CustomField' || prev.kind === 'String')) {
+    return { field: fieldName(prev), op: 'IN' };
+  }
+  return null;
+}
+
+function isLikelyField(name: string): boolean {
+  const upper = name.toUpperCase();
+  // Keywords aren't fields.
+  if (BOOLEAN_CONTINUATION.has(upper)) return false;
+  if (upper === 'IN' || upper === 'IS' || upper === 'EMPTY' || upper === 'NULL' || upper === 'ORDER' || upper === 'BY') return false;
+  // System fields are definitely fields.
+  if (resolveSystemField(name)) return true;
+  // Unknown idents at clause-start are still likely fields (user is typing a
+  // custom-field name or an unknown identifier) — suggester will filter.
+  return true;
+}
+
+function fieldName(t: Token): string {
+  if (t.kind === 'Ident') return t.value.toLowerCase();
+  if (t.kind === 'CustomField') return t.value;
+  if (t.kind === 'String') return t.value;
+  return '';
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function emptyField(): PositionContext {
+  return { expected: 'field', prefix: '', inValueList: false, pickedValues: [] };
+}
+
+function withPrefix(ctx: PositionContext, prefix: string): PositionContext {
+  return { ...ctx, prefix };
+}
+
+function extractPrefix(source: string, cursor: number, tokens: readonly Token[]): string {
+  const last = tokens[tokens.length - 1]!;
+  // Cursor sits right at end of last token → prefix = that token's lexeme.
+  if (cursor === last.span.end) {
+    if (last.kind === 'Ident') return last.value;
+    if (last.kind === 'String') {
+      // Strip surrounding quotes from prefix.
+      return last.value;
+    }
+    return '';
+  }
+  // Cursor past the last token (whitespace after) → empty prefix.
+  return '';
+}

--- a/backend/src/modules/search/search.suggest.position.ts
+++ b/backend/src/modules/search/search.suggest.position.ts
@@ -22,7 +22,6 @@ import { tokenize, type Token } from './search.tokenizer.js';
 import type { PositionContext } from './search.suggest.types.js';
 
 const BOOLEAN_CONTINUATION = new Set(['AND', 'OR', 'NOT']);
-const IN_OPS = new Set(['IN', 'NOT']); // "NOT IN" handled specially via lookahead
 
 /**
  * Analyse `source` with a cursor at byte offset `cursor`. Returns a

--- a/backend/src/modules/search/search.suggest.providers.ts
+++ b/backend/src/modules/search/search.suggest.providers.ts
@@ -6,10 +6,12 @@
  * the query level (never client-side) — a user searching `assignee = al` must
  * not see `alice@othercorp.com` if they share no projects.
  *
- * Providers are synchronous contract-wise but async by impl; the orchestrator
- * fans them out via `Promise.all` for the current position context.
+ * Providers are async by impl. The orchestrator routes a single provider per
+ * request based on the resolved field's type, so each endpoint call executes
+ * exactly one provider — no concurrent fan-out here.
  */
 
+import { Prisma } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import type { Completion } from './search.suggest.types.js';
 import { rankByPrefix } from './search.suggest.rank.js';
@@ -23,9 +25,11 @@ export async function suggestUsers(
   accessibleProjectIds: readonly string[],
 ): Promise<Completion[]> {
   const prefixLc = prefix.toLowerCase();
-  // Users scoped to projects the caller can see. ADMIN / RELEASE_MANAGER would
-  // see everyone via the system-role path upstream; here we play conservative
-  // and stick to `UserProjectRole` join.
+  // Deliberate: this filter only returns users with an explicit UserProjectRole
+  // row. System-role ADMIN/SUPER_ADMIN users without direct project memberships
+  // are excluded — an admin can still self-assign by typing their email, but
+  // including every admin in every project's autocomplete would inflate the
+  // list and confuse users. Revisit if UX feedback flags this as surprising.
   const users = accessibleProjectIds.length > 0
     ? await prisma.user.findMany({
         where: {
@@ -112,7 +116,11 @@ export async function suggestStatuses(
     detail: 'system key',
     score: 0,
   }));
-  // WorkflowStatus entries — scoped to project list via workflow_schemes.
+  // WorkflowStatus rows are tenant-global (no `projectId` column — they form a
+  // shared catalogue referenced via WorkflowScheme). Returning all of them here
+  // is intentional: the compiler's top-level scope filter (R3) still clips the
+  // final issue result to accessible projects, so a leak at suggest layer is
+  // bounded to "user sees a status name they can't actually match against".
   if (accessibleProjectIds.length > 0) {
     const statuses = await prisma.workflowStatus.findMany({
       where: prefix
@@ -288,17 +296,25 @@ export async function suggestLabels(
   accessibleProjectIds: readonly string[],
 ): Promise<Completion[]> {
   if (accessibleProjectIds.length === 0) return [];
-  // Distinct raw-SQL — Prisma can't express DISTINCT on a JSON path in typed API.
-  // We use `$queryRaw` with safe parameter binding (R1).
+  // Distinct raw-SQL — Prisma typed API can't express DISTINCT on a JSON path.
+  // Two R1-critical details:
+  //   1. Project-scope filter is the FIRST AND clause with NO bare `OR` at its
+  //      level. Splitting it across an OR would bypass scope (pre-push review
+  //      caught this as a silent cross-project leak).
+  //   2. Array parameters go through `IN (Prisma.join(...))`, not `ANY(...::uuid[])`
+  //      — Prisma's template tag serialises JS arrays as positional parameter
+  //      placeholders, which `ANY()` cannot consume.
   type Row = { label: string };
-  const prefixParam = prefix ? `%${prefix.toLowerCase()}%` : '%';
+  const prefixFilter = prefix
+    ? Prisma.sql`AND (icfv.value->'v')::text ILIKE ${`%${prefix.toLowerCase()}%`}`
+    : Prisma.empty;
   const rows = await prisma.$queryRaw<Row[]>`
     SELECT DISTINCT jsonb_array_elements_text(icfv.value->'v') AS label
     FROM issue_custom_field_values icfv
     JOIN custom_fields cf ON cf.id = icfv.custom_field_id AND cf.field_type = 'LABEL'
     JOIN issues i ON i.id = icfv.issue_id
-    WHERE i.project_id = ANY(${[...accessibleProjectIds]}::uuid[])
-      AND (${prefix ? 1 : 0}) = 0 OR (icfv.value->'v')::text ILIKE ${prefixParam}
+    WHERE i.project_id IN (${Prisma.join([...accessibleProjectIds])})
+      ${prefixFilter}
     LIMIT ${MAX_RESULTS}
   `;
   return rankByPrefix(

--- a/backend/src/modules/search/search.suggest.providers.ts
+++ b/backend/src/modules/search/search.suggest.providers.ts
@@ -1,0 +1,361 @@
+/**
+ * TTSRH-1 PR-6 — DB-backed suggesters (TTSRH-25).
+ *
+ * Each provider queries Prisma with the caller's project scope and returns a
+ * ranked list of `Completion` objects. Scope-filtering per R3 ТЗ is applied at
+ * the query level (never client-side) — a user searching `assignee = al` must
+ * not see `alice@othercorp.com` if they share no projects.
+ *
+ * Providers are synchronous contract-wise but async by impl; the orchestrator
+ * fans them out via `Promise.all` for the current position context.
+ */
+
+import { prisma } from '../../prisma/client.js';
+import type { Completion } from './search.suggest.types.js';
+import { rankByPrefix } from './search.suggest.rank.js';
+
+const MAX_RESULTS = 20;
+
+// ─── User / assignee / reporter ────────────────────────────────────────────
+
+export async function suggestUsers(
+  prefix: string,
+  accessibleProjectIds: readonly string[],
+): Promise<Completion[]> {
+  const prefixLc = prefix.toLowerCase();
+  // Users scoped to projects the caller can see. ADMIN / RELEASE_MANAGER would
+  // see everyone via the system-role path upstream; here we play conservative
+  // and stick to `UserProjectRole` join.
+  const users = accessibleProjectIds.length > 0
+    ? await prisma.user.findMany({
+        where: {
+          isActive: true,
+          projectRoles: {
+            some: { projectId: { in: [...accessibleProjectIds] } },
+          },
+          ...(prefix
+            ? {
+                OR: [
+                  { name: { contains: prefixLc, mode: 'insensitive' } },
+                  { email: { contains: prefixLc, mode: 'insensitive' } },
+                ],
+              }
+            : {}),
+        },
+        select: { id: true, name: true, email: true },
+        take: MAX_RESULTS,
+        orderBy: [{ name: 'asc' }],
+      })
+    : [];
+
+  return rankByPrefix(
+    users.map((u) => ({
+      kind: 'value' as const,
+      label: u.name,
+      insert: `"${u.email}"`,
+      detail: u.email,
+      icon: { kind: 'avatar' as const, value: u.email },
+      score: 0,
+    })),
+    prefix,
+  );
+}
+
+// ─── Project ───────────────────────────────────────────────────────────────
+
+export async function suggestProjects(
+  prefix: string,
+  accessibleProjectIds: readonly string[],
+): Promise<Completion[]> {
+  if (accessibleProjectIds.length === 0) return [];
+  const prefixLc = prefix.toLowerCase();
+  const projects = await prisma.project.findMany({
+    where: {
+      id: { in: [...accessibleProjectIds] },
+      ...(prefix
+        ? {
+            OR: [
+              { key: { contains: prefixLc, mode: 'insensitive' } },
+              { name: { contains: prefixLc, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    },
+    select: { id: true, key: true, name: true },
+    take: MAX_RESULTS,
+    orderBy: [{ key: 'asc' }],
+  });
+  return rankByPrefix(
+    projects.map((p) => ({
+      kind: 'value' as const,
+      label: `${p.key} — ${p.name}`,
+      insert: p.key,
+      detail: p.name,
+      score: 0,
+    })),
+    prefix,
+  );
+}
+
+// ─── Workflow status ───────────────────────────────────────────────────────
+
+export async function suggestStatuses(
+  prefix: string,
+  accessibleProjectIds: readonly string[],
+): Promise<Completion[]> {
+  // System-key shortcuts first (OPEN/IN_PROGRESS/REVIEW/DONE/CANCELLED).
+  const systemKeys = ['OPEN', 'IN_PROGRESS', 'REVIEW', 'DONE', 'CANCELLED'];
+  const base: Completion[] = systemKeys.map((s) => ({
+    kind: 'value' as const,
+    label: s,
+    insert: s,
+    detail: 'system key',
+    score: 0,
+  }));
+  // WorkflowStatus entries — scoped to project list via workflow_schemes.
+  if (accessibleProjectIds.length > 0) {
+    const statuses = await prisma.workflowStatus.findMany({
+      where: prefix
+        ? { name: { contains: prefix.toLowerCase(), mode: 'insensitive' } }
+        : {},
+      select: { id: true, name: true, category: true, color: true },
+      take: MAX_RESULTS,
+      orderBy: [{ name: 'asc' }],
+    });
+    for (const s of statuses) {
+      base.push({
+        kind: 'value',
+        label: s.name,
+        insert: `"${s.name}"`,
+        detail: s.category.toLowerCase(),
+        icon: { kind: 'color-dot', value: s.color },
+        score: 0,
+      });
+    }
+  }
+  return rankByPrefix(base, prefix);
+}
+
+// ─── Issue type ────────────────────────────────────────────────────────────
+
+export async function suggestIssueTypes(prefix: string): Promise<Completion[]> {
+  const types = await prisma.issueTypeConfig.findMany({
+    where: prefix
+      ? { name: { contains: prefix.toLowerCase(), mode: 'insensitive' } }
+      : {},
+    select: { id: true, name: true, systemKey: true, iconName: true, iconColor: true },
+    take: MAX_RESULTS,
+    orderBy: [{ name: 'asc' }],
+  });
+  return rankByPrefix(
+    types.map((t) => ({
+      kind: 'value' as const,
+      label: t.name,
+      insert: t.systemKey ?? `"${t.name}"`,
+      detail: t.systemKey ?? 'custom',
+      icon: t.iconName ? { kind: 'svg' as const, value: t.iconName } : undefined,
+      score: 0,
+    })),
+    prefix,
+  );
+}
+
+// ─── Sprint ────────────────────────────────────────────────────────────────
+
+export async function suggestSprints(
+  prefix: string,
+  accessibleProjectIds: readonly string[],
+): Promise<Completion[]> {
+  // Top rows — the three sprint functions. Users tend to want these.
+  const functionShortcuts: Completion[] = [
+    { kind: 'function', label: 'openSprints()', insert: 'openSprints()', detail: 'Active sprints in your projects', score: 0 },
+    { kind: 'function', label: 'closedSprints()', insert: 'closedSprints()', detail: 'Completed sprints', score: 0 },
+    { kind: 'function', label: 'futureSprints()', insert: 'futureSprints()', detail: 'Planned sprints', score: 0 },
+  ];
+  if (accessibleProjectIds.length === 0) return rankByPrefix(functionShortcuts, prefix);
+  const sprints = await prisma.sprint.findMany({
+    where: {
+      projectId: { in: [...accessibleProjectIds] },
+      ...(prefix ? { name: { contains: prefix.toLowerCase(), mode: 'insensitive' } } : {}),
+    },
+    select: { id: true, name: true, state: true, startDate: true, endDate: true },
+    take: MAX_RESULTS,
+    orderBy: [{ startDate: 'desc' }],
+  });
+  const dynamic: Completion[] = sprints.map((s) => ({
+    kind: 'value',
+    label: s.name,
+    insert: `"${s.name}"`,
+    detail: `${s.state.toLowerCase()}${s.startDate ? ` · ${s.startDate.toISOString().slice(0, 10)}` : ''}`,
+    score: 0,
+  }));
+  return rankByPrefix([...functionShortcuts, ...dynamic], prefix);
+}
+
+// ─── Release ───────────────────────────────────────────────────────────────
+
+export async function suggestReleases(
+  prefix: string,
+  accessibleProjectIds: readonly string[],
+): Promise<Completion[]> {
+  const functionShortcuts: Completion[] = [
+    { kind: 'function', label: 'unreleasedVersions()', insert: 'unreleasedVersions()', detail: 'Unreleased versions', score: 0 },
+    { kind: 'function', label: 'releasedVersions()', insert: 'releasedVersions()', detail: 'Released versions', score: 0 },
+    { kind: 'function', label: 'earliestUnreleasedVersion()', insert: 'earliestUnreleasedVersion()', detail: 'Closest upcoming release', score: 0 },
+    { kind: 'function', label: 'latestReleasedVersion()', insert: 'latestReleasedVersion()', detail: 'Last shipped release', score: 0 },
+  ];
+  if (accessibleProjectIds.length === 0) return rankByPrefix(functionShortcuts, prefix);
+  const releases = await prisma.release.findMany({
+    where: {
+      projectId: { in: [...accessibleProjectIds] },
+      ...(prefix ? { name: { contains: prefix.toLowerCase(), mode: 'insensitive' } } : {}),
+    },
+    select: { id: true, name: true, releaseDate: true, plannedDate: true },
+    take: MAX_RESULTS,
+    orderBy: [{ plannedDate: 'desc' }],
+  });
+  const dynamic: Completion[] = releases.map((r) => ({
+    kind: 'value',
+    label: r.name,
+    insert: `"${r.name}"`,
+    detail: r.releaseDate
+      ? `released · ${r.releaseDate.toISOString().slice(0, 10)}`
+      : r.plannedDate
+        ? `planned · ${r.plannedDate.toISOString().slice(0, 10)}`
+        : 'unreleased',
+    score: 0,
+  }));
+  return rankByPrefix([...functionShortcuts, ...dynamic], prefix);
+}
+
+// ─── Issue (key-lookup) ────────────────────────────────────────────────────
+
+export async function suggestIssues(
+  prefix: string,
+  accessibleProjectIds: readonly string[],
+): Promise<Completion[]> {
+  if (!prefix || accessibleProjectIds.length === 0) return [];
+  // Accept both `TTMP-123` and `TTMP-1`-like partials. Extract project key + number.
+  const match = /^([A-Za-z][A-Za-z0-9]*)-(\d+)?$/.exec(prefix);
+  if (match) {
+    const [, projectKey, numStr] = match;
+    const proj = await prisma.project.findFirst({
+      where: { key: projectKey!.toUpperCase(), id: { in: [...accessibleProjectIds] } },
+      select: { id: true, key: true },
+    });
+    if (!proj) return [];
+    const num = numStr ? Number.parseInt(numStr, 10) : null;
+    const issues = await prisma.issue.findMany({
+      where: {
+        projectId: proj.id,
+        ...(num != null ? { number: { gte: num, lt: num + 10 } } : {}),
+      },
+      select: { projectId: true, number: true, title: true, project: { select: { key: true } } },
+      take: MAX_RESULTS,
+      orderBy: { number: 'asc' },
+    });
+    return issues.map((i) => ({
+      kind: 'value' as const,
+      label: `${i.project.key}-${i.number} — ${i.title}`,
+      insert: `${i.project.key}-${i.number}`,
+      detail: i.title,
+      score: 1,
+    }));
+  }
+  // No project-key prefix → fall back to title-substring search across accessible projects.
+  const issues = await prisma.issue.findMany({
+    where: {
+      projectId: { in: [...accessibleProjectIds] },
+      title: { contains: prefix.toLowerCase(), mode: 'insensitive' },
+    },
+    select: { number: true, title: true, project: { select: { key: true } } },
+    take: MAX_RESULTS,
+    orderBy: { updatedAt: 'desc' },
+  });
+  return issues.map((i) => ({
+    kind: 'value' as const,
+    label: `${i.project.key}-${i.number} — ${i.title}`,
+    insert: `${i.project.key}-${i.number}`,
+    detail: i.title,
+    score: 1,
+  }));
+}
+
+// ─── Label (distinct from issue_custom_field_values.value->>'v' in LABEL-typed CFs) ──
+
+export async function suggestLabels(
+  prefix: string,
+  accessibleProjectIds: readonly string[],
+): Promise<Completion[]> {
+  if (accessibleProjectIds.length === 0) return [];
+  // Distinct raw-SQL — Prisma can't express DISTINCT on a JSON path in typed API.
+  // We use `$queryRaw` with safe parameter binding (R1).
+  type Row = { label: string };
+  const prefixParam = prefix ? `%${prefix.toLowerCase()}%` : '%';
+  const rows = await prisma.$queryRaw<Row[]>`
+    SELECT DISTINCT jsonb_array_elements_text(icfv.value->'v') AS label
+    FROM issue_custom_field_values icfv
+    JOIN custom_fields cf ON cf.id = icfv.custom_field_id AND cf.field_type = 'LABEL'
+    JOIN issues i ON i.id = icfv.issue_id
+    WHERE i.project_id = ANY(${[...accessibleProjectIds]}::uuid[])
+      AND (${prefix ? 1 : 0}) = 0 OR (icfv.value->'v')::text ILIKE ${prefixParam}
+    LIMIT ${MAX_RESULTS}
+  `;
+  return rankByPrefix(
+    rows.map((r) => ({
+      kind: 'value' as const,
+      label: r.label,
+      insert: `"${r.label}"`,
+      score: 0,
+    })),
+    prefix,
+  );
+}
+
+// ─── Group (membersOf arg) ─────────────────────────────────────────────────
+
+export async function suggestGroups(prefix: string): Promise<Completion[]> {
+  const groups = await prisma.userGroup.findMany({
+    where: prefix
+      ? { name: { contains: prefix.toLowerCase(), mode: 'insensitive' } }
+      : {},
+    select: { id: true, name: true, _count: { select: { members: true } } },
+    take: MAX_RESULTS,
+    orderBy: [{ name: 'asc' }],
+  });
+  return rankByPrefix(
+    groups.map((g) => ({
+      kind: 'value' as const,
+      label: g.name,
+      insert: `"${g.name}"`,
+      detail: `${g._count.members} members`,
+      score: 0,
+    })),
+    prefix,
+  );
+}
+
+// ─── Checkpoint type ───────────────────────────────────────────────────────
+
+export async function suggestCheckpointTypes(prefix: string): Promise<Completion[]> {
+  const types = await prisma.checkpointType.findMany({
+    where: {
+      isActive: true,
+      ...(prefix ? { name: { contains: prefix.toLowerCase(), mode: 'insensitive' } } : {}),
+    },
+    select: { id: true, name: true, color: true, weight: true },
+    take: MAX_RESULTS,
+    orderBy: [{ name: 'asc' }],
+  });
+  return rankByPrefix(
+    types.map((t) => ({
+      kind: 'value' as const,
+      label: t.name,
+      insert: `"${t.name}"`,
+      detail: t.weight.toLowerCase(),
+      icon: { kind: 'color-dot' as const, value: t.color },
+      score: 0,
+    })),
+    prefix,
+  );
+}

--- a/backend/src/modules/search/search.suggest.rank.ts
+++ b/backend/src/modules/search/search.suggest.rank.ts
@@ -1,0 +1,70 @@
+/**
+ * TTSRH-1 PR-6 — fuzzy-ranking utility for suggest completions.
+ *
+ * §5.11 ТЗ: priority order = exact → startsWith → contains → subsequence.
+ * Stable within each tier — items in different tiers rank by score (1.0 / 0.75
+ * / 0.5 / 0.25), items in the same tier keep their input order. This matches
+ * Jira's autocomplete feel: the best literal match wins; ties are preserved.
+ *
+ * Case-insensitive. Empty prefix = return input unchanged (used for initial
+ * popup-open before the user types anything).
+ */
+
+import type { Completion } from './search.suggest.types.js';
+
+export function rankByPrefix<T extends Completion>(items: readonly T[], prefix: string): T[] {
+  if (!prefix) {
+    // Caller sees insertion order — no ranking needed.
+    return items.map((i, idx) => ({ ...i, score: 1 - idx * 0.0001 }));
+  }
+  const lower = prefix.toLowerCase();
+  const ranked: Array<{ item: T; tier: number; idx: number }> = [];
+  for (let idx = 0; idx < items.length; idx++) {
+    const item = items[idx]!;
+    const label = item.label.toLowerCase();
+    const insert = item.insert.toLowerCase();
+    const haystack = label.length > 0 ? label : insert;
+    const tier = matchTier(haystack, lower);
+    if (tier >= 0) ranked.push({ item, tier, idx });
+  }
+  ranked.sort((a, b) => a.tier - b.tier || a.idx - b.idx);
+  return ranked.map(({ item, tier }, i) => ({
+    ...item,
+    score: tierScore(tier) - i * 0.0001,
+  }));
+}
+
+/**
+ * Tier membership. Lower is better:
+ *   0 — exact match
+ *   1 — label starts with prefix
+ *   2 — label contains prefix
+ *   3 — label is a subsequence of prefix (each prefix char appears in order)
+ * Returns -1 if no match.
+ */
+function matchTier(haystack: string, needle: string): number {
+  if (haystack === needle) return 0;
+  if (haystack.startsWith(needle)) return 1;
+  if (haystack.includes(needle)) return 2;
+  if (isSubsequence(haystack, needle)) return 3;
+  return -1;
+}
+
+function isSubsequence(haystack: string, needle: string): boolean {
+  let i = 0;
+  for (const ch of haystack) {
+    if (ch === needle[i]) i++;
+    if (i === needle.length) return true;
+  }
+  return false;
+}
+
+function tierScore(tier: number): number {
+  switch (tier) {
+    case 0: return 1.0;
+    case 1: return 0.75;
+    case 2: return 0.5;
+    case 3: return 0.25;
+    default: return 0;
+  }
+}

--- a/backend/src/modules/search/search.suggest.static.ts
+++ b/backend/src/modules/search/search.suggest.static.ts
@@ -198,5 +198,8 @@ export function suggestOperators(allowed: readonly string[], prefix: string): Co
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
 function describeType(t: TtqlType): string {
-  return t.toLowerCase().replace('_', ' ');
+  // `AI_ASSIGNEE_TYPE` → `ai assignee type` — replace ALL underscores, not just
+  // the first. Previous `.replace('_', ' ')` (string literal) missed every
+  // underscore after position 0.
+  return t.toLowerCase().replace(/_/g, ' ');
 }

--- a/backend/src/modules/search/search.suggest.static.ts
+++ b/backend/src/modules/search/search.suggest.static.ts
@@ -1,0 +1,202 @@
+/**
+ * TTSRH-1 PR-6 — static suggesters (no DB access).
+ *
+ * Covers: field names (from `SYSTEM_FIELDS` + custom-field registry), function
+ * names (filtered by variant, MVP-only), enum constants (PRIORITY/STATUS_CATEGORY/
+ * AI_STATUS/AI_ASSIGNEE_TYPE/CHECKPOINT_STATE), boolean literals, and offset
+ * shortcuts for date fields.
+ *
+ * Static suggesters return results synchronously — no `await`, no cache key.
+ * DB-backed providers live in `search.suggest.providers.ts`.
+ */
+
+import { SYSTEM_FIELDS, type CustomFieldDef } from './search.schema.js';
+import { functionsForVariant } from './search.functions.js';
+import type { QueryVariant, TtqlType } from './search.types.js';
+import type { Completion } from './search.suggest.types.js';
+import { rankByPrefix } from './search.suggest.rank.js';
+
+// ─── Field suggester ────────────────────────────────────────────────────────
+
+export function suggestFields(
+  prefix: string,
+  customFields: readonly CustomFieldDef[],
+): Completion[] {
+  const systemCompletions: Completion[] = SYSTEM_FIELDS.flatMap((f) => {
+    const names = [f.name, ...f.synonyms];
+    return names.map((n) => ({
+      kind: 'field' as const,
+      label: n === f.name ? f.label : `${f.label} (${n})`,
+      insert: n,
+      detail: describeType(f.type),
+      score: 0,
+    }));
+  });
+
+  const customCompletions: Completion[] = customFields.map((cf) => ({
+    kind: 'field' as const,
+    label: cf.name,
+    insert: cf.name.includes(' ') ? `"${cf.name}"` : cf.name,
+    detail: `custom · ${describeType(cf.type)}`,
+    score: 0,
+  }));
+
+  return rankByPrefix([...systemCompletions, ...customCompletions], prefix);
+}
+
+// ─── Function suggester ────────────────────────────────────────────────────
+
+export function suggestFunctions(prefix: string, variant: QueryVariant): Completion[] {
+  const fns = functionsForVariant(variant).map((fn) => ({
+    kind: 'function' as const,
+    label: `${fn.name}(${fn.args.map((a) => (a.optional ? `[${a.name}]` : a.name)).join(', ')})`,
+    insert: `${fn.name}(${requiredArgsPlaceholder(fn.args)})`,
+    detail: fn.description,
+    score: 0,
+  }));
+  return rankByPrefix(fns, prefix);
+}
+
+function requiredArgsPlaceholder(args: readonly { name: string; optional: boolean }[]): string {
+  // For functions with no required args, insert just `()` so the user can keep
+  // typing. For functions with required args, insert placeholders — the editor
+  // can tab-navigate if it supports snippets.
+  const required = args.filter((a) => !a.optional);
+  if (required.length === 0) return '';
+  return required.map((a) => `<${a.name}>`).join(', ');
+}
+
+// ─── Enum suggesters ───────────────────────────────────────────────────────
+
+const PRIORITY_VALUES = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'];
+const STATUS_CATEGORY_VALUES = ['TODO', 'IN_PROGRESS', 'DONE'];
+const AI_STATUS_VALUES = ['NOT_STARTED', 'IN_PROGRESS', 'DONE', 'FAILED'];
+const AI_ASSIGNEE_TYPE_VALUES = ['HUMAN', 'AGENT', 'MIXED'];
+const CHECKPOINT_STATE_VALUES = ['PENDING', 'ON_TRACK', 'WARNING', 'OVERDUE', 'ERROR', 'SATISFIED'];
+const BOOL_VALUES = ['true', 'false'];
+
+const ENUM_BY_FIELD: Record<string, readonly string[]> = {
+  priority: PRIORITY_VALUES,
+  statuscategory: STATUS_CATEGORY_VALUES,
+  aistatus: AI_STATUS_VALUES,
+  aiassigneetype: AI_ASSIGNEE_TYPE_VALUES,
+  checkpointstate: CHECKPOINT_STATE_VALUES,
+};
+
+const ENUM_BY_TYPE: Partial<Record<TtqlType, readonly string[]>> = {
+  PRIORITY: PRIORITY_VALUES,
+  STATUS_CATEGORY: STATUS_CATEGORY_VALUES,
+  AI_STATUS: AI_STATUS_VALUES,
+  AI_ASSIGNEE_TYPE: AI_ASSIGNEE_TYPE_VALUES,
+  CHECKPOINT_STATE: CHECKPOINT_STATE_VALUES,
+};
+
+export function suggestEnum(
+  fieldName: string,
+  prefix: string,
+  picked: readonly string[] = [],
+): Completion[] | null {
+  const values = ENUM_BY_FIELD[fieldName.toLowerCase()];
+  if (!values) return null;
+  return enumCompletions(values, prefix, picked);
+}
+
+export function suggestEnumByType(
+  type: TtqlType,
+  prefix: string,
+  picked: readonly string[] = [],
+): Completion[] | null {
+  const values = ENUM_BY_TYPE[type];
+  if (!values) return null;
+  return enumCompletions(values, prefix, picked);
+}
+
+function enumCompletions(values: readonly string[], prefix: string, picked: readonly string[]): Completion[] {
+  const pickedLc = new Set(picked.map((p) => p.toLowerCase()));
+  const filtered = values.filter((v) => !pickedLc.has(v.toLowerCase()));
+  return rankByPrefix(
+    filtered.map((v) => ({
+      kind: 'value' as const,
+      label: v,
+      insert: v,
+      score: 0,
+    })),
+    prefix,
+  );
+}
+
+// ─── Boolean suggester ─────────────────────────────────────────────────────
+
+export function suggestBool(prefix: string): Completion[] {
+  return rankByPrefix(
+    BOOL_VALUES.map((v) => ({ kind: 'value' as const, label: v, insert: v, score: 0 })),
+    prefix,
+  );
+}
+
+// ─── Relative-date / offset suggester ──────────────────────────────────────
+
+const RELATIVE_SHORTCUTS = [
+  { insert: '"-1d"', label: '"-1d" — yesterday' },
+  { insert: '"-7d"', label: '"-7d" — last week' },
+  { insert: '"-1M"', label: '"-1M" — last month' },
+  { insert: '"1d"', label: '"1d" — tomorrow' },
+  { insert: '"1w"', label: '"1w" — next week' },
+  { insert: 'now()', label: 'now()' },
+  { insert: 'today()', label: 'today()' },
+  { insert: 'startOfDay()', label: 'startOfDay()' },
+  { insert: 'startOfWeek()', label: 'startOfWeek()' },
+  { insert: 'startOfMonth()', label: 'startOfMonth()' },
+];
+
+export function suggestDateShortcuts(prefix: string): Completion[] {
+  return rankByPrefix(
+    RELATIVE_SHORTCUTS.map((s) => ({
+      kind: 'value' as const,
+      label: s.label,
+      insert: s.insert,
+      score: 0,
+    })),
+    prefix,
+  );
+}
+
+// ─── Operator suggester ────────────────────────────────────────────────────
+
+const OP_BY_OP_KIND: Record<string, { label: string; insert: string }> = {
+  EQ: { label: '=', insert: '=' },
+  NEQ: { label: '!=', insert: '!=' },
+  GT: { label: '>', insert: '>' },
+  GTE: { label: '>=', insert: '>=' },
+  LT: { label: '<', insert: '<' },
+  LTE: { label: '<=', insert: '<=' },
+  CONTAINS: { label: '~ (contains)', insert: '~' },
+  NOT_CONTAINS: { label: '!~ (does not contain)', insert: '!~' },
+  IN: { label: 'IN', insert: 'IN ' },
+  NOT_IN: { label: 'NOT IN', insert: 'NOT IN ' },
+  IS_EMPTY: { label: 'IS EMPTY', insert: 'IS EMPTY' },
+  IS_NOT_EMPTY: { label: 'IS NOT EMPTY', insert: 'IS NOT EMPTY' },
+};
+
+/**
+ * Operators allowed for a field. Works for system fields — custom fields get
+ * their allowed ops from `CustomFieldDef.operators` directly (caller handles).
+ */
+export function suggestOperators(allowed: readonly string[], prefix: string): Completion[] {
+  const completions = allowed
+    .map((op) => OP_BY_OP_KIND[op])
+    .filter((o): o is NonNullable<typeof o> => !!o)
+    .map((o) => ({
+      kind: 'operator' as const,
+      label: o.label,
+      insert: o.insert,
+      score: 0,
+    }));
+  return rankByPrefix(completions, prefix);
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function describeType(t: TtqlType): string {
+  return t.toLowerCase().replace('_', ' ');
+}

--- a/backend/src/modules/search/search.suggest.ts
+++ b/backend/src/modules/search/search.suggest.ts
@@ -1,0 +1,187 @@
+/**
+ * TTSRH-1 PR-6 — orchestrator for the TTS-QL suggest pipeline.
+ *
+ * Input: raw JQL + cursor offset (or explicit field/operator/prefix overrides
+ * from the Basic-builder). Output: `SuggestResponse` with ranked completions
+ * + a `context` block describing what the cursor is looking at (used by the
+ * editor for conditional formatting).
+ *
+ * Provider routing follows §5.11 ТЗ:
+ *   - field          → static (SYSTEM_FIELDS + custom fields).
+ *   - operator       → static (per-field allowed operators).
+ *   - value          → provider by expected type, scoped to project access.
+ *   - keyword/func   → static.
+ */
+
+import { analysePosition } from './search.suggest.position.js';
+import {
+  suggestBool,
+  suggestDateShortcuts,
+  suggestEnum,
+  suggestEnumByType,
+  suggestFields,
+  suggestFunctions,
+  suggestOperators,
+} from './search.suggest.static.js';
+import {
+  suggestCheckpointTypes,
+  suggestGroups,
+  suggestIssues,
+  suggestIssueTypes,
+  suggestLabels,
+  suggestProjects,
+  suggestReleases,
+  suggestSprints,
+  suggestStatuses,
+  suggestUsers,
+} from './search.suggest.providers.js';
+import type { Completion, SuggestContext, SuggestResponse } from './search.suggest.types.js';
+import { resolveSystemField, type CustomFieldDef } from './search.schema.js';
+import type { TtqlType } from './search.types.js';
+
+export async function suggest(
+  source: string,
+  cursor: number,
+  ctx: SuggestContext,
+  customFields: readonly CustomFieldDef[],
+): Promise<SuggestResponse> {
+  // Basic-builder path: caller passes field/operator/prefix directly.
+  if (ctx.field || ctx.operator || ctx.prefix !== undefined) {
+    const completions = await completionsForField(
+      ctx.field ?? '',
+      ctx.operator ?? '=',
+      ctx.prefix ?? '',
+      ctx,
+      customFields,
+      [],
+    );
+    return {
+      completions,
+      context: {
+        expectedField: ctx.field,
+        expectedType: typeFor(ctx.field ?? '', customFields),
+        inValueList: false,
+      },
+    };
+  }
+
+  // Text-editor path: analyse cursor position in the raw JQL.
+  const pos = analysePosition(source, cursor);
+  switch (pos.expected) {
+    case 'field':
+      return {
+        completions: suggestFields(pos.prefix, customFields),
+        context: { inValueList: false },
+      };
+    case 'operator': {
+      const allowed = allowedOpsForField(pos.field ?? '', customFields);
+      return {
+        completions: suggestOperators(allowed, pos.prefix),
+        context: { expectedField: pos.field, inValueList: false },
+      };
+    }
+    case 'value': {
+      const completions = await completionsForField(
+        pos.field ?? '',
+        pos.operator ?? '=',
+        pos.prefix,
+        ctx,
+        customFields,
+        pos.pickedValues,
+      );
+      return {
+        completions,
+        context: {
+          expectedField: pos.field,
+          expectedType: typeFor(pos.field ?? '', customFields),
+          inValueList: pos.inValueList,
+        },
+      };
+    }
+    case 'function-arg':
+    case 'keyword':
+    default:
+      return {
+        completions: suggestFunctions(pos.prefix, ctx.variant),
+        context: { inValueList: false },
+      };
+  }
+}
+
+// ─── Value routing per field type ──────────────────────────────────────────
+
+async function completionsForField(
+  fieldName: string,
+  operator: string,
+  prefix: string,
+  ctx: SuggestContext,
+  customFields: readonly CustomFieldDef[],
+  picked: readonly string[],
+): Promise<Completion[]> {
+  const type = typeFor(fieldName, customFields);
+  if (!type) {
+    // Unknown field — fall back to function suggestions so the user can at
+    // least see what's available in the current variant.
+    return suggestFunctions(prefix, ctx.variant);
+  }
+
+  // Enum fast-path.
+  const fieldEnum = suggestEnum(fieldName, prefix, picked);
+  if (fieldEnum) return fieldEnum;
+  const typeEnum = suggestEnumByType(type, prefix, picked);
+  if (typeEnum) return typeEnum;
+
+  switch (type) {
+    case 'USER':
+      return suggestUsers(prefix, ctx.accessibleProjectIds);
+    case 'PROJECT':
+      return suggestProjects(prefix, ctx.accessibleProjectIds);
+    case 'STATUS':
+      return suggestStatuses(prefix, ctx.accessibleProjectIds);
+    case 'ISSUE_TYPE':
+      return suggestIssueTypes(prefix);
+    case 'SPRINT':
+      return suggestSprints(prefix, ctx.accessibleProjectIds);
+    case 'RELEASE':
+      return suggestReleases(prefix, ctx.accessibleProjectIds);
+    case 'ISSUE':
+      return suggestIssues(prefix, ctx.accessibleProjectIds);
+    case 'LABEL':
+      return suggestLabels(prefix, ctx.accessibleProjectIds);
+    case 'GROUP':
+      return suggestGroups(prefix);
+    case 'CHECKPOINT_TYPE':
+      return suggestCheckpointTypes(prefix);
+    case 'BOOL':
+      return suggestBool(prefix);
+    case 'DATE':
+    case 'DATETIME':
+      return suggestDateShortcuts(prefix);
+    case 'NUMBER':
+      // Number values — no dynamic pool. Return empty; editor uses plain input.
+      return [];
+    case 'TEXT':
+    case 'JSON':
+      // Text values — no dynamic pool. Editor shows quote-wrap hint.
+      return [];
+    default:
+      return [];
+  }
+}
+
+function typeFor(fieldName: string, customFields: readonly CustomFieldDef[]): TtqlType | undefined {
+  if (!fieldName) return undefined;
+  const sys = resolveSystemField(fieldName);
+  if (sys) return sys.type;
+  const lc = fieldName.toLowerCase();
+  const cf = customFields.find((f) => f.name.toLowerCase() === lc || f.id === fieldName);
+  return cf?.type;
+}
+
+function allowedOpsForField(fieldName: string, customFields: readonly CustomFieldDef[]): readonly string[] {
+  if (!fieldName) return [];
+  const sys = resolveSystemField(fieldName);
+  if (sys) return sys.operators;
+  const cf = customFields.find((f) => f.name.toLowerCase() === fieldName.toLowerCase() || f.id === fieldName);
+  return cf?.operators ?? [];
+}

--- a/backend/src/modules/search/search.suggest.types.ts
+++ b/backend/src/modules/search/search.suggest.types.ts
@@ -1,0 +1,76 @@
+/**
+ * TTSRH-1 PR-6 — public types for the TTS-QL suggest pipeline.
+ *
+ * Matches §5.11 ТЗ contract. Shape is stable across versions — frontend
+ * consumers (CodeMirror autocomplete, Basic-builder chip popovers) bind to it.
+ */
+
+import type { QueryVariant, TtqlType } from './search.types.js';
+
+export type CompletionKind = 'field' | 'operator' | 'function' | 'value' | 'keyword';
+
+/** Visual indicator next to a completion item. */
+export interface CompletionIcon {
+  kind: 'avatar' | 'color-dot' | 'svg' | 'emoji';
+  /** URL for avatar, hex for color-dot, identifier for svg/emoji. */
+  value: string;
+}
+
+export interface Completion {
+  kind: CompletionKind;
+  /** What the user sees in the popup row. */
+  label: string;
+  /** What gets inserted on Tab/Enter — pre-escaped, with quotes if needed. */
+  insert: string;
+  /** Optional secondary text (email for users, category for statuses, etc.). */
+  detail?: string;
+  icon?: CompletionIcon;
+  /** 0..1 ranking score — higher = more relevant. Callers sort DESC. */
+  score: number;
+}
+
+export type ExpectedKind =
+  | 'field'
+  | 'operator'
+  | 'value'
+  | 'keyword'
+  | 'function-arg';
+
+/** Snapshot of what the cursor is looking at. Output of the position analyser. */
+export interface PositionContext {
+  expected: ExpectedKind;
+  /** Text from the last significant boundary to the cursor — the partial word. */
+  prefix: string;
+  /** Resolved field when `expected === 'value' | 'operator'`. */
+  field?: string;
+  /** Resolved operator when `expected === 'value'`. */
+  operator?: string;
+  /** True when cursor is inside an `IN (…)` list — caller may want to dedupe. */
+  inValueList: boolean;
+  /** Values already picked inside the current `IN (…)` — used to dedupe. */
+  pickedValues: readonly string[];
+}
+
+/** Context passed to the suggest pipeline. */
+export interface SuggestContext {
+  userId: string;
+  accessibleProjectIds: readonly string[];
+  variant: QueryVariant;
+  /**
+   * Optional explicit overrides — used by the Basic-builder chip popover, which
+   * provides `field`/`operator`/`prefix` directly instead of asking the position
+   * analyser to derive them from raw JQL.
+   */
+  field?: string;
+  operator?: string;
+  prefix?: string;
+}
+
+export interface SuggestResponse {
+  completions: Completion[];
+  context: {
+    expectedField?: string;
+    expectedType?: TtqlType | 'OFFSET' | 'ISSUE_KEY';
+    inValueList: boolean;
+  };
+}

--- a/backend/tests/search-suggest.unit.test.ts
+++ b/backend/tests/search-suggest.unit.test.ts
@@ -1,0 +1,227 @@
+/**
+ * TTSRH-1 PR-6 — unit tests for TTS-QL suggest pipeline (pure layers).
+ *
+ * Covers position analyser + rank + static suggesters. DB-backed providers
+ * (UserSuggester, ProjectSuggester, …) run only in integration tests since
+ * they hit Postgres — this file asserts the contract layer.
+ */
+import { describe, expect, it } from 'vitest';
+import { analysePosition } from '../src/modules/search/search.suggest.position.js';
+import { rankByPrefix } from '../src/modules/search/search.suggest.rank.js';
+import {
+  suggestBool,
+  suggestDateShortcuts,
+  suggestEnum,
+  suggestEnumByType,
+  suggestFields,
+  suggestFunctions,
+  suggestOperators,
+} from '../src/modules/search/search.suggest.static.js';
+import type { Completion } from '../src/modules/search/search.suggest.types.js';
+
+// ─── Position analyser ─────────────────────────────────────────────────────
+
+describe('position analyser — cursor at structural boundaries', () => {
+  it.each([
+    ['', 0, 'field'],
+    ['   ', 3, 'field'],
+    ['priority = HIGH AND ', 20, 'field'],
+    ['NOT ', 4, 'field'],
+    ['(priority = HIGH OR ', 20, 'field'],
+  ])('%j @%d → expect field', (src, cursor, expected) => {
+    const p = analysePosition(src, cursor);
+    expect(p.expected).toBe(expected);
+  });
+
+  it('after a field → expect operator', () => {
+    const p = analysePosition('priority', 8);
+    expect(p.expected).toBe('field'); // editing the field itself
+    expect(p.prefix).toBe('priority');
+  });
+
+  it('after field + space → expect operator', () => {
+    const p = analysePosition('priority ', 9);
+    expect(p.expected).toBe('operator');
+    expect(p.field).toBe('priority');
+  });
+
+  it('after compare op → expect value', () => {
+    const p = analysePosition('priority = ', 11);
+    expect(p.expected).toBe('value');
+    expect(p.field).toBe('priority');
+    expect(p.operator).toBe('=');
+  });
+
+  it('after IN ( → expect value in list', () => {
+    const p = analysePosition('status IN (', 11);
+    expect(p.expected).toBe('value');
+    expect(p.field).toBe('status');
+    expect(p.inValueList).toBe(true);
+  });
+
+  it('dedupe picked values inside IN list', () => {
+    const p = analysePosition('status IN (OPEN, ', 17);
+    expect(p.expected).toBe('value');
+    expect(p.inValueList).toBe(true);
+    expect(p.pickedValues).toContain('OPEN');
+  });
+
+  it('unterminated string → graceful fallback to field', () => {
+    const p = analysePosition('summary = "oops', 15);
+    expect(p.expected).toBe('field');
+  });
+
+  it('ORDER BY → expect field', () => {
+    const p = analysePosition('priority = HIGH ORDER BY ', 25);
+    expect(p.expected).toBe('field');
+  });
+});
+
+// ─── Rank ─────────────────────────────────────────────────────────────────
+
+describe('rankByPrefix — tier ordering', () => {
+  const items: Completion[] = [
+    { kind: 'field', label: 'priority', insert: 'priority', score: 0 },
+    { kind: 'field', label: 'project', insert: 'project', score: 0 },
+    { kind: 'field', label: 'assignee', insert: 'assignee', score: 0 },
+    { kind: 'field', label: 'reporter', insert: 'reporter', score: 0 },
+  ];
+
+  it('empty prefix returns all items in order', () => {
+    const ranked = rankByPrefix(items, '');
+    expect(ranked).toHaveLength(4);
+    expect(ranked[0]!.label).toBe('priority');
+  });
+
+  it('exact match wins', () => {
+    const ranked = rankByPrefix(items, 'project');
+    expect(ranked[0]!.label).toBe('project');
+    expect(ranked[0]!.score).toBeGreaterThan(0.9);
+  });
+
+  it('startsWith beats contains', () => {
+    const ranked = rankByPrefix(items, 'pr');
+    // priority and project both start with `pr` — one wins by input order.
+    expect(['priority', 'project']).toContain(ranked[0]!.label);
+    expect(ranked[0]!.score).toBeGreaterThan(0.7);
+  });
+
+  it('case-insensitive', () => {
+    const ranked = rankByPrefix(items, 'PROJ');
+    expect(ranked[0]!.label).toBe('project');
+  });
+
+  it('subsequence match is lowest tier but still ranked', () => {
+    const extra: Completion[] = [
+      ...items,
+      { kind: 'field', label: 'custom_field_with_pr', insert: 'custom_field_with_pr', score: 0 },
+    ];
+    const ranked = rankByPrefix(extra, 'pr');
+    // startsWith > contains > subsequence; all `pr` matches present, but
+    // `priority`/`project` lead, `reporter` (contains) follows,
+    // then `custom_field_with_pr` (contains because 'pr' literally appears).
+    expect(ranked.map((r) => r.label).slice(0, 2).sort()).toEqual(['priority', 'project']);
+  });
+
+  it('no match → filtered out', () => {
+    const ranked = rankByPrefix(items, 'xyz');
+    expect(ranked).toHaveLength(0);
+  });
+});
+
+// ─── Static suggesters ────────────────────────────────────────────────────
+
+describe('suggestFields', () => {
+  it('returns system fields and custom fields with prefix filter', () => {
+    const completions = suggestFields('prior', []);
+    expect(completions.some((c) => c.label.toLowerCase().includes('priority'))).toBe(true);
+  });
+
+  it('includes custom fields', () => {
+    const completions = suggestFields('Story', [
+      { id: 'u1', name: 'Story Points', type: 'NUMBER', fieldType: 'NUMBER', operators: ['EQ'], sortable: false },
+    ]);
+    expect(completions.some((c) => c.label === 'Story Points')).toBe(true);
+  });
+
+  it('custom-field insert wraps spaces in quotes', () => {
+    const completions = suggestFields('Story', [
+      { id: 'u1', name: 'Story Points', type: 'NUMBER', fieldType: 'NUMBER', operators: ['EQ'], sortable: false },
+    ]);
+    const sp = completions.find((c) => c.label === 'Story Points');
+    expect(sp?.insert).toBe('"Story Points"');
+  });
+});
+
+describe('suggestFunctions', () => {
+  it('variant=default includes user-only functions', () => {
+    const completions = suggestFunctions('my', 'default');
+    expect(completions.some((c) => c.label.startsWith('myopenissues'))).toBe(true);
+  });
+
+  it('variant=checkpoint includes releasePlannedDate', () => {
+    const completions = suggestFunctions('release', 'checkpoint');
+    expect(completions.some((c) => c.label.toLowerCase().includes('releaseplanneddate'))).toBe(true);
+  });
+
+  it('variant=default excludes checkpoint-only releasePlannedDate', () => {
+    const completions = suggestFunctions('release', 'default');
+    expect(completions.some((c) => c.label.toLowerCase().startsWith('releaseplanneddate'))).toBe(false);
+  });
+
+  it('phase=PHASE_2 functions are filtered out', () => {
+    const completions = suggestFunctions('', 'default');
+    expect(completions.some((c) => c.label.toLowerCase().startsWith('watchedissues'))).toBe(false);
+  });
+});
+
+describe('suggestEnum', () => {
+  it.each([
+    ['priority', 'CRITICAL'],
+    ['statusCategory', 'TODO'],
+    ['aiStatus', 'FAILED'],
+    ['aiAssigneeType', 'AGENT'],
+  ])('field=%s → includes %s', (field, expected) => {
+    const completions = suggestEnum(field, '') ?? [];
+    expect(completions.some((c) => c.insert === expected)).toBe(true);
+  });
+
+  it('dedupe picked values', () => {
+    const completions = suggestEnum('priority', '', ['HIGH']) ?? [];
+    expect(completions.some((c) => c.insert === 'HIGH')).toBe(false);
+  });
+
+  it('case-insensitive dedupe', () => {
+    const completions = suggestEnum('priority', '', ['high']) ?? [];
+    expect(completions.some((c) => c.insert === 'HIGH')).toBe(false);
+  });
+
+  it('unknown field → null', () => {
+    expect(suggestEnum('bogusField', '')).toBeNull();
+  });
+
+  it('by type: CHECKPOINT_STATE', () => {
+    const completions = suggestEnumByType('CHECKPOINT_STATE', '') ?? [];
+    expect(completions.some((c) => c.insert === 'OVERDUE')).toBe(true);
+  });
+});
+
+describe('suggestBool / suggestDateShortcuts', () => {
+  it('bool returns true/false', () => {
+    const c = suggestBool('');
+    expect(c.map((x) => x.insert).sort()).toEqual(['false', 'true']);
+  });
+
+  it('date shortcuts include now() and "-7d"', () => {
+    const c = suggestDateShortcuts('');
+    expect(c.some((x) => x.insert === 'now()')).toBe(true);
+    expect(c.some((x) => x.insert === '"-7d"')).toBe(true);
+  });
+});
+
+describe('suggestOperators', () => {
+  it('maps TtqlOpKind to display operators', () => {
+    const c = suggestOperators(['EQ', 'NEQ', 'IS_EMPTY', 'IS_NOT_EMPTY'], '');
+    expect(c.map((x) => x.insert).sort()).toEqual(['!=', '=', 'IS EMPTY', 'IS NOT EMPTY']);
+  });
+});

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1496,7 +1496,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 2 | `ttsrh-1/parser` | Tokenizer + Parser + AST + golden-set | 14 | PR-1 | TTSRH-2 | 🟢 Merged ([#101](https://github.com/NovakPAai/tasktime-mvp/pull/101)) |
 | 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 | 🟢 Merged ([#102](https://github.com/NovakPAai/tasktime-mvp/pull/102)) |
 | 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 | 🟢 Merged ([#103](https://github.com/NovakPAai/tasktime-mvp/pull/103)) |
-| 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 | ✅ Done (готов к push после merge PR-4) |
+| 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 | 🟢 Merged ([#104](https://github.com/NovakPAai/tasktime-mvp/pull/104)) |
 | 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 | ✅ Done (готов к push после merge PR-5) |
 | 7 | `ttsrh-1/saved-filters` | SavedFilter CRUD/share/favorite + User.preferences | 8 | PR-5 | TTSRH-8, TTSRH-9 | 📋 Планируется |
 | 8 | `ttsrh-1/export` | `/search/export` CSV/XLSX | 4 | PR-5 | TTSRH-10 | 📋 Планируется |

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1497,7 +1497,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 | 🟢 Merged ([#102](https://github.com/NovakPAai/tasktime-mvp/pull/102)) |
 | 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 | 🟢 Merged ([#103](https://github.com/NovakPAai/tasktime-mvp/pull/103)) |
 | 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 | ✅ Done (готов к push после merge PR-4) |
-| 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 | 📋 Планируется |
+| 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 | ✅ Done (готов к push после merge PR-5) |
 | 7 | `ttsrh-1/saved-filters` | SavedFilter CRUD/share/favorite + User.preferences | 8 | PR-5 | TTSRH-8, TTSRH-9 | 📋 Планируется |
 | 8 | `ttsrh-1/export` | `/search/export` CSV/XLSX | 4 | PR-5 | TTSRH-10 | 📋 Планируется |
 | 9 | `ttsrh-1/frontend-shell` | SearchPage shell + route + sidebar + URL sync | 6 | PR-5 | TTSRH-12, часть TTSRH-19 | 📋 Планируется |

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,67 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.32**
+**Last version: 2.33**
+
+---
+
+## [2.33] [2026-04-21] feat(search): TTSRH-1 PR-6 — Value Suggesters backend + GET /search/suggest + /implement-tz playbook
+
+**PR:** (to be filled after push)
+**Ветка:** `ttsrh-1/suggesters`
+
+### Что было
+
+После PR-5 `GET /search/suggest` возвращал 501. Редактор TTS-QL не мог предлагать значения — пользователь писал всё руками.
+
+### Что теперь
+
+`GET /api/search/suggest` live. 13 провайдеров значений из §5.11 ТЗ:
+
+- **`search.suggest.types.ts`** — `Completion { kind, label, insert, detail?, icon?, score }`, `PositionContext`, `SuggestContext`, `SuggestResponse`.
+- **`search.suggest.position.ts`** — позиционный анализатор. Tokenize'ит source до cursor, применяет heuristic rules: после `AND`/`OR`/`NOT`/пусто → field; после field → operator; после op/`IN (` → value; после `ORDER BY` → field; fails open на tokenizer-ошибках. Корректно обрабатывает editing-in-progress (только для Ident/String/Number/RelativeDate/CustomField, не для delimiters).
+- **`search.suggest.rank.ts`** — fuzzy-ranking: exact (1.0) → startsWith (0.75) → contains (0.5) → subsequence (0.25). Case-insensitive. Пустой prefix возвращает input-order.
+- **`search.suggest.static.ts`** — static suggesters без DB: `suggestFields` (system + custom), `suggestFunctions` (filter by variant, MVP-only), `suggestEnum` (priority/statusCategory/aiStatus/aiAssigneeType/checkpointState), `suggestBool`, `suggestDateShortcuts` (now/today/startOfX/-7d), `suggestOperators` (TtqlOpKind → display label).
+- **`search.suggest.providers.ts`** — 9 DB-backed провайдеров: Users (scoped по UserProjectRole), Projects, Statuses (system-keys + WorkflowStatus с color-dot), IssueTypes, Sprints (+ 3 function-shortcuts первыми), Releases (+ 4 function-shortcuts), Issues (key-based или title-substring, scoped), Labels (raw-SQL `jsonb_array_elements_text` на LABEL-type CFs), Groups, CheckpointTypes. Все scope'ятся по `accessibleProjectIds` (R3).
+- **`search.suggest.ts`** — orchestrator. Два пути: Basic-builder (explicit field/op/prefix) и text-editor (analyse position). Routing по type с fallbacks: unknown field → functions, unknown type → empty.
+- **`search.router.ts`** — `GET /search/suggest?jql=&cursor=&field=&operator=&prefix=&variant=` подключён. Authenticate + Zod query params + accessibleProjectIds.
+- **`.claude/commands/implement-tz.md`** — новый **/implement-tz playbook**: декомпозиция ТЗ → план PR'ов → цикл (branch → implement → test → docs → commit → pre-push-reviewer → fix → check prev CI → merge → rebase → push → schedule auto-check). Пользователь пишет `Реализуй ТЗ X` — цикл запускается автоматически.
+
+### Тесты (433 passing, +36 к PR-5)
+
+- **`tests/search-suggest.unit.test.ts`** (36 кейсов):
+  - Position analyser: 8 сценариев (пустой, after AND/NOT/(, after field, after op, IN (, dedupe picked, unterminated string, ORDER BY).
+  - rankByPrefix: 7 кейсов (пустой prefix, exact/startsWith/contains/subsequence tiers, case-insensitive, no-match).
+  - suggestFields: 3 (system + custom + quoted wrap).
+  - suggestFunctions: 4 (variant filter, Phase-2 exclude).
+  - suggestEnum: 5 (per-field mapping, dedupe picked, case-insensitive, unknown field, by type).
+  - suggestBool/DateShortcuts/Operators: 3.
+
+DB-backed провайдеры тестируются в integration layer (требуют Postgres).
+
+### Изменения
+
+- `backend/src/modules/search/search.suggest.types.ts` — новый.
+- `backend/src/modules/search/search.suggest.position.ts` — новый.
+- `backend/src/modules/search/search.suggest.rank.ts` — новый.
+- `backend/src/modules/search/search.suggest.static.ts` — новый.
+- `backend/src/modules/search/search.suggest.providers.ts` — новый.
+- `backend/src/modules/search/search.suggest.ts` — новый (orchestrator).
+- `backend/src/modules/search/search.router.ts` — `GET /search/suggest` подключён.
+- `backend/tests/search-suggest.unit.test.ts` — новый.
+- `backend/package.json` — `test:parser` включает suggest-тест.
+- `.claude/commands/implement-tz.md` — playbook для запуска циклов.
+- `docs/tz/TTSRH-1.md` §13.9 — статус PR-6 → ✅ Done.
+
+### Влияние на prod
+
+Под `FEATURES_ADVANCED_SEARCH=false` — эндпоинт недоступен. При включении: auto-complete в редакторе + в Basic-chip popover работают одинаково (single source of truth).
+
+### Проверки
+
+- `npx tsc --noEmit` — чисто
+- `npm run lint` — 0 errors, 0 new warnings
+- `npm run test:parser` — **433 passing**
 
 ---
 


### PR DESCRIPTION
## Summary

TTSRH-1 PR-6 — `GET /api/search/suggest` live. 13 провайдеров значений §5.11 ТЗ: единая точка autocomplete для TTS-QL-редактора и Basic-builder chip-popover'ов.

- **`search.suggest.position.ts`** — позиционный анализатор: tokenize-до-cursor + heuristic rules (IN-list → boolean boundary → ORDER BY → field/op → field-named). Fails open на tokenizer-ошибках.
- **`search.suggest.rank.ts`** — fuzzy ranking: exact (1.0) → startsWith (0.75) → contains (0.5) → subsequence (0.25), case-insensitive.
- **`search.suggest.static.ts`** — без DB: fields (system + custom), functions (variant + MVP filter), enum (priority/statusCategory/aiStatus/aiAssigneeType/checkpointState с дедупом picked), bool, date shortcuts, operators.
- **`search.suggest.providers.ts`** — 9 DB-backed, все с R3 scope: Users, Projects, Statuses (system-keys + global WorkflowStatus), IssueTypes, Sprints (+ function-shortcuts), Releases, Issues (key/title), Labels (raw-SQL jsonb с `Prisma.join` + `Prisma.sql` — R1-safe), Groups, CheckpointTypes.
- **`search.suggest.ts`** — orchestrator: Basic-builder путь и text-editor путь, routing по TtqlType.
- **`search.router.ts`** — `GET /search/suggest` c `searchRateLimit` + Zod query-DTO (jql max 10000, field/op/prefix max 200).

## Ценный side-effect: `/implement-tz` playbook

Новый [.claude/commands/implement-tz.md](.claude/commands/implement-tz.md) — full cycle для реализации большого ТЗ по циклу PR'ов. Триггер `Реализуй ТЗ X` или `/implement-tz X`. Документирует декомпозицию, цикл одного PR (branch→implement→test→docs→commit→pre-push-reviewer→fix→merge-prev→rebase→push→schedule CI check), anti-patterns и wakeup-обработку.

## Тесты — 433 passing (+36 к PR-5)

- **`tests/search-suggest.unit.test.ts`** (36 кейсов): position analyser 8 (пустой, AND, NOT, `(`, field, op, IN list, dedupe picked, unterminated string graceful, ORDER BY), rank 7 tiers, suggestFields 3, suggestFunctions 4 variant filter, suggestEnum 5 с дедупом и case-insensitive, suggestBool/DateShortcuts/Operators.

## Pre-push review

🟠 3 · 🟡 4 · 🔵 2. Все применены в follow-up:

- 🟠 **Cross-project label leak** — `AND ... OR` precedence в `suggestLabels` позволял скрытый leak. Фикс: prefix-filter через отдельный `Prisma.sql` под AND.
- 🟠 **`$queryRaw` array interpolation** — `${[...]}::uuid[]` не работает (Prisma сериализует как positional params, ANY их не принимает). Фикс: `IN (${Prisma.join(...)})`.
- 🟠 **suggestStatuses scope** — WorkflowStatus tenant-global (schema без projectId); добавлен JSDoc объясняющий что compiler'ом R3 защищает результат.
- 🟡 **Rate-limit на /search/suggest** — добавлен `searchRateLimit` middleware (autocomplete на keystroke).
- 🟡 **Zod на /search/suggest** — query-DTO с length caps.
- 🟡 **suggestUsers scope exclusion** — inline-комментарий про намеренное исключение ADMIN без project-memberships.
- 🟡 **Misleading "fans out via Promise.all" comment** — убран (orchestrator вызывает один provider за раз).
- 🔵 **`describeType` regex-global** — `.replace('_', ' ')` → `.replace(/_/g, ' ')`.

## Test plan

- [x] Backend `npx tsc --noEmit` — чисто
- [x] Backend `npm run lint` — 0 errors, 0 new warnings
- [x] `npm run test:parser` — 433 passing
- [x] Pre-push review зелёный после фиксов
- [ ] Integration `npm test` в CI — с Postgres

## Зависимости

- **Зависит от:** PR-5 ([#104](https://github.com/NovakPAai/getstime-mvp/pull/104)) — merged 🟢.
- **Следующий:** PR-7 (SavedFilter CRUD + sharing + User.preferences).

## Плановая дельта

- Прогресс: **PR-6 / 21** по §13.9 ТЗ.
- Версия: 2.32 в [version_history.md](version_history.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
