### PR TITLE
feat(saved-filters): TTSRH-1 PR-7 — SavedFilter CRUD + share + favorite + preferences

### DIFF
--- a/backend/src/modules/saved-filters/saved-filters.dto.ts
+++ b/backend/src/modules/saved-filters/saved-filters.dto.ts
@@ -1,0 +1,87 @@
+/**
+ * TTSRH-1 PR-7 — Zod DTO для SavedFilter CRUD, share, favorite, preferences.
+ *
+ * Публичный API:
+ *   • listQueryDto, createDto, updateDto, shareDto, favoriteDto, preferencesDto.
+ *
+ * Инварианты:
+ *   • `jql.max = 10_000` (как на /search/issues, §5.6 ТЗ).
+ *   • `name.max = 200` — UI-предел.
+ *   • `sharedWith` принимает 2 параллельных массива `users[]`, `groups[]` —
+ *     структура соответствует схеме `SavedFilterShare` (XOR userId/groupId).
+ *   • `preferences.searchDefaults.columns` — массив строк до 50 элементов,
+ *     чтобы не дать пользователю залить произвольный JSON в `User.preferences`.
+ *   • При `visibility=SHARED` список `sharedWith` может быть пустым — это
+ *     валидный промежуточный state (владелец может поделиться позже через
+ *     `POST /:id/share`).
+ */
+
+import { z } from 'zod';
+import { FilterPermission, FilterVisibility } from '@prisma/client';
+
+const visibilityValues = Object.values(FilterVisibility) as [FilterVisibility, ...FilterVisibility[]];
+const permissionValues = Object.values(FilterPermission) as [FilterPermission, ...FilterPermission[]];
+
+const scopeEnum = z.enum(['mine', 'shared', 'public', 'favorite']);
+
+export const listQueryDto = z.object({
+  scope: scopeEnum.optional(),
+});
+
+const columnsSchema = z
+  .array(z.string().min(1).max(100))
+  .max(50)
+  .optional();
+
+const sharedWithSchema = z
+  .object({
+    users: z.array(z.string().uuid()).max(500).optional(),
+    groups: z.array(z.string().uuid()).max(100).optional(),
+    permission: z.enum(permissionValues).optional(),
+  })
+  .optional();
+
+export const createDto = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(2_000).nullable().optional(),
+  jql: z.string().min(1).max(10_000),
+  visibility: z.enum(visibilityValues).optional(),
+  columns: columnsSchema,
+  sharedWith: sharedWithSchema,
+});
+
+export const updateDto = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(2_000).nullable().optional(),
+    jql: z.string().min(1).max(10_000).optional(),
+    visibility: z.enum(visibilityValues).optional(),
+    columns: columnsSchema,
+  })
+  .refine((v) => Object.keys(v).length > 0, { message: 'At least one field must be provided' });
+
+export const favoriteDto = z.object({
+  value: z.boolean(),
+});
+
+export const shareDto = z.object({
+  users: z.array(z.string().uuid()).max(500).optional(),
+  groups: z.array(z.string().uuid()).max(100).optional(),
+  permission: z.enum(permissionValues).optional(),
+});
+
+export const preferencesDto = z.object({
+  searchDefaults: z
+    .object({
+      columns: z.array(z.string().min(1).max(100)).max(50).optional(),
+      pageSize: z.number().int().min(10).max(100).optional(),
+    })
+    .optional(),
+});
+
+export type ListQueryDto = z.infer<typeof listQueryDto>;
+export type CreateDto = z.infer<typeof createDto>;
+export type UpdateDto = z.infer<typeof updateDto>;
+export type FavoriteDto = z.infer<typeof favoriteDto>;
+export type ShareDto = z.infer<typeof shareDto>;
+export type PreferencesDto = z.infer<typeof preferencesDto>;

--- a/backend/src/modules/saved-filters/saved-filters.dto.ts
+++ b/backend/src/modules/saved-filters/saved-filters.dto.ts
@@ -33,6 +33,10 @@ const columnsSchema = z
   .max(50)
   .optional();
 
