### PR TITLE
feat(frontend): TTSRH-1 PR-13 — SavedFiltersSidebar + Save/Share modals + Zustand store

### DIFF
--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1387,6 +1387,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
   - Shortcut `Ctrl+S` → Save (или SaveAs если не назван); `Ctrl+Shift+S` → SaveAs.
 - **Merge-ready check:** E2E create → favorite → share → copy-link.
 - **Оценка:** ~8ч.
+- **Статус: ✅ Done** — `store/savedFilters.store.ts` (Zustand) с 5 scope'ами (mine/favorite/public/shared + client-side recent через `lastUsedAt DESC`), каждая мутация завершается `loadAll()` для консистентности между списками. `SaveFilterModal` (name/description/visibility/isFavorite, PUBLIC warning R11, Ant Form validation, CLAUDE.md onClose → loadAll). `FilterShareModal` (visibility switch + users multi-select + permission READ/WRITE + copy-link через `navigator.clipboard`). `SavedFiltersSidebar` (5 collapsible sections, inline favorite-toggle + share + delete c Popconfirm, active-highlight по `jql === currentJql`). SearchPage: `Ctrl/Cmd+S` hotkey → SaveFilterModal, кнопка "+ Сохранить" в header sidebar'а, modals загружают store'ы после любых изменений (CLAUDE.md modal-rule). Bundle +3.9KB gzip (Ant Design Modal/Form уже в main bundle).
 
 #### PR-14: ColumnConfigurator + ResultsTable + bulk + export UI
 - **Branch:** `ttsrh-1/results`
