### PR TITLE
feat(frontend): TTSRH-1 PR-9 — SearchPage shell + /search route + sidebar submenu + URL sync

### DIFF
--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1339,6 +1339,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
   - `frontend/src/api/search.ts`, `frontend/src/api/savedFilters.ts` (тонкие клиенты для PR-5, PR-6, PR-7).
 - **Merge-ready check:** страница открывается, URL-sync работает на пустом JQL, снэпшот-тест layout.
 - **Оценка:** ~6ч.
+- **Статус: ✅ Done** — API-клиенты `api/search.ts` (searchIssues/validate/schema/suggest/export) + `api/savedFilters.ts` (CRUD/share/favorite/markUsed + preferences). `pages/SearchPage.tsx` переписан: 3-column grid (320px | fr | 360px), JQL-textarea + Ctrl/Cmd+Enter submit + status-line (`role=status aria-live`), results preview (PR-14 заменит полной таблицей). `useSearchUrlState` hook синхронизирует `?jql=&view=&columns=&page=`. Route `/search/saved/:filterId` — fetch SavedFilter → replace URL state + markSavedFilterUsed. Sidebar: «Избранные фильтры» submenu (до 5, fetch `listSavedFilters('favorite')` при `isActive('/search')`). Frontend CI = lint+typecheck+build (без unit-тестов); E2E идут в PR-20.
 
 #### PR-10: JqlEditor (CodeMirror 6) + inline errors
 - **Branch:** `ttsrh-1/jql-editor`
