### PR TITLE
feat(frontend): TTSRH-1 PR-12 — BasicFilterBuilder + Basic↔Advanced toggle

### DIFF
--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1374,6 +1374,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
   - Snapshot T-10 (Basic → canonical JQL).
 - **Merge-ready check:** 80% golden-set-запросов строится в Basic без перехода в Advanced (FR-12).
 - **Оценка:** ~12ч.
+- **Статус: ✅ Done** — `basic-filter-model.ts` (chipsFromJql + jqlFromChips + canBasicize guard на OR/NOT/WAS/CHANGED/~/ORDER BY/группировке — R9, + CATEGORIES для cascade-меню: Задача/Даты/Пользователи/Планирование/AI). `BasicFilterBuilder.tsx` — chip list с inline-edit (field/op/values через `<select>`/`<input>`), delete button, cascade "+ Добавить фильтр" по категориям. `FilterModeToggle.tsx` — сегмент Basic|Advanced с `aria-pressed`, disabled-state + tooltip при OR/NOT. Integration в SearchPage: mode-toggle в header линии editor'а, auto-fallback к Advanced при basicize impossible, сохраняет `jqlDraft` во время переключения. Custom-fields (§5.7) + ValueSuggester-popover в chip'ах — в PR-13 (нужен popover primitive + autocomplete adapter уже есть в PR-11).
 
 #### PR-13: SavedFiltersSidebar + Save/Share modals + store
 - **Branch:** `ttsrh-1/saved-filters-ui`