+// Note: `permission` is a single value applied to ALL users+groups in one create/share call.
+// Per-share granular permissions (e.g. user X = WRITE, group Y = READ) are not supported in
+// this PR — callers who need them should issue separate `POST /:id/share` calls (replace-
+// semantics) or wait for a future per-share endpoint. This matches the §5.6 HTTP API shape.
 const sharedWithSchema = z
   .object({
     users: z.array(z.string().uuid()).max(500).optional(),
@@ -70,18 +74,11 @@ export const shareDto = z.object({
   permission: z.enum(permissionValues).optional(),
 });
 
-export const preferencesDto = z.object({
-  searchDefaults: z
-    .object({
-      columns: z.array(z.string().min(1).max(100)).max(50).optional(),
-      pageSize: z.number().int().min(10).max(100).optional(),
-    })
-    .optional(),
-});
+// Note: `preferencesDto` lives in `users/users.dto.ts` as `updatePreferencesDto` (it's
+// attached to the users module because the route is `/api/users/me/preferences`).
 
 export type ListQueryDto = z.infer<typeof listQueryDto>;
 export type CreateDto = z.infer<typeof createDto>;
 export type UpdateDto = z.infer<typeof updateDto>;
 export type FavoriteDto = z.infer<typeof favoriteDto>;
 export type ShareDto = z.infer<typeof shareDto>;
-export type PreferencesDto = z.infer<typeof preferencesDto>;

--- a/backend/src/modules/saved-filters/saved-filters.router.ts
+++ b/backend/src/modules/saved-filters/saved-filters.router.ts
@@ -1,33 +1,154 @@
-import { Router, type Request, type Response } from 'express';
-import { authenticate } from '../../shared/middleware/auth.js';
-
 /**
- * TTSRH-1 PR-1 — stub-роутер для сохранённых фильтров (TTS-QL). Модели SavedFilter /
- * SavedFilterShare уже мигрированы в этой же ветке, но CRUD-логика поступит в PR-7
- * (см. §13.5 в docs/tz/TTSRH-1.md). До этого — 501.
+ * TTSRH-1 PR-7 — SavedFilter CRUD + share + favorite routes.
  *
- * Gate по `features.advancedSearch` — в app.ts.
+ * Публичный API (§5.6 ТЗ):
+ *   GET    /api/saved-filters?scope=mine|shared|public|favorite
+ *   POST   /api/saved-filters
+ *   GET    /api/saved-filters/:id
+ *   PATCH  /api/saved-filters/:id
+ *   DELETE /api/saved-filters/:id
+ *   POST   /api/saved-filters/:id/favorite      { value: bool }
+ *   POST   /api/saved-filters/:id/share         { users?, groups?, permission }
+ *   POST   /api/saved-filters/:id/use           — инкремент useCount, вызывает фронт
+ *                                                  перед исполнением (§5.6 прим.).
+ *
+ * Gate по `features.advancedSearch` — в app.ts (условный mount).
+ *
+ * Инварианты:
+ *   • Все handlers проходят через authenticate (401 если не логинен).
+ *   • Zod-валидация на body/query обязательна (см. saved-filters.dto.ts).
+ *   • RBAC (R-SF-1 / R-SF-2) — в service; роутер только передаёт userId.
+ *   • Write-audit пишется из service (после успешной мутации).
  */
+
+import { Router, type Response } from 'express';
+import { authenticate } from '../../shared/middleware/auth.js';
+import { validate } from '../../shared/middleware/validate.js';
+import type { AuthRequest } from '../../shared/types/index.js';
+import {
+  listQueryDto,
+  createDto,
+  updateDto,
+  favoriteDto,
+  shareDto,
+  type ListQueryDto,
+  type CreateDto,
+  type UpdateDto,
+  type FavoriteDto,
+  type ShareDto,
+} from './saved-filters.dto.js';
+import * as service from './saved-filters.service.js';
+
 const router = Router();
 router.use(authenticate);
 
-function notImplemented(endpoint: string) {
-  return (_req: Request, res: Response): void => {
-    res.status(501).json({
-      error: 'NOT_IMPLEMENTED',
-      endpoint,
-      message:
-        'Saved-filter endpoints are under development. See docs/tz/TTSRH-1.md — delivered in PR-7.',
-    });
-  };
+function requireUser(req: AuthRequest, res: Response): string | null {
+  if (!req.user) {
+    res.status(401).json({ error: 'Authentication required' });
+    return null;
+  }
+  return req.user.userId;
 }
 
-router.get('/saved-filters', notImplemented('GET /saved-filters'));
-router.post('/saved-filters', notImplemented('POST /saved-filters'));
-router.get('/saved-filters/:id', notImplemented('GET /saved-filters/:id'));
-router.patch('/saved-filters/:id', notImplemented('PATCH /saved-filters/:id'));
-router.delete('/saved-filters/:id', notImplemented('DELETE /saved-filters/:id'));
-router.post('/saved-filters/:id/favorite', notImplemented('POST /saved-filters/:id/favorite'));
-router.post('/saved-filters/:id/share', notImplemented('POST /saved-filters/:id/share'));
+router.get('/saved-filters', validate(listQueryDto, 'query'), async (req: AuthRequest, res, next) => {
+  try {
+    const userId = requireUser(req, res);
+    if (!userId) return;
+    const { scope } = req.query as ListQueryDto;
+    const filters = await service.listFilters(userId, scope);
+    res.json({ filters });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/saved-filters', validate(createDto), async (req: AuthRequest, res, next) => {
+  try {
+    const userId = requireUser(req, res);
+    if (!userId) return;
+    const dto = req.body as CreateDto;
+    const filter = await service.createFilter(userId, dto);
+    res.status(201).json(filter);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/saved-filters/:id', async (req: AuthRequest, res, next) => {
+  try {
+    const userId = requireUser(req, res);
+    if (!userId) return;
+    const filter = await service.getFilter(userId, req.params.id as string);
+    res.json(filter);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.patch('/saved-filters/:id', validate(updateDto), async (req: AuthRequest, res, next) => {
+  try {
+    const userId = requireUser(req, res);
+    if (!userId) return;
+    const dto = req.body as UpdateDto;
+    const filter = await service.updateFilter(userId, req.params.id as string, dto);
+    res.json(filter);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/saved-filters/:id', async (req: AuthRequest, res, next) => {
+  try {
+    const userId = requireUser(req, res);
+    if (!userId) return;
+    await service.deleteFilter(userId, req.params.id as string);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post(
+  '/saved-filters/:id/favorite',
+  validate(favoriteDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const userId = requireUser(req, res);
+      if (!userId) return;
+      const { value } = req.body as FavoriteDto;
+      const filter = await service.setFavorite(userId, req.params.id as string, value);
+      res.json(filter);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+router.post(
+  '/saved-filters/:id/share',
+  validate(shareDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const userId = requireUser(req, res);
+      if (!userId) return;
+      const dto = req.body as ShareDto;
+      const filter = await service.shareFilter(userId, req.params.id as string, dto);
+      res.json(filter);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+router.post('/saved-filters/:id/use', async (req: AuthRequest, res, next) => {
+  try {
+    const userId = requireUser(req, res);
+    if (!userId) return;
+    await service.incrementUseStats(userId, req.params.id as string);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/backend/src/modules/saved-filters/saved-filters.service.ts
+++ b/backend/src/modules/saved-filters/saved-filters.service.ts
@@ -1,0 +1,407 @@
+/**
+ * TTSRH-1 PR-7 — SavedFilter CRUD + sharing + favorite + useCount tracking.
+ *
+ * Публичный API:
+ *   • listFilters(userId, scope?) — возвращает фильтры по scope'у.
+ *   • getFilter(userId, filterId) — с RBAC-проверкой (R-SF-1).
+ *   • createFilter(userId, dto) — + audit.
+ *   • updateFilter(userId, filterId, dto) — owner OR SHARED-WRITE (R-SF-2).
+ *   • deleteFilter(userId, filterId) — только owner.
+ *   • setFavorite(userId, filterId, value) — доступ по R-SF-1 (read-доступ).
+ *   • shareFilter(userId, filterId, dto) — только owner. Replace-семантика на shares.
+ *   • incrementUseStats(userId, filterId) — вызывает фронт при execute.
+ *   • getUserFavorites(userId, limit) — top-N по useCount/lastUsedAt (для сайдбара).
+ *
+ * Инварианты:
+ *   • R-SF-1 (read): owner всегда; PRIVATE — только owner; SHARED — owner ∪ shares (user
+ *     direct или через UserGroupMember); PUBLIC — любой аутентифицированный.
+ *   • R-SF-2 (write): owner всегда; SHARED с permission=WRITE — user из shares; PUBLIC
+ *     даже write-запрещён другим.
+ *   • Share создаёт строки SavedFilterShare с XOR (userId ⊕ groupId) — DB-level CHECK
+ *     constraint не даёт нарушить это. Replace-семантика: старые shares удаляются,
+ *     новые создаются в одной транзакции.
+ *   • `useCount` инкрементируется атомарно через `{ increment: 1 }` (race-safe).
+ *   • AuditLog пишется после успешной мутации (не перед — чтобы не логировать
+ *     неуспешные попытки).
+ *
+ * Не бросает на DB-ошибках — пробрасывает AppError с http-status.
+ */
+
+import type { FilterPermission, FilterVisibility, Prisma, SavedFilter } from '@prisma/client';
+import { prisma } from '../../prisma/client.js';
+import { AppError } from '../../shared/middleware/error-handler.js';
+import type { CreateDto, UpdateDto, ShareDto } from './saved-filters.dto.js';
+
+export type SavedFilterScope = 'mine' | 'shared' | 'public' | 'favorite';
+
+export interface FilterShareView {
+  id: string;
+  userId: string | null;
+  groupId: string | null;
+  permission: FilterPermission;
+}
+
+export interface SavedFilterView {
+  id: string;
+  ownerId: string;
+  name: string;
+  description: string | null;
+  jql: string;
+  visibility: FilterVisibility;
+  columns: string[] | null;
+  isFavorite: boolean;
+  lastUsedAt: Date | null;
+  useCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+  shares: FilterShareView[];
+  permission: 'READ' | 'WRITE';
+}
+
+type SavedFilterWithShares = SavedFilter & {
+  shares: { id: string; userId: string | null; groupId: string | null; permission: FilterPermission }[];
+};
+
+function toView(filter: SavedFilterWithShares, viewerUserId: string, canWrite: boolean): SavedFilterView {
+  return {
+    id: filter.id,
+    ownerId: filter.ownerId,
+    name: filter.name,
+    description: filter.description,
+    jql: filter.jql,
+    visibility: filter.visibility,
+    columns: Array.isArray(filter.columns) ? (filter.columns as string[]) : null,
+    isFavorite: filter.ownerId === viewerUserId ? filter.isFavorite : false,
+    lastUsedAt: filter.lastUsedAt,
+    useCount: filter.useCount,
+    createdAt: filter.createdAt,
+    updatedAt: filter.updatedAt,
+    shares: filter.shares.map((s) => ({
+      id: s.id,
+      userId: s.userId,
+      groupId: s.groupId,
+      permission: s.permission,
+    })),
+    permission: canWrite ? 'WRITE' : 'READ',
+  };
+}
+
+async function getUserGroupIds(userId: string): Promise<string[]> {
+  const rows = await prisma.userGroupMember.findMany({
+    where: { userId },
+    select: { groupId: true },
+  });
+  return rows.map((r) => r.groupId);
+}
+
+interface AccessDecision {
+  filter: SavedFilterWithShares;
+  canRead: boolean;
+  canWrite: boolean;
+}
+
+async function resolveAccess(userId: string, filterId: string): Promise<AccessDecision> {
+  const filter = await prisma.savedFilter.findUnique({
+    where: { id: filterId },
+    include: { shares: true },
+  });
+  if (!filter) throw new AppError(404, 'SavedFilter not found');
+
+  if (filter.ownerId === userId) return { filter, canRead: true, canWrite: true };
+
+  if (filter.visibility === 'PRIVATE') return { filter, canRead: false, canWrite: false };
+
+  if (filter.visibility === 'PUBLIC') return { filter, canRead: true, canWrite: false };
+
+  // SHARED: check direct user-share OR group-membership.
+  const directShare = filter.shares.find((s) => s.userId === userId);
+  if (directShare) {
+    return { filter, canRead: true, canWrite: directShare.permission === 'WRITE' };
+  }
+
+  const userGroupIds = await getUserGroupIds(userId);
+  if (userGroupIds.length > 0) {
+    const groupShare = filter.shares.find((s) => s.groupId !== null && userGroupIds.includes(s.groupId));
+    if (groupShare) {
+      return { filter, canRead: true, canWrite: groupShare.permission === 'WRITE' };
+    }
+  }
+
+  return { filter, canRead: false, canWrite: false };
+}
+
+export async function listFilters(userId: string, scope: SavedFilterScope = 'mine'): Promise<SavedFilterView[]> {
+  if (scope === 'mine') {
+    const rows = await prisma.savedFilter.findMany({
+      where: { ownerId: userId },
+      include: { shares: true },
+      orderBy: [{ updatedAt: 'desc' }],
+    });
+    return rows.map((r) => toView(r, userId, true));
+  }
+
+  if (scope === 'favorite') {
+    const rows = await prisma.savedFilter.findMany({
+      where: { ownerId: userId, isFavorite: true },
+      include: { shares: true },
+      orderBy: [{ useCount: 'desc' }, { lastUsedAt: 'desc' }],
+    });
+    return rows.map((r) => toView(r, userId, true));
+  }
+
+  if (scope === 'public') {
+    const rows = await prisma.savedFilter.findMany({
+      where: { visibility: 'PUBLIC' },
+      include: { shares: true },
+      orderBy: [{ updatedAt: 'desc' }],
+      take: 200,
+    });
+    return rows.map((r) => toView(r, userId, r.ownerId === userId));
+  }
+
+  // scope === 'shared': filters shared with me directly OR via my groups, excluding ones I own.
+  const userGroupIds = await getUserGroupIds(userId);
+  const rows = await prisma.savedFilter.findMany({
+    where: {
+      visibility: 'SHARED',
+      ownerId: { not: userId },
+      shares: {
+        some: {
+          OR: [
+            { userId },
+            ...(userGroupIds.length > 0 ? [{ groupId: { in: userGroupIds } }] : []),
+          ],
+        },
+      },
+    },
+    include: { shares: true },
+    orderBy: [{ updatedAt: 'desc' }],
+    take: 200,
+  });
+  return rows.map((r) => {
+    const directShare = r.shares.find((s) => s.userId === userId);
+    const groupShare = r.shares.find((s) => s.groupId !== null && userGroupIds.includes(s.groupId));
+    const canWrite = directShare?.permission === 'WRITE' || groupShare?.permission === 'WRITE';
+    return toView(r, userId, Boolean(canWrite));
+  });
+}
+
+export async function getFilter(userId: string, filterId: string): Promise<SavedFilterView> {
+  const { filter, canRead, canWrite } = await resolveAccess(userId, filterId);
+  if (!canRead) throw new AppError(403, 'Forbidden');
+  return toView(filter, userId, canWrite);
+}
+
+async function resolveShareTargets(
+  input: { users?: string[]; groups?: string[] } | undefined,
+): Promise<{ userIds: string[]; groupIds: string[] }> {
+  const userIds = Array.from(new Set(input?.users ?? []));
+  const groupIds = Array.from(new Set(input?.groups ?? []));
+
+  if (userIds.length > 0) {
+    const existing = await prisma.user.findMany({
+      where: { id: { in: userIds } },
+      select: { id: true },
+    });
+    if (existing.length !== userIds.length) {
+      throw new AppError(400, 'One or more users do not exist');
+    }
+  }
+  if (groupIds.length > 0) {
+    const existing = await prisma.userGroup.findMany({
+      where: { id: { in: groupIds } },
+      select: { id: true },
+    });
+    if (existing.length !== groupIds.length) {
+      throw new AppError(400, 'One or more groups do not exist');
+    }
+  }
+  return { userIds, groupIds };
+}
+
+export async function createFilter(userId: string, dto: CreateDto): Promise<SavedFilterView> {
+  const visibility = dto.visibility ?? 'PRIVATE';
+
+  // sharedWith only meaningful for SHARED; on PRIVATE/PUBLIC we silently drop to avoid surprises.
+  const shouldWriteShares = visibility === 'SHARED';
+  const { userIds, groupIds } = shouldWriteShares
+    ? await resolveShareTargets(dto.sharedWith)
+    : { userIds: [], groupIds: [] };
+  const permission: FilterPermission = dto.sharedWith?.permission ?? 'READ';
+
+  const created = await prisma.$transaction(async (tx) => {
+    const filter = await tx.savedFilter.create({
+      data: {
+        ownerId: userId,
+        name: dto.name,
+        description: dto.description ?? null,
+        jql: dto.jql,
+        visibility,
+        columns: dto.columns ? (dto.columns as Prisma.InputJsonValue) : undefined,
+      },
+    });
+    if (shouldWriteShares && (userIds.length > 0 || groupIds.length > 0)) {
+      await tx.savedFilterShare.createMany({
+        data: [
+          ...userIds.map((id) => ({ filterId: filter.id, userId: id, permission })),
+          ...groupIds.map((id) => ({ filterId: filter.id, groupId: id, permission })),
+        ],
+      });
+    }
+    return tx.savedFilter.findUniqueOrThrow({
+      where: { id: filter.id },
+      include: { shares: true },
+    });
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      action: 'savedFilter.created',
+      entityType: 'savedFilter',
+      entityId: created.id,
+      userId,
+      details: {
+        name: created.name,
+        visibility: created.visibility,
+        shareCount: created.shares.length,
+      },
+    },
+  });
+
+  return toView(created, userId, true);
+}
+
+export async function updateFilter(userId: string, filterId: string, dto: UpdateDto): Promise<SavedFilterView> {
+  const { filter, canRead, canWrite } = await resolveAccess(userId, filterId);
+  if (!canRead) throw new AppError(403, 'Forbidden');
+  if (!canWrite) throw new AppError(403, 'Forbidden');
+
+  const data: Prisma.SavedFilterUpdateInput = {};
+  if (dto.name !== undefined) data.name = dto.name;
+  if (dto.description !== undefined) data.description = dto.description;
+  if (dto.jql !== undefined) data.jql = dto.jql;
+  if (dto.visibility !== undefined && filter.ownerId === userId) data.visibility = dto.visibility;
+  if (dto.columns !== undefined) {
+    data.columns = dto.columns as Prisma.InputJsonValue;
+  }
+
+  const updated = await prisma.savedFilter.update({
+    where: { id: filterId },
+    data,
+    include: { shares: true },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      action: 'savedFilter.updated',
+      entityType: 'savedFilter',
+      entityId: filterId,
+      userId,
+      details: {
+        changedKeys: Object.keys(data),
+      },
+    },
+  });
+
+  return toView(updated, userId, true);
+}
+
+export async function deleteFilter(userId: string, filterId: string): Promise<void> {
+  const filter = await prisma.savedFilter.findUnique({ where: { id: filterId }, select: { ownerId: true } });
+  if (!filter) throw new AppError(404, 'SavedFilter not found');
+  if (filter.ownerId !== userId) throw new AppError(403, 'Only the owner may delete this filter');
+
+  await prisma.savedFilter.delete({ where: { id: filterId } });
+
+  await prisma.auditLog.create({
+    data: {
+      action: 'savedFilter.deleted',
+      entityType: 'savedFilter',
+      entityId: filterId,
+      userId,
+    },
+  });
+}
+
+export async function setFavorite(userId: string, filterId: string, value: boolean): Promise<SavedFilterView> {
+  const { filter, canRead } = await resolveAccess(userId, filterId);
+  if (!canRead) throw new AppError(403, 'Forbidden');
+
+  // We only toggle isFavorite on filters owned by the user — favorites are a per-user flag, but
+  // the current schema stores it as a single field on SavedFilter so only the owner may use it.
+  // Non-owners who want to bookmark shared filters need a future "per-user favorite" table.
+  if (filter.ownerId !== userId) {
+    throw new AppError(400, 'Favoriting shared/public filters is not supported yet');
+  }
+
+  const updated = await prisma.savedFilter.update({
+    where: { id: filterId },
+    data: { isFavorite: value },
+    include: { shares: true },
+  });
+  return toView(updated, userId, true);
+}
+
+export async function shareFilter(userId: string, filterId: string, dto: ShareDto): Promise<SavedFilterView> {
+  const existing = await prisma.savedFilter.findUnique({ where: { id: filterId }, select: { ownerId: true, visibility: true } });
+  if (!existing) throw new AppError(404, 'SavedFilter not found');
+  if (existing.ownerId !== userId) throw new AppError(403, 'Only the owner may share this filter');
+
+  const { userIds, groupIds } = await resolveShareTargets(dto);
+  const permission: FilterPermission = dto.permission ?? 'READ';
+
+  const updated = await prisma.$transaction(async (tx) => {
+    await tx.savedFilterShare.deleteMany({ where: { filterId } });
+    if (userIds.length > 0 || groupIds.length > 0) {
+      await tx.savedFilterShare.createMany({
+        data: [
+          ...userIds.map((id) => ({ filterId, userId: id, permission })),
+          ...groupIds.map((id) => ({ filterId, groupId: id, permission })),
+        ],
+      });
+      // If someone shared to a list while visibility is still PRIVATE, promote to SHARED.
+      if (existing.visibility === 'PRIVATE') {
+        await tx.savedFilter.update({ where: { id: filterId }, data: { visibility: 'SHARED' } });
+      }
+    }
+    return tx.savedFilter.findUniqueOrThrow({
+      where: { id: filterId },
+      include: { shares: true },
+    });
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      action: 'savedFilter.shared',
+      entityType: 'savedFilter',
+      entityId: filterId,
+      userId,
+      details: {
+        userCount: userIds.length,
+        groupCount: groupIds.length,
+        permission,
+      },
+    },
+  });
+
+  return toView(updated, userId, true);
+}
+
+export async function incrementUseStats(userId: string, filterId: string): Promise<void> {
+  const { canRead } = await resolveAccess(userId, filterId);
+  if (!canRead) throw new AppError(403, 'Forbidden');
+  await prisma.savedFilter.update({
+    where: { id: filterId },
+    data: { useCount: { increment: 1 }, lastUsedAt: new Date() },
+  });
+}
+
+export async function getUserFavorites(userId: string, limit = 5): Promise<SavedFilterView[]> {
+  const rows = await prisma.savedFilter.findMany({
+    where: { ownerId: userId, isFavorite: true },
+    include: { shares: true },
+    orderBy: [{ useCount: 'desc' }, { lastUsedAt: 'desc' }],
+    take: limit,
+  });
+  return rows.map((r) => toView(r, userId, true));
+}

--- a/backend/src/modules/saved-filters/saved-filters.service.ts
+++ b/backend/src/modules/saved-filters/saved-filters.service.ts
@@ -27,7 +27,7 @@
  * Не бросает на DB-ошибках — пробрасывает AppError с http-status.
  */
 
-import type { FilterPermission, FilterVisibility, Prisma, SavedFilter } from '@prisma/client';
+import { Prisma, type FilterPermission, type FilterVisibility, type SavedFilter } from '@prisma/client';
 import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import type { CreateDto, UpdateDto, ShareDto } from './saved-filters.dto.js';
@@ -277,19 +277,34 @@ export async function updateFilter(userId: string, filterId: string, dto: Update
   if (!canWrite) throw new AppError(403, 'Forbidden');
 
   const data: Prisma.SavedFilterUpdateInput = {};
-  if (dto.name !== undefined) data.name = dto.name;
-  if (dto.description !== undefined) data.description = dto.description;
-  if (dto.jql !== undefined) data.jql = dto.jql;
-  if (dto.visibility !== undefined && filter.ownerId === userId) data.visibility = dto.visibility;
+  const changedKeys: string[] = [];
+  if (dto.name !== undefined) { data.name = dto.name; changedKeys.push('name'); }
+  if (dto.description !== undefined) { data.description = dto.description; changedKeys.push('description'); }
+  if (dto.jql !== undefined) { data.jql = dto.jql; changedKeys.push('jql'); }
+  // Visibility change is owner-only — SHARED-WRITE must NOT escalate to PUBLIC.
+  if (dto.visibility !== undefined && filter.ownerId === userId) {
+    data.visibility = dto.visibility;
+    changedKeys.push('visibility');
+  }
   if (dto.columns !== undefined) {
     data.columns = dto.columns as Prisma.InputJsonValue;
+    changedKeys.push('columns');
   }
 
-  const updated = await prisma.savedFilter.update({
-    where: { id: filterId },
-    data,
-    include: { shares: true },
-  });
+  let updated;
+  try {
+    updated = await prisma.savedFilter.update({
+      where: { id: filterId },
+      data,
+      include: { shares: true },
+    });
+  } catch (err) {
+    // Filter deleted between resolveAccess and update — surface as 404, not 500.
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      throw new AppError(404, 'SavedFilter not found');
+    }
+    throw err;
+  }
 
   await prisma.auditLog.create({
     data: {
@@ -297,13 +312,11 @@ export async function updateFilter(userId: string, filterId: string, dto: Update
       entityType: 'savedFilter',
       entityId: filterId,
       userId,
-      details: {
-        changedKeys: Object.keys(data),
-      },
+      details: { changedKeys },
     },
   });
 
-  return toView(updated, userId, true);
+  return toView(updated, userId, canWrite);
 }
 
 export async function deleteFilter(userId: string, filterId: string): Promise<void> {
@@ -334,11 +347,19 @@ export async function setFavorite(userId: string, filterId: string, value: boole
     throw new AppError(400, 'Favoriting shared/public filters is not supported yet');
   }
 
-  const updated = await prisma.savedFilter.update({
-    where: { id: filterId },
-    data: { isFavorite: value },
-    include: { shares: true },
-  });
+  let updated;
+  try {
+    updated = await prisma.savedFilter.update({
+      where: { id: filterId },
+      data: { isFavorite: value },
+      include: { shares: true },
+    });
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      throw new AppError(404, 'SavedFilter not found');
+    }
+    throw err;
+  }
   return toView(updated, userId, true);
 }
 
@@ -363,6 +384,10 @@ export async function shareFilter(userId: string, filterId: string, dto: ShareDt
       if (existing.visibility === 'PRIVATE') {
         await tx.savedFilter.update({ where: { id: filterId }, data: { visibility: 'SHARED' } });
       }
+    } else if (existing.visibility === 'SHARED') {
+      // Owner emptied the share list on a SHARED filter — demote back to PRIVATE so the
+      // `visibility` field doesn't lie. PUBLIC is left alone (owner's explicit choice).
+      await tx.savedFilter.update({ where: { id: filterId }, data: { visibility: 'PRIVATE' } });
     }
     return tx.savedFilter.findUniqueOrThrow({
       where: { id: filterId },
@@ -390,10 +415,17 @@ export async function shareFilter(userId: string, filterId: string, dto: ShareDt
 export async function incrementUseStats(userId: string, filterId: string): Promise<void> {
   const { canRead } = await resolveAccess(userId, filterId);
   if (!canRead) throw new AppError(403, 'Forbidden');
-  await prisma.savedFilter.update({
-    where: { id: filterId },
-    data: { useCount: { increment: 1 }, lastUsedAt: new Date() },
-  });
+  try {
+    await prisma.savedFilter.update({
+      where: { id: filterId },
+      data: { useCount: { increment: 1 }, lastUsedAt: new Date() },
+    });
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      throw new AppError(404, 'SavedFilter not found');
+    }
+    throw err;
+  }
 }
 
 export async function getUserFavorites(userId: string, limit = 5): Promise<SavedFilterView[]> {

--- a/backend/src/modules/users/users.dto.ts
+++ b/backend/src/modules/users/users.dto.ts
@@ -8,6 +8,20 @@ export const updateUserDto = z.object({
   email: z.string().email().optional(),
 });
 
+// TTSRH-1 PR-7: per-user UI preferences (search columns, page size).
+// We keep the shape versioned-by-object (`searchDefaults`) to allow future keys
+// (`checkpointDefaults`, etc.) without migrating existing rows.
+export const updatePreferencesDto = z
+  .object({
+    searchDefaults: z
+      .object({
+        columns: z.array(z.string().min(1).max(100)).max(50).optional(),
+        pageSize: z.number().int().min(10).max(100).optional(),
+      })
+      .optional(),
+  })
+  .refine((v) => Object.keys(v).length > 0, { message: 'At least one preference section must be provided' });
+
 export const assignSystemRoleDto = z.object({
   role: z.enum(systemRoleValues),
 });
@@ -20,5 +34,6 @@ export const setSystemRolesDto = z.object({
 });
 
 export type UpdateUserDto = z.infer<typeof updateUserDto>;
+export type UpdatePreferencesDto = z.infer<typeof updatePreferencesDto>;
 export type AssignSystemRoleDto = z.infer<typeof assignSystemRoleDto>;
 export type SetSystemRolesDto = z.infer<typeof setSystemRolesDto>;

--- a/backend/src/modules/users/users.router.ts
+++ b/backend/src/modules/users/users.router.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { authenticate } from '../../shared/middleware/auth.js';
 import { requireRole } from '../../shared/middleware/rbac.js';
 import { validate } from '../../shared/middleware/validate.js';
-import { updateUserDto } from './users.dto.js';
+import { updatePreferencesDto, updateUserDto } from './users.dto.js';
 import * as usersService from './users.service.js';
 import { logAudit } from '../../shared/middleware/audit.js';
 import type { AuthRequest } from '../../shared/types/index.js';
@@ -19,6 +19,38 @@ router.get('/', async (_req, res, next) => {
     next(err);
   }
 });
+
+// TTSRH-1 PR-7 — per-user UI preferences (search columns, page size). Must be
+// declared before `/:id` so Express doesn't greedy-match `me` as an id.
+router.get('/me/preferences', async (req: AuthRequest, res, next) => {
+  try {
+    if (!req.user) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+    const prefs = await usersService.getPreferences(req.user.userId);
+    res.json(prefs);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.patch(
+  '/me/preferences',
+  validate(updatePreferencesDto),
+  async (req: AuthRequest, res, next) => {
+    try {
+      if (!req.user) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+      const prefs = await usersService.updatePreferences(req.user.userId, req.body);
+      res.json(prefs);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 
 router.get('/:id', async (req, res, next) => {
   try {

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -2,7 +2,7 @@ import { prisma } from '../../prisma/client.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { isSuperAdmin } from '../../shared/auth/roles.js';
 import type { SystemRoleType } from '@prisma/client';
-import type { UpdateUserDto } from './users.dto.js';
+import type { UpdatePreferencesDto, UpdateUserDto } from './users.dto.js';
 
 const userSelect = {
   id: true,
@@ -229,6 +229,29 @@ export async function getSystemRoles(userId: string): Promise<SystemRoleType[]> 
 
 const NA_SUFFIX = ' (N/A)';
 const MAX_NAME_LEN = 255;
+
+// TTSRH-1 PR-7: per-user preferences — read/merge semantics.
+// Merge is shallow over top-level keys (`searchDefaults`, …) and replace within; this matches
+// TTUI-90 §5.4. PATCH with partial payload only overwrites the keys provided.
+export async function getPreferences(userId: string): Promise<Record<string, unknown>> {
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { preferences: true } });
+  if (!user) throw new AppError(404, 'User not found');
+  return (user.preferences as Record<string, unknown> | null) ?? {};
+}
+
+export async function updatePreferences(userId: string, dto: UpdatePreferencesDto): Promise<Record<string, unknown>> {
+  const existing = await getPreferences(userId);
+  const merged: Record<string, unknown> = { ...existing };
+  for (const [key, value] of Object.entries(dto)) {
+    if (value === undefined) continue;
+    merged[key] = value;
+  }
+  await prisma.user.update({
+    where: { id: userId },
+    data: { preferences: merged as never },
+  });
+  return merged;
+}
 
 export async function deactivateUser(id: string) {
   const user = await prisma.user.findUnique({ where: { id } });

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -242,9 +242,24 @@ export async function getPreferences(userId: string): Promise<Record<string, unk
 export async function updatePreferences(userId: string, dto: UpdatePreferencesDto): Promise<Record<string, unknown>> {
   const existing = await getPreferences(userId);
   const merged: Record<string, unknown> = { ...existing };
+  // Two-level merge: partial PATCH like `{searchDefaults: {pageSize: 50}}` must not wipe
+  // sibling keys (`columns`) already stored under `searchDefaults`. We only deep-merge one
+  // level because section values are plain objects with scalar/array fields.
   for (const [key, value] of Object.entries(dto)) {
     if (value === undefined) continue;
-    merged[key] = value;
+    const prev = merged[key];
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      prev !== null &&
+      typeof prev === 'object' &&
+      !Array.isArray(prev)
+    ) {
+      merged[key] = { ...(prev as Record<string, unknown>), ...(value as Record<string, unknown>) };
+    } else {
+      merged[key] = value;
+    }
   }
   await prisma.user.update({
     where: { id: userId },

--- a/backend/tests/env.ts
+++ b/backend/tests/env.ts
@@ -7,6 +7,11 @@ loadEnv({ path: '.env.test', override: true });
 
 process.env.NODE_ENV = 'test';
 
+// TTSRH-1 PR-7: saved-filter + search tests exercise the feature-flagged mount.
+// Default OFF in prod, but tests always expect the routes to be live unless a
+// specific test explicitly overrides it.
+process.env.FEATURES_ADVANCED_SEARCH ??= 'true';
+
 if (process.env.DATABASE_URL) {
   const sourceUrl = new URL(process.env.DATABASE_URL);
   const databaseName = sourceUrl.pathname.split('/').filter(Boolean).at(-1) ?? 'tasktime';

--- a/backend/tests/saved-filters.test.ts
+++ b/backend/tests/saved-filters.test.ts
@@ -1,0 +1,389 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+
+import { createTestUser, request } from './helpers.js';
+
+const prisma = new PrismaClient();
+
+let ownerToken: string;
+let ownerId: string;
+let otherToken: string;
+let otherId: string;
+let thirdToken: string;
+let thirdId: string;
+
+beforeEach(async () => {
+  // Tables with FK fan-out from users — clear in dependency order.
+  await prisma.savedFilterShare.deleteMany();
+  await prisma.savedFilter.deleteMany();
+  await prisma.userGroupMember.deleteMany();
+  await prisma.userGroup.deleteMany();
+  await prisma.auditLog.deleteMany();
+  await prisma.refreshToken.deleteMany();
+  await prisma.user.deleteMany();
+
+  const owner = await createTestUser('owner@test.com', 'Password123', 'Owner');
+  ownerToken = owner.accessToken;
+  ownerId = owner.user.id;
+  const other = await createTestUser('other@test.com', 'Password123', 'Other');
+  otherToken = other.accessToken;
+  otherId = other.user.id;
+  const third = await createTestUser('third@test.com', 'Password123', 'Third');
+  thirdToken = third.accessToken;
+  thirdId = third.user.id;
+});
+
+async function createFilter(
+  token: string,
+  body: Record<string, unknown> = { name: 'F', jql: 'project = "ABC"' },
+) {
+  return request.post('/api/saved-filters').set('Authorization', `Bearer ${token}`).send(body);
+}
+
+describe('SavedFilter CRUD', () => {
+  it('POST /api/saved-filters - creates a PRIVATE filter by default', async () => {
+    const res = await createFilter(ownerToken, {
+      name: 'My HIGH issues',
+      description: 'Critical & high priority',
+      jql: 'priority IN (CRITICAL, HIGH)',
+      columns: ['key', 'summary', 'priority'],
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.ownerId).toBe(ownerId);
+    expect(res.body.visibility).toBe('PRIVATE');
+    expect(res.body.columns).toEqual(['key', 'summary', 'priority']);
+    expect(res.body.isFavorite).toBe(false);
+    expect(res.body.permission).toBe('WRITE');
+  });
+
+  it('POST /api/saved-filters - 400 on missing name', async () => {
+    const res = await createFilter(ownerToken, { jql: 'x = 1' });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /api/saved-filters - 401 without auth', async () => {
+    const res = await request.post('/api/saved-filters').send({ name: 'X', jql: 'x = 1' });
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /api/saved-filters?scope=mine - returns own filters only', async () => {
+    await createFilter(ownerToken, { name: 'O1', jql: 'x = 1' });
+    await createFilter(otherToken, { name: 'P2', jql: 'x = 2' });
+
+    const res = await request.get('/api/saved-filters').set('Authorization', `Bearer ${ownerToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.filters).toHaveLength(1);
+    expect(res.body.filters[0].name).toBe('O1');
+  });
+
+  it('GET /api/saved-filters?scope=public - returns PUBLIC filters from anyone', async () => {
+    await createFilter(ownerToken, { name: 'Public', jql: 'x = 1', visibility: 'PUBLIC' });
+    await createFilter(otherToken, { name: 'Private', jql: 'x = 2' });
+
+    const res = await request
+      .get('/api/saved-filters?scope=public')
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.filters).toHaveLength(1);
+    expect(res.body.filters[0].name).toBe('Public');
+  });
+
+  it('GET /api/saved-filters/:id - 403 on PRIVATE filter owned by someone else', async () => {
+    const created = await createFilter(ownerToken, { name: 'Secret', jql: 'x = 1' });
+    const res = await request
+      .get(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('GET /api/saved-filters/:id - 200 for owner', async () => {
+    const created = await createFilter(ownerToken);
+    const res = await request
+      .get(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${ownerToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.permission).toBe('WRITE');
+  });
+
+  it('PATCH /api/saved-filters/:id - owner can update', async () => {
+    const created = await createFilter(ownerToken);
+    const res = await request
+      .patch(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ name: 'Renamed' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Renamed');
+  });
+
+  it('PATCH /api/saved-filters/:id - 403 for non-owner without WRITE share', async () => {
+    const created = await createFilter(ownerToken);
+    const res = await request
+      .patch(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ name: 'Hacked' });
+    expect(res.status).toBe(403);
+  });
+
+  it('DELETE /api/saved-filters/:id - owner can delete', async () => {
+    const created = await createFilter(ownerToken);
+    const res = await request
+      .delete(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${ownerToken}`);
+    expect(res.status).toBe(204);
+
+    const after = await request
+      .get(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${ownerToken}`);
+    expect(after.status).toBe(404);
+  });
+
+  it('DELETE /api/saved-filters/:id - non-owner cannot delete even SHARED-WRITE', async () => {
+    const created = await createFilter(ownerToken, {
+      name: 'S', jql: 'x = 1', visibility: 'SHARED',
+      sharedWith: { users: [otherId], permission: 'WRITE' },
+    });
+    const res = await request
+      .delete(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('SavedFilter sharing', () => {
+  it('POST /api/saved-filters/:id/share - owner shares with users (READ default)', async () => {
+    const created = await createFilter(ownerToken, { name: 'S', jql: 'x = 1' });
+    const res = await request
+      .post(`/api/saved-filters/${created.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ users: [otherId] });
+    expect(res.status).toBe(200);
+    expect(res.body.visibility).toBe('SHARED');
+    expect(res.body.shares).toHaveLength(1);
+    expect(res.body.shares[0].userId).toBe(otherId);
+    expect(res.body.shares[0].permission).toBe('READ');
+  });
+
+  it('SHARED + READ - shared user can GET but cannot PATCH', async () => {
+    const created = await createFilter(ownerToken, { name: 'S', jql: 'x = 1' });
+    await request
+      .post(`/api/saved-filters/${created.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ users: [otherId] });
+
+    const getRes = await request
+      .get(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.permission).toBe('READ');
+
+    const patchRes = await request
+      .patch(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ name: 'Hacked' });
+    expect(patchRes.status).toBe(403);
+  });
+
+  it('SHARED + WRITE - shared user can PATCH', async () => {
+    const created = await createFilter(ownerToken, { name: 'S', jql: 'x = 1' });
+    await request
+      .post(`/api/saved-filters/${created.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ users: [otherId], permission: 'WRITE' });
+
+    const res = await request
+      .patch(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ jql: 'updated = 1' });
+    expect(res.status).toBe(200);
+  });
+
+  it('SHARED via group - user in group gains READ access', async () => {
+    const group = await prisma.userGroup.create({ data: { name: 'QA' } });
+    await prisma.userGroupMember.create({ data: { groupId: group.id, userId: thirdId } });
+
+    const created = await createFilter(ownerToken, { name: 'Grp', jql: 'x = 1' });
+    await request
+      .post(`/api/saved-filters/${created.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ groups: [group.id] });
+
+    const res = await request
+      .get(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${thirdToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.permission).toBe('READ');
+
+    // A non-member still cannot read.
+    const deny = await request
+      .get(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(deny.status).toBe(403);
+  });
+
+  it('POST /share - replace semantics: old shares removed on re-share', async () => {
+    const created = await createFilter(ownerToken, { name: 'S', jql: 'x = 1' });
+    await request
+      .post(`/api/saved-filters/${created.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ users: [otherId] });
+    const reshare = await request
+      .post(`/api/saved-filters/${created.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ users: [thirdId] });
+    expect(reshare.status).toBe(200);
+    expect(reshare.body.shares).toHaveLength(1);
+    expect(reshare.body.shares[0].userId).toBe(thirdId);
+  });
+
+  it('POST /share - 403 if caller is not the owner', async () => {
+    const created = await createFilter(ownerToken, { name: 'S', jql: 'x = 1' });
+    const res = await request
+      .post(`/api/saved-filters/${created.body.id}/share`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ users: [thirdId] });
+    expect(res.status).toBe(403);
+  });
+
+  it('POST /share - 400 if sharing with nonexistent user', async () => {
+    const created = await createFilter(ownerToken, { name: 'S', jql: 'x = 1' });
+    const res = await request
+      .post(`/api/saved-filters/${created.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ users: ['00000000-0000-0000-0000-000000000000'] });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('SavedFilter favorite + use tracking', () => {
+  it('POST /:id/favorite - owner can favorite their filter', async () => {
+    const created = await createFilter(ownerToken);
+    const res = await request
+      .post(`/api/saved-filters/${created.body.id}/favorite`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ value: true });
+    expect(res.status).toBe(200);
+    expect(res.body.isFavorite).toBe(true);
+  });
+
+  it('POST /:id/favorite - non-owner (400 — per-user favorites out of scope)', async () => {
+    const created = await createFilter(ownerToken, {
+      name: 'S', jql: 'x = 1', visibility: 'PUBLIC',
+    });
+    const res = await request
+      .post(`/api/saved-filters/${created.body.id}/favorite`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ value: true });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /:id/use - increments useCount atomically', async () => {
+    const created = await createFilter(ownerToken);
+    await request
+      .post(`/api/saved-filters/${created.body.id}/use`)
+      .set('Authorization', `Bearer ${ownerToken}`);
+    await request
+      .post(`/api/saved-filters/${created.body.id}/use`)
+      .set('Authorization', `Bearer ${ownerToken}`);
+
+    const after = await request
+      .get(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${ownerToken}`);
+    expect(after.body.useCount).toBe(2);
+    expect(after.body.lastUsedAt).not.toBeNull();
+  });
+
+  it('GET /?scope=favorite - returns only favorited filters sorted by useCount', async () => {
+    const a = await createFilter(ownerToken, { name: 'A', jql: 'x = 1' });
+    const b = await createFilter(ownerToken, { name: 'B', jql: 'x = 2' });
+    const c = await createFilter(ownerToken, { name: 'C', jql: 'x = 3' });
+
+    await request.post(`/api/saved-filters/${a.body.id}/favorite`).set('Authorization', `Bearer ${ownerToken}`).send({ value: true });
+    await request.post(`/api/saved-filters/${c.body.id}/favorite`).set('Authorization', `Bearer ${ownerToken}`).send({ value: true });
+    // Bump useCount on C so it ranks first.
+    for (let i = 0; i < 3; i++) {
+      await request.post(`/api/saved-filters/${c.body.id}/use`).set('Authorization', `Bearer ${ownerToken}`);
+    }
+    await request.post(`/api/saved-filters/${a.body.id}/use`).set('Authorization', `Bearer ${ownerToken}`);
+
+    const res = await request
+      .get('/api/saved-filters?scope=favorite')
+      .set('Authorization', `Bearer ${ownerToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.filters.map((f: { name: string }) => f.name)).toEqual(['C', 'A']);
+    expect(res.body.filters.every((f: { id: string }) => f.id !== b.body.id)).toBe(true);
+  });
+});
+
+describe('SavedFilter audit log', () => {
+  it('writes savedFilter.created / updated / deleted / shared rows', async () => {
+    const created = await createFilter(ownerToken);
+
+    await request
+      .patch(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ name: 'New name' });
+
+    await request
+      .post(`/api/saved-filters/${created.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ users: [otherId] });
+
+    await request
+      .delete(`/api/saved-filters/${created.body.id}`)
+      .set('Authorization', `Bearer ${ownerToken}`);
+
+    const logs = await prisma.auditLog.findMany({
+      where: { entityType: 'savedFilter' },
+      orderBy: { createdAt: 'asc' },
+      select: { action: true },
+    });
+    expect(logs.map((l) => l.action)).toEqual([
+      'savedFilter.created',
+      'savedFilter.updated',
+      'savedFilter.shared',
+      'savedFilter.deleted',
+    ]);
+  });
+});
+
+describe('User preferences', () => {
+  it('GET /api/users/me/preferences - returns empty object for a new user', async () => {
+    const res = await request.get('/api/users/me/preferences').set('Authorization', `Bearer ${ownerToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({});
+  });
+
+  it('PATCH /api/users/me/preferences - sets searchDefaults', async () => {
+    const res = await request
+      .patch('/api/users/me/preferences')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ searchDefaults: { columns: ['key', 'summary'], pageSize: 50 } });
+    expect(res.status).toBe(200);
+    expect(res.body.searchDefaults.columns).toEqual(['key', 'summary']);
+    expect(res.body.searchDefaults.pageSize).toBe(50);
+  });
+
+  it('PATCH /api/users/me/preferences - 400 on columns above max (51)', async () => {
+    const columns = Array.from({ length: 51 }, (_, i) => `c${i}`);
+    const res = await request
+      .patch('/api/users/me/preferences')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ searchDefaults: { columns } });
+    expect(res.status).toBe(400);
+  });
+
+  it('PATCH /api/users/me/preferences - 400 on empty body', async () => {
+    const res = await request
+      .patch('/api/users/me/preferences')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('PATCH /api/users/me/preferences - 401 without auth', async () => {
+    const res = await request
+      .patch('/api/users/me/preferences')
+      .send({ searchDefaults: { pageSize: 50 } });
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/tests/saved-filters.test.ts
+++ b/backend/tests/saved-filters.test.ts
@@ -252,6 +252,72 @@ describe('SavedFilter sharing', () => {
       .send({ users: ['00000000-0000-0000-0000-000000000000'] });
     expect(res.status).toBe(400);
   });
+
+  it('POST /share with empty list downgrades SHARED → PRIVATE (PUBLIC untouched)', async () => {
+    const shared = await createFilter(ownerToken, { name: 'S', jql: 'x = 1' });
+    await request
+      .post(`/api/saved-filters/${shared.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ users: [otherId] });
+
+    const emptied = await request
+      .post(`/api/saved-filters/${shared.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({});
+    expect(emptied.status).toBe(200);
+    expect(emptied.body.visibility).toBe('PRIVATE');
+    expect(emptied.body.shares).toHaveLength(0);
+
+    const pub = await createFilter(ownerToken, { name: 'P', jql: 'x = 1', visibility: 'PUBLIC' });
+    const emptyOnPublic = await request
+      .post(`/api/saved-filters/${pub.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({});
+    expect(emptyOnPublic.body.visibility).toBe('PUBLIC');
+  });
+
+  it('GET /?scope=shared - returns filters shared with me, not mine, and not visible to non-recipient', async () => {
+    const created = await createFilter(ownerToken, { name: 'S', jql: 'x = 1' });
+    await request
+      .post(`/api/saved-filters/${created.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ users: [otherId] });
+
+    const recipient = await request
+      .get('/api/saved-filters?scope=shared')
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(recipient.status).toBe(200);
+    expect(recipient.body.filters).toHaveLength(1);
+    expect(recipient.body.filters[0].id).toBe(created.body.id);
+
+    // Owner's own SHARED filter must not appear in their own shared scope.
+    const owner = await request
+      .get('/api/saved-filters?scope=shared')
+      .set('Authorization', `Bearer ${ownerToken}`);
+    expect(owner.body.filters).toHaveLength(0);
+
+    // A third party not in shares sees nothing.
+    const third = await request
+      .get('/api/saved-filters?scope=shared')
+      .set('Authorization', `Bearer ${thirdToken}`);
+    expect(third.body.filters).toHaveLength(0);
+  });
+
+  it('GET /?scope=shared - finds filter shared via group membership', async () => {
+    const group = await prisma.userGroup.create({ data: { name: 'QA' } });
+    await prisma.userGroupMember.create({ data: { groupId: group.id, userId: thirdId } });
+    const created = await createFilter(ownerToken, { name: 'Grp', jql: 'x = 1' });
+    await request
+      .post(`/api/saved-filters/${created.body.id}/share`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ groups: [group.id] });
+
+    const res = await request
+      .get('/api/saved-filters?scope=shared')
+      .set('Authorization', `Bearer ${thirdToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.filters.map((f: { id: string }) => f.id)).toEqual([created.body.id]);
+  });
 });
 
 describe('SavedFilter favorite + use tracking', () => {
@@ -361,6 +427,21 @@ describe('User preferences', () => {
     expect(res.status).toBe(200);
     expect(res.body.searchDefaults.columns).toEqual(['key', 'summary']);
     expect(res.body.searchDefaults.pageSize).toBe(50);
+  });
+
+  it('PATCH /api/users/me/preferences - partial update preserves sibling keys', async () => {
+    await request
+      .patch('/api/users/me/preferences')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ searchDefaults: { columns: ['key', 'summary'], pageSize: 50 } });
+    const res = await request
+      .patch('/api/users/me/preferences')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ searchDefaults: { pageSize: 25 } });
+    expect(res.status).toBe(200);
+    // Sibling key `columns` must survive a partial PATCH over its parent section.
+    expect(res.body.searchDefaults.columns).toEqual(['key', 'summary']);
+    expect(res.body.searchDefaults.pageSize).toBe(25);
   });
 
   it('PATCH /api/users/me/preferences - 400 on columns above max (51)', async () => {

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1313,6 +1313,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
   - Integration T-6 (CRUD + sharing + RBAC negative).
 - **Merge-ready check:** T-6 зелёные; SavedFilter PUBLIC + невидимые проекты → 0 задач (SEC-8).
 - **Оценка:** ~8ч.
+- **Статус: ✅ Done** — 24 integration-теста (CRUD × 10, Sharing × 6, Favorite/use × 4, Audit × 1, Preferences × 5) + shallow-merge preferences + owner-only favorite + group-share через `UserGroupMember`. Добавлен `POST /:id/use` для incrementUseStats (инкремент `useCount` + `lastUsedAt`). В §13.9 — 🟢 Merged после слияния PR.
 
 #### PR-8: Export CSV/XLSX
 - **Branch:** `ttsrh-1/export`
@@ -1498,7 +1499,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 | 🟢 Merged ([#103](https://github.com/NovakPAai/tasktime-mvp/pull/103)) |
 | 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 | 🟢 Merged ([#104](https://github.com/NovakPAai/tasktime-mvp/pull/104)) |
 | 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 | ✅ Done (готов к push после merge PR-5) |
-| 7 | `ttsrh-1/saved-filters` | SavedFilter CRUD/share/favorite + User.preferences | 8 | PR-5 | TTSRH-8, TTSRH-9 | 📋 Планируется |
+| 7 | `ttsrh-1/saved-filters` | SavedFilter CRUD/share/favorite + User.preferences | 8 | PR-5 | TTSRH-8, TTSRH-9 | ✅ Done (готов к push после merge PR-6) |
 | 8 | `ttsrh-1/export` | `/search/export` CSV/XLSX | 4 | PR-5 | TTSRH-10 | 📋 Планируется |
 | 9 | `ttsrh-1/frontend-shell` | SearchPage shell + route + sidebar + URL sync | 6 | PR-5 | TTSRH-12, часть TTSRH-19 | 📋 Планируется |
 | 10 | `ttsrh-1/jql-editor` | JqlEditor (CM6) + inline errors + lazy-load | 13 | PR-9 | TTSRH-13, TTSRH-14 | 📋 Планируется |

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1498,7 +1498,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 3 | `ttsrh-1/validator` | Field registry + Validator + functions + `/search/schema`, `/validate` | 14 | PR-2 | TTSRH-3, TTSRH-6 | 🟢 Merged ([#102](https://github.com/NovakPAai/tasktime-mvp/pull/102)) |
 | 4 | `ttsrh-1/compiler` | Compiler system + custom fields + scope-фильтр R3 | 18 | PR-3 | TTSRH-4, TTSRH-5 | 🟢 Merged ([#103](https://github.com/NovakPAai/tasktime-mvp/pull/103)) |
 | 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 | 🟢 Merged ([#104](https://github.com/NovakPAai/tasktime-mvp/pull/104)) |
-| 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 | ✅ Done (готов к push после merge PR-5) |
+| 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 | 🟢 Merged ([#106](https://github.com/NovakPAai/tasktime-mvp/pull/106)) |
 | 7 | `ttsrh-1/saved-filters` | SavedFilter CRUD/share/favorite + User.preferences | 8 | PR-5 | TTSRH-8, TTSRH-9 | ✅ Done (готов к push после merge PR-6) |
 | 8 | `ttsrh-1/export` | `/search/export` CSV/XLSX | 4 | PR-5 | TTSRH-10 | 📋 Планируется |
 | 9 | `ttsrh-1/frontend-shell` | SearchPage shell + route + sidebar + URL sync | 6 | PR-5 | TTSRH-12, часть TTSRH-19 | 📋 Планируется |

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,74 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.33**
+**Last version: 2.34**
+
+---
+
+## [2.34] [2026-04-21] feat(saved-filters): TTSRH-1 PR-7 — SavedFilter CRUD + share + favorite + User preferences
+
+**PR:** (to be filled after push)
+**Ветка:** `ttsrh-1/saved-filters`
+
+### Что было
+
+После PR-6 `/api/saved-filters/*` возвращали 501; `/api/users/me/preferences` не существовало. Пользователь не мог сохранить JQL-запрос, передать его коллеге, отметить избранным или зафиксировать набор колонок как дефолт — ни один flow §5.6 ТЗ не работал.
+
+### Что теперь
+
+Полный CRUD `/api/saved-filters` с RBAC, sharing'ом через пользователей и группы, а также Zod-DTO `PATCH /api/users/me/preferences`:
+
+- **`saved-filters.dto.ts`** — Zod схемы `listQueryDto`, `createDto`, `updateDto`, `favoriteDto`, `shareDto`, `preferencesDto`. Инварианты: `name` ≤ 200 символов, `jql` ≤ 10K (как на `/search/issues`), `columns` ≤ 50 строк, `sharedWith.users` ≤ 500 UUID, `sharedWith.groups` ≤ 100 UUID — чтобы не пропустить DoS через очень большие JSON-массивы в `User.preferences`.
+- **`saved-filters.service.ts`** — весь бизнес-слой:
+  - `listFilters(userId, scope)` — 4 scope'а: `mine` (owner), `favorite` (owner + isFavorite, сорт `useCount DESC, lastUsedAt DESC` — под сайдбарное submenu §5.7), `public` (все аутентифицированные), `shared` (SHARED-фильтры через прямые shares или группы пользователя, `ownerId: { not: userId }`).
+  - `getFilter`, `updateFilter`, `deleteFilter` — с RBAC-проверкой (R-SF-1 read, R-SF-2 write).
+  - `createFilter` — транзакционно создаёт `SavedFilter` + `SavedFilterShare[]` (если visibility=SHARED), валидирует существование shared-users/groups (400 при unknown UUID). `sharedWith` игнорируется для PRIVATE/PUBLIC, чтобы не плодить зомби-строки.
+  - `shareFilter` — replace-семантика: старые shares удаляются в той же транзакции, новые создаются. При первом share auto-promote PRIVATE → SHARED. Owner-only.
+  - `setFavorite` — только для owner'а (per-user favorites over shared/public filters — future).
+  - `incrementUseStats` — атомарный `{ increment: 1 }` + `lastUsedAt=now()` (race-safe на конкурентных запросах).
+  - `getUserFavorites(userId, limit=5)` — готовый хелпер для будущего `SavedFiltersSidebar`.
+  - RBAC: `resolveAccess(userId, filterId)` единственная точка правды, читает `SavedFilter` + `shares` + `userGroupMember` и возвращает `{canRead, canWrite}`.
+  - AuditLog: `savedFilter.created|updated|deleted|shared` — через `prisma.auditLog.create` с `userId/entityType/entityId/details`.
+- **`saved-filters.router.ts`** — live (раньше был stub-501):
+  - `GET /saved-filters?scope=` (Zod query), `POST /saved-filters` (201), `GET/PATCH/DELETE /:id` (403 на чужое, 404 на несуществующее).
+  - `POST /:id/favorite {value:bool}`, `POST /:id/share {users?,groups?,permission?}`, `POST /:id/use` (204, инкремент).
+  - Всё под `authenticate` middleware; 401 при `!req.user`. Gate по `features.advancedSearch` — в app.ts (без изменений).
+- **`users.router.ts` + `users.service.ts`** — `GET/PATCH /api/users/me/preferences`:
+  - `getPreferences` — читает `User.preferences`, возвращает `{}` если `null` (новый пользователь).
+  - `updatePreferences` — shallow-merge сверху (PATCH семантика): `{searchDefaults: {columns}}` не перетирает другие top-level ключи (`checkpointDefaults`, и т.д. — паттерн TTUI-90 §5.4).
+  - `me/preferences` регистрируется ПЕРЕД `/:id`, чтобы Express не greedy-match'ил `me` как UUID.
+- **`tests/env.ts`** — `process.env.FEATURES_ADVANCED_SEARCH ??= 'true'` (setup-файл vitest). Без этого `createApp()` не монтирует `/api/saved-filters/*` и все integration-тесты сразу падают 404.
+
+### Тесты (интеграционные, требуют Postgres — прогонит CI)
+
+**`tests/saved-filters.test.ts`** — 24 кейса:
+
+- **CRUD (10)**: create PRIVATE default, 400 на missing name, 401 без auth, list `scope=mine` фильтрует чужие, `scope=public` включает PUBLIC со всех, 403 на чужой PRIVATE, 200 для owner, PATCH owner-ok, PATCH non-owner 403, DELETE owner 204 + follow-up GET 404, DELETE non-owner 403 даже при SHARED-WRITE.
+- **Sharing (6)**: share users READ по умолчанию, READ → GET ok + PATCH 403, WRITE → PATCH ok, share через группу + non-member 403, replace-семантика (старые shares заменяются), 403 для не-owner'а, 400 на nonexistent UUID.
+- **Favorite + use (4)**: owner toggle favorite, non-owner PUBLIC → 400, `/use` инкрементирует useCount+lastUsedAt, `scope=favorite` сортирует по useCount.
+- **Audit (1)**: create/update/share/delete пишет 4 строки в AuditLog с правильным entityType + action.
+- **Preferences (5)**: GET empty object для нового user'а, PATCH searchDefaults, 400 на columns>50, 400 на empty body, 401 без auth.
+
+### Изменения
+
+- `backend/src/modules/saved-filters/saved-filters.dto.ts` — новый.
+- `backend/src/modules/saved-filters/saved-filters.service.ts` — новый.
+- `backend/src/modules/saved-filters/saved-filters.router.ts` — live (был stub).
+- `backend/src/modules/users/users.dto.ts` — + `updatePreferencesDto`.
+- `backend/src/modules/users/users.service.ts` — + `getPreferences`, `updatePreferences`.
+- `backend/src/modules/users/users.router.ts` — + `GET/PATCH /me/preferences` (перед `/:id`).
+- `backend/tests/env.ts` — `FEATURES_ADVANCED_SEARCH ??= 'true'` default в тестах.
+- `backend/tests/saved-filters.test.ts` — новый, 24 integration-кейса.
+- `docs/tz/TTSRH-1.md` §13.5/§13.9 — статус PR-7 → ✅ Done.
+
+### Влияние на prod
+
+Под `FEATURES_ADVANCED_SEARCH=false` эндпоинты недоступны (ассоциированный mount не монтируется — см. app.ts:176). При включении: фронт может создавать/редактировать/делить фильтры, хранить UI-колонки в `User.preferences`, сайдбар готов к списку избранных (getUserFavorites).
+
+### Проверки
+
+- `npx tsc --noEmit` — чисто
+- `npm run lint` — 0 errors, 0 new warnings
 
 ---
 


### PR DESCRIPTION
## Summary

- **Saved filters backend** (`/api/saved-filters/*`) — live (раньше stub-501). CRUD + sharing по users/groups + favorite + `/use` stats. Gate под `features.advancedSearch` сохранён (app.ts).
- **User preferences** (`GET/PATCH /api/users/me/preferences`) — JSON-column на `User.preferences`, shallow-merge на top-level, deep-merge на один уровень (partial PATCH не затирает sibling-ключи секции).
- **RBAC**: `resolveAccess()` = single source of truth — owner/visibility/direct-share/group-share → `{canRead, canWrite}`. Write-share не может эскалировать visibility; favorite only для owner'а.
- **Audit**: `savedFilter.created/updated/deleted/shared` через `prisma.auditLog.create` без PII-leak'а (только name, visibility, changedKeys — не `jql`).
- **Race-safe**: атомарный `useCount: {increment: 1}`, P2025 (Prisma "record not found") отлавливается и мапится в 404 в `updateFilter/setFavorite/incrementUseStats`.
- **Invariant invariants**: shareFilter с пустыми users+groups авто-демутит SHARED → PRIVATE (PUBLIC сохраняется).

## Pre-push review counts

🟠 × 2 (applied), 🟡 × 4 (applied), ⚪ × 1 (applied), без unresolved.

## Test plan

Все integration-тесты в `backend/tests/saved-filters.test.ts` (требуют Postgres — CI прогонит):

- [x] **CRUD (10)**: create default PRIVATE, 400 missing name, 401 no auth, scope=mine, scope=public, 403 на чужой PRIVATE, 200 для owner, PATCH owner-ok, PATCH non-owner 403, DELETE owner 204 + 404, DELETE non-owner на SHARED-WRITE 403.
- [x] **Sharing (8)**: share users READ default, READ → PATCH 403, WRITE → PATCH ok, share through group + non-member 403, replace-семантика, 403 не-owner, 400 nonexistent UUID, empty list downgrade SHARED → PRIVATE + PUBLIC preserved, scope=shared (direct + group-membership).
- [x] **Favorite + use (4)**: owner toggle favorite, non-owner 400, `/use` инкремент, scope=favorite sort by useCount.
- [x] **Audit (1)**: 4 log rows на create/update/share/delete.
- [x] **Preferences (6)**: GET empty, PATCH searchDefaults, 400 columns>50, 400 empty body, 401 no auth, partial update preserves siblings.

Локально: `npx tsc --noEmit` чисто, `npm run lint` 0 errors (2 pre-existing warnings в monitoring.router.ts / metrics.ts).

## Зависимости

- Блокирующий: PR-6 (#106) — merged ✅.
- Блокирует: PR-13 `ttsrh-1/saved-filters-ui` (frontend Sidebar + Save/Share modals).

## Плановая дельта

~1174 LoC в 10 файлах, внутри §8 эстимата (8ч backend → matched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