@@ -1501,8 +1502,8 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 5 | `ttsrh-1/endpoints` | `/search/issues` + rate-limit + timeout + fuzz-harness | 10 | PR-4 | TTSRH-7, TTSRH-11 | 🟢 Merged ([#104](https://github.com/NovakPAai/tasktime-mvp/pull/104)) |
 | 6 | `ttsrh-1/suggesters` | Value Suggesters backend + `/search/suggest` | 10 | PR-5 | TTSRH-25 | 🟢 Merged ([#106](https://github.com/NovakPAai/tasktime-mvp/pull/106)) |
 | 7 | `ttsrh-1/saved-filters` | SavedFilter CRUD/share/favorite + User.preferences | 8 | PR-5 | TTSRH-8, TTSRH-9 | 🟢 Merged ([#107](https://github.com/NovakPAai/tasktime-mvp/pull/107)) |
-| 8 | `ttsrh-1/export` | `/search/export` CSV/XLSX | 4 | PR-5 | TTSRH-10 | ✅ Done (готов к push после merge PR-7) |
-| 9 | `ttsrh-1/frontend-shell` | SearchPage shell + route + sidebar + URL sync | 6 | PR-5 | TTSRH-12, часть TTSRH-19 | 📋 Планируется |
+| 8 | `ttsrh-1/export` | `/search/export` CSV/XLSX | 4 | PR-5 | TTSRH-10 | 🟢 Merged ([#108](https://github.com/NovakPAai/tasktime-mvp/pull/108)) |
+| 9 | `ttsrh-1/frontend-shell` | SearchPage shell + route + sidebar + URL sync | 6 | PR-5 | TTSRH-12, часть TTSRH-19 | ✅ Done (готов к push после merge PR-8) |
 | 10 | `ttsrh-1/jql-editor` | JqlEditor (CM6) + inline errors + lazy-load | 13 | PR-9 | TTSRH-13, TTSRH-14 | 📋 Планируется |
 | 11 | `ttsrh-1/value-suggester` | ValueSuggesterPopup + CM6 adapter | 10 | PR-6, PR-10 | TTSRH-26 | 📋 Планируется |
 | 12 | `ttsrh-1/basic-builder` | BasicFilterBuilder + Basic↔Advanced toggle | 12 | PR-11 | TTSRH-15 | 📋 Планируется |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -194,6 +194,7 @@ export default function App() {
             {/* TTSRH-1 PR-1: /search mounted only when advanced-search flag is on.
                 When disabled, the <Route path="*"> catch-all below redirects to "/". */}
             {frontendFeatures.advancedSearch && <Route path="search" element={<SearchPage />} />}
+            {frontendFeatures.advancedSearch && <Route path="search/saved/:filterId" element={<SearchPage />} />}
             <Route path="uat" element={<UatTestsPage />} />
             {/*
               TTSEC-2 round 16 — partial revert of round 15's global AdminGate.

--- a/frontend/src/api/savedFilters.ts
+++ b/frontend/src/api/savedFilters.ts
@@ -1,0 +1,119 @@
+/**
+ * TTSRH-1 PR-9 — тонкий api-клиент для /api/saved-filters/*.
+ *
+ * Покрывает контракт §5.6 ТЗ:
+ *   • listSavedFilters(scope?) — 'mine'/'shared'/'public'/'favorite'.
+ *   • getSavedFilter, createSavedFilter, updateSavedFilter, deleteSavedFilter.
+ *   • setSavedFilterFavorite(id, bool), shareSavedFilter(id, {users, groups, permission}).
+ *   • markSavedFilterUsed(id) — для инкремента useCount/lastUsedAt.
+ */
+
+import api from './client';
+
+export type FilterVisibility = 'PRIVATE' | 'SHARED' | 'PUBLIC';
+export type FilterPermission = 'READ' | 'WRITE';
+export type SavedFilterScope = 'mine' | 'shared' | 'public' | 'favorite';
+
+export interface SavedFilterShareView {
+  id: string;
+  userId: string | null;
+  groupId: string | null;
+  permission: FilterPermission;
+}
+
+export interface SavedFilter {
+  id: string;
+  ownerId: string;
+  name: string;
+  description: string | null;
+  jql: string;
+  visibility: FilterVisibility;
+  columns: string[] | null;
+  isFavorite: boolean;
+  lastUsedAt: string | null;
+  useCount: number;
+  createdAt: string;
+  updatedAt: string;
+  shares: SavedFilterShareView[];
+  permission: FilterPermission;
+}
+
+export async function listSavedFilters(scope?: SavedFilterScope): Promise<SavedFilter[]> {
+  const { data } = await api.get<{ filters: SavedFilter[] }>('/saved-filters', {
+    params: scope ? { scope } : undefined,
+  });
+  return data.filters;
+}
+
+export async function getSavedFilter(id: string): Promise<SavedFilter> {
+  const { data } = await api.get<SavedFilter>(`/saved-filters/${id}`);
+  return data;
+}
+
+export interface CreateSavedFilterInput {
+  name: string;
+  description?: string | null;
+  jql: string;
+  visibility?: FilterVisibility;
+  columns?: string[];
+  sharedWith?: { users?: string[]; groups?: string[]; permission?: FilterPermission };
+}
+
+export async function createSavedFilter(input: CreateSavedFilterInput): Promise<SavedFilter> {
+  const { data } = await api.post<SavedFilter>('/saved-filters', input);
+  return data;
+}
+
+export interface UpdateSavedFilterInput {
+  name?: string;
+  description?: string | null;
+  jql?: string;
+  visibility?: FilterVisibility;
+  columns?: string[];
+}
+
+export async function updateSavedFilter(id: string, input: UpdateSavedFilterInput): Promise<SavedFilter> {
+  const { data } = await api.patch<SavedFilter>(`/saved-filters/${id}`, input);
+  return data;
+}
+
+export async function deleteSavedFilter(id: string): Promise<void> {
+  await api.delete(`/saved-filters/${id}`);
+}
+
+export async function setSavedFilterFavorite(id: string, value: boolean): Promise<SavedFilter> {
+  const { data } = await api.post<SavedFilter>(`/saved-filters/${id}/favorite`, { value });
+  return data;
+}
+
+export interface ShareSavedFilterInput {
+  users?: string[];
+  groups?: string[];
+  permission?: FilterPermission;
+}
+
+export async function shareSavedFilter(id: string, input: ShareSavedFilterInput): Promise<SavedFilter> {
+  const { data } = await api.post<SavedFilter>(`/saved-filters/${id}/share`, input);
+  return data;
+}
+
+export async function markSavedFilterUsed(id: string): Promise<void> {
+  await api.post(`/saved-filters/${id}/use`);
+}
+
+// ─── User preferences ──────────────────────────────────────────────────────
+
+export interface UserPreferences {
+  searchDefaults?: { columns?: string[]; pageSize?: number };
+  [key: string]: unknown;
+}
+
+export async function getMyPreferences(): Promise<UserPreferences> {
+  const { data } = await api.get<UserPreferences>('/users/me/preferences');
+  return data;
+}
+
+export async function updateMyPreferences(patch: UserPreferences): Promise<UserPreferences> {
+  const { data } = await api.patch<UserPreferences>('/users/me/preferences', patch);
+  return data;
+}

--- a/frontend/src/api/savedFilters.ts
+++ b/frontend/src/api/savedFilters.ts
@@ -103,9 +103,11 @@ export async function markSavedFilterUsed(id: string): Promise<void> {
 
 // ─── User preferences ──────────────────────────────────────────────────────
 
+// Concrete shape matches backend updatePreferencesDto. Future sections (like
+// `checkpointDefaults`) should be added here explicitly as they land, rather
+// than relying on an `[key: string]: unknown` escape hatch.
 export interface UserPreferences {
   searchDefaults?: { columns?: string[]; pageSize?: number };
-  [key: string]: unknown;
 }
 
 export async function getMyPreferences(): Promise<UserPreferences> {

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -1,0 +1,143 @@
+/**
+ * TTSRH-1 PR-9 — тонкий api-клиент для /api/search/*.
+ *
+ * Публичный API покрывает контракт §5.6 ТЗ:
+ *   • searchIssues(jql, startAt?, limit?) — выполнить JQL-запрос.
+ *   • validateJql(jql, variant?) — без выполнения, для inline-squiggle'ов.
+ *   • getSearchSchema(variant?) — для Basic-builder / help-popover.
+ *   • suggestCompletions({jql?, cursor?, field?, operator?, prefix?, variant?}) — автокомплит.
+ *   • exportIssues(jql, format, columns?) — возвращает Blob для saveAs.
+ *
+ * Все methods пробрасывают axios-ошибки — вышележащие store/hook'и ловят статус и
+ * достают `error.response.data` для UI-сообщения. Никаких обёрток — frontend
+ * остаётся источником правды по UX-flow ошибок.
+ */
+
+import api from './client';
+
+export type IssueSearchRow = {
+  id: string;
+  projectId: string;
+  number: number;
+  title: string;
+  priority: string | null;
+  createdAt: string;
+  updatedAt: string;
+  project: { id: string; key: string; name: string };
+  assignee: { id: string; name: string; email: string } | null;
+  workflowStatus: { id: string; name: string; category: string; color: string | null; systemKey: string | null } | null;
+  [key: string]: unknown;
+};
+
+export interface SearchIssuesResponse {
+  total: number;
+  startAt: number;
+  limit: number;
+  issues: IssueSearchRow[];
+  warnings?: Array<{ start: number; end: number; code: string; message: string }>;
+  compileWarnings?: Array<{ code: string; message: string }>;
+  projectScopeOverflowed?: boolean;
+}
+
+export async function searchIssues(
+  jql: string,
+  opts: { startAt?: number; limit?: number } = {},
+): Promise<SearchIssuesResponse> {
+  const { data } = await api.post<SearchIssuesResponse>('/search/issues', {
+    jql,
+    startAt: opts.startAt ?? 0,
+    limit: opts.limit ?? 50,
+  });
+  return data;
+}
+
+export interface ValidationResponse {
+  valid: boolean;
+  errors: Array<{ start: number; end: number; code: string; message: string; hint?: string }>;
+  warnings: Array<{ start: number; end: number; code: string; message: string }>;
+  ast: unknown | null;
+}
+
+export async function validateJql(jql: string, variant?: 'default' | 'checkpoint'): Promise<ValidationResponse> {
+  const { data } = await api.post<ValidationResponse>('/search/validate', {
+    jql,
+    variant,
+  });
+  return data;
+}
+
+export interface SchemaField {
+  name: string;
+  label: string;
+  type: string;
+  synonyms: string[];
+  operators: string[];
+  sortable: boolean;
+  custom: boolean;
+  description: string | null;
+  uuid?: string;
+}
+
+export interface SchemaFunction {
+  name: string;
+  args: Array<{ name: string; type: string; optional: boolean }>;
+  returnType: string;
+  phase: string;
+  description?: string;
+}
+
+export interface SearchSchemaResponse {
+  variant: 'default' | 'checkpoint';
+  fields: SchemaField[];
+  functions: SchemaFunction[];
+}
+
+export async function getSearchSchema(variant?: 'default' | 'checkpoint'): Promise<SearchSchemaResponse> {
+  const { data } = await api.get<SearchSchemaResponse>('/search/schema', {
+    params: variant ? { variant } : undefined,
+  });
+  return data;
+}
+
+export interface SuggestRequest {
+  jql?: string;
+  cursor?: number;
+  field?: string;
+  operator?: string;
+  prefix?: string;
+  variant?: 'default' | 'checkpoint';
+}
+
+export interface Completion {
+  kind: 'field' | 'operator' | 'function' | 'value' | 'keyword';
+  label: string;
+  insert: string;
+  detail?: string;
+  icon?: string;
+  score: number;
+}
+
+export interface SuggestResponse {
+  completions: Completion[];
+}
+
+export async function suggestCompletions(req: SuggestRequest): Promise<SuggestResponse> {
+  const params: Record<string, string | number> = {};
+  if (req.jql !== undefined) params.jql = req.jql;
+  if (req.cursor !== undefined) params.cursor = req.cursor;
+  if (req.field) params.field = req.field;
+  if (req.operator) params.operator = req.operator;
+  if (req.prefix) params.prefix = req.prefix;
+  if (req.variant) params.variant = req.variant;
+  const { data } = await api.get<SuggestResponse>('/search/suggest', { params });
+  return data;
+}
+
+export async function exportIssues(
+  jql: string,
+  format: 'csv' | 'xlsx',
+  columns?: string[],
+): Promise<Blob> {
+  const { data } = await api.post('/search/export', { jql, format, columns }, { responseType: 'blob' });
+  return data as Blob;
+}

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -15,6 +15,10 @@
 
 import api from './client';
 
+// Named fields preserve intellisense/type-checking. Custom-field columns are
+// returned by the API under arbitrary string keys — an intersection with a
+// Record keeps them accessible (as `unknown`) without suppressing typos on the
+// named fields (a bare `[key: string]: unknown` index signature would).
 export type IssueSearchRow = {
   id: string;
   projectId: string;
@@ -26,8 +30,7 @@ export type IssueSearchRow = {
   project: { id: string; key: string; name: string };
   assignee: { id: string; name: string; email: string } | null;
   workflowStatus: { id: string; name: string; category: string; color: string | null; systemKey: string | null } | null;
-  [key: string]: unknown;
-};
+} & Record<string, unknown>;
 
 export interface SearchIssuesResponse {
   total: number;

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -106,13 +106,13 @@ export default function Sidebar({
 
   // TTSRH-1 PR-9: top-5 favorite saved filters, fetched lazily when /search is active.
   // Failures are swallowed — sidebar never surfaces errors to the user (the main
-  // SearchPage does, which avoids double-reporting). `user` toggles as a dep so the
-  // list refreshes on login/logout. Backend handles the empty case gracefully (flag
-  // off → 404 → silently [] here).
+  // SearchPage does, which avoids double-reporting). Dep narrowed to a boolean so
+  // intra-search URL changes (?jql=&page=) don't re-trigger a fetch on every keystroke.
+  const isSearchActive = path.startsWith('/search');
   const [searchFavorites, setSearchFavorites] = useState<SavedFilter[]>([]);
   useEffect(() => {
     if (!frontendFeatures.advancedSearch) return;
-    if (!path.startsWith('/search')) return;
+    if (!isSearchActive) return;
     if (!user) return;
     let cancelled = false;
     (async () => {
@@ -126,7 +126,7 @@ export default function Sidebar({
     return () => {
       cancelled = true;
     };
-  }, [path, user]);
+  }, [isSearchActive, user]);
 
   const isPlanningOpen = openKeys.includes('planning-submenu');
   const isAdminOpen = openKeys.includes('admin-submenu');

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { canViewCheckpointAudit, hasRequiredRole } from '../../lib/roles';
 import { features as frontendFeatures } from '../../lib/features';
+import { listSavedFilters, type SavedFilter } from '../../api/savedFilters';
 import type { SystemRoleType, User } from '../../types';
 
 // ─── Design tokens (Paper 1KR-0 dark + computed light) ───────────────────────
@@ -102,6 +103,30 @@ export default function Sidebar({
   const isMobile = useIsMobile();
   const tokens = isLight ? T.light : T.dark;
   const path = location.pathname;
+
+  // TTSRH-1 PR-9: top-5 favorite saved filters, fetched lazily when /search is active.
+  // Failures are swallowed — sidebar never surfaces errors to the user (the main
+  // SearchPage does, which avoids double-reporting). `user` toggles as a dep so the
+  // list refreshes on login/logout. Backend handles the empty case gracefully (flag
+  // off → 404 → silently [] here).
+  const [searchFavorites, setSearchFavorites] = useState<SavedFilter[]>([]);
+  useEffect(() => {
+    if (!frontendFeatures.advancedSearch) return;
+    if (!path.startsWith('/search')) return;
+    if (!user) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const filters = await listSavedFilters('favorite');
+        if (!cancelled) setSearchFavorites(filters);
+      } catch {
+        if (!cancelled) setSearchFavorites([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [path, user]);
 
   const isPlanningOpen = openKeys.includes('planning-submenu');
   const isAdminOpen = openKeys.includes('admin-submenu');
@@ -350,16 +375,42 @@ export default function Sidebar({
             <span style={textStyle('/flow-teams')}>Потоковые команды</span>
           </div>
 
-          {/* TTSRH-1 PR-1: «Поиск задач» (/search). Стоит перед Planning-submenu — см. §5.7 ТЗ.
-              Полный sidebar-item с submenu «Избранные фильтры» будет в PR-9. */}
+          {/* TTSRH-1 PR-9: «Поиск задач» (/search) между Flow Teams и Planning (§5.7 ТЗ).
+              Sub-menu «Избранные фильтры» раскрывается при активной странице: до 5
+              фильтров, сорт `useCount DESC, lastUsedAt DESC`. Клик → /search/saved/:id. */}
           {frontendFeatures.advancedSearch && (
-            <div data-testid="nav-search" style={itemStyle('/search')} onClick={() => onNavigate('/search')} onMouseEnter={() => setHovered('/search')} onMouseLeave={() => setHovered(null)}>
-              <svg width="16" height="16" fill="none" viewBox="0 0 16 16" style={{ flexShrink: 0 }}>
-                <circle cx="7" cy="7" r="4.5" stroke={itemColor('/search')} strokeWidth="1.5" />
-                <path d="M10.5 10.5l3 3" stroke={itemColor('/search')} strokeWidth="1.5" strokeLinecap="round" />
-              </svg>
-              <span style={textStyle('/search')}>Поиск задач</span>
-            </div>
+            <>
+              <div data-testid="nav-search" style={itemStyle('/search')} onClick={() => onNavigate('/search')} onMouseEnter={() => setHovered('/search')} onMouseLeave={() => setHovered(null)}>
+                <svg width="16" height="16" fill="none" viewBox="0 0 16 16" style={{ flexShrink: 0 }}>
+                  <circle cx="7" cy="7" r="4.5" stroke={itemColor('/search')} strokeWidth="1.5" />
+                  <path d="M10.5 10.5l3 3" stroke={itemColor('/search')} strokeWidth="1.5" strokeLinecap="round" />
+                </svg>
+                <span style={textStyle('/search')}>Поиск задач</span>
+              </div>
+              {isActive('/search') && !collapsed && searchFavorites.length > 0 && (
+                <div data-testid="nav-search-favorites">
+                  {searchFavorites.slice(0, 5).map((f) => {
+                    const href = `/search/saved/${f.id}`;
+                    return (
+                      <div
+                        key={f.id}
+                        data-testid={`nav-search-favorite-${f.id}`}
+                        style={subItemStyle(href)}
+                        onClick={() => onNavigate(href)}
+                        onMouseEnter={() => setHovered(href)}
+                        onMouseLeave={() => setHovered(null)}
+                        title={f.description ?? f.jql}
+                      >
+                        <svg width="12" height="12" fill="none" viewBox="0 0 12 12" style={{ flexShrink: 0 }}>
+                          <path d="M6 1l1.5 3.2 3.5.4-2.6 2.4.7 3.4L6 8.7l-3.1 1.7.7-3.4L1 4.6l3.5-.4L6 1z" fill={isActive(href) ? tokens.acc : tokens.inactive} />
+                        </svg>
+                        <span style={{ ...subTextStyle(href), overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.name}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </>
           )}
 
           {/* Planning submenu */}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,50 +1,295 @@
-import { useThemeStore } from '../store/theme.store';
-
 /**
- * TTSRH-1 PR-1 — placeholder-страница «Поиск задач». Роут /search смонтирован условно
- * в App.tsx под `features.advancedSearch`, поэтому сюда попадают только сборки, где
- * флаг включён. До merge PR-9 (SearchPage shell) здесь рендерится «под разработкой»-
- * сообщение, чтобы UAT-стейдж мог проверить факт мaunting и активный-пункт сайдбара.
- * Полная реализация — §5.7 в docs/tz/TTSRH-1.md и PR-9..PR-14 в §13.6 ТЗ.
+ * TTSRH-1 PR-9 — SearchPage shell с 3-колоночным layout + URL-синхронизацией.
+ *
+ * Сейчас (shell): placeholder'ы для SidebarFilters | ResultsArea | DetailPreview.
+ * Реальное наполнение поступает в PR-10 (JqlEditor + inline errors), PR-12
+ * (BasicFilterBuilder), PR-13 (SavedFiltersSidebar + modals) и PR-14
+ * (ColumnConfigurator + ResultsTable + BulkActionsBar + ExportMenu).
+ *
+ * Что уже live:
+ *   • Роут `/search` + `/search/saved/:filterId` (App.tsx).
+ *   • 3-column CSS grid layout (320px | fr | 360px).
+ *   • URL state `?jql=&view=&columns=&page=` через useSearchUrlState.
+ *   • Fetch SavedFilter при `/search/saved/:id` — заменяет state из URL.
+ *   • Submit по Enter / Ctrl+Enter (оба variant'а, UX-resilient).
+ *
+ * Инварианты:
+ *   • Пустой `jql` допустим (ничего не выполняется, results area показывает hint).
+ *   • Обработка ошибок `/search/issues` → `ResultsArea` показывает статус-строкой,
+ *     не throw — страница должна продолжать работать после неудачного запроса.
+ *   • a11y (A11Y-1): errors и status-messages идут через `role="status"`/`aria-live`.
  */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { searchIssues, type IssueSearchRow } from '../api/search';
+import { getSavedFilter, markSavedFilterUsed } from '../api/savedFilters';
+import { useThemeStore } from '../store/theme.store';
+import { useSearchUrlState } from './search/useSearchUrlState';
+
+type LoadState = { status: 'idle' } | { status: 'loading' } | { status: 'ok'; total: number; issues: IssueSearchRow[] } | { status: 'error'; message: string };
+
+const PAGE_SIZE = 50;
+
 export default function SearchPage() {
   const { mode } = useThemeStore();
   const isLight = mode === 'light';
-  const c = isLight
-    ? { bg: '#F6F8FA', t1: '#1F2328', t3: '#656D76', border: '#D0D7DE' }
-    : { bg: '#080B14', t1: '#E2E8F8', t3: '#8B949E', border: '#21262D' };
+  const { filterId } = useParams<{ filterId?: string }>();
+  const { state, updateUrl } = useSearchUrlState();
+  const [jqlDraft, setJqlDraft] = useState(state.jql);
+  const [load, setLoad] = useState<LoadState>({ status: 'idle' });
+
+  // Sync draft when URL changes (browser back/forward).
+  useEffect(() => {
+    setJqlDraft(state.jql);
+  }, [state.jql]);
+
+  // Load saved filter when `/search/saved/:filterId` route is used.
+  useEffect(() => {
+    if (!filterId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const filter = await getSavedFilter(filterId);
+        if (cancelled) return;
+        updateUrl({ jql: filter.jql, columns: filter.columns ?? [], page: 1 }, { push: false });
+        // Fire-and-forget increment of useCount/lastUsedAt.
+        markSavedFilterUsed(filterId).catch(() => undefined);
+      } catch {
+        if (!cancelled) setLoad({ status: 'error', message: 'Фильтр не найден или недоступен' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [filterId, updateUrl]);
+
+  const runQuery = useCallback(
+    async (jql: string, page: number) => {
+      if (!jql.trim()) {
+        setLoad({ status: 'idle' });
+        return;
+      }
+      setLoad({ status: 'loading' });
+      try {
+        const startAt = (page - 1) * PAGE_SIZE;
+        const out = await searchIssues(jql, { startAt, limit: PAGE_SIZE });
+        setLoad({ status: 'ok', total: out.total, issues: out.issues });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Ошибка выполнения';
+        setLoad({ status: 'error', message: msg });
+      }
+    },
+    [],
+  );
+
+  // Run on URL-driven state change.
+  useEffect(() => {
+    void runQuery(state.jql, state.page);
+  }, [state.jql, state.page, runQuery]);
+
+  const submit = useCallback(() => {
+    updateUrl({ jql: jqlDraft.trim(), page: 1 }, { push: true });
+  }, [jqlDraft, updateUrl]);
+
+  // ─── Styles (Paper-like tokens, inline — matches Sidebar.tsx) ───────────
+  const c = useMemo(
+    () =>
+      isLight
+        ? { bg: '#F6F8FA', panel: '#FFFFFF', border: '#D0D7DE', t1: '#1F2328', t2: '#424A53', t3: '#656D76', acc: '#4F6EF7' }
+        : { bg: '#080B14', panel: '#0F1320', border: '#21262D', t1: '#E2E8F8', t2: '#B1BAC4', t3: '#8B949E', acc: '#4F6EF7' },
+    [isLight],
+  );
 
   return (
     <div
       data-testid="search-page"
       style={{
         minHeight: '100%',
-        padding: '32px 24px',
-        fontFamily: '"Inter", system-ui, sans-serif',
-        color: c.t1,
+        padding: '16px 20px',
         background: c.bg,
+        color: c.t1,
+        fontFamily: '"Inter", system-ui, sans-serif',
+        fontSize: 13,
+        lineHeight: 1.5,
       }}
     >
-      <h1 style={{ fontSize: 22, fontWeight: 600, marginBottom: 8 }}>Поиск задач</h1>
-      <p style={{ fontSize: 14, color: c.t3, marginBottom: 24, maxWidth: 640 }}>
-        Продвинутый поиск с TTS-QL (TaskTime Query Language) — внутренним языком запросов,
-        совместимым с JQL. Страница находится в разработке по тикету TTSRH-1.
-      </p>
+      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+        <h1 style={{ fontSize: 18, fontWeight: 600, margin: 0 }}>Поиск задач</h1>
+        <div style={{ color: c.t3, fontSize: 12 }}>
+          TTS-QL · <a href="https://github.com/NovakPAai/tasktime-mvp/blob/main/docs/tz/TTSRH-1.md" target="_blank" rel="noreferrer" style={{ color: c.acc }}>справка</a>
+        </div>
+      </header>
+
       <div
         style={{
-          padding: '20px 24px',
-          border: `1px dashed ${c.border}`,
-          borderRadius: 10,
-          maxWidth: 640,
-          fontSize: 13,
-          lineHeight: 1.6,
-          color: c.t3,
+          display: 'grid',
+          gridTemplateColumns: '320px minmax(0, 1fr) 360px',
+          gap: 12,
+          alignItems: 'stretch',
         }}
       >
-        Готовность: <b style={{ color: c.t1 }}>foundation merged</b>. Редактор TTS-QL,
-        сохранённые фильтры, конструктор Basic и массовые действия появятся в последующих
-        PR — см. <code>docs/tz/TTSRH-1.md §13.6</code>.
+        {/* Column 1 — Sidebar (PR-13: saved filters list) */}
+        <aside
+          data-testid="search-sidebar"
+          style={{
+            background: c.panel,
+            border: `1px solid ${c.border}`,
+            borderRadius: 8,
+            padding: 16,
+            minHeight: 480,
+            color: c.t3,
+          }}
+        >
+          <div style={{ fontWeight: 600, color: c.t1, marginBottom: 6, fontSize: 13 }}>Мои фильтры</div>
+          <div style={{ fontSize: 12 }}>
+            Список сохранённых фильтров появится в PR-13 (§13.6 ТЗ).
+          </div>
+        </aside>
+
+        {/* Column 2 — Main (editor + results) */}
+        <main
+          data-testid="search-main"
+          style={{
+            background: c.panel,
+            border: `1px solid ${c.border}`,
+            borderRadius: 8,
+            padding: 16,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 12,
+          }}
+        >
+          <div>
+            <label htmlFor="jql-input" style={{ display: 'block', fontSize: 12, color: c.t3, marginBottom: 6 }}>
+              JQL / TTS-QL
+            </label>
+            <textarea
+              id="jql-input"
+              data-testid="search-jql-input"
+              value={jqlDraft}
+              onChange={(e) => setJqlDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey || !e.shiftKey)) {
+                  e.preventDefault();
+                  submit();
+                }
+              }}
+              placeholder='project = "TTMP" AND assignee = currentUser()'
+              spellCheck={false}
+              rows={3}
+              style={{
+                width: '100%',
+                boxSizing: 'border-box',
+                fontFamily: '"JetBrains Mono", "SF Mono", Menlo, monospace',
+                fontSize: 13,
+                padding: 10,
+                border: `1px solid ${c.border}`,
+                borderRadius: 6,
+                background: isLight ? '#FAFBFC' : '#080B14',
+                color: c.t1,
+                resize: 'vertical',
+              }}
+            />
+            <div style={{ display: 'flex', gap: 8, marginTop: 8, alignItems: 'center' }}>
+              <button
+                data-testid="search-run"
+                onClick={submit}
+                style={{
+                  background: c.acc,
+                  color: '#fff',
+                  border: 'none',
+                  borderRadius: 6,
+                  padding: '6px 14px',
+                  fontSize: 13,
+                  fontWeight: 500,
+                  cursor: 'pointer',
+                }}
+              >
+                Выполнить
+              </button>
+              <div role="status" aria-live="polite" style={{ color: c.t3, fontSize: 12 }}>
+                {load.status === 'idle' && 'Введите запрос и нажмите Enter'}
+                {load.status === 'loading' && 'Выполняется…'}
+                {load.status === 'ok' && `Найдено: ${load.total}`}
+                {load.status === 'error' && <span style={{ color: '#e5484d' }}>Ошибка: {load.message}</span>}
+              </div>
+            </div>
+          </div>
+
+          <div
+            data-testid="search-results"
+            style={{
+              flex: 1,
+              borderTop: `1px solid ${c.border}`,
+              paddingTop: 12,
+              minHeight: 240,
+            }}
+          >
+            {load.status === 'ok' ? (
+              <SearchResultsPreview issues={load.issues} color={c} />
+            ) : (
+              <div style={{ color: c.t3, fontSize: 12 }}>
+                Результаты появятся здесь. Полноценная таблица (сортировка, bulk-actions, экспорт) — в PR-14.
+              </div>
+            )}
+          </div>
+        </main>
+
+        {/* Column 3 — Detail preview (PR-14) */}
+        <aside
+          data-testid="search-preview"
+          style={{
+            background: c.panel,
+            border: `1px solid ${c.border}`,
+            borderRadius: 8,
+            padding: 16,
+            minHeight: 480,
+            color: c.t3,
+            fontSize: 12,
+          }}
+        >
+          Preview задачи появится в PR-14.
+        </aside>
       </div>
     </div>
+  );
+}
+
+function SearchResultsPreview({
+  issues,
+  color,
+}: {
+  issues: IssueSearchRow[];
+  color: { panel: string; border: string; t1: string; t2: string; t3: string; acc: string };
+}) {
+  if (issues.length === 0) {
+    return <div style={{ color: color.t3, fontSize: 12 }}>Нет задач, удовлетворяющих запросу.</div>;
+  }
+  return (
+    <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {issues.slice(0, 20).map((issue) => {
+        const keyLabel = `${issue.project.key}-${issue.number}`;
+        return (
+          <li
+            key={issue.id}
+            style={{
+              display: 'flex',
+              gap: 10,
+              padding: '6px 8px',
+              border: `1px solid ${color.border}`,
+              borderRadius: 6,
+              fontSize: 13,
+              color: color.t1,
+            }}
+          >
+            <span style={{ fontFamily: '"JetBrains Mono", monospace', color: color.acc, minWidth: 80 }}>{keyLabel}</span>
+            <span style={{ flex: 1 }}>{issue.title}</span>
+            <span style={{ color: color.t3, fontSize: 11 }}>{issue.workflowStatus?.name ?? issue.priority ?? ''}</span>
+          </li>
+        );
+      })}
+      {issues.length > 20 && <li style={{ color: color.t3, fontSize: 12 }}>…и ещё {issues.length - 20}. Полная таблица — PR-14.</li>}
+    </ul>
   );
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -170,7 +170,9 @@ export default function SearchPage() {
               value={jqlDraft}
               onChange={(e) => setJqlDraft(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey || !e.shiftKey)) {
+                // Ctrl/Cmd+Enter submits. Plain Enter must insert a newline so
+                // multi-line JQL stays editable.
+                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
                   e.preventDefault();
                   submit();
                 }

--- a/frontend/src/pages/search/useSearchUrlState.ts
+++ b/frontend/src/pages/search/useSearchUrlState.ts
@@ -1,0 +1,84 @@
+/**
+ * TTSRH-1 PR-9 — двусторонний bridge между URL-параметрами и локальным состоянием
+ * SearchPage.
+ *
+ * URL-формат: `/search?jql=<url-encoded>&view=table&columns=key,status,assignee&page=2`.
+ *
+ * Инварианты:
+ *   • `jql`/`view`/`columns`/`page` читаются на mount.
+ *   • Запись в URL идёт через `navigate(url, { replace: true })` — чтобы не плодить
+ *     history-entries на каждый keystroke. Первое успешное выполнение должно
+ *     использовать `replace: false` (push) из вызывающего кода — отдаём контроль
+ *     consumer'у через `updateUrl(state, { push })`.
+ *   • `columns` — comma-separated list; каждая колонка тримится и пустые отбрасываются.
+ *   • `page` — positive int, по умолчанию 1. Невалидные значения игнорируются.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+export type SearchView = 'table';
+
+export interface SearchUrlState {
+  jql: string;
+  view: SearchView;
+  columns: string[];
+  page: number;
+}
+
+const DEFAULT_VIEW: SearchView = 'table';
+const DEFAULT_PAGE = 1;
+
+function parseColumns(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0);
+}
+
+function parsePage(raw: string | null): number {
+  if (!raw) return DEFAULT_PAGE;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 1 ? n : DEFAULT_PAGE;
+}
+
+function parseView(raw: string | null): SearchView {
+  // Only 'table' is supported in PR-9; future 'board'/'timeline' fall back to table.
+  return raw === 'table' ? 'table' : DEFAULT_VIEW;
+}
+
+export function useSearchUrlState(): {
+  state: SearchUrlState;
+  updateUrl: (next: Partial<SearchUrlState>, opts?: { push?: boolean }) => void;
+} {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+
+  const state: SearchUrlState = useMemo(
+    () => ({
+      jql: params.get('jql') ?? '',
+      view: parseView(params.get('view')),
+      columns: parseColumns(params.get('columns')),
+      page: parsePage(params.get('page')),
+    }),
+    [params],
+  );
+
+  const updateUrl = useCallback(
+    (next: Partial<SearchUrlState>, opts?: { push?: boolean }) => {
+      const merged: SearchUrlState = { ...state, ...next };
+      const qs = new URLSearchParams();
+      if (merged.jql) qs.set('jql', merged.jql);
+      if (merged.view !== DEFAULT_VIEW) qs.set('view', merged.view);
+      if (merged.columns.length > 0) qs.set('columns', merged.columns.join(','));
+      if (merged.page !== DEFAULT_PAGE) qs.set('page', String(merged.page));
+      const search = qs.toString();
+      const url = search ? `/search?${search}` : '/search';
+      navigate(url, { replace: !opts?.push });
+    },
+    [state, navigate],
+  );
+
+  return { state, updateUrl };
+}

--- a/frontend/src/pages/search/useSearchUrlState.ts
+++ b/frontend/src/pages/search/useSearchUrlState.ts
@@ -14,7 +14,7 @@
  *   • `page` — positive int, по умолчанию 1. Невалидные значения игнорируются.
  */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 export type SearchView = 'table';
@@ -65,9 +65,18 @@ export function useSearchUrlState(): {
     [params],
   );
 
+  // `state` goes into a ref so `updateUrl` keeps a stable identity across renders.
+  // Without this, any consumer effect that lists `updateUrl` in its dep array
+  // would re-fire after every URL mutation and cascade into an infinite loop
+  // (e.g. the `/search/saved/:filterId` fetch that calls `updateUrl` itself).
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
   const updateUrl = useCallback(
     (next: Partial<SearchUrlState>, opts?: { push?: boolean }) => {
-      const merged: SearchUrlState = { ...state, ...next };
+      const merged: SearchUrlState = { ...stateRef.current, ...next };
       const qs = new URLSearchParams();
       if (merged.jql) qs.set('jql', merged.jql);
       if (merged.view !== DEFAULT_VIEW) qs.set('view', merged.view);
@@ -77,8 +86,21 @@ export function useSearchUrlState(): {
       const url = search ? `/search?${search}` : '/search';
       navigate(url, { replace: !opts?.push });
     },
-    [state, navigate],
+    [navigate],
   );
+
+  // One-time self-heal: if URL has a malformed `page` value (e.g. `page=0`),
+  // `parsePage` silently falls back to 1 but the URL still reads wrong. Correct
+  // it on mount so the URL and the rendered state don't drift.
+  useEffect(() => {
+    const raw = params.get('page');
+    if (raw !== null && parsePage(raw) !== Number(raw)) {
+      updateUrl({ page: DEFAULT_PAGE }, { push: false });
+    }
+    // Only run once per mount; dep-less effects like this are intentional —
+    // any subsequent URL mutation goes through our own updateUrl and is safe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return { state, updateUrl };
 }

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,55 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.35**
+**Last version: 2.36**
+
+---
+
+## [2.36] [2026-04-21] feat(frontend): TTSRH-1 PR-9 — SearchPage shell + /search route + sidebar submenu + URL sync
+
+**PR:** (to be filled after push)
+**Ветка:** `ttsrh-1/frontend-shell`
+
+### Что было
+
+После PR-8 вся backend-поверхность TTS-QL была live (`/search/{issues,validate,schema,suggest,export}` + `/saved-filters/*` + `/users/me/preferences`), но frontend не имел страницы `/search` — только placeholder-stub из PR-1. Пользователь не мог протестировать запросы даже с `FEATURES_ADVANCED_SEARCH=true`.
+
+### Что теперь
+
+Полноценная страница `/search` + оболочка будущих PR-10..PR-14 + тонкие API-клиенты:
+
+- **`frontend/src/api/search.ts`** — `searchIssues / validateJql / getSearchSchema / suggestCompletions / exportIssues` (blob для saveAs). Типизированные ответы: `SearchIssuesResponse`, `ValidationResponse`, `SearchSchemaResponse`, `SuggestResponse`.
+- **`frontend/src/api/savedFilters.ts`** — CRUD + share + favorite + markUsed + `getMyPreferences / updateMyPreferences`. `SavedFilter` интерфейс с `permission: 'READ'|'WRITE'` и nested `shares[]`.
+- **`frontend/src/pages/SearchPage.tsx`** — переписан со stub'а. 3-column CSS grid (`320px | minmax(0,1fr) | 360px`): `SidebarFilters` | `JqlEditor + ResultsArea` | `DetailPreview`. Левая/правая колонки сейчас — placeholder'ы с refs на будущие PR (13/14). Средняя колонка работает:
+  - `<textarea>` с `Ctrl/Cmd+Enter` → submit (plain Enter вставляет newline для мульти-строк).
+  - Run-button + `role="status" aria-live="polite"` status-line (idle/loading/ok/error — A11Y-1).
+  - При `status=ok` рендерится preview-список (до 20 результатов, ключ + title + status) — PR-14 заменит полной `ResultsTable`.
+- **`frontend/src/pages/search/useSearchUrlState.ts`** — bridge между URL `?jql=&view=&columns=&page=` и локальным state. `updateUrl` имеет стабильную identity (via stateRef) — без этого `/search/saved/:filterId` попадал в infinite loop. Default dropping: `view=table` и `page=1` не записываются в URL. Mount-time self-heal для invalid `page=N`.
+- **`frontend/src/App.tsx`** — добавлен route `/search/saved/:filterId` под тем же gate'ом `features.advancedSearch`. Обе ветки используют `<SearchPage />` — он сам fetch'ит фильтр по `useParams().filterId` → `getSavedFilter` → replace URL state + fire-and-forget `markSavedFilterUsed`.
+- **`frontend/src/components/layout/Sidebar.tsx`** — при `isActive('/search')` под пунктом разворачивается submenu «Избранные фильтры»: до 5 item'ов, fetch `listSavedFilters('favorite')`. Dep-массив сужен до boolean `isSearchActive` — intra-search URL changes не триггерят redundant fetch.
+
+### Изменения
+
+- `frontend/src/api/search.ts` — новый (~100L).
+- `frontend/src/api/savedFilters.ts` — новый (~80L).
+- `frontend/src/pages/search/useSearchUrlState.ts` — новый (~90L).
+- `frontend/src/pages/SearchPage.tsx` — переписан (placeholder → 3-column shell, ~250L).
+- `frontend/src/App.tsx` — + `/search/saved/:filterId` route.
+- `frontend/src/components/layout/Sidebar.tsx` — + submenu fetch + render.
+- `docs/tz/TTSRH-1.md` §13.6/§13.9 — статус PR-9 → ✅ Done.
+
+### Влияние на prod
+
+Под `VITE_FEATURES_ADVANCED_SEARCH=false` страница и submenu не рендерятся (App.tsx catch-all → `/`). При `=true`:
+- `/search` открывается, URL-sync работает на пустом JQL.
+- Sub-menu «Избранные фильтры» подгружается из `/api/saved-filters?scope=favorite`.
+- Реальный JQL-editor (CodeMirror 6), Basic-builder, Save/Share-модалки, full-table — в PR-10..PR-14.
+
+### Проверки
+
+- `npx tsc --noEmit` (frontend) — чисто
+- `npm run lint` (frontend) — 0 errors, 0 new warnings
+- `npm run build` (Vite) — чисто, 4.5s
 
 ---
 


### PR DESCRIPTION
## Summary

- **Thin API clients**: `api/search.ts` (searchIssues / validate / schema / suggest / export) + `api/savedFilters.ts` (CRUD / share / favorite / markUsed / preferences). Полностью типизированные ответы.
- **SearchPage rewrite**: 3-column CSS grid (`320px | 1fr | 360px`) = sidebar placeholder | JQL-editor + results preview | detail placeholder. Плейсхолдеры явно указывают на будущие PR (13 / 14). Средняя колонка уже работает: textarea с Ctrl/Cmd+Enter submit + `role=status aria-live` status-line + preview до 20 результатов.
- **URL state hook** (`useSearchUrlState`): двусторонний bridge `?jql=&view=&columns=&page=` ↔ локальный state. Replace-семантика navigate (история не плодится на keystroke'ы) + push option для явных действий. Defaults не попадают в URL.
- **Route** `/search/saved/:filterId`: тот же `<SearchPage>` — fetch'ит фильтр через `getSavedFilter`, replace URL state, fire-and-forget `markSavedFilterUsed`.
- **Sidebar submenu** «Избранные фильтры»: при `isActive('/search')` подгружает `listSavedFilters('favorite')` (до 5), click → `/search/saved/:id`.

## Pre-push review counts

🟠 × 1 (infinite loop on /search/saved/:id — stateRef fix) · 🟡 × 3 (Enter-newline, Sidebar dep narrowing, page=0 self-heal) · 🔵 × 2 (IssueSearchRow type tighten, UserPreferences). Все applied.

## Test plan

Frontend CI = lint + typecheck + build (unit-тестов нет, E2E идут в PR-20 per §13.8):

- [x] `npx tsc --noEmit` (frontend) — чисто.
- [x] `npm run lint` (frontend) — 0 errors (8 pre-existing warnings в unrelated файлах).
- [x] `npm run build` (Vite) — чисто, ~4.5s. Bundle size в норме (под-500KB chunks где нужно; search-специфичные deps lazy-load'ятся в PR-10 с CM6).

## Ручной smoke

Под `VITE_FEATURES_ADVANCED_SEARCH=true` (локально):

- `/search` рендерит 3-column layout, пункт сайдбара «Поиск задач» имеет active state.
- Textarea принимает multi-line JQL; Ctrl+Enter submit, plain Enter вставляет newline.
- URL обновляется на successful submit; browser back/forward восстанавливает state.
- `/search/saved/:filterId` подтягивает сохранённый фильтр и не попадает в infinite loop.
- Sidebar submenu «Избранные фильтры» появляется только на `/search*`.

Под `VITE_FEATURES_ADVANCED_SEARCH=false`:

- `/search` и submenu не рендерятся, App catch-all редиректит на `/`.

## Зависимости

- Блокирующие: PR-5 (#104), PR-6 (#106), PR-7 (#107), PR-8 (#108) — все merged ✅.
- Блокирует: PR-10 (CM6 JqlEditor), PR-11 (ValueSuggesterPopup), PR-12 (BasicFilterBuilder), PR-13 (SavedFiltersSidebar + modals), PR-14 (ResultsTable + BulkActions).

## Плановая дельта

~731 LoC (API clients + SearchPage + hook + sidebar + App.tsx + docs), внутри §8 эстимата (~6ч frontend shell → matched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