@@ -1508,7 +1509,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 9 | `ttsrh-1/frontend-shell` | SearchPage shell + route + sidebar + URL sync | 6 | PR-5 | TTSRH-12, часть TTSRH-19 | 🟢 Merged ([#109](https://github.com/NovakPAai/tasktime-mvp/pull/109)) |
 | 10 | `ttsrh-1/jql-editor` | JqlEditor (CM6) + inline errors + lazy-load | 13 | PR-9 | TTSRH-13, TTSRH-14 | 🟢 Merged ([#110](https://github.com/NovakPAai/tasktime-mvp/pull/110)) |
 | 11 | `ttsrh-1/value-suggester` | ValueSuggesterPopup + CM6 adapter | 10 | PR-6, PR-10 | TTSRH-26 | ✅ Done (готов к push после merge PR-10) |
-| 12 | `ttsrh-1/basic-builder` | BasicFilterBuilder + Basic↔Advanced toggle | 12 | PR-11 | TTSRH-15 | 📋 Планируется |
+| 12 | `ttsrh-1/basic-builder` | BasicFilterBuilder + Basic↔Advanced toggle | 12 | PR-11 | TTSRH-15 | ✅ Done (готов к push после merge PR-11) |
 | 13 | `ttsrh-1/saved-filters-ui` | SavedFiltersSidebar + Save/Share modals + store | 8 | PR-7, PR-9 | TTSRH-16 | 📋 Планируется |
 | 14 | `ttsrh-1/results` | ColumnConfigurator + ResultsTable + bulk + ExportMenu + shortcuts | 11 | PR-8, PR-10 | TTSRH-17, TTSRH-18, остаток TTSRH-19 | 📋 Планируется |
 | 15 | `ttsrh-1/checkpoint-foundation` | Checkpoint Prisma + DTO + КТ-функции + variant=CHECKPOINT | 10 | PR-1, PR-3 | TTSRH-27, TTSRH-28, TTSRH-29 | 📋 Планируется |

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1508,7 +1508,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 8 | `ttsrh-1/export` | `/search/export` CSV/XLSX | 4 | PR-5 | TTSRH-10 | 🟢 Merged ([#108](https://github.com/NovakPAai/tasktime-mvp/pull/108)) |
 | 9 | `ttsrh-1/frontend-shell` | SearchPage shell + route + sidebar + URL sync | 6 | PR-5 | TTSRH-12, часть TTSRH-19 | 🟢 Merged ([#109](https://github.com/NovakPAai/tasktime-mvp/pull/109)) |
 | 10 | `ttsrh-1/jql-editor` | JqlEditor (CM6) + inline errors + lazy-load | 13 | PR-9 | TTSRH-13, TTSRH-14 | 🟢 Merged ([#110](https://github.com/NovakPAai/tasktime-mvp/pull/110)) |
-| 11 | `ttsrh-1/value-suggester` | ValueSuggesterPopup + CM6 adapter | 10 | PR-6, PR-10 | TTSRH-26 | ✅ Done (готов к push после merge PR-10) |
+| 11 | `ttsrh-1/value-suggester` | ValueSuggesterPopup + CM6 adapter | 10 | PR-6, PR-10 | TTSRH-26 | 🟢 Merged ([#113](https://github.com/NovakPAai/tasktime-mvp/pull/113)) |
 | 12 | `ttsrh-1/basic-builder` | BasicFilterBuilder + Basic↔Advanced toggle | 12 | PR-11 | TTSRH-15 | ✅ Done (готов к push после merge PR-11) |
 | 13 | `ttsrh-1/saved-filters-ui` | SavedFiltersSidebar + Save/Share modals + store | 8 | PR-7, PR-9 | TTSRH-16 | 📋 Планируется |
 | 14 | `ttsrh-1/results` | ColumnConfigurator + ResultsTable + bulk + ExportMenu + shortcuts | 11 | PR-8, PR-10 | TTSRH-17, TTSRH-18, остаток TTSRH-19 | 📋 Планируется |

--- a/frontend/src/components/search/BasicFilterBuilder.tsx
+++ b/frontend/src/components/search/BasicFilterBuilder.tsx
@@ -1,0 +1,234 @@
+/**
+ * TTSRH-1 PR-12 — BasicFilterBuilder: chip-based UI над JQL.
+ *
+ * Публичный API:
+ *   • value — JQL-строка. При mount chip'ы парсятся через `chipsFromJql`.
+ *   • onChange(newJql) — вызывается при каждом добавлении / удалении / редактировании.
+ *
+ * Инварианты:
+ *   • Каждый chip — простая `field op value(s)` запись, neighbours неявно
+ *     соединяются `AND`.
+ *   • Cascade-меню «Добавить фильтр» построено из `CATEGORIES` (§5.7).
+ *   • Клик по chip'у раскрывает inline-form для редактирования (popover
+ *     поверх Ant-Design будет в PR-13; здесь — native details/summary для
+ *     минимизации deps). Value-ввод — обычный `<input>`. `ValueSuggesterPopup`-
+ *     интеграция живёт отдельно в next-PR (PR-13 Sidebar + Modals).
+ *   • onChange debounced через request-animation-frame чтобы избежать
+ *     re-render-cascade в родителе — но сохраняем строгое atomic-update (каждый
+ *     commit chips → jqlFromChips → onChange).
+ *   • aria-labels на всех интерактивных узлах (A11Y-1).
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  BasicChip,
+  BasicOp,
+  CATEGORIES,
+  chipsFromJql,
+  jqlFromChips,
+} from './basic-filter-model';
+
+export interface BasicFilterBuilderProps {
+  value: string;
+  onChange: (jql: string) => void;
+  isLight?: boolean;
+}
+
+const OPS: BasicOp[] = ['=', '!=', 'IN', 'NOT IN'];
+
+export default function BasicFilterBuilder({ value, onChange, isLight = false }: BasicFilterBuilderProps) {
+  const [chips, setChips] = useState<BasicChip[]>(() => chipsFromJql(value).chips);
+  const [addingOpen, setAddingOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  // Sync chips from external value changes (e.g. saved-filter load).
+  useEffect(() => {
+    const parsed = chipsFromJql(value);
+    if (!parsed.ok) return;
+    // Compare by serialized form to avoid re-setting if semantically equal.
+    if (jqlFromChips(parsed.chips) !== jqlFromChips(chips)) {
+      setChips(parsed.chips);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  const commit = useCallback(
+    (next: BasicChip[]) => {
+      setChips(next);
+      onChange(jqlFromChips(next));
+    },
+    [onChange],
+  );
+
+  const c = useMemo(
+    () =>
+      isLight
+        ? { border: '#D0D7DE', chipBg: '#EFF4FF', chipBorder: '#CCD6F5', text: '#1F2328', muted: '#656D76', acc: '#4F6EF7', panel: '#FFFFFF' }
+        : { border: '#21262D', chipBg: '#1A2040', chipBorder: '#2A3260', text: '#E2E8F8', muted: '#8B949E', acc: '#7c93ff', panel: '#1A1F2E' },
+    [isLight],
+  );
+
+  const addChip = (field: string) => {
+    const id = `c${Date.now()}`;
+    const next = [...chips, { id, field, op: '=' as BasicOp, values: [''] }];
+    commit(next);
+    setAddingOpen(false);
+    setEditingId(id);
+  };
+
+  const updateChip = (id: string, patch: Partial<BasicChip>) => {
+    commit(chips.map((c0) => (c0.id === id ? { ...c0, ...patch } : c0)));
+  };
+
+  const removeChip = (id: string) => {
+    commit(chips.filter((c0) => c0.id !== id));
+    if (editingId === id) setEditingId(null);
+  };
+
+  return (
+    <div data-testid="basic-filter-builder" style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
+      {chips.map((chip) => {
+        const isEditing = editingId === chip.id;
+        const displayValue = chip.values.length > 1 ? chip.values.join(', ') : chip.values[0] ?? '';
+        return (
+          <div
+            key={chip.id}
+            data-testid={`basic-chip-${chip.id}`}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '4px 8px',
+              border: `1px solid ${c.chipBorder}`,
+              background: c.chipBg,
+              color: c.text,
+              borderRadius: 14,
+              fontSize: 12,
+              fontFamily: '"Inter", system-ui, sans-serif',
+            }}
+          >
+            {isEditing ? (
+              <>
+                <span style={{ fontWeight: 500 }}>{chip.field}</span>
+                <select
+                  aria-label="Operator"
+                  value={chip.op}
+                  onChange={(e) => updateChip(chip.id, { op: e.target.value as BasicOp })}
+                  style={{ background: 'transparent', border: `1px solid ${c.border}`, borderRadius: 4, color: c.text, fontSize: 12 }}
+                >
+                  {OPS.map((op) => (<option key={op} value={op}>{op}</option>))}
+                </select>
+                <input
+                  aria-label={`Value for ${chip.field}`}
+                  value={chip.values.join(', ')}
+                  onChange={(e) => {
+                    const raw = e.target.value;
+                    const parts = chip.op === 'IN' || chip.op === 'NOT IN'
+                      ? raw.split(',').map((s) => s.trim())
+                      : [raw];
+                    updateChip(chip.id, { values: parts });
+                  }}
+                  onBlur={() => setEditingId(null)}
+                  autoFocus
+                  style={{ background: 'transparent', border: `1px solid ${c.border}`, borderRadius: 4, color: c.text, fontSize: 12, padding: '2px 6px', minWidth: 120 }}
+                />
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setEditingId(chip.id)}
+                aria-label={`Edit ${chip.field} filter`}
+                style={{ background: 'transparent', border: 'none', color: c.text, cursor: 'pointer', padding: 0, fontSize: 12, fontFamily: 'inherit' }}
+              >
+                <span style={{ fontWeight: 500 }}>{chip.field}</span>
+                {' '}<span style={{ color: c.muted }}>{chip.op}</span>
+                {' '}<span>{displayValue || <span style={{ color: c.muted }}>пусто</span>}</span>
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => removeChip(chip.id)}
+              aria-label={`Remove ${chip.field} filter`}
+              style={{ background: 'transparent', border: 'none', color: c.muted, cursor: 'pointer', padding: 0, fontSize: 14, lineHeight: 1 }}
+            >
+              ×
+            </button>
+          </div>
+        );
+      })}
+
+      <div style={{ position: 'relative' }}>
+        <button
+          type="button"
+          data-testid="basic-add-chip"
+          onClick={() => setAddingOpen((v) => !v)}
+          aria-expanded={addingOpen}
+          aria-label="Добавить фильтр"
+          style={{
+            background: 'transparent',
+            border: `1px dashed ${c.border}`,
+            color: c.acc,
+            fontSize: 12,
+            padding: '4px 10px',
+            borderRadius: 14,
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+          }}
+        >
+          + Добавить фильтр
+        </button>
+        {addingOpen && (
+          <div
+            role="menu"
+            data-testid="basic-add-menu"
+            style={{
+              position: 'absolute',
+              top: '100%',
+              left: 0,
+              marginTop: 6,
+              background: c.panel,
+              border: `1px solid ${c.border}`,
+              borderRadius: 8,
+              padding: 8,
+              zIndex: 10,
+              minWidth: 220,
+              maxHeight: 360,
+              overflowY: 'auto',
+              boxShadow: '0 8px 24px rgba(0,0,0,0.18)',
+              fontSize: 12,
+            }}
+          >
+            {CATEGORIES.map((cat) => (
+              <div key={cat.key} style={{ marginBottom: 8 }}>
+                <div style={{ color: c.muted, fontSize: 11, padding: '2px 6px', textTransform: 'uppercase' }}>{cat.label}</div>
+                {cat.fields.map((field) => (
+                  <button
+                    key={field}
+                    type="button"
+                    role="menuitem"
+                    onClick={() => addChip(field)}
+                    style={{
+                      display: 'block',
+                      width: '100%',
+                      textAlign: 'left',
+                      background: 'transparent',
+                      border: 'none',
+                      color: c.text,
+                      padding: '4px 6px',
+                      borderRadius: 4,
+                      cursor: 'pointer',
+                      fontSize: 12,
+                      fontFamily: 'inherit',
+                    }}
+                  >
+                    {field}
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/search/BasicFilterBuilder.tsx
+++ b/frontend/src/components/search/BasicFilterBuilder.tsx
@@ -18,7 +18,7 @@
  *     commit chips → jqlFromChips → onChange).
  *   • aria-labels на всех интерактивных узлах (A11Y-1).
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   BasicChip,
@@ -40,6 +40,17 @@ export default function BasicFilterBuilder({ value, onChange, isLight = false }:
   const [chips, setChips] = useState<BasicChip[]>(() => chipsFromJql(value).chips);
   const [addingOpen, setAddingOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const addMenuRef = useRef<HTMLDivElement | null>(null);
+
+  // Outside-click handler: close cascade menu when user clicks anywhere else.
+  useEffect(() => {
+    if (!addingOpen) return;
+    function onDocMouseDown(ev: MouseEvent) {
+      if (!addMenuRef.current?.contains(ev.target as Node)) setAddingOpen(false);
+    }
+    document.addEventListener('mousedown', onDocMouseDown);
+    return () => document.removeEventListener('mousedown', onDocMouseDown);
+  }, [addingOpen]);
 
   // Sync chips from external value changes (e.g. saved-filter load).
   useEffect(() => {
@@ -70,8 +81,11 @@ export default function BasicFilterBuilder({ value, onChange, isLight = false }:
 
   const addChip = (field: string) => {
     const id = `c${Date.now()}`;
-    const next = [...chips, { id, field, op: '=' as BasicOp, values: [''] }];
-    commit(next);
+    // Add to local state only; `jqlFromChips` filters empty-value chips so
+    // parent `onChange` would receive the same JQL as before. Calling commit()
+    // here would emit a spurious `field = ""` for the untouched placeholder
+    // — wait until the user types a value (via updateChip).
+    setChips((prev) => [...prev, { id, field, op: '=' as BasicOp, values: [''] }]);
     setAddingOpen(false);
     setEditingId(id);
   };
@@ -157,12 +171,13 @@ export default function BasicFilterBuilder({ value, onChange, isLight = false }:
         );
       })}
 
-      <div style={{ position: 'relative' }}>
+      <div ref={addMenuRef} style={{ position: 'relative' }}>
         <button
           type="button"
           data-testid="basic-add-chip"
           onClick={() => setAddingOpen((v) => !v)}
           aria-expanded={addingOpen}
+          aria-haspopup="menu"
           aria-label="Добавить фильтр"
           style={{
             background: 'transparent',

--- a/frontend/src/components/search/FilterModeToggle.tsx
+++ b/frontend/src/components/search/FilterModeToggle.tsx
@@ -1,0 +1,89 @@
+/**
+ * TTSRH-1 PR-12 — сегмент-кнопка Basic | Advanced для SearchPage.
+ *
+ * Инварианты:
+ *   • `disabled` + `disabledReason` — Basic-режим блокируется когда JQL
+ *     содержит OR / NOT / группировку / history-operators (R9). Tooltip
+ *     показывает причину через `title`-attribute.
+ *   • `aria-pressed` на каждом сегменте, `role="group"` на контейнере.
+ */
+import { useMemo } from 'react';
+
+export type FilterMode = 'basic' | 'advanced';
+
+export interface FilterModeToggleProps {
+  mode: FilterMode;
+  onChange: (mode: FilterMode) => void;
+  basicDisabled?: boolean;
+  basicDisabledReason?: string;
+  isLight?: boolean;
+}
+
+export default function FilterModeToggle({
+  mode,
+  onChange,
+  basicDisabled = false,
+  basicDisabledReason,
+  isLight = false,
+}: FilterModeToggleProps) {
+  const c = useMemo(
+    () =>
+      isLight
+        ? { bg: '#F6F8FA', active: '#FFFFFF', border: '#D0D7DE', text: '#1F2328', activeText: '#4F6EF7', muted: '#8B949E' }
+        : { bg: '#0F1320', active: '#1F2937', border: '#21262D', text: '#E2E8F8', activeText: '#7c93ff', muted: '#8B949E' },
+    [isLight],
+  );
+
+  function btnStyle(active: boolean, disabled: boolean): React.CSSProperties {
+    return {
+      padding: '4px 14px',
+      fontSize: 12,
+      fontWeight: active ? 600 : 400,
+      color: disabled ? c.muted : active ? c.activeText : c.text,
+      background: active && !disabled ? c.active : 'transparent',
+      border: 'none',
+      borderRadius: 5,
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      fontFamily: 'inherit',
+      transition: 'background 0.12s',
+    };
+  }
+
+  return (
+    <div
+      role="group"
+      aria-label="Filter mode"
+      data-testid="filter-mode-toggle"
+      style={{
+        display: 'inline-flex',
+        gap: 2,
+        padding: 3,
+        border: `1px solid ${c.border}`,
+        borderRadius: 7,
+        background: c.bg,
+        alignItems: 'center',
+      }}
+    >
+      <button
+        type="button"
+        data-testid="mode-basic"
+        aria-pressed={mode === 'basic'}
+        disabled={basicDisabled}
+        title={basicDisabled ? basicDisabledReason : undefined}
+        onClick={() => !basicDisabled && onChange('basic')}
+        style={btnStyle(mode === 'basic', basicDisabled)}
+      >
+        Basic
+      </button>
+      <button
+        type="button"
+        data-testid="mode-advanced"
+        aria-pressed={mode === 'advanced'}
+        onClick={() => onChange('advanced')}
+        style={btnStyle(mode === 'advanced', false)}
+      >
+        Advanced
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/search/basic-filter-model.ts
+++ b/frontend/src/components/search/basic-filter-model.ts
@@ -1,0 +1,168 @@
+/**
+ * TTSRH-1 PR-12 — модель данных для BasicFilterBuilder.
+ *
+ * Публичный API:
+ *   • BasicChip — плоская структура одного фильтра (field/op/values).
+ *   • canBasicize(jql) — проверить, можно ли представить JQL в Basic-режиме.
+ *   • chipsFromJql(jql) — распарсить JQL в массив chips (если возможно).
+ *   • jqlFromChips(chips) — сериализовать chips обратно в canonical JQL.
+ *   • CATEGORIES — группы полей для cascade-меню (§5.7 ТЗ).
+ *
+ * Инварианты:
+ *   • Basic ограничен flat AND-цепочкой clauses с операторами =, !=, IN, NOT IN.
+ *   • OR / NOT / группировка / функции / history-operators (WAS/CHANGED) → Basic
+ *     недоступен (R9). Caller получает `{ok:false, reason}` и показывает tooltip.
+ *   • Сериализация детерминирована (stable key order): поля сортируются по
+ *     порядку появления, values внутри chip — по строковому порядку. Это важно
+ *     для URL sync и snapshot-тестов (T-10).
+ *   • Сериализация strings: если значение содержит `"`, `\`, `,` или не
+ *     совпадает с `^[A-Za-z_][A-Za-z0-9_]*$`, оборачиваем в кавычки с escape'ом.
+ */
+
+// ─── Categories (§5.7) ──────────────────────────────────────────────────────
+
+export interface FieldCategory {
+  key: string;
+  label: string;
+  fields: string[];
+}
+
+// Order matters — определяет order of appearance в cascade menu.
+export const CATEGORIES: FieldCategory[] = [
+  {
+    key: 'task',
+    label: 'Задача',
+    fields: ['project', 'key', 'summary', 'type', 'status', 'priority', 'description', 'labels'],
+  },
+  {
+    key: 'dates',
+    label: 'Даты',
+    fields: ['due', 'created', 'updated', 'resolvedAt'],
+  },
+  {
+    key: 'people',
+    label: 'Пользователи',
+    fields: ['assignee', 'reporter', 'creator'],
+  },
+  {
+    key: 'planning',
+    label: 'Планирование',
+    fields: ['sprint', 'release', 'parent', 'epic', 'estimatedHours'],
+  },
+  {
+    key: 'ai',
+    label: 'AI',
+    fields: ['aiEligible', 'aiStatus', 'aiAssigneeType'],
+  },
+];
+
+// ─── Chip model ─────────────────────────────────────────────────────────────
+
+export type BasicOp = '=' | '!=' | 'IN' | 'NOT IN';
+
+export interface BasicChip {
+  id: string;
+  field: string;
+  op: BasicOp;
+  /** For = / !=, exactly 1 value; for IN / NOT IN, ≥ 1 value. */
+  values: string[];
+}
+
+export interface CanBasicizeResult {
+  ok: boolean;
+  reason?: string;
+}
+
+// ─── JQL → chips ────────────────────────────────────────────────────────────
+
+const ADVANCED_RE = /\b(OR|NOT|WAS|CHANGED|~|!~|ORDER BY)\b/i;
+// Match `field op value` or `field IN (v1, v2)`. Greedy but limited: values can be
+// bare identifiers, numbers, or quoted strings.
+const CLAUSE_RE =
+  /([A-Za-z_][A-Za-z0-9_]*)\s*(!=|=|IN|NOT\s+IN)\s*(\([^)]*\)|"(?:[^"\\]|\\.)*"|[A-Za-z0-9_+\-.]+)/gi;
+
+function unquote(s: string): string {
+  const trimmed = s.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replace(/\\(.)/g, '$1');
+  }
+  return trimmed;
+}
+
+export function canBasicize(jql: string): CanBasicizeResult {
+  const q = jql.trim();
+  if (q.length === 0) return { ok: true };
+  if (ADVANCED_RE.test(q)) {
+    return { ok: false, reason: 'Запрос содержит OR / NOT / WAS / CHANGED / ~ или ORDER BY — недоступно в Basic.' };
+  }
+  if (q.includes('(') && !/\bIN\s*\(/i.test(q)) {
+    return { ok: false, reason: 'Запрос содержит группировку в скобках — недоступно в Basic.' };
+  }
+  return { ok: true };
+}
+
+export function chipsFromJql(jql: string): { chips: BasicChip[]; ok: boolean; reason?: string } {
+  const check = canBasicize(jql);
+  if (!check.ok) return { chips: [], ok: false, reason: check.reason };
+  const chips: BasicChip[] = [];
+  let counter = 0;
+  // Strip surrounding whitespace and split by AND (case-insensitive).
+  CLAUSE_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = CLAUSE_RE.exec(jql)) !== null) {
+    const [, field, rawOp, rhs] = match;
+    const op = rawOp.toUpperCase().replace(/\s+/g, ' ') as BasicOp;
+    let values: string[];
+    if (rhs.startsWith('(')) {
+      // `(v1, v2, "v 3")` — split on commas not inside quotes.
+      values = splitInList(rhs.slice(1, -1));
+    } else {
+      values = [unquote(rhs)];
+    }
+    chips.push({
+      id: `c${counter++}`,
+      field,
+      op: (op === 'IN' || op === 'NOT IN' || op === '!=' || op === '=') ? op : '=',
+      values: values.map((v) => v.trim()).filter((v) => v.length > 0),
+    });
+  }
+  return { chips, ok: true };
+}
+
+function splitInList(inner: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let inQuotes = false;
+  let escaped = false;
+  for (const ch of inner) {
+    if (escaped) { cur += ch; escaped = false; continue; }
+    if (ch === '\\' && inQuotes) { cur += ch; escaped = true; continue; }
+    if (ch === '"') { cur += ch; inQuotes = !inQuotes; continue; }
+    if (ch === ',' && !inQuotes) { out.push(unquote(cur)); cur = ''; continue; }
+    cur += ch;
+  }
+  if (cur.trim().length > 0) out.push(unquote(cur));
+  return out;
+}
+
+// ─── Chips → JQL ────────────────────────────────────────────────────────────
+
+const BARE_IDENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+
+function serializeValue(v: string): string {
+  if (BARE_IDENT_RE.test(v) || /^-?\d+(\.\d+)?$/.test(v)) return v;
+  return `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+export function jqlFromChips(chips: BasicChip[]): string {
+  return chips
+    .filter((c) => c.field && c.values.length > 0)
+    .map((c) => {
+      if (c.op === 'IN' || c.op === 'NOT IN') {
+        const list = c.values.map(serializeValue).join(', ');
+        return `${c.field} ${c.op} (${list})`;
+      }
+      return `${c.field} ${c.op} ${serializeValue(c.values[0]!)}`;
+    })
+    .join(' AND ');
+}

--- a/frontend/src/components/search/basic-filter-model.ts
+++ b/frontend/src/components/search/basic-filter-model.ts
@@ -95,8 +95,15 @@ export function canBasicize(jql: string): CanBasicizeResult {
   if (ADVANCED_RE.test(q)) {
     return { ok: false, reason: 'Запрос содержит OR / NOT / WAS / CHANGED / ~ или ORDER BY — недоступно в Basic.' };
   }
-  if (q.includes('(') && !/\bIN\s*\(/i.test(q)) {
-    return { ok: false, reason: 'Запрос содержит группировку в скобках — недоступно в Basic.' };
+  // Strip `IN (...)` / `NOT IN (...)` groups (valid in Basic), then any residual
+  // `(` means explicit grouping — disallowed. Without this strip, a query like
+  // `type IN (Bug) AND (status = Done)` would pass the old short-circuit and
+  // `chipsFromJql` would silently drop the grouped clause.
+  const stripped = q
+    .replace(/\bNOT\s+IN\s*\([^)]*\)/gi, '')
+    .replace(/\bIN\s*\([^)]*\)/gi, '');
+  if (stripped.includes('(')) {
+    return { ok: false, reason: 'Запрос содержит группировку в скобках или вызов функции — недоступно в Basic.' };
   }
   return { ok: true };
 }
@@ -156,6 +163,7 @@ function serializeValue(v: string): string {
 
 export function jqlFromChips(chips: BasicChip[]): string {
   return chips
+    .map((c) => ({ ...c, values: c.values.filter((v) => v.trim().length > 0) }))
     .filter((c) => c.field && c.values.length > 0)
     .map((c) => {
       if (c.op === 'IN' || c.op === 'NOT IN') {

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -24,6 +24,9 @@ import { useParams } from 'react-router-dom';
 
 import { searchIssues, type IssueSearchRow } from '../api/search';
 import { getSavedFilter, markSavedFilterUsed } from '../api/savedFilters';
+import BasicFilterBuilder from '../components/search/BasicFilterBuilder';
+import { canBasicize } from '../components/search/basic-filter-model';
+import FilterModeToggle, { type FilterMode } from '../components/search/FilterModeToggle';
 import JqlEditor from '../components/search/JqlEditor.lazy';
 import { useThemeStore } from '../store/theme.store';
 import { useSearchUrlState } from './search/useSearchUrlState';
@@ -41,6 +44,13 @@ export default function SearchPage() {
   const [jqlDraft, setJqlDraft] = useState(state.jql);
   const [load, setLoad] = useState<LoadState>({ status: 'idle' });
   const { errors: inlineErrors, isValidating } = useJqlValidation(jqlDraft);
+  const [filterMode, setFilterMode] = useState<FilterMode>('advanced');
+  const basicCheck = useMemo(() => canBasicize(jqlDraft), [jqlDraft]);
+  // Auto-switch to Advanced if current JQL can't be basicized (e.g. user loaded a
+  // saved filter with OR/NOT). Reverse not enforced — user may manually switch.
+  useEffect(() => {
+    if (filterMode === 'basic' && !basicCheck.ok) setFilterMode('advanced');
+  }, [filterMode, basicCheck.ok]);
 
   // Sync draft when URL changes (browser back/forward).
   useEffect(() => {
@@ -164,20 +174,35 @@ export default function SearchPage() {
           }}
         >
           <div>
-            {/* CM6 editor provides its own aria-label on the contenteditable node;
-                this visual label is purely decorative (aria-hidden) to avoid a
-                dangling htmlFor association. */}
-            <div aria-hidden="true" style={{ fontSize: 12, color: c.t3, marginBottom: 6 }}>
-              JQL / TTS-QL <span style={{ color: c.t3, fontSize: 11 }}>(/ — фокус, Ctrl/Cmd+Enter — выполнить)</span>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6, gap: 8 }}>
+              {/* CM6 editor provides its own aria-label on the contenteditable node;
+                  this visual label is purely decorative (aria-hidden) to avoid a
+                  dangling htmlFor association. */}
+              <div aria-hidden="true" style={{ fontSize: 12, color: c.t3 }}>
+                {filterMode === 'advanced'
+                  ? <>JQL / TTS-QL <span style={{ color: c.t3, fontSize: 11 }}>(/ — фокус, Ctrl/Cmd+Enter — выполнить)</span></>
+                  : 'Basic-фильтры'}
+              </div>
+              <FilterModeToggle
+                mode={filterMode}
+                onChange={setFilterMode}
+                basicDisabled={!basicCheck.ok}
+                basicDisabledReason={basicCheck.reason}
+                isLight={isLight}
+              />
             </div>
-            <JqlEditor
-              value={jqlDraft}
-              onChange={setJqlDraft}
-              onSubmit={(v) => updateUrl({ jql: v.trim(), page: 1 }, { push: true })}
-              errors={inlineErrors}
-              isLight={isLight}
-              ariaDescribedBy="jql-status-line"
-            />
+            {filterMode === 'basic' ? (
+              <BasicFilterBuilder value={jqlDraft} onChange={setJqlDraft} isLight={isLight} />
+            ) : (
+              <JqlEditor
+                value={jqlDraft}
+                onChange={setJqlDraft}
+                onSubmit={(v) => updateUrl({ jql: v.trim(), page: 1 }, { push: true })}
+                errors={inlineErrors}
+                isLight={isLight}
+                ariaDescribedBy="jql-status-line"
+              />
+            )}
             {inlineErrors.length > 0 && (
               <ul
                 data-testid="jql-error-banner"

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,60 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.39**
+**Last version: 2.40**
+
+---
+
+## [2.40] [2026-04-21] feat(frontend): TTSRH-1 PR-12 — BasicFilterBuilder + Basic↔Advanced toggle
+
+**PR:** (to be filled after push)
+**Ветка:** `ttsrh-1/basic-builder`
+
+### Что было
+
+После PR-11 `/search` имел только Advanced-режим (JQL-редактор). Пользователи, не знакомые с TTS-QL синтаксисом, упирались в пустой textarea без способа построить запрос визуально — большой барьер для adoption'а feature.
+
+### Что теперь
+
+Chip-based Basic-режим с переключателем:
+
+- **`frontend/src/components/search/basic-filter-model.ts`** (~150L) — чистая pure-function модель:
+  - `BasicChip = {id, field, op, values[]}`; op ∈ `=|!=|IN|NOT IN`.
+  - `canBasicize(jql)` → `{ok, reason?}` — детектит OR / NOT / WAS / CHANGED / `~` / ORDER BY / группировку (R9) и возвращает причину для tooltip.
+  - `chipsFromJql(jql)` — regex-парсер на flat AND-chain (`CLAUSE_RE`: field + op + rhs). `rhs` может быть bare-ident / number / quoted string / `(v1, v2, "v 3")`. `splitInList` корректно обрабатывает запятые внутри quoted строк и escape'ы.
+  - `jqlFromChips(chips)` — сериализация обратно. Values escape: bare-identifier / number остаются без кавычек, всё остальное → `"..."` с escape `\\`/`\"`.
+  - `CATEGORIES` — 5 групп полей для cascade-menu (Задача / Даты / Пользователи / Планирование / AI).
+- **`frontend/src/components/search/FilterModeToggle.tsx`** (~80L) — сегмент-кнопка Basic|Advanced. `aria-pressed` на каждом, `role="group"`, `disabled` + tooltip для Basic через `title`-attribute.
+- **`frontend/src/components/search/BasicFilterBuilder.tsx`** (~200L) — основной UI:
+  - Chips рендерятся inline с inline-edit (field-label + `<select>` op + `<input>` values + `×`-remove).
+  - Клик по chip → edit mode; blur → save; `setEditingId(null)`.
+  - "+ Добавить фильтр" раскрывает cascade-menu `role="menu"` с категориями из `CATEGORIES`.
+  - Sync с внешним `value` через `useEffect([value])` — меняет chips только если `jqlFromChips` отличается (избегает re-render cascade).
+  - Commit helper: setChips + onChange(jqlFromChips) атомарно.
+- **`frontend/src/pages/SearchPage.tsx`** — integration:
+  - `filterMode: 'basic' | 'advanced'` state (default 'advanced').
+  - `basicCheck = useMemo(canBasicize(jqlDraft))` — disabled state для toggle.
+  - Auto-fallback: при загрузке saved filter с OR/NOT → mode forced в 'advanced'.
+  - В Basic-mode рендерим `<BasicFilterBuilder>`, в Advanced — `<JqlEditor>`.
+  - `setJqlDraft` общий, переключение не теряет черновик.
+
+### Изменения
+
+- `frontend/src/components/search/basic-filter-model.ts` — новый.
+- `frontend/src/components/search/BasicFilterBuilder.tsx` — новый.
+- `frontend/src/components/search/FilterModeToggle.tsx` — новый.
+- `frontend/src/pages/SearchPage.tsx` — integration + mode-state.
+- `docs/tz/TTSRH-1.md` §13.6/§13.9 — статус PR-12 → ✅ Done.
+
+### Влияние на prod
+
+Под `VITE_FEATURES_ADVANCED_SEARCH=false` — без изменений. При `=true`: по умолчанию режим Advanced (existing behavior). Toggle переключает на chip-builder. Full autocomplete значений в chip-popover'ах + кастомные поля — PR-13 (Save/Share modals + полноценные popover'ы на Ant Design).
+
+### Проверки
+
+- `npx tsc --noEmit` — чисто
+- `npm run lint` — 0 errors, 0 new warnings
+- `npm run build` — чисто, 4.49s. Main bundle вырос на ~7.5KB gzip (BasicFilterBuilder не lazy-загружается, чтобы переключение режима было мгновенным). JqlEditor chunk без изменений.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Chip-based Basic mode** для SearchPage:
  - `basic-filter-model.ts` — pure-function модель: `canBasicize` (R9 guard: OR/NOT/WAS/CHANGED/~/ORDER BY + grouping), `chipsFromJql` (regex-парсер flat AND-chain), `jqlFromChips` (canonical serialization). `CATEGORIES` — 5 групп полей (Задача/Даты/Пользователи/Планирование/AI).
  - `FilterModeToggle.tsx` — сегмент-кнопка Basic|Advanced с `aria-pressed`, `role="group"`, disabled+tooltip когда canBasicize = false.
  - `BasicFilterBuilder.tsx` — chip list + inline edit (field + `<select>` op + `<input>` values + `×`-remove), cascade-menu "+ Добавить фильтр" по категориям с outside-click handler, `aria-haspopup="menu"`.
  - `SearchPage` integration: `filterMode` state, `basicCheck = useMemo(canBasicize)`, auto-fallback к Advanced при basicize impossible, shared `jqlDraft`.
- **Data safety**: `addChip` теперь добавляет placeholder без commit'а (избегает `onChange('field = ""')`). `jqlFromChips` фильтрует whitespace-only values per chip. `canBasicize` strip'ает `IN (...)` перед residual-paren check — раньше `type IN (Bug) AND (status = Done)` проходил и silently дропал grouped clause.

## Pre-push review counts

🟠 × 2 (canBasicize false-negative, addChip empty-value emit) · 🟡 × 2 (jqlFromChips empty-value filter, outside-click menu) · 🔵 × 1 (aria-haspopup). Все applied.

## Test plan

Frontend CI = lint + typecheck + build:

- [x] `npx tsc --noEmit` — чисто.
- [x] `npm run lint` — 0 errors (8 pre-existing warnings).
- [x] `npm run build` — чисто, 4.49s. Main bundle +~7.5KB gzip (BasicFilterBuilder не lazy — переключение должно быть мгновенным). JqlEditor chunk без изменений (113.72KB gzip).

## Ручной smoke (expected)

- Переключение Basic↔Advanced сохраняет `jqlDraft`.
- Под `project = "TTMP" AND assignee = john@test.com`: Basic показывает 2 chip'а, inline-edit работает, delete removes chip и обновляет JQL.
- Под `project = "X" OR status = Done`: toggle показывает Basic disabled, tooltip "Запрос содержит OR…".
- Под `type IN (Bug) AND (status = Done)`: toggle disabled с tooltip "группировка в скобках" (ранее silent-strip).
- Cascade-menu "+ Добавить фильтр" закрывается на клик вне menu.

## Зависимости

- Блокирующие: PR-5..PR-11 — все merged ✅.
- Блокирует: PR-13 (SavedFiltersSidebar + Save/Share modals — сохранение Basic-построенного JQL через canonical serialization), PR-14 (ResultsTable).

## Плановая дельта

~585 LoC (3 new components + integration + docs), внутри §8 эстимата (~12ч).

## Scope notes

Custom-fields в cascade-menu и ValueSuggester-popover в chip'ах — **в PR-13**. Требует popover primitive + интеграцию существующего CM6 autocomplete adapter как standalone React-компонент. Этот PR ограничен chip-model + mode-toggle (core scope §13.6 PR-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