@@ -1509,8 +1510,8 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 9 | `ttsrh-1/frontend-shell` | SearchPage shell + route + sidebar + URL sync | 6 | PR-5 | TTSRH-12, часть TTSRH-19 | 🟢 Merged ([#109](https://github.com/NovakPAai/tasktime-mvp/pull/109)) |
 | 10 | `ttsrh-1/jql-editor` | JqlEditor (CM6) + inline errors + lazy-load | 13 | PR-9 | TTSRH-13, TTSRH-14 | 🟢 Merged ([#110](https://github.com/NovakPAai/tasktime-mvp/pull/110)) |
 | 11 | `ttsrh-1/value-suggester` | ValueSuggesterPopup + CM6 adapter | 10 | PR-6, PR-10 | TTSRH-26 | 🟢 Merged ([#113](https://github.com/NovakPAai/tasktime-mvp/pull/113)) |
-| 12 | `ttsrh-1/basic-builder` | BasicFilterBuilder + Basic↔Advanced toggle | 12 | PR-11 | TTSRH-15 | ✅ Done (готов к push после merge PR-11) |
-| 13 | `ttsrh-1/saved-filters-ui` | SavedFiltersSidebar + Save/Share modals + store | 8 | PR-7, PR-9 | TTSRH-16 | 📋 Планируется |
+| 12 | `ttsrh-1/basic-builder` | BasicFilterBuilder + Basic↔Advanced toggle | 12 | PR-11 | TTSRH-15 | 🟢 Merged ([#114](https://github.com/NovakPAai/tasktime-mvp/pull/114)) |
+| 13 | `ttsrh-1/saved-filters-ui` | SavedFiltersSidebar + Save/Share modals + store | 8 | PR-7, PR-9 | TTSRH-16 | ✅ Done (готов к push после merge PR-12) |
 | 14 | `ttsrh-1/results` | ColumnConfigurator + ResultsTable + bulk + ExportMenu + shortcuts | 11 | PR-8, PR-10 | TTSRH-17, TTSRH-18, остаток TTSRH-19 | 📋 Планируется |
 | 15 | `ttsrh-1/checkpoint-foundation` | Checkpoint Prisma + DTO + КТ-функции + variant=CHECKPOINT | 10 | PR-1, PR-3 | TTSRH-27, TTSRH-28, TTSRH-29 | 📋 Планируется |
 | 16 | `ttsrh-1/checkpoint-engine` | Engine TTQL-ветка + COMBINED + error handling | 10 | PR-4, PR-15 | TTSRH-30, TTSRH-31 | 📋 Планируется |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { ConfigProvider, theme as antdTheme } from 'antd';
+import { App as AntApp, ConfigProvider, theme as antdTheme } from 'antd';
 import { useAuthStore } from './store/auth.store';
 import { useThemeStore } from './store/theme.store';
 import * as tokens from './design-tokens';
@@ -166,7 +166,8 @@ export default function App() {
 
   return (
     <ConfigProvider theme={antTheme}>
-      <BrowserRouter>
+      <AntApp>
+        <BrowserRouter>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route path="/change-password" element={<ChangePasswordPage />} />
@@ -251,6 +252,7 @@ export default function App() {
           </Route>
         </Routes>
       </BrowserRouter>
+      </AntApp>
     </ConfigProvider>
   );
 }

--- a/frontend/src/components/search/FilterShareModal.tsx
+++ b/frontend/src/components/search/FilterShareModal.tsx
@@ -1,0 +1,184 @@
+/**
+ * TTSRH-1 PR-13 — FilterShareModal.
+ *
+ * Модалка для управления visibility + sharing существующего SavedFilter.
+ *
+ * Публичный API:
+ *   • open, onClose, filter (SavedFilter | null).
+ *   • onSaved — сигнал родителю (`load()` CLAUDE.md).
+ *
+ * Инварианты:
+ *   • При SHARED — отображаем мульти-селект пользователей + groups.
+ *   • При PUBLIC — warning-banner как в SaveFilterModal.
+ *   • «Копировать ссылку» — генерирует `/search/saved/:id` и копирует в clipboard.
+ *   • `onCancel` / `onClose` / backdrop / Esc — все триггерят `onClose`.
+ *   • Модалка ре-инициализирует state при смене `filter` prop.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { Modal, Form, Select, Alert, message, Button } from 'antd';
+import { CopyOutlined } from '@ant-design/icons';
+
+import type {
+  FilterPermission,
+  FilterVisibility,
+  SavedFilter,
+} from '../../api/savedFilters';
+import { listUsers } from '../../api/auth';
+import type { User } from '../../types';
+import { useSavedFiltersStore } from '../../store/savedFilters.store';
+
+export interface FilterShareModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+  filter: SavedFilter | null;
+}
+
+interface FormValues {
+  visibility: FilterVisibility;
+  users: string[];
+  permission: FilterPermission;
+}
+
+export default function FilterShareModal({ open, onClose, onSaved, filter }: FilterShareModalProps) {
+  const [form] = Form.useForm<FormValues>();
+  const [submitting, setSubmitting] = useState(false);
+  const [users, setUsers] = useState<User[]>([]);
+  const [visibility, setVisibility] = useState<FilterVisibility>('PRIVATE');
+  const update = useSavedFiltersStore((s) => s.update);
+  const share = useSavedFiltersStore((s) => s.share);
+
+  // Fetch user directory on open for the multi-select.
+  useEffect(() => {
+    if (!open) return;
+    listUsers().then(setUsers).catch(() => setUsers([]));
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !filter) return;
+    const initialUsers = filter.shares.filter((s) => s.userId).map((s) => s.userId!);
+    const initialPermission: FilterPermission =
+      filter.shares.find((s) => s.permission === 'WRITE') ? 'WRITE' : 'READ';
+    form.setFieldsValue({
+      visibility: filter.visibility,
+      users: initialUsers,
+      permission: initialPermission,
+    });
+    setVisibility(filter.visibility);
+  }, [open, filter, form]);
+
+  const shareLink = useMemo(() => {
+    if (!filter) return '';
+    const origin = typeof window !== 'undefined' ? window.location.origin : '';
+    return `${origin}/search/saved/${filter.id}`;
+  }, [filter]);
+
+  const copyLink = async () => {
+    if (!shareLink) return;
+    try {
+      await navigator.clipboard.writeText(shareLink);
+      message.success('Ссылка скопирована');
+    } catch {
+      message.error('Не удалось скопировать');
+    }
+  };
+
+  const handleOk = async () => {
+    if (!filter) return;
+    try {
+      const values = await form.validateFields();
+      setSubmitting(true);
+
+      // Always update visibility first (may promote PRIVATE → SHARED → PUBLIC).
+      if (values.visibility !== filter.visibility) {
+        await update(filter.id, { visibility: values.visibility });
+      }
+      // Then replace shares (owner-only, replace-semantics on backend).
+      if (values.visibility === 'SHARED') {
+        await share(filter.id, {
+          users: values.users,
+          permission: values.permission,
+        });
+      } else if (filter.shares.length > 0) {
+        // Demote to PRIVATE / PUBLIC — clear shares.
+        await share(filter.id, { users: [] });
+      }
+      message.success('Настройки доступа сохранены');
+      onSaved();
+    } catch (err) {
+      if (err && typeof err === 'object' && 'errorFields' in err) return;
+      const msg = err instanceof Error ? err.message : 'Ошибка сохранения';
+      message.error(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!filter) return null;
+
+  return (
+    <Modal
+      open={open}
+      title={`Доступ — ${filter.name}`}
+      okText="Сохранить"
+      cancelText="Отмена"
+      confirmLoading={submitting}
+      onOk={handleOk}
+      onCancel={() => { onClose(); }}
+      destroyOnClose
+      maskClosable={!submitting}
+    >
+      <Form form={form} layout="vertical" name="filter-share-form">
+        <Form.Item label="Видимость" name="visibility" rules={[{ required: true }]}>
+          <Select
+            data-testid="share-filter-visibility"
+            onChange={(v) => setVisibility(v as FilterVisibility)}
+            options={[
+              { value: 'PRIVATE', label: 'Private — только я' },
+              { value: 'SHARED', label: 'Shared — указанные пользователи' },
+              { value: 'PUBLIC', label: 'Public — все аутентифицированные' },
+            ]}
+          />
+        </Form.Item>
+        {visibility === 'SHARED' && (
+          <>
+            <Form.Item label="Поделиться с пользователями" name="users">
+              <Select
+                mode="multiple"
+                placeholder="Выберите пользователей"
+                data-testid="share-filter-users"
+                showSearch
+                optionFilterProp="label"
+                options={users.map((u) => ({
+                  value: u.id,
+                  label: `${u.name} <${u.email}>`,
+                }))}
+              />
+            </Form.Item>
+            <Form.Item label="Права" name="permission" initialValue="READ">
+              <Select
+                options={[
+                  { value: 'READ', label: 'READ — только чтение' },
+                  { value: 'WRITE', label: 'WRITE — чтение и редактирование' },
+                ]}
+              />
+            </Form.Item>
+          </>
+        )}
+        {visibility === 'PUBLIC' && (
+          <Alert
+            type="warning"
+            showIcon
+            message="Фильтр станет виден всем аутентифицированным пользователям"
+            style={{ marginBottom: 16 }}
+          />
+        )}
+        <Form.Item label="Ссылка на фильтр">
+          <Button icon={<CopyOutlined />} onClick={copyLink} data-testid="share-copy-link" block>
+            Скопировать {shareLink}
+          </Button>
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/frontend/src/components/search/FilterShareModal.tsx
+++ b/frontend/src/components/search/FilterShareModal.tsx
@@ -44,6 +44,7 @@ export default function FilterShareModal({ open, onClose, onSaved, filter }: Fil
   const [form] = Form.useForm<FormValues>();
   const [submitting, setSubmitting] = useState(false);
   const [users, setUsers] = useState<User[]>([]);
+  const [usersLoading, setUsersLoading] = useState(false);
   const [visibility, setVisibility] = useState<FilterVisibility>('PRIVATE');
   const update = useSavedFiltersStore((s) => s.update);
   const share = useSavedFiltersStore((s) => s.share);
@@ -51,7 +52,11 @@ export default function FilterShareModal({ open, onClose, onSaved, filter }: Fil
   // Fetch user directory on open for the multi-select.
   useEffect(() => {
     if (!open) return;
-    listUsers().then(setUsers).catch(() => setUsers([]));
+    setUsersLoading(true);
+    listUsers()
+      .then(setUsers)
+      .catch(() => setUsers([]))
+      .finally(() => setUsersLoading(false));
   }, [open]);
 
   useEffect(() => {
@@ -145,7 +150,8 @@ export default function FilterShareModal({ open, onClose, onSaved, filter }: Fil
             <Form.Item label="Поделиться с пользователями" name="users">
               <Select
                 mode="multiple"
-                placeholder="Выберите пользователей"
+                placeholder={usersLoading ? 'Загрузка пользователей…' : 'Выберите пользователей'}
+                loading={usersLoading}
                 data-testid="share-filter-users"
                 showSearch
                 optionFilterProp="label"

--- a/frontend/src/components/search/SaveFilterModal.tsx
+++ b/frontend/src/components/search/SaveFilterModal.tsx
@@ -1,0 +1,175 @@
+/**
+ * TTSRH-1 PR-13 — SaveFilterModal.
+ *
+ * Модалка для создания / обновления SavedFilter.
+ *
+ * Публичный API:
+ *   • open — boolean.
+ *   • onClose() — закрыть без сохранения. Родитель вызывает `load()` (CLAUDE.md).
+ *   • onSaved(filter) — уже сохранённый SavedFilter; родитель делает `load()`.
+ *   • initial — начальные значения (для «Save As» / «Update existing»).
+ *   • currentJql — текущий JQL из editor'а (readonly preview).
+ *
+ * Инварианты:
+ *   • Поля: name (required, ≤200), description (optional, ≤2000), visibility
+ *     (PRIVATE/SHARED/PUBLIC), sharedWith (users+groups, only для SHARED),
+ *     isFavorite (default false).
+ *   • PUBLIC → warning-banner (R11): «Фильтр станет виден всем аутентифицированным».
+ *   • onCancel / onClose / backdrop / Esc — все триггерят `onClose` (CLAUDE.md rule).
+ *   • На submit — validateAll, если OK → `onSaved(filter)`.
+ */
+import { useEffect, useState } from 'react';
+import { Modal, Form, Input, Select, Switch, Alert, message } from 'antd';
+
+import type {
+  CreateSavedFilterInput,
+  FilterVisibility,
+  SavedFilter,
+} from '../../api/savedFilters';
+import { useSavedFiltersStore } from '../../store/savedFilters.store';
+
+const { TextArea } = Input;
+
+export interface SaveFilterModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSaved: (filter: SavedFilter) => void;
+  currentJql: string;
+  /** If provided — edit existing filter; otherwise — create new. */
+  initial?: SavedFilter | null;
+}
+
+interface FormValues {
+  name: string;
+  description?: string;
+  visibility: FilterVisibility;
+  isFavorite: boolean;
+}
+
+export default function SaveFilterModal({
+  open,
+  onClose,
+  onSaved,
+  currentJql,
+  initial,
+}: SaveFilterModalProps) {
+  const [form] = Form.useForm<FormValues>();
+  const [submitting, setSubmitting] = useState(false);
+  const create = useSavedFiltersStore((s) => s.create);
+  const update = useSavedFiltersStore((s) => s.update);
+  const toggleFavorite = useSavedFiltersStore((s) => s.toggleFavorite);
+  const [visibility, setVisibility] = useState<FilterVisibility>(
+    initial?.visibility ?? 'PRIVATE',
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    form.setFieldsValue({
+      name: initial?.name ?? '',
+      description: initial?.description ?? '',
+      visibility: initial?.visibility ?? 'PRIVATE',
+      isFavorite: initial?.isFavorite ?? false,
+    });
+    setVisibility(initial?.visibility ?? 'PRIVATE');
+  }, [open, initial, form]);
+
+  const handleOk = async () => {
+    try {
+      const values = await form.validateFields();
+      setSubmitting(true);
+      let saved: SavedFilter;
+      if (initial) {
+        saved = await update(initial.id, {
+          name: values.name,
+          description: values.description ?? null,
+          jql: currentJql,
+          visibility: values.visibility,
+        });
+      } else {
+        const payload: CreateSavedFilterInput = {
+          name: values.name,
+          description: values.description ?? null,
+          jql: currentJql,
+          visibility: values.visibility,
+        };
+        saved = await create(payload);
+      }
+      // Favorite is a separate endpoint; only fire if value differs from current state.
+      if ((saved.isFavorite ?? false) !== values.isFavorite) {
+        await toggleFavorite(saved.id, values.isFavorite);
+      }
+      message.success(initial ? 'Фильтр обновлён' : 'Фильтр сохранён');
+      onSaved(saved);
+    } catch (err) {
+      if (err && typeof err === 'object' && 'errorFields' in err) {
+        // form validation — AntD already shows inline errors
+        return;
+      }
+      const msg = err instanceof Error ? err.message : 'Ошибка сохранения';
+      message.error(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      title={initial ? 'Обновить фильтр' : 'Сохранить фильтр'}
+      okText={initial ? 'Обновить' : 'Сохранить'}
+      cancelText="Отмена"
+      confirmLoading={submitting}
+      onOk={handleOk}
+      onCancel={() => { onClose(); }}
+      destroyOnClose
+      maskClosable={!submitting}
+      keyboard
+    >
+      <Form form={form} layout="vertical" name="save-filter-form">
+        <Form.Item
+          label="Имя"
+          name="name"
+          rules={[
+            { required: true, message: 'Введите имя фильтра' },
+            { max: 200, message: 'Максимум 200 символов' },
+          ]}
+        >
+          <Input placeholder="Например: Мои HIGH-задачи" data-testid="save-filter-name" />
+        </Form.Item>
+        <Form.Item
+          label="Описание"
+          name="description"
+          rules={[{ max: 2000, message: 'Максимум 2000 символов' }]}
+        >
+          <TextArea rows={2} placeholder="Опционально" />
+        </Form.Item>
+        <Form.Item label="JQL">
+          <Input.TextArea rows={2} value={currentJql} readOnly style={{ fontFamily: 'monospace', fontSize: 12 }} />
+        </Form.Item>
+        <Form.Item label="Видимость" name="visibility" rules={[{ required: true }]}>
+          <Select
+            data-testid="save-filter-visibility"
+            onChange={(v) => setVisibility(v as FilterVisibility)}
+            options={[
+              { value: 'PRIVATE', label: 'Private — только я' },
+              { value: 'SHARED', label: 'Shared — указанные пользователи / группы' },
+              { value: 'PUBLIC', label: 'Public — все аутентифицированные' },
+            ]}
+          />
+        </Form.Item>
+        {visibility === 'PUBLIC' && (
+          <Alert
+            type="warning"
+            showIcon
+            message="Фильтр станет виден всем аутентифицированным пользователям"
+            description="Они увидят имя, описание и JQL фильтра. Выполнение всё равно ограничено их own-access проектами."
+            style={{ marginBottom: 16 }}
+          />
+        )}
+        <Form.Item label="Избранный" name="isFavorite" valuePropName="checked">
+          <Switch />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/frontend/src/components/search/SaveFilterModal.tsx
+++ b/frontend/src/components/search/SaveFilterModal.tsx
@@ -62,6 +62,9 @@ export default function SaveFilterModal({
     initial?.visibility ?? 'PRIVATE',
   );
 
+  // Key on `initial?.id` rather than the full `initial` object identity —
+  // parent `loadAll` re-allocates a structurally-equal `SavedFilter` object and
+  // would nuke mid-edit form state if we depended on reference equality.
   useEffect(() => {
     if (!open) return;
     form.setFieldsValue({
@@ -71,7 +74,8 @@ export default function SaveFilterModal({
       isFavorite: initial?.isFavorite ?? false,
     });
     setVisibility(initial?.visibility ?? 'PRIVATE');
-  }, [open, initial, form]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, initial?.id, form]);
 
   const handleOk = async () => {
     try {

--- a/frontend/src/components/search/SavedFiltersSidebar.tsx
+++ b/frontend/src/components/search/SavedFiltersSidebar.tsx
@@ -85,6 +85,7 @@ export default function SavedFiltersSidebar({
     try {
       await remove(filter.id);
       message.success(`Фильтр «${filter.name}» удалён`);
+      await loadAll();
     } catch (err) {
       message.error(err instanceof Error ? err.message : 'Ошибка удаления');
     }
@@ -93,6 +94,7 @@ export default function SavedFiltersSidebar({
   const handleToggleFav = async (filter: SavedFilter) => {
     try {
       await toggleFavorite(filter.id, !filter.isFavorite);
+      await loadAll();
     } catch (err) {
       message.error(err instanceof Error ? err.message : 'Ошибка');
     }
@@ -195,7 +197,7 @@ export default function SavedFiltersSidebar({
                       {f.isFavorite ? <StarFilled /> : <StarOutlined />}
                     </button>
                   </Tooltip>
-                  {f.permission === 'WRITE' && (
+                  {section.scopeKey === 'mine' && (
                     <Tooltip title="Поделиться">
                       <button
                         type="button"
@@ -214,7 +216,7 @@ export default function SavedFiltersSidebar({
                       </button>
                     </Tooltip>
                   )}
-                  {f.permission === 'WRITE' && section.scopeKey === 'mine' && (
+                  {section.scopeKey === 'mine' && (
                     <Popconfirm
                       title="Удалить фильтр?"
                       onConfirm={() => handleDelete(f)}

--- a/frontend/src/components/search/SavedFiltersSidebar.tsx
+++ b/frontend/src/components/search/SavedFiltersSidebar.tsx
@@ -1,0 +1,248 @@
+/**
+ * TTSRH-1 PR-13 — SavedFiltersSidebar.
+ *
+ * Левая колонка SearchPage с 5 списками:
+ *   • Мои (scope='mine')
+ *   • Избранные (scope='favorite')
+ *   • Общедоступные (scope='public')
+ *   • Поделены со мной (scope='shared')
+ *   • Недавние (client-side compute на mine + lastUsedAt DESC)
+ *
+ * Публичный API:
+ *   • onSelectFilter(filter) — родитель навигирует на `/search/saved/:id` или
+ *     заливает JQL в editor. Мы не дёргаем роутер сами чтобы sidebar оставался
+ *     re-usable вне SearchPage.
+ *   • onOpenShare(filter) — открыть FilterShareModal.
+ *   • currentJql — чтобы подсветить соответствующий фильтр в списке (match by jql).
+ *
+ * Инварианты:
+ *   • Mount → `loadAll()` на store.
+ *   • Favorite-toggle — inline кнопка-звезда, не открывает модалку.
+ *   • Delete — через `Popconfirm` (AntD), confirm → remove + reload.
+ *   • Каждый section collapsible через `<details>`/`<summary>` для минимальной
+ *     зависимости (no AntD Collapse).
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { Popconfirm, Tooltip, message } from 'antd';
+import { StarFilled, StarOutlined, ShareAltOutlined, DeleteOutlined } from '@ant-design/icons';
+
+import type { SavedFilter } from '../../api/savedFilters';
+import { useSavedFiltersStore } from '../../store/savedFilters.store';
+
+export interface SavedFiltersSidebarProps {
+  currentJql: string;
+  onSelectFilter: (filter: SavedFilter) => void;
+  onOpenShare: (filter: SavedFilter) => void;
+  isLight?: boolean;
+}
+
+interface Section {
+  key: string;
+  label: string;
+  scopeKey: 'mine' | 'favorite' | 'public' | 'shared' | 'recent';
+}
+
+const SECTIONS: Section[] = [
+  { key: 'mine', label: 'Мои', scopeKey: 'mine' },
+  { key: 'favorite', label: 'Избранные', scopeKey: 'favorite' },
+  { key: 'public', label: 'Общедоступные', scopeKey: 'public' },
+  { key: 'shared', label: 'Поделены со мной', scopeKey: 'shared' },
+  { key: 'recent', label: 'Недавние', scopeKey: 'recent' },
+];
+
+export default function SavedFiltersSidebar({
+  currentJql,
+  onSelectFilter,
+  onOpenShare,
+  isLight = false,
+}: SavedFiltersSidebarProps) {
+  const store = useSavedFiltersStore();
+  const { loading, error, toggleFavorite, remove, loadAll } = store;
+  const [openSections, setOpenSections] = useState<Set<string>>(new Set(['mine', 'favorite']));
+
+  useEffect(() => {
+    loadAll().catch(() => undefined);
+  }, [loadAll]);
+
+  const c = useMemo(
+    () =>
+      isLight
+        ? { text: '#1F2328', muted: '#656D76', border: '#D0D7DE', activeBg: '#EFF4FF', activeBorder: '#C9D6F8', hover: '#F6F8FA' }
+        : { text: '#E2E8F8', muted: '#8B949E', border: '#21262D', activeBg: '#1A2040', activeBorder: '#2A3260', hover: '#1A1F2E' },
+    [isLight],
+  );
+
+  const toggleSection = (key: string) => {
+    setOpenSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const handleDelete = async (filter: SavedFilter) => {
+    try {
+      await remove(filter.id);
+      message.success(`Фильтр «${filter.name}» удалён`);
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : 'Ошибка удаления');
+    }
+  };
+
+  const handleToggleFav = async (filter: SavedFilter) => {
+    try {
+      await toggleFavorite(filter.id, !filter.isFavorite);
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : 'Ошибка');
+    }
+  };
+
+  const sectionData = (scope: Section['scopeKey']): SavedFilter[] => {
+    if (scope === 'mine') return store.mine;
+    if (scope === 'favorite') return store.favorite;
+    if (scope === 'public') return store.public;
+    if (scope === 'shared') return store.shared;
+    return store.recent;
+  };
+
+  return (
+    <div data-testid="saved-filters-sidebar" style={{ display: 'flex', flexDirection: 'column', gap: 8, fontSize: 12 }}>
+      {loading && <div style={{ color: c.muted }}>Загрузка…</div>}
+      {error && <div style={{ color: '#e5484d', fontSize: 11 }}>Ошибка: {error}</div>}
+      {SECTIONS.map((section) => {
+        const items = sectionData(section.scopeKey);
+        const isOpen = openSections.has(section.key);
+        return (
+          <section key={section.key} data-testid={`sidebar-section-${section.key}`}>
+            <button
+              type="button"
+              onClick={() => toggleSection(section.key)}
+              aria-expanded={isOpen}
+              style={{
+                display: 'flex',
+                width: '100%',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                background: 'transparent',
+                border: 'none',
+                color: c.text,
+                fontWeight: 600,
+                fontSize: 12,
+                padding: '4px 0',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              <span>{section.label} <span style={{ color: c.muted, fontWeight: 400 }}>({items.length})</span></span>
+              <span style={{ color: c.muted, fontSize: 10 }}>{isOpen ? '▾' : '▸'}</span>
+            </button>
+            {isOpen && items.length === 0 && (
+              <div style={{ color: c.muted, padding: '4px 6px', fontSize: 11 }}>— пусто —</div>
+            )}
+            {isOpen && items.map((f) => {
+              const isActive = f.jql === currentJql && currentJql.length > 0;
+              return (
+                <div
+                  key={f.id}
+                  data-testid={`sidebar-filter-${f.id}`}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 4,
+                    padding: '4px 6px',
+                    border: `1px solid ${isActive ? c.activeBorder : 'transparent'}`,
+                    background: isActive ? c.activeBg : 'transparent',
+                    borderRadius: 4,
+                    marginBottom: 2,
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => onSelectFilter(f)}
+                    title={f.description ?? f.jql}
+                    style={{
+                      flex: 1,
+                      textAlign: 'left',
+                      background: 'transparent',
+                      border: 'none',
+                      color: c.text,
+                      fontSize: 12,
+                      padding: 0,
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {f.name}
+                  </button>
+                  <Tooltip title={f.isFavorite ? 'Убрать из избранного' : 'В избранное'}>
+                    <button
+                      type="button"
+                      aria-label="favorite"
+                      onClick={() => handleToggleFav(f)}
+                      style={{
+                        background: 'transparent',
+                        border: 'none',
+                        color: f.isFavorite ? '#F6C24C' : c.muted,
+                        cursor: 'pointer',
+                        padding: 2,
+                        fontSize: 12,
+                      }}
+                    >
+                      {f.isFavorite ? <StarFilled /> : <StarOutlined />}
+                    </button>
+                  </Tooltip>
+                  {f.permission === 'WRITE' && (
+                    <Tooltip title="Поделиться">
+                      <button
+                        type="button"
+                        aria-label="share"
+                        onClick={() => onOpenShare(f)}
+                        style={{
+                          background: 'transparent',
+                          border: 'none',
+                          color: c.muted,
+                          cursor: 'pointer',
+                          padding: 2,
+                          fontSize: 12,
+                        }}
+                      >
+                        <ShareAltOutlined />
+                      </button>
+                    </Tooltip>
+                  )}
+                  {f.permission === 'WRITE' && section.scopeKey === 'mine' && (
+                    <Popconfirm
+                      title="Удалить фильтр?"
+                      onConfirm={() => handleDelete(f)}
+                      okText="Удалить"
+                      cancelText="Отмена"
+                    >
+                      <button
+                        type="button"
+                        aria-label="delete"
+                        style={{
+                          background: 'transparent',
+                          border: 'none',
+                          color: c.muted,
+                          cursor: 'pointer',
+                          padding: 2,
+                          fontSize: 12,
+                        }}
+                      >
+                        <DeleteOutlined />
+                      </button>
+                    </Popconfirm>
+                  )}
+                </div>
+              );
+            })}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -23,11 +23,15 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { searchIssues, type IssueSearchRow } from '../api/search';
-import { getSavedFilter, markSavedFilterUsed } from '../api/savedFilters';
+import { getSavedFilter, markSavedFilterUsed, type SavedFilter } from '../api/savedFilters';
 import BasicFilterBuilder from '../components/search/BasicFilterBuilder';
 import { canBasicize } from '../components/search/basic-filter-model';
 import FilterModeToggle, { type FilterMode } from '../components/search/FilterModeToggle';
+import FilterShareModal from '../components/search/FilterShareModal';
 import JqlEditor from '../components/search/JqlEditor.lazy';
+import SaveFilterModal from '../components/search/SaveFilterModal';
+import SavedFiltersSidebar from '../components/search/SavedFiltersSidebar';
+import { useSavedFiltersStore } from '../store/savedFilters.store';
 import { useThemeStore } from '../store/theme.store';
 import { useSearchUrlState } from './search/useSearchUrlState';
 import { useJqlValidation } from './search/useJqlValidation';
@@ -46,6 +50,28 @@ export default function SearchPage() {
   const { errors: inlineErrors, isValidating } = useJqlValidation(jqlDraft);
   const [filterMode, setFilterMode] = useState<FilterMode>('advanced');
   const basicCheck = useMemo(() => canBasicize(jqlDraft), [jqlDraft]);
+  const [saveModalOpen, setSaveModalOpen] = useState(false);
+  const [saveModalInitial, setSaveModalInitial] = useState<SavedFilter | null>(null);
+  const [shareModalFilter, setShareModalFilter] = useState<SavedFilter | null>(null);
+  const loadAllSavedFilters = useSavedFiltersStore((s) => s.loadAll);
+
+  const openSaveModal = useCallback(() => {
+    setSaveModalInitial(null);
+    setSaveModalOpen(true);
+  }, []);
+
+  // Ctrl/Cmd+S → Save. preventDefault чтобы не триггерить browser "Save Page".
+  useEffect(() => {
+    function onKey(ev: KeyboardEvent) {
+      if ((ev.ctrlKey || ev.metaKey) && ev.key.toLowerCase() === 's') {
+        ev.preventDefault();
+        if (!jqlDraft.trim()) return;
+        openSaveModal();
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [jqlDraft, openSaveModal]);
   // Auto-switch to Advanced if current JQL can't be basicized (e.g. user loaded a
   // saved filter with OR/NOT). Reverse not enforced — user may manually switch.
   useEffect(() => {
@@ -142,22 +168,51 @@ export default function SearchPage() {
           alignItems: 'stretch',
         }}
       >
-        {/* Column 1 — Sidebar (PR-13: saved filters list) */}
+        {/* Column 1 — SavedFiltersSidebar */}
         <aside
           data-testid="search-sidebar"
           style={{
             background: c.panel,
             border: `1px solid ${c.border}`,
             borderRadius: 8,
-            padding: 16,
+            padding: 12,
             minHeight: 480,
-            color: c.t3,
+            color: c.t1,
+            overflowY: 'auto',
+            maxHeight: 'calc(100vh - 120px)',
           }}
         >
-          <div style={{ fontWeight: 600, color: c.t1, marginBottom: 6, fontSize: 13 }}>Мои фильтры</div>
-          <div style={{ fontSize: 12 }}>
-            Список сохранённых фильтров появится в PR-13 (§13.6 ТЗ).
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+            <div style={{ fontWeight: 600, color: c.t1, fontSize: 13 }}>Фильтры</div>
+            <button
+              type="button"
+              onClick={openSaveModal}
+              disabled={!jqlDraft.trim()}
+              title={jqlDraft.trim() ? 'Сохранить (Ctrl+S)' : 'Введите JQL для сохранения'}
+              data-testid="sidebar-save-filter"
+              style={{
+                background: jqlDraft.trim() ? c.acc : 'transparent',
+                color: jqlDraft.trim() ? '#fff' : c.t3,
+                border: `1px solid ${jqlDraft.trim() ? c.acc : c.border}`,
+                borderRadius: 5,
+                padding: '3px 10px',
+                fontSize: 11,
+                cursor: jqlDraft.trim() ? 'pointer' : 'not-allowed',
+                fontFamily: 'inherit',
+              }}
+            >
+              + Сохранить
+            </button>
           </div>
+          <SavedFiltersSidebar
+            currentJql={state.jql}
+            isLight={isLight}
+            onSelectFilter={(f) => {
+              updateUrl({ jql: f.jql, columns: f.columns ?? [], page: 1 }, { push: true });
+              markSavedFilterUsed(f.id).catch(() => undefined);
+            }}
+            onOpenShare={(f) => setShareModalFilter(f)}
+          />
         </aside>
 
         {/* Column 2 — Main (editor + results) */}
@@ -294,6 +349,33 @@ export default function SearchPage() {
           Preview задачи появится в PR-14.
         </aside>
       </div>
+
+      <SaveFilterModal
+        open={saveModalOpen}
+        onClose={() => {
+          setSaveModalOpen(false);
+          void loadAllSavedFilters(); // CLAUDE.md rule: onClose → reload parent data
+        }}
+        onSaved={(f) => {
+          setSaveModalOpen(false);
+          updateUrl({ jql: f.jql, columns: f.columns ?? [], page: 1 }, { push: false });
+          void loadAllSavedFilters();
+        }}
+        initial={saveModalInitial}
+        currentJql={jqlDraft}
+      />
+      <FilterShareModal
+        open={shareModalFilter !== null}
+        filter={shareModalFilter}
+        onClose={() => {
+          setShareModalFilter(null);
+          void loadAllSavedFilters();
+        }}
+        onSaved={() => {
+          setShareModalFilter(null);
+          void loadAllSavedFilters();
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -61,13 +61,19 @@ export default function SearchPage() {
   }, []);
 
   // Ctrl/Cmd+S → Save. preventDefault чтобы не триггерить browser "Save Page".
+  // Skip when focus is inside another form control (AntD modal inputs etc.) —
+  // исключение: CM6 JqlEditor (`.cm-editor`), там Ctrl+S должен сохранять.
   useEffect(() => {
     function onKey(ev: KeyboardEvent) {
-      if ((ev.ctrlKey || ev.metaKey) && ev.key.toLowerCase() === 's') {
-        ev.preventDefault();
-        if (!jqlDraft.trim()) return;
-        openSaveModal();
-      }
+      if (!(ev.ctrlKey || ev.metaKey) || ev.key.toLowerCase() !== 's') return;
+      const el = document.activeElement as HTMLElement | null;
+      const tag = el?.tagName?.toLowerCase();
+      const isEditable = el?.getAttribute('contenteditable') === 'true';
+      const isCmEditor = el?.closest('.cm-editor') != null;
+      if (!isCmEditor && (tag === 'input' || tag === 'textarea' || tag === 'select' || isEditable)) return;
+      ev.preventDefault();
+      if (!jqlDraft.trim()) return;
+      openSaveModal();
     }
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
@@ -188,6 +194,7 @@ export default function SearchPage() {
               type="button"
               onClick={openSaveModal}
               disabled={!jqlDraft.trim()}
+              aria-label="Сохранить текущий фильтр"
               title={jqlDraft.trim() ? 'Сохранить (Ctrl+S)' : 'Введите JQL для сохранения'}
               data-testid="sidebar-save-filter"
               style={{

--- a/frontend/src/store/savedFilters.store.ts
+++ b/frontend/src/store/savedFilters.store.ts
@@ -1,0 +1,139 @@
+/**
+ * TTSRH-1 PR-13 — Zustand store для SavedFilters UI.
+ *
+ * Публичный API:
+ *   • state: `{mine, favorite, public, shared, recent, loading, error}` — 5 scope'ов
+ *     из §5.7 ТЗ + loading/error для UX.
+ *   • load(scope?) — fetch one or all scopes.
+ *   • loadAll() — параллельный fetch всех 5 scope'ов.
+ *   • create/update/delete/toggleFavorite/share — proxy к api/savedFilters.
+ *   • «Недавние» вычисляются из `mine` сортировкой по `lastUsedAt DESC` (client-side —
+ *     backend не имеет специального scope'а `recent`). Пустой `lastUsedAt` кладётся
+ *     в конец.
+ *
+ * Инварианты:
+ *   • Все мутации завершаются `loadAll()` чтобы состояние 5 списков было
+ *     согласованным (filter может переехать из `mine` в `shared` после share).
+ *   • Ошибки сохраняются в `error`, но не throw'ются — UI решает как показывать.
+ *   • `scope='recent'` не проходит в backend, он вычисляется локально.
+ */
+
+import { create } from 'zustand';
+
+import {
+  createSavedFilter,
+  deleteSavedFilter,
+  listSavedFilters,
+  setSavedFilterFavorite,
+  shareSavedFilter,
+  updateSavedFilter,
+  type CreateSavedFilterInput,
+  type SavedFilter,
+  type SavedFilterScope,
+  type ShareSavedFilterInput,
+  type UpdateSavedFilterInput,
+} from '../api/savedFilters';
+
+export type SidebarScope = 'mine' | 'favorite' | 'public' | 'shared' | 'recent';
+
+interface SavedFiltersState {
+  mine: SavedFilter[];
+  favorite: SavedFilter[];
+  public: SavedFilter[];
+  shared: SavedFilter[];
+  /** Derived client-side from `mine` sorted by lastUsedAt DESC (null last). */
+  recent: SavedFilter[];
+  loading: boolean;
+  error: string | null;
+
+  load: (scope: SavedFilterScope) => Promise<void>;
+  loadAll: () => Promise<void>;
+  create: (input: CreateSavedFilterInput) => Promise<SavedFilter>;
+  update: (id: string, input: UpdateSavedFilterInput) => Promise<SavedFilter>;
+  remove: (id: string) => Promise<void>;
+  toggleFavorite: (id: string, value: boolean) => Promise<void>;
+  share: (id: string, input: ShareSavedFilterInput) => Promise<void>;
+}
+
+function computeRecent(mine: SavedFilter[]): SavedFilter[] {
+  return [...mine]
+    .sort((a, b) => {
+      const at = a.lastUsedAt ? new Date(a.lastUsedAt).getTime() : -Infinity;
+      const bt = b.lastUsedAt ? new Date(b.lastUsedAt).getTime() : -Infinity;
+      return bt - at;
+    })
+    .slice(0, 10);
+}
+
+export const useSavedFiltersStore = create<SavedFiltersState>((set, get) => ({
+  mine: [],
+  favorite: [],
+  public: [],
+  shared: [],
+  recent: [],
+  loading: false,
+  error: null,
+
+  load: async (scope) => {
+    set({ loading: true, error: null });
+    try {
+      const data = await listSavedFilters(scope);
+      const patch: Partial<SavedFiltersState> = { [scope]: data };
+      if (scope === 'mine') patch.recent = computeRecent(data);
+      set({ ...patch, loading: false });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Ошибка загрузки';
+      set({ loading: false, error: msg });
+    }
+  },
+
+  loadAll: async () => {
+    set({ loading: true, error: null });
+    try {
+      const [mine, favorite, pub, shared] = await Promise.all([
+        listSavedFilters('mine'),
+        listSavedFilters('favorite'),
+        listSavedFilters('public'),
+        listSavedFilters('shared'),
+      ]);
+      set({
+        mine,
+        favorite,
+        public: pub,
+        shared,
+        recent: computeRecent(mine),
+        loading: false,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Ошибка загрузки';
+      set({ loading: false, error: msg });
+    }
+  },
+
+  create: async (input) => {
+    const created = await createSavedFilter(input);
+    await get().loadAll();
+    return created;
+  },
+
+  update: async (id, input) => {
+    const updated = await updateSavedFilter(id, input);
+    await get().loadAll();
+    return updated;
+  },
+
+  remove: async (id) => {
+    await deleteSavedFilter(id);
+    await get().loadAll();
+  },
+
+  toggleFavorite: async (id, value) => {
+    await setSavedFilterFavorite(id, value);
+    await get().loadAll();
+  },
+
+  share: async (id, input) => {
+    await shareSavedFilter(id, input);
+    await get().loadAll();
+  },
+}));

--- a/frontend/src/store/savedFilters.store.ts
+++ b/frontend/src/store/savedFilters.store.ts
@@ -65,7 +65,7 @@ function computeRecent(mine: SavedFilter[]): SavedFilter[] {
     .slice(0, 10);
 }
 
-export const useSavedFiltersStore = create<SavedFiltersState>((set, get) => ({
+export const useSavedFiltersStore = create<SavedFiltersState>((set) => ({
   mine: [],
   favorite: [],
   public: [],
@@ -106,34 +106,32 @@ export const useSavedFiltersStore = create<SavedFiltersState>((set, get) => ({
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Ошибка загрузки';
-      set({ loading: false, error: msg });
+      // Clear lists on failure so stale data isn't shown next to the error banner.
+      set({ loading: false, error: msg, mine: [], favorite: [], public: [], shared: [], recent: [] });
     }
   },
 
+  // Mutations return the API response but DO NOT call loadAll — the caller
+  // (modal's onSaved / onClose) is the single refresh trigger per CLAUDE.md
+  // modal-refresh rule. This eliminates double-fetch (8 parallel HTTP roundtrips
+  // per save action).
   create: async (input) => {
-    const created = await createSavedFilter(input);
-    await get().loadAll();
-    return created;
+    return await createSavedFilter(input);
   },
 
   update: async (id, input) => {
-    const updated = await updateSavedFilter(id, input);
-    await get().loadAll();
-    return updated;
+    return await updateSavedFilter(id, input);
   },
 
   remove: async (id) => {
     await deleteSavedFilter(id);
-    await get().loadAll();
   },
 
   toggleFavorite: async (id, value) => {
     await setSavedFilterFavorite(id, value);
-    await get().loadAll();
   },
 
   share: async (id, input) => {
     await shareSavedFilter(id, input);
-    await get().loadAll();
   },
 }));

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,72 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.40**
+**Last version: 2.41**
+
+---
+
+## [2.41] [2026-04-21] feat(frontend): TTSRH-1 PR-13 — SavedFiltersSidebar + Save/Share modals + Zustand store
+
+**PR:** (to be filled after push)
+**Ветка:** `ttsrh-1/saved-filters-ui`
+
+### Что было
+
+После PR-12 SearchPage уже имел JqlEditor + BasicFilterBuilder, но backend'овые фильтры (CRUD + share из PR-7) не имели UI. Левая колонка была placeholder'ом «Список появится в PR-13». Пользователи не могли сохранять, делить и переиспользовать запросы.
+
+### Что теперь
+
+Полноценный UI для SavedFilters c 5 списками + 2 модалками + Ctrl+S:
+
+- **`frontend/src/store/savedFilters.store.ts`** (~130L) — Zustand-стор:
+  - 5 scope'ов: `mine / favorite / public / shared / recent` (recent — client-side compute на mine sorted by lastUsedAt DESC, top 10).
+  - `load(scope)` / `loadAll()` (параллельный Promise.all).
+  - `create / update / remove / toggleFavorite / share` — тонкие обёртки над `api/savedFilters`, каждая завершается `loadAll()` для синхронизации между списками (filter может переехать из mine → shared → public после изменения visibility).
+  - Ошибки сохраняются в `error`, не throw'ятся — UI решает как показывать.
+- **`frontend/src/components/search/SaveFilterModal.tsx`** (~170L) — Ant Design Modal с Form-validation:
+  - Поля: name (required ≤200), description (≤2000), jql (readonly preview), visibility (Select PRIVATE/SHARED/PUBLIC), isFavorite (Switch).
+  - Обрабатывает create и update через `initial` prop.
+  - PUBLIC → Alert-warning (R11 из §5.9).
+  - Favorite toggling — отдельный endpoint, вызывается только если значение изменилось.
+  - `onClose` / `onCancel` / backdrop / Esc → все триггерят parent `load()` (CLAUDE.md).
+- **`frontend/src/components/search/FilterShareModal.tsx`** (~160L) — управление visibility + sharing:
+  - Visibility switch (PRIVATE/SHARED/PUBLIC).
+  - При SHARED — multi-select пользователей из `/api/users` + permission READ/WRITE.
+  - Copy-link кнопка: `${origin}/search/saved/:id` → `navigator.clipboard.writeText` + AntD `message.success`.
+  - Replace-semantics: visibility → update(), затем `share({users, permission})`.
+- **`frontend/src/components/search/SavedFiltersSidebar.tsx`** (~220L) — левая колонка:
+  - 5 collapsible sections через native `<details>`-style buttons с `aria-expanded`.
+  - Per-item actions: favorite toggle (⭐), share (если permission=WRITE), delete (Popconfirm, только для mine).
+  - Active highlight: `jql === currentJql` подсвечивает текущий фильтр.
+  - Tooltip на item — показывает description || jql.
+- **`frontend/src/pages/SearchPage.tsx`** — integration:
+  - Placeholder-секция заменена на `<SavedFiltersSidebar>` + кнопка «+ Сохранить».
+  - `saveModalOpen / shareModalFilter` — local state модалок.
+  - `Ctrl/Cmd+S` hotkey → openSaveModal (preventDefault на browser "Save Page"). Игнорируется на пустом JQL.
+  - Select-filter из sidebar → `updateUrl` + fire-and-forget `markSavedFilterUsed`.
+  - Все onClose/onSaved вызывают `loadAllSavedFilters()` — CLAUDE.md FR-18.
+
+### Изменения
+
+- `frontend/src/store/savedFilters.store.ts` — новый.
+- `frontend/src/components/search/SaveFilterModal.tsx` — новый.
+- `frontend/src/components/search/FilterShareModal.tsx` — новый.
+- `frontend/src/components/search/SavedFiltersSidebar.tsx` — новый.
+- `frontend/src/pages/SearchPage.tsx` — sidebar integration + modals + Ctrl+S hotkey.
+- `docs/tz/TTSRH-1.md` §13.6/§13.9 — статус PR-13 → ✅ Done.
+
+### Влияние на prod
+
+Под `VITE_FEATURES_ADVANCED_SEARCH=false` — без изменений. При `=true`:
+- Sidebar подгружает 5 списков (4 backend + 1 client-compute) при mount.
+- Ctrl+S сохраняет текущий JQL.
+- Share-флоу даёт copy-link и управление визиблити/members.
+
+### Проверки
+
+- `npx tsc --noEmit` — чисто
+- `npm run lint` — 0 errors, 0 new warnings
+- `npm run build` — чисто, 4.52s. Main bundle +3.9KB gzip (AntD Modal/Form/Select уже в bundle). JqlEditor chunk unchanged.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Zustand store** (`savedFilters.store.ts`): 5 scope'ов (mine/favorite/public/shared/recent — recent client-computed из `mine` по `lastUsedAt DESC`). `loadAll()` параллельно fetchит 4 backend scope'а. Ошибки clear'ят все списки — no stale-data ambiguity.
- **SaveFilterModal** (AntD Form): name/description/visibility/isFavorite, PUBLIC warning R11, create+update через `initial` prop. `useEffect dep [open, initial?.id]` — parent re-renders не нукают form state mid-edit.
- **FilterShareModal**: visibility switch, multi-select users (с `loading` indicator), permission READ/WRITE, copy-link через `navigator.clipboard`.
- **SavedFiltersSidebar**: 5 collapsible sections, per-item actions (favorite ⭐, share, delete Popconfirm — только для owner'а), active-highlight по `jql === currentJql`.
- **SearchPage integration**: Placeholder заменён на sidebar. Ctrl/Cmd+S → SaveFilterModal (с guard'ом против input/textarea/select focus, исключая CM6 `.cm-editor`). "+ Сохранить" button в sidebar header. Все modals onClose/onSaved → `loadAllSavedFilters()` (CLAUDE.md FR-18).
- **AntApp wrapper**: `<App>` обёртка вокруг ConfigProvider, чтобы static `message.*` работал в AntD v5.

## Pre-push review counts

🟠 × 3 (share-button owner-guard, AntApp wrapper, loadAll clear on error) · 🟡 × 4 (useEffect id-dep, users-loading state, Ctrl+S focus guard, store мутации без внутреннего loadAll). Все applied.

## Test plan

Frontend CI = lint + typecheck + build:
- [x] `npx tsc --noEmit` — чисто.
- [x] `npm run lint` — 0 errors (8 pre-existing warnings).
- [x] `npm run build` — чисто, 4.51s. Main bundle +3.9KB gzip. JqlEditor chunk unchanged.

## Ручной smoke (expected)

- `/search` с `VITE_FEATURES_ADVANCED_SEARCH=true`: sidebar показывает 5 sections, lazy-fetched при mount.
- Ctrl+S на пустом JQL → no-op. На non-empty → SaveFilterModal.
- Save с visibility=PUBLIC → Alert warning, save работает.
- Share-icon виден только для mine-фильтров.
- FilterShareModal: копировать ссылку → clipboard.writeText + success toast.
- Delete через Popconfirm → confirmation step → reload sidebar.

## Зависимости

- Блокирующие: PR-5..PR-12 — все merged ✅.
- Блокирует: PR-14 (ResultsTable + ColumnConfigurator + BulkActions + ExportMenu).

## Плановая дельта

~904 LoC (store + 3 компонента + integration + docs), в пределах §8 эстимата (~8ч).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
