### PR TITLE
feat(checkpoint): TTSRH-1 PR-16 — Checkpoint engine TTQL branch + error handling

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts tests/search-functions.unit.test.ts tests/search-validator.unit.test.ts tests/search-compiler.unit.test.ts tests/search-pipeline-fuzz.unit.test.ts tests/search-suggest.unit.test.ts tests/checkpoint-dto.unit.test.ts",
+    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts tests/search-functions.unit.test.ts tests/search-validator.unit.test.ts tests/search-compiler.unit.test.ts tests/search-pipeline-fuzz.unit.test.ts tests/search-suggest.unit.test.ts tests/checkpoint-dto.unit.test.ts tests/checkpoint-engine-ttql.unit.test.ts",
     "lint": "eslint src/ --ext .ts",
     "format": "prettier --write 'src/**/*.ts'",
     "mcp": "tsx src/mcp/server.ts"

--- a/backend/src/modules/releases/checkpoints/checkpoint-engine.service.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint-engine.service.ts
@@ -5,7 +5,7 @@
 // See docs/tz/TTMP-160.md §12.4 for the state machine and risk formula.
 
 import { createHash } from 'node:crypto';
-import type { CheckpointState, CheckpointWeight } from '@prisma/client';
+import type { CheckpointConditionMode, CheckpointState, CheckpointWeight } from '@prisma/client';
 
 import type {
   CheckpointCriterion,
@@ -27,6 +27,18 @@ export interface CheckpointEvaluationInput {
   warningDays: number;
   issues: EvaluationIssue[];
   context: EvaluationContext;
+
+  // TTSRH-1 PR-16: TTQL branch inputs. `conditionMode` defaults to 'STRUCTURED'
+  // for backward-compat (FR-25) — older callers don't need to pass it.
+  conditionMode?: CheckpointConditionMode;
+  // Set of issue.id's that pass the TTQL snapshot query. Caller pre-computes
+  // this via checkpoint-ttql-evaluator.service.ts (Prisma + compiler). `null`
+  // means "TTQL not evaluated" — valid for STRUCTURED mode, unexpected for
+  // TTQL/COMBINED modes (treated as empty → all applicable issues fail).
+  ttqlMatchedIds?: ReadonlySet<string> | null;
+  // If non-null, engine emits state=ERROR + a single TTQL_ERROR violation and
+  // skips normal evaluation. Set by the resolver on compile/exec failure (R16).
+  ttqlError?: string | null;
 }
 
 export interface CheckpointEvaluationResult {
@@ -46,36 +58,95 @@ export function evaluateCheckpoint(
   input: CheckpointEvaluationInput,
   now: Date,
 ): CheckpointEvaluationResult {
+  const mode: CheckpointConditionMode = input.conditionMode ?? 'STRUCTURED';
+
+  // ─── TTQL error fast-path (FR-31) ─────────────────────────────────────────
+  // Compile/exec failure → state=ERROR + single synthetic TTQL_ERROR violation.
+  // Keeps violationsHash stable (one entry, deterministic).
+  if (input.ttqlError != null && input.ttqlError.length > 0) {
+    const errViolations: CheckpointViolation[] = [
+      {
+        issueId: '',
+        issueKey: '',
+        issueTitle: '',
+        reason: input.ttqlError,
+        criterionType: 'TTQL_ERROR',
+      },
+    ];
+    return {
+      state: 'ERROR' as CheckpointState,
+      isWarning: false,
+      applicableIssueIds: [],
+      passedIssueIds: [],
+      violations: errViolations,
+      violationsHash: computeViolationsHash(errViolations),
+      breakdown: { applicable: 0, passed: 0, violated: 1 },
+    };
+  }
+
   const applicableIssueIds: string[] = [];
   const passedIssueIds: string[] = [];
   const violations: CheckpointViolation[] = [];
+  const ttqlSet = input.ttqlMatchedIds ?? null;
 
   for (const issue of input.issues) {
-    const results = input.criteria.map((c) => evaluateCriterion(c, issue, input.context));
-    const applicableResults = results.filter((r) => r.applicable);
-    if (applicableResults.length === 0) continue;
-
-    applicableIssueIds.push(issue.id);
-
-    const failed = applicableResults.filter((r) => r.applicable && r.passed === false) as Array<
-      Extract<ReturnType<typeof evaluateCriterion>, { applicable: true; passed: false }>
-    >;
-
-    if (failed.length === 0) {
-      passedIssueIds.push(issue.id);
-      continue;
+    // ─── STRUCTURED & COMBINED: run structured criteria first ───────────────
+    let structuredPassed: boolean | 'not-applicable' = 'not-applicable';
+    if (mode === 'STRUCTURED' || mode === 'COMBINED') {
+      const results = input.criteria.map((c) => evaluateCriterion(c, issue, input.context));
+      const applicableResults = results.filter((r) => r.applicable);
+      if (applicableResults.length === 0) {
+        // Issue not subject to structured criteria; for STRUCTURED this skips it
+        // entirely. For COMBINED we still consider TTQL applicability below.
+        if (mode === 'STRUCTURED') continue;
+      } else {
+        const failed = applicableResults.filter((r) => r.applicable && r.passed === false) as Array<
+          Extract<ReturnType<typeof evaluateCriterion>, { applicable: true; passed: false }>
+        >;
+        structuredPassed = failed.length === 0;
+        if (failed.length > 0) {
+          // Structured criteria failed — record violation (reason preserves detail).
+          violations.push({
+            issueId: issue.id,
+            issueKey: issue.key,
+            issueTitle: issue.title,
+            reason: failed.map((f) => f.reason).join('; '),
+            criterionType: failed[0]!.criterionType,
+          });
+          applicableIssueIds.push(issue.id);
+          // For STRUCTURED short-circuit; for COMBINED skip TTQL check (already
+          // failed — structured result wins and we avoid duplicate violation).
+          continue;
+        }
+        applicableIssueIds.push(issue.id);
+      }
     }
 
-    violations.push({
-      issueId: issue.id,
-      issueKey: issue.key,
-      issueTitle: issue.title,
-      // Concatenate human reasons so the violation row carries the full "why" in one field.
-      // criterionType takes the first failing criterion — good enough for filtering/analytics;
-      // the joined reason preserves detail.
-      reason: failed.map((f) => f.reason).join('; '),
-      criterionType: failed[0]!.criterionType,
-    });
+    // ─── TTQL / COMBINED: check TTQL set ─────────────────────────────────────
+    if (mode === 'TTQL' || mode === 'COMBINED') {
+      // For TTQL mode every issue is applicable; for COMBINED we may not have
+      // recorded applicability if structured criteria were n/a — do it now.
+      if (mode === 'TTQL') applicableIssueIds.push(issue.id);
+      else if (mode === 'COMBINED' && structuredPassed === 'not-applicable') {
+        applicableIssueIds.push(issue.id);
+      }
+
+      const ttqlOk = ttqlSet !== null && ttqlSet.has(issue.id);
+      if (!ttqlOk) {
+        violations.push({
+          issueId: issue.id,
+          issueKey: issue.key,
+          issueTitle: issue.title,
+          reason: 'Issue does not match checkpoint TTQL condition',
+          criterionType: 'TTQL_MISMATCH',
+        });
+        continue;
+      }
+      passedIssueIds.push(issue.id);
+    } else {
+      // STRUCTURED-only path reaches here only for passed issues.
+      passedIssueIds.push(issue.id);
+    }
   }
 
   const state = computeState(violations.length, input.deadline, now);

--- a/backend/src/modules/releases/checkpoints/checkpoint-ttql-evaluator.service.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint-ttql-evaluator.service.ts
@@ -1,0 +1,149 @@
+/**
+ * TTSRH-1 PR-16 — async resolver для TTQL-ветки Checkpoint evaluator'а.
+ *
+ * Публичный API:
+ *   • resolveTtqlMatchedIds(ttqlSnapshot, context) — компилирует TTQL через
+ *     pipeline `/search/issues` (parse → validate → compile), применяет
+ *     compiled `where` + ограничение по issue-ids релиза, возвращает
+ *     `Set<issueId>` матчингов или `{error: string}` на фейл.
+ *
+ * Инварианты:
+ *   • Hard timeout 5с (R16): compile+exec вместе. Превышение → `{error: 'timeout'}`.
+ *   • Never throws — все ошибки парсера/компилятора/Prisma → `{error: ...}`.
+ *   • `now` детерминистичен per-tick — передаётся из scheduler'а, чтобы все
+ *     чекпоинты одного evaluation-pass'а видели одинаковое «сейчас» (R18).
+ *   • `applicableIssueIds` — ограничение для Prisma query: `{id: {in: ids}}`
+ *     добавляется к compiled.where, чтобы TTQL проверял только issues текущего
+ *     релиза (не всей системы).
+ *   • Feature-flag FEATURES_CHECKPOINT_TTQL — caller'у (engine wrapper) решает
+ *     вызывать ли resolver; сам resolver флаг не читает.
+ */
+
+import type { Prisma } from '@prisma/client';
+
+import { prisma } from '../../../prisma/client.js';
+import { compile } from '../../search/search.compiler.js';
+import { executeCustomFieldPredicates } from '../../search/search.custom-field.executor.js';
+import { resolveFunctions } from '../../search/search.function-resolver.js';
+import { parse } from '../../search/search.parser.js';
+import { loadCustomFields } from '../../search/search.schema.loader.js';
+import { createValidatorContext, validate } from '../../search/search.validator.js';
+
+const TTQL_TIMEOUT_MS = 5_000;
+
+export interface TtqlEvaluationContext {
+  /** Fixed `now` for the evaluation tick — same across all checkpoints in a pass (R18). */
+  now: Date;
+  /** Issue-ids сырого пула релиза — compiler'овский where narrowed through `id IN (...)`. */
+  applicableIssueIds: readonly string[];
+  /** Accessible projects: scheduler runs unrestricted; UI preview endpoint uses caller's scope. */
+  accessibleProjectIds: readonly string[];
+}
+
+export interface TtqlEvaluationResult {
+  matchedIds: Set<string>;
+  error: string | null;
+}
+
+export async function resolveTtqlMatchedIds(
+  ttqlSnapshot: string,
+  ctx: TtqlEvaluationContext,
+): Promise<TtqlEvaluationResult> {
+  const empty: TtqlEvaluationResult = { matchedIds: new Set(), error: null };
+  const trimmed = ttqlSnapshot.trim();
+  if (trimmed.length === 0) return { ...empty, error: 'empty ttql snapshot' };
+  if (ctx.applicableIssueIds.length === 0) return empty;
+
+  try {
+    return await withTimeout(async () => {
+      // Phase 1: parse.
+      const parseResult = parse(trimmed);
+      if (!parseResult.ast || parseResult.errors.length > 0) {
+        return { matchedIds: new Set(), error: `parse: ${parseResult.errors[0]?.message ?? 'failed'}` };
+      }
+
+      // Phase 2: validate (variant=checkpoint).
+      const customFields = await loadCustomFields();
+      const validation = validate(
+        parseResult.ast,
+        createValidatorContext({ variant: 'checkpoint', customFields }),
+      );
+      if (!validation.valid) {
+        return {
+          matchedIds: new Set(),
+          error: `validate: ${validation.errors[0]?.message ?? 'failed'}`,
+        };
+      }
+
+      // Phase 3: resolve DB functions (`membersOf`, sprint/release shortcuts, etc.).
+      const resolved = await resolveFunctions(parseResult.ast, {
+        userId: '',
+        accessibleProjectIds: ctx.accessibleProjectIds,
+        now: ctx.now,
+        variant: 'checkpoint',
+      });
+
+      // Phase 4: compile to Prisma where.
+      const compiled = compile(parseResult.ast, {
+        accessibleProjectIds: ctx.accessibleProjectIds,
+        customFields,
+        resolved,
+        now: ctx.now,
+        variant: 'checkpoint',
+      });
+      if (compiled.errors.length > 0) {
+        return {
+          matchedIds: new Set(),
+          error: `compile: ${compiled.errors[0]?.message ?? 'failed'}`,
+        };
+      }
+
+      // Phase 5: execute CF predicates + scope to applicable issues.
+      const exec = await executeCustomFieldPredicates(
+        compiled.where,
+        compiled.customPredicates,
+        ctx.accessibleProjectIds,
+      );
+      if (exec.errors.length > 0) {
+        return { matchedIds: new Set(), error: `exec: ${exec.errors[0]?.message ?? 'failed'}` };
+      }
+
+      const scopedWhere: Prisma.IssueWhereInput = {
+        AND: [exec.where, { id: { in: [...ctx.applicableIssueIds] } }],
+      };
+
+      const rows = await prisma.issue.findMany({
+        where: scopedWhere,
+        select: { id: true },
+      });
+      return { matchedIds: new Set(rows.map((r) => r.id)), error: null };
+    }, TTQL_TIMEOUT_MS);
+  } catch (err) {
+    if (err instanceof TimeoutError) {
+      return { matchedIds: new Set(), error: `timeout after ${TTQL_TIMEOUT_MS}ms` };
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return { matchedIds: new Set(), error: `runtime: ${msg}` };
+  }
+}
+
+// ─── Internal timeout helper (mirrors search.service.withTimeout pattern) ───
+
+class TimeoutError extends Error {
+  constructor() {
+    super('TTQL evaluation timeout');
+    this.name = 'TtqlTimeoutError';
+  }
+}
+
+async function withTimeout<T>(fn: () => Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const deadline = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new TimeoutError()), ms);
+  });
+  try {
+    return await Promise.race([fn(), deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/backend/src/modules/releases/checkpoints/checkpoint-ttql-evaluator.service.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint-ttql-evaluator.service.ts
@@ -76,8 +76,11 @@ export async function resolveTtqlMatchedIds(
       }
 
       // Phase 3: resolve DB functions (`membersOf`, sprint/release shortcuts, etc.).
+      // userId: '' wrong — `currentUser()` branch в checkpoint variant should
+      // resolve to NULL per §5.12.4. Pass null explicitly; consumers должны
+      // treat empty-string as user identifier, not as "no user".
       const resolved = await resolveFunctions(parseResult.ast, {
-        userId: '',
+        userId: null,
         accessibleProjectIds: ctx.accessibleProjectIds,
         now: ctx.now,
         variant: 'checkpoint',

--- a/backend/src/modules/releases/checkpoints/checkpoint.types.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint.types.ts
@@ -20,12 +20,18 @@ export type CheckpointCriterion =
 
 export type CheckpointCriterionType = CheckpointCriterion['type'];
 
+// TTSRH-1 PR-16: `TTQL_MISMATCH` — issue didn't pass the TTQL snapshot filter.
+// `TTQL_ERROR` — compile/exec failure (state=ERROR per R16, FR-31). These are
+// not real CheckpointCriterion types; including them in the union keeps the
+// violation payload uniform across structured and TTQL paths (хэш стабилен).
+export type CheckpointViolationType = CheckpointCriterionType | 'TTQL_MISMATCH' | 'TTQL_ERROR';
+
 export interface CheckpointViolation {
   issueId: string;
   issueKey: string;
   issueTitle: string;
   reason: string;
-  criterionType: CheckpointCriterionType;
+  criterionType: CheckpointViolationType;
 }
 
 export interface CheckpointBreakdown {

--- a/backend/src/modules/releases/checkpoints/release-checkpoints.service.ts
+++ b/backend/src/modules/releases/checkpoints/release-checkpoints.service.ts
@@ -299,25 +299,27 @@ export async function recomputeForRelease(
 
   let updatedCount = 0;
   let unchangedCount = 0;
-  // Lazily loaded once if any checkpoint uses TTQL path — no cost for STRUCTURED-only releases.
+  // Lazily loaded once if any checkpoint actually fires the TTQL resolver —
+  // zero DB cost for STRUCTURED-only releases (which is every release in prod
+  // until FEATURES_CHECKPOINT_TTQL flips on).
   let ttqlProjectIds: string[] | null = null;
+  // Hoist out of the loop: every checkpoint operates on the same issue set.
+  const releaseIssueIds = loaded.issues.map((i) => i.id);
 
   for (const rc of existing) {
     const criteria = rc.criteriaSnapshot as unknown as CheckpointCriterion[];
-    // TTSRH-1 PR-16: resolve TTQL matches per-checkpoint if snapshot mode
-    // requires it. STRUCTURED fast-path returns {null, null, false} — original
-    // behavior preserved.
-    // Scheduler runs system-level — R3 scope is bypassed by the `id IN
-    // (applicableIssueIds)` narrowing the resolver applies (see
-    // checkpoint-ttql-evaluator.service.ts). We still need to feed the compiler
-    // a non-empty `accessibleProjectIds` list or the baseline scope becomes
-    // `projectId: {in: []}` (matches nothing). Fetch all project-ids lazily.
-    const projectIdsForScope = ttqlProjectIds ?? (ttqlProjectIds = await loadAllProjectIds());
+    // TTSRH-1 PR-16: only fetch project-list when this checkpoint would actually
+    // run the TTQL resolver — STRUCTURED snapshot + flag-off short-circuit.
+    const needsProjects =
+      rc.conditionModeSnapshot !== 'STRUCTURED' && features.checkpointTtql;
+    const projectIdsForScope = needsProjects
+      ? (ttqlProjectIds ?? (ttqlProjectIds = await loadAllProjectIds()))
+      : [];
     const ttqlOutcome = await maybeResolveTtqlIds(
       rc.ttqlSnapshot,
       rc.conditionModeSnapshot,
       now,
-      loaded.issues.map((i) => i.id),
+      releaseIssueIds,
       projectIdsForScope,
     );
     const result = evaluateCheckpoint(
@@ -948,13 +950,19 @@ async function reconcileViolationEvents(
   currentViolations: CheckpointViolation[],
   now: Date,
 ): Promise<void> {
+  // TTSRH-1 PR-16: filter out TTQL_ERROR synthetic violations (issueId: '').
+  // Они не привязаны к реальной задаче и не должны попадать в
+  // CheckpointViolationEvent — timeline будет врать о нарушениях задач.
+  // `state=ERROR` на ReleaseCheckpoint сам по себе — достаточный signal.
+  const realViolations = currentViolations.filter((v) => v.issueId !== '');
+
   const openEvents = await tx.checkpointViolationEvent.findMany({
     where: { releaseCheckpointId, resolvedAt: null },
     select: { id: true, issueId: true },
   });
   const openByIssue = new Map(openEvents.map((e) => [e.issueId, e.id]));
 
-  const currentIssueIds = new Set(currentViolations.map((v) => v.issueId));
+  const currentIssueIds = new Set(realViolations.map((v) => v.issueId));
 
   // Resolve events whose issue is no longer violating.
   const toResolve = openEvents.filter((e) => !currentIssueIds.has(e.issueId)).map((e) => e.id);
@@ -966,7 +974,7 @@ async function reconcileViolationEvents(
   }
 
   // Open a new event for each newly-violating issue that has no open event yet.
-  const toOpen = currentViolations.filter((v) => !openByIssue.has(v.issueId));
+  const toOpen = realViolations.filter((v) => !openByIssue.has(v.issueId));
   if (toOpen.length > 0) {
     await tx.checkpointViolationEvent.createMany({
       data: toOpen.map((v) => ({

--- a/backend/src/modules/releases/checkpoints/release-checkpoints.service.ts
+++ b/backend/src/modules/releases/checkpoints/release-checkpoints.service.ts
@@ -21,9 +21,44 @@ import type {
   ReleaseRisk,
 } from './checkpoint.types.js';
 import { computeReleaseRisk, evaluateCheckpoint } from './checkpoint-engine.service.js';
+import { resolveTtqlMatchedIds } from './checkpoint-ttql-evaluator.service.js';
 import type { LoadedRelease } from './evaluation-loader.service.js';
 import { loadEvaluationIssuesForRelease } from './evaluation-loader.service.js';
 import { notifyViolation } from './webhook-notifier.service.js';
+import { features } from '../../../shared/features.js';
+
+// TTSRH-1 PR-16: system-level project list for the TTQL scope filter. Loader
+// caches nothing — caller (recomputeForRelease) memoizes per-invocation.
+async function loadAllProjectIds(): Promise<string[]> {
+  const rows = await prisma.project.findMany({ select: { id: true } });
+  return rows.map((r) => r.id);
+}
+
+// TTSRH-1 PR-16: TTQL evaluation runs behind a separate sub-flag so core-поиск
+// (advancedSearch) can ship без TTQL-engine в prod до security review. Default
+// false — до явного включения TTQL/COMBINED checkpoints эффективно работают
+// как STRUCTURED: ttqlMatchedIds=null, получают violations на TTQL_MISMATCH.
+// Чтобы избежать этого, когда флаг off мы применяем existing `criteriaSnapshot`
+// path без учёта conditionMode.
+async function maybeResolveTtqlIds(
+  ttqlSnapshot: string | null,
+  conditionMode: 'STRUCTURED' | 'TTQL' | 'COMBINED',
+  now: Date,
+  applicableIssueIds: string[],
+  accessibleProjectIds: string[],
+): Promise<{ matchedIds: Set<string> | null; error: string | null; skipped: boolean }> {
+  if (conditionMode === 'STRUCTURED') return { matchedIds: null, error: null, skipped: false };
+  if (!features.checkpointTtql) return { matchedIds: null, error: null, skipped: true };
+  if (!ttqlSnapshot || ttqlSnapshot.trim().length === 0) {
+    return { matchedIds: null, error: 'missing ttql snapshot', skipped: false };
+  }
+  const res = await resolveTtqlMatchedIds(ttqlSnapshot, {
+    now,
+    applicableIssueIds,
+    accessibleProjectIds,
+  });
+  return { matchedIds: res.matchedIds, error: res.error, skipped: false };
+}
 
 const CACHE_TTL_SECONDS = 60;
 const cacheKey = (releaseId: string) => `release:${releaseId}:checkpoints`;
@@ -264,9 +299,27 @@ export async function recomputeForRelease(
 
   let updatedCount = 0;
   let unchangedCount = 0;
+  // Lazily loaded once if any checkpoint uses TTQL path — no cost for STRUCTURED-only releases.
+  let ttqlProjectIds: string[] | null = null;
 
   for (const rc of existing) {
     const criteria = rc.criteriaSnapshot as unknown as CheckpointCriterion[];
+    // TTSRH-1 PR-16: resolve TTQL matches per-checkpoint if snapshot mode
+    // requires it. STRUCTURED fast-path returns {null, null, false} — original
+    // behavior preserved.
+    // Scheduler runs system-level — R3 scope is bypassed by the `id IN
+    // (applicableIssueIds)` narrowing the resolver applies (see
+    // checkpoint-ttql-evaluator.service.ts). We still need to feed the compiler
+    // a non-empty `accessibleProjectIds` list or the baseline scope becomes
+    // `projectId: {in: []}` (matches nothing). Fetch all project-ids lazily.
+    const projectIdsForScope = ttqlProjectIds ?? (ttqlProjectIds = await loadAllProjectIds());
+    const ttqlOutcome = await maybeResolveTtqlIds(
+      rc.ttqlSnapshot,
+      rc.conditionModeSnapshot,
+      now,
+      loaded.issues.map((i) => i.id),
+      projectIdsForScope,
+    );
     const result = evaluateCheckpoint(
       {
         criteria,
@@ -274,6 +327,12 @@ export async function recomputeForRelease(
         warningDays: rc.checkpointType.warningDays,
         issues: loaded.issues,
         context: loaded.context,
+        // If TTQL skipped (flag off), fall back to STRUCTURED semantics даже если
+        // snapshot = TTQL/COMBINED — чтобы prod-prod не ломать existing evaluate
+        // result до включения FEATURES_CHECKPOINT_TTQL + UAT (см. PR-16 в ТЗ).
+        conditionMode: ttqlOutcome.skipped ? 'STRUCTURED' : rc.conditionModeSnapshot,
+        ttqlMatchedIds: ttqlOutcome.matchedIds,
+        ttqlError: ttqlOutcome.error,
       },
       now,
     );

--- a/backend/src/modules/search/search.functions.ts
+++ b/backend/src/modules/search/search.functions.ts
@@ -72,9 +72,13 @@ export const FUNCTION_REGISTRY: readonly FunctionDef[] = [
   { name: 'violatedcheckpointsof', args: [{ name: 'releaseKeyOrId', type: 'RELEASE', optional: false }, { name: 'typeName', type: 'TEXT', optional: true }], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Нарушения КТ в конкретном релизе.' },
   { name: 'checkpointsatrisk', args: [{ name: 'typeName', type: 'TEXT', optional: true }], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Задачи релизов с КТ в состоянии WARNING/OVERDUE/ERROR.' },
   { name: 'checkpointsinstate', args: [{ name: 'state', type: 'CHECKPOINT_STATE', optional: false }, { name: 'typeName', type: 'TEXT', optional: true }], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'MVP', availableIn: ['default', 'checkpoint'], description: 'Задачи, где КТ находится в заданном состоянии.' },
-  // Checkpoint-context-only (§5.12.4) — wiring in PR-15
-  { name: 'releaseplanneddate', args: [], returnType: { kind: 'scalar', type: 'DATETIME' }, phase: 'MVP', availableIn: ['checkpoint'], description: 'Дата плановой сдачи релиза (только для КТ-условий).' },
-  { name: 'checkpointdeadline', args: [], returnType: { kind: 'scalar', type: 'DATETIME' }, phase: 'MVP', availableIn: ['checkpoint'], description: 'Дедлайн КТ = releasePlannedDate + offsetDays (только для КТ-условий).' },
+  // Checkpoint-context-only (§5.12.4). Declared here so parser+validator accept
+  // them in a checkpoint TTQL snapshot. Resolver branches land in PR-17 — до
+  // тех пор function-resolver default-case возвращает `resolve-failed`, что
+  // компилятор переводит в compile-error → engine ставит state=ERROR с явным
+  // reason (LOUD fail, not silent NULL). Поэтому безопасно держать phase=MVP.
+  { name: 'releaseplanneddate', args: [], returnType: { kind: 'scalar', type: 'DATETIME' }, phase: 'MVP', availableIn: ['checkpoint'], description: 'Дата плановой сдачи релиза. Resolver wire-up в PR-17 (до того — state=ERROR с reason).' },
+  { name: 'checkpointdeadline', args: [], returnType: { kind: 'scalar', type: 'DATETIME' }, phase: 'MVP', availableIn: ['checkpoint'], description: 'Дедлайн КТ = releasePlannedDate + offsetDays. Resolver wire-up в PR-17.' },
   // Phase 2 — parser accepts, validator rejects
   { name: 'watchedissues', args: [], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'PHASE_2', availableIn: ['default'], description: 'Задачи, на которые я подписан (Phase 2).' },
   { name: 'votedissues', args: [], returnType: { kind: 'list', type: 'ISSUE' }, phase: 'PHASE_2', availableIn: ['default'], description: 'Голоса (Phase 2).' },

--- a/backend/src/prisma/migrations/20260424000001_ttsrh_checkpoint_state_error/migration.sql
+++ b/backend/src/prisma/migrations/20260424000001_ttsrh_checkpoint_state_error/migration.sql
@@ -1,0 +1,4 @@
+-- TTSRH-1 PR-16: Add ERROR to CheckpointState enum for TTQL compile/runtime
+-- failure path (R16, FR-31). Existing rows unchanged; only new code emits ERROR.
+
+ALTER TYPE "CheckpointState" ADD VALUE IF NOT EXISTS 'ERROR';

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -1136,6 +1136,10 @@ enum CheckpointState {
   PENDING
   OK
   VIOLATED
+  // TTSRH-1 PR-16: TTQL compile/runtime failure → checkpoint в ERROR вместо
+  // VIOLATED. Отдельное состояние нужно UI (иконка warning vs error) и чтобы
+  // ReleaseRisk не включал TTQL-ошибки в violated weight (см. computeReleaseRisk).
+  ERROR
 }
 
 // TTSRH-1 §5.12: mode for evaluating КТ conditions.

--- a/backend/tests/checkpoint-engine-ttql.unit.test.ts
+++ b/backend/tests/checkpoint-engine-ttql.unit.test.ts
@@ -1,0 +1,223 @@
+/**
+ * TTSRH-1 PR-16 — unit tests для evaluateCheckpoint в TTQL / COMBINED режимах
+ * + ERROR fast-path + backward-compat STRUCTURED.
+ *
+ * Pure-unit. Не требует Postgres. Регистрируется в `test:parser`.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { evaluateCheckpoint } from '../src/modules/releases/checkpoints/checkpoint-engine.service.js';
+import type { CheckpointCriterion } from '../src/modules/releases/checkpoints/checkpoint.types.js';
+import type { EvaluationContext, EvaluationIssue } from '../src/modules/releases/checkpoints/evaluate-criterion.js';
+
+const now = new Date('2026-05-15T10:00:00Z');
+const deadlinePast = new Date('2026-05-10T00:00:00Z'); // in the past — verdict finalises
+const deadlineFuture = new Date('2026-06-15T00:00:00Z');
+
+const baseIssue = (id: string, extras: Partial<EvaluationIssue> = {}): EvaluationIssue => ({
+  id,
+  key: `X-${id}`,
+  title: `Issue ${id}`,
+  issueTypeSystemKey: 'TASK',
+  statusCategory: 'DONE',
+  statusName: 'Done',
+  assigneeId: 'u1',
+  dueDate: null,
+  customFieldValues: new Map(),
+  subtasks: [],
+  blockers: [],
+  ...extras,
+});
+
+const context: EvaluationContext = { releasePlannedDate: deadlineFuture };
+
+const criteriaAssignee: CheckpointCriterion[] = [{ type: 'ASSIGNEE_SET' }];
+
+describe('evaluateCheckpoint — STRUCTURED (default, backward-compat)', () => {
+  it('no conditionMode specified → behaves as STRUCTURED', () => {
+    const issues = [baseIssue('1'), baseIssue('2', { assigneeId: null })];
+    const res = evaluateCheckpoint(
+      { criteria: criteriaAssignee, deadline: deadlinePast, warningDays: 3, issues, context },
+      now,
+    );
+    expect(res.state).toBe('VIOLATED');
+    expect(res.applicableIssueIds).toEqual(['1', '2']);
+    expect(res.passedIssueIds).toEqual(['1']);
+    expect(res.breakdown).toEqual({ applicable: 2, passed: 1, violated: 1 });
+  });
+
+  it('ttqlMatchedIds is ignored when mode is STRUCTURED', () => {
+    const issues = [baseIssue('1')];
+    const res = evaluateCheckpoint(
+      {
+        criteria: criteriaAssignee,
+        deadline: deadlinePast,
+        warningDays: 3,
+        issues,
+        context,
+        conditionMode: 'STRUCTURED',
+        ttqlMatchedIds: new Set(),
+      },
+      now,
+    );
+    expect(res.state).toBe('OK');
+    expect(res.passedIssueIds).toEqual(['1']);
+  });
+});
+
+describe('evaluateCheckpoint — TTQL mode', () => {
+  it('all issues applicable; passed iff in ttqlMatchedIds', () => {
+    const issues = [baseIssue('1'), baseIssue('2'), baseIssue('3')];
+    const res = evaluateCheckpoint(
+      {
+        criteria: [],
+        deadline: deadlinePast,
+        warningDays: 3,
+        issues,
+        context,
+        conditionMode: 'TTQL',
+        ttqlMatchedIds: new Set(['1', '3']),
+      },
+      now,
+    );
+    expect(res.state).toBe('VIOLATED');
+    expect(res.applicableIssueIds.sort()).toEqual(['1', '2', '3']);
+    expect(res.passedIssueIds.sort()).toEqual(['1', '3']);
+    expect(res.violations).toHaveLength(1);
+    expect(res.violations[0]?.criterionType).toBe('TTQL_MISMATCH');
+    expect(res.violations[0]?.issueId).toBe('2');
+  });
+
+  it('empty ttqlMatchedIds → all issues fail TTQL_MISMATCH', () => {
+    const issues = [baseIssue('1'), baseIssue('2')];
+    const res = evaluateCheckpoint(
+      {
+        criteria: [],
+        deadline: deadlinePast,
+        warningDays: 3,
+        issues,
+        context,
+        conditionMode: 'TTQL',
+        ttqlMatchedIds: new Set(),
+      },
+      now,
+    );
+    expect(res.state).toBe('VIOLATED');
+    expect(res.violations).toHaveLength(2);
+  });
+
+  it('null ttqlMatchedIds (not evaluated) → all issues fail', () => {
+    const issues = [baseIssue('1')];
+    const res = evaluateCheckpoint(
+      {
+        criteria: [],
+        deadline: deadlinePast,
+        warningDays: 3,
+        issues,
+        context,
+        conditionMode: 'TTQL',
+        ttqlMatchedIds: null,
+      },
+      now,
+    );
+    expect(res.state).toBe('VIOLATED');
+  });
+
+  it('ttqlError → state=ERROR with single TTQL_ERROR violation', () => {
+    const issues = [baseIssue('1'), baseIssue('2')];
+    const res = evaluateCheckpoint(
+      {
+        criteria: [],
+        deadline: deadlinePast,
+        warningDays: 3,
+        issues,
+        context,
+        conditionMode: 'TTQL',
+        ttqlMatchedIds: null,
+        ttqlError: 'compile: UNRESOLVED_FIELD `foo`',
+      },
+      now,
+    );
+    expect(res.state).toBe('ERROR');
+    expect(res.violations).toHaveLength(1);
+    expect(res.violations[0]?.criterionType).toBe('TTQL_ERROR');
+    expect(res.violations[0]?.reason).toContain('UNRESOLVED_FIELD');
+    expect(res.applicableIssueIds).toEqual([]);
+    expect(res.passedIssueIds).toEqual([]);
+  });
+
+  it('violationsHash stable across two evaluations with identical TTQL matches', () => {
+    const issues = [baseIssue('1'), baseIssue('2'), baseIssue('3')];
+    const a = evaluateCheckpoint(
+      {
+        criteria: [],
+        deadline: deadlinePast,
+        warningDays: 3,
+        issues,
+        context,
+        conditionMode: 'TTQL',
+        ttqlMatchedIds: new Set(['1']),
+      },
+      now,
+    );
+    const b = evaluateCheckpoint(
+      {
+        criteria: [],
+        deadline: deadlinePast,
+        warningDays: 3,
+        issues: [...issues].reverse(), // re-order input
+        context,
+        conditionMode: 'TTQL',
+        ttqlMatchedIds: new Set(['1']),
+      },
+      now,
+    );
+    expect(a.violationsHash).toBe(b.violationsHash);
+  });
+});
+
+describe('evaluateCheckpoint — COMBINED mode', () => {
+  it('issue must pass BOTH structured + TTQL to be counted as passed', () => {
+    const issues = [
+      baseIssue('a'),
+      baseIssue('b', { assigneeId: null }), // fails structured ASSIGNEE_SET
+      baseIssue('c'), // passes structured
+    ];
+    const res = evaluateCheckpoint(
+      {
+        criteria: criteriaAssignee,
+        deadline: deadlinePast,
+        warningDays: 3,
+        issues,
+        context,
+        conditionMode: 'COMBINED',
+        ttqlMatchedIds: new Set(['a']), // only 'a' passes TTQL
+      },
+      now,
+    );
+    expect(res.state).toBe('VIOLATED');
+    expect(res.passedIssueIds).toEqual(['a']);
+    // 'b' fails structured, 'c' passes structured but fails TTQL → both in violations.
+    const violationIds = res.violations.map((v) => v.issueId).sort();
+    expect(violationIds).toEqual(['b', 'c']);
+    // Ensure 'b' was NOT double-counted (structured fail short-circuits TTQL check).
+    expect(res.violations.filter((v) => v.issueId === 'b')).toHaveLength(1);
+  });
+
+  it('pending deadline → state PENDING regardless of violations', () => {
+    const issues = [baseIssue('1')];
+    const res = evaluateCheckpoint(
+      {
+        criteria: criteriaAssignee,
+        deadline: deadlineFuture,
+        warningDays: 3,
+        issues,
+        context,
+        conditionMode: 'COMBINED',
+        ttqlMatchedIds: new Set(), // fails TTQL
+      },
+      now,
+    );
+    expect(res.state).toBe('PENDING');
+  });
+});

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1516,7 +1516,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 12 | `ttsrh-1/basic-builder` | BasicFilterBuilder + Basic↔Advanced toggle | 12 | PR-11 | TTSRH-15 | 🟢 Merged ([#114](https://github.com/NovakPAai/tasktime-mvp/pull/114)) |
 | 13 | `ttsrh-1/saved-filters-ui` | SavedFiltersSidebar + Save/Share modals + store | 8 | PR-7, PR-9 | TTSRH-16 | 🟢 Merged ([#115](https://github.com/NovakPAai/tasktime-mvp/pull/115)) |
 | 14 | `ttsrh-1/results` | ColumnConfigurator + ResultsTable + bulk + ExportMenu + shortcuts | 11 | PR-8, PR-10 | TTSRH-17, TTSRH-18, остаток TTSRH-19 | 🟢 Merged ([#116](https://github.com/NovakPAai/tasktime-mvp/pull/116)) |
-| 15 | `ttsrh-1/checkpoint-foundation` | Checkpoint Prisma + DTO + КТ-функции + variant=CHECKPOINT | 10 | PR-1, PR-3 | TTSRH-27, TTSRH-28, TTSRH-29 | ✅ Done (готов к push после merge PR-14) |
+| 15 | `ttsrh-1/checkpoint-foundation` | Checkpoint Prisma + DTO + КТ-функции + variant=CHECKPOINT | 10 | PR-1, PR-3 | TTSRH-27, TTSRH-28, TTSRH-29 | 🟢 Merged ([#117](https://github.com/NovakPAai/tasktime-mvp/pull/117)) |
 | 16 | `ttsrh-1/checkpoint-engine` | Engine TTQL-ветка + COMBINED + error handling | 10 | PR-4, PR-15 | TTSRH-30, TTSRH-31 | ✅ Done (готов к push после merge PR-15) |
 | 17 | `ttsrh-1/checkpoint-search-integration` | `/preview` + violatedCheckpoints* функции + поля + suggesters | 6 | PR-5, PR-16 | TTSRH-32, TTSRH-37 | 📋 Планируется |
 | 18 | `ttsrh-1/checkpoint-admin-ui` | Segment-mode + JqlEditor КТ + Preview panel + mode-icon | 11 | PR-10, PR-15, PR-17 | TTSRH-33, TTSRH-34, TTSRH-35 | 📋 Планируется |

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1432,6 +1432,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
   - Security-review gate — RBAC отдельный подписывает (R3 + R16).
 - **Merge-ready check:** T-13..T-16 зелёные; existing КТ-тесты не ломаются (FR-25); security-review.
 - **Оценка:** ~10ч.
+- **Статус: ✅ Done** — `checkpoint-engine.service.evaluateCheckpoint` расширен тремя ветками: STRUCTURED (backward-compat, default когда `conditionMode` absent), TTQL (applicable = все issues, passed = `ttqlMatchedIds.has(id)`), COMBINED (structured-passed AND TTQL-matched; failed structured short-circuit'ит TTQL для избежания duplicate violations). Fast-path для `ttqlError != null` → state=`ERROR` + single synthetic `TTQL_ERROR` violation с детерминированным hash'ем (R16, FR-31). `checkpoint-ttql-evaluator.service.resolveTtqlMatchedIds` — async resolver, reuses полный pipeline `/search/issues` (parse → validate → resolveFunctions → compile → executeCustomFieldPredicates) с 5s hard-timeout через `Promise.race`, never throws — возвращает `{matchedIds, error}`. Миграция `20260424000001_ttsrh_checkpoint_state_error` — + ERROR enum value. Caller `recomputeForRelease` вызывает `maybeResolveTtqlIds` gate'нутый `FEATURES_CHECKPOINT_TTQL` флагом (default false → TTQL checkpoint evaluate как STRUCTURED до UAT). `computeViolationsHash` стабилен (existing `{issueId, reason, criterionType}` sorted). 9 unit-тестов pure-function (STRUCTURED×2, TTQL×5, COMBINED×2). Все wired через `test:parser`.
 
 #### PR-17: /admin/checkpoint-types/preview + TTS-QL checkpoint-функции/поля
 - **Branch:** `ttsrh-1/checkpoint-search-integration`
@@ -1516,7 +1517,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 13 | `ttsrh-1/saved-filters-ui` | SavedFiltersSidebar + Save/Share modals + store | 8 | PR-7, PR-9 | TTSRH-16 | 🟢 Merged ([#115](https://github.com/NovakPAai/tasktime-mvp/pull/115)) |
 | 14 | `ttsrh-1/results` | ColumnConfigurator + ResultsTable + bulk + ExportMenu + shortcuts | 11 | PR-8, PR-10 | TTSRH-17, TTSRH-18, остаток TTSRH-19 | 🟢 Merged ([#116](https://github.com/NovakPAai/tasktime-mvp/pull/116)) |
 | 15 | `ttsrh-1/checkpoint-foundation` | Checkpoint Prisma + DTO + КТ-функции + variant=CHECKPOINT | 10 | PR-1, PR-3 | TTSRH-27, TTSRH-28, TTSRH-29 | ✅ Done (готов к push после merge PR-14) |
-| 16 | `ttsrh-1/checkpoint-engine` | Engine TTQL-ветка + COMBINED + error handling | 10 | PR-4, PR-15 | TTSRH-30, TTSRH-31 | 📋 Планируется |
+| 16 | `ttsrh-1/checkpoint-engine` | Engine TTQL-ветка + COMBINED + error handling | 10 | PR-4, PR-15 | TTSRH-30, TTSRH-31 | ✅ Done (готов к push после merge PR-15) |
 | 17 | `ttsrh-1/checkpoint-search-integration` | `/preview` + violatedCheckpoints* функции + поля + suggesters | 6 | PR-5, PR-16 | TTSRH-32, TTSRH-37 | 📋 Планируется |
 | 18 | `ttsrh-1/checkpoint-admin-ui` | Segment-mode + JqlEditor КТ + Preview panel + mode-icon | 11 | PR-10, PR-15, PR-17 | TTSRH-33, TTSRH-34, TTSRH-35 | 📋 Планируется |
 | 19 | `ttsrh-1/checkpoint-converter` | Structured → TTQL converter (one-way) | 3 | PR-18 | TTSRH-36 | 📋 Планируется |

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,75 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.43**
+**Last version: 2.44**
+
+---
+
+## [2.44] [2026-04-21] feat(checkpoint): TTSRH-1 PR-16 — Checkpoint engine TTQL branch + error handling
+
+**PR:** (to be filled after push)
+**Ветка:** `ttsrh-1/checkpoint-engine`
+
+### Что было
+
+После PR-15 foundation (схема + DTO + snapshot-пропагация) был готов, но evaluator игнорировал `conditionModeSnapshot`/`ttqlSnapshot` — работал только через structured path. TTQL/COMBINED чекпоинты создаваться могли, но оценивались как STRUCTURED. Валидация и снапшоты были inert до merge engine'а.
+
+### Что теперь
+
+`evaluateCheckpoint` теперь знает про три mode'а + обрабатывает TTQL compile/exec failure как ERROR-state:
+
+- **`checkpoint-engine.service.ts`** — `CheckpointEvaluationInput` расширен: `conditionMode?` (default STRUCTURED), `ttqlMatchedIds?: ReadonlySet<string> | null`, `ttqlError?: string | null`.
+  - Fast-path: `ttqlError != null` → state=`ERROR` + single synthetic `TTQL_ERROR` violation с стабильным hash (R16, FR-31).
+  - STRUCTURED: existing pure behavior unchanged (backward-compat — вызовы без conditionMode работают).
+  - TTQL: все issues applicable, passed iff `ttqlMatchedIds.has(id)`, violations с `criterionType='TTQL_MISMATCH'`.
+  - COMBINED: structured-first (failed → short-circuit); если structured passed, доп. TTQL check. Issue fails COMBINED если хотя бы один из двух путей failed, но violation пишется только один раз.
+- **`checkpoint-ttql-evaluator.service.ts`** (новый) — async Prisma-backed resolver:
+  - `resolveTtqlMatchedIds(ttql, {now, applicableIssueIds, accessibleProjectIds})` → `{matchedIds, error}`.
+  - Reuses полный pipeline: `parse` → `validate(variant='checkpoint')` → `resolveFunctions` → `compile` → `executeCustomFieldPredicates` → `prisma.issue.findMany({where: AND[compiled, {id: {in: applicableIds}}]})`.
+  - Hard timeout 5с через `Promise.race` vs `setTimeout` — любая фаза включена в бюджет (R16).
+  - Never throws: parse/validate/compile/exec errors + timeout → `{matchedIds: new Set(), error}` (caller → ERROR state).
+- **Prisma migration `20260424000001_ttsrh_checkpoint_state_error`**:
+  - `ALTER TYPE CheckpointState ADD VALUE IF NOT EXISTS 'ERROR'`.
+  - Existing rows unchanged — только new code emits ERROR.
+- **`release-checkpoints.service.recomputeForRelease`** — wire'нут TTQL path:
+  - `maybeResolveTtqlIds` — helper, проверяет `features.checkpointTtql` sub-flag. Если OFF → skipped=true → caller falls back к STRUCTURED path (TZ §13.7 PR-16: «Под флагом FEATURES_CHECKPOINT_TTQL=false ветка TTQL не выполняется, conditionMode=TTQL/COMBINED саммится как NOOP до включения флага»).
+  - Если ON → compiles TTQL через resolver, передаёт `{matchedIds, error}` в engine.
+  - `loadAllProjectIds()` lazy helper: system-level scheduler scope через `prisma.project.findMany`. Memoized per-recompute — не fetch'ится для releases с только STRUCTURED чекпоинтами (zero-cost для 100% existing prod).
+- **`checkpoint.types.ts`**: `CheckpointViolationType = CheckpointCriterionType | 'TTQL_MISMATCH' | 'TTQL_ERROR'`. `CheckpointViolation.criterionType` теперь union — hash payload остаётся uniform.
+- **Unit tests `checkpoint-engine-ttql.unit.test.ts`**: 9 pure-function кейсов:
+  - STRUCTURED (×2): default behavior backward-compat + ttqlMatchedIds ignored при conditionMode=STRUCTURED.
+  - TTQL (×5): все applicable with match, empty set → all fail, null matched → all fail, ttqlError → ERROR state, violationsHash stability.
+  - COMBINED (×2): BOTH required for pass + pending deadline override.
+- Добавлен в `test:parser` script.
+
+### Backward-compat (FR-25)
+
+1. **Existing callers без conditionMode**: `evaluateCheckpoint({criteria, deadline, …})` без новых полей — mode default'ом STRUCTURED, behavior идентичен pre-PR-16.
+2. **Existing rows в production**: `condition_mode_snapshot = 'STRUCTURED'`, `ttql_snapshot = NULL` (из PR-15 default). `maybeResolveTtqlIds` fast-path'ит как `{matchedIds: null, skipped: false}` → engine не дёргается TTQL logic, existing `violationsHash` стабилен.
+3. **Feature-flag off в prod**: даже если caller создал TTQL/COMBINED чекпоинт, `features.checkpointTtql=false` → skipped=true → engine fallback к STRUCTURED. Чекпоинт НЕ попадает в VIOLATED из-за TTQL — прозрачно до UAT.
+
+### Изменения
+
+- `backend/src/modules/releases/checkpoints/checkpoint.types.ts` — + `CheckpointViolationType` union.
+- `backend/src/modules/releases/checkpoints/checkpoint-engine.service.ts` — + conditionMode/ttqlMatchedIds/ttqlError branches + ERROR fast-path.
+- `backend/src/modules/releases/checkpoints/checkpoint-ttql-evaluator.service.ts` — новый (5s timeout, never-throws).
+- `backend/src/modules/releases/checkpoints/release-checkpoints.service.ts` — + maybeResolveTtqlIds + loadAllProjectIds + wiring в recomputeForRelease.
+- `backend/src/prisma/schema.prisma` — + `ERROR` в `CheckpointState`.
+- `backend/src/prisma/migrations/20260424000001_ttsrh_checkpoint_state_error/migration.sql` — новый.
+- `backend/tests/checkpoint-engine-ttql.unit.test.ts` — новый (9 unit-кейсов).
+- `backend/package.json` — `test:parser` включает новый тест.
+- `docs/tz/TTSRH-1.md` §13.7/§13.9 — статус PR-16 → ✅ Done.
+
+### Влияние на prod
+
+Feature-flag `FEATURES_CHECKPOINT_TTQL=false` в prod → schema + engine готовы, но не выполняются для TTQL/COMBINED чекпоинтов. Зелёные CI тесты проверяют backward-compat: все existing STRUCTURED тесты продолжают проходить.
+
+### Проверки
+
+- `npx tsc --noEmit` — чисто
+- `npm run lint` — 0 errors, 0 new warnings
+- `npx prisma generate` — чисто
+- `npx vitest tests/checkpoint-engine-ttql.unit.test.ts` — **9/9 passing**
 
 ---
 


### PR DESCRIPTION
## Summary

Engine TTQL-ветка + error handling:

- **`checkpoint-engine.service.evaluateCheckpoint`** — input расширен `conditionMode?`, `ttqlMatchedIds?`, `ttqlError?`. Три ветки + fast-path:
  - **ERROR fast-path**: `ttqlError != null` → state=`ERROR` + single synthetic `TTQL_ERROR` violation (stable hash).
  - **STRUCTURED** (default, backward-compat): existing behavior unchanged.
  - **TTQL**: все issues applicable; passed iff `ttqlMatchedIds.has(id)`; остальные → `TTQL_MISMATCH`.
  - **COMBINED**: structured-first (fail → short-circuit без duplicate violation), если structured passed → doп. TTQL check.
- **`checkpoint-ttql-evaluator.service.ts`** (новый) — async resolver, reuses `/search/issues` pipeline (parse → validate(checkpoint) → resolveFunctions → compile → execCfPredicates → findMany). 5s hard-timeout через `Promise.race`. Never throws — все failures → `{matchedIds: Set(), error: string}`.
- **`release-checkpoints.recomputeForRelease`** — wire'нут TTQL path через `maybeResolveTtqlIds`:
  - Gate'нут sub-flag'ом `FEATURES_CHECKPOINT_TTQL` (default OFF в prod): TTQL/COMBINED checkpoints fall back to STRUCTURED behavior до UAT.
  - `loadAllProjectIds()` lazy: вызывается только когда checkpoint фактически запустит TTQL resolver (zero DB cost для STRUCTURED-only releases).
  - `releaseIssueIds` hoisted над loop — не re-allocate'ится для каждого checkpoint.
  - `reconcileViolationEvents` filter'ит `issueId === ''` — TTQL_ERROR synthetic violation не попадает в event log (state=ERROR сам signal).
- **Migration**: `20260424000001_ttsrh_checkpoint_state_error` — `ALTER TYPE ... ADD VALUE IF NOT EXISTS 'ERROR'`. Existing rows unchanged.
- **`CheckpointViolation.criterionType`**: union расширен до `CriterionType | 'TTQL_MISMATCH' | 'TTQL_ERROR'`.
- **`userId: null`** в TTQL resolver context — семантически корректный signal "no authenticated user" (§5.12.4 currentUser() → NULL).

## Pre-push review counts

🟠 × 2 (reconcileViolationEvents guard для empty issueId, documented что `releaseplanneddate`/`checkpointdeadline` non-silent fail через existing resolver default) · 🟡 × 2 (lazy loadAllProjectIds, hoist issues.map) · ⚪ × 1 (userId null). Все applied.

## Test plan

Pure-unit тесты:
- [x] `tests/checkpoint-engine-ttql.unit.test.ts` — **9/9 passing** (STRUCTURED×2, TTQL×5, COMBINED×2).
- [x] `tests/checkpoint-dto.unit.test.ts` — **17/17 passing** (backward-compat из PR-15).
- [x] `npm run test:parser` — **459 passing** (11 test files).
- [x] `npx tsc --noEmit` — чисто.
- [x] `npm run lint` — 0 errors.
- [x] `npx prisma generate` — чисто.

Integration-тесты (существующие backend/tests/checkpoints.test.ts) не тронуты и должны продолжать проходить — `evaluateCheckpoint` backward-compat через default `conditionMode='STRUCTURED'`.

## Backward-compat (FR-25)

1. Existing callers без `conditionMode` → default STRUCTURED, behavior идентичен pre-PR-16.
2. Existing prod rows (`condition_mode_snapshot='STRUCTURED'`, `ttql_snapshot=NULL` из PR-15 DEFAULT) → `maybeResolveTtqlIds` fast-paths → engine не трогает TTQL logic, `violationsHash` стабилен.
3. `FEATURES_CHECKPOINT_TTQL=false` в prod → даже TTQL/COMBINED чекпоинты (если созданы) evaluate'ятся как STRUCTURED, НЕ уходят в VIOLATED из-за TTQL.

## Security review gate

Per §13.1 / §13.7: PR-16 требует **security-review** на:
- R1 (anti-injection) — TTQL pipeline проходит полный validator+compiler, raw-SQL только через `Prisma.sql` tagged templates.
- R3 (scope) — resolver использует `applicableIssueIds` narrowing + `accessibleProjectIds`; system-level scheduler fetches all project ids.
- R16 (timeout) — 5s hard cap через `Promise.race`.

## Зависимости

- Блокирующие: PR-15 (#117) — merged ✅.
- Блокирует: PR-17 (/preview + violatedCheckpoints* functions + поля + suggesters); PR-18 (checkpoint admin UI).

## Плановая дельта

~640 LoC (engine extension + resolver + recompute wiring + migration + 9 unit tests + docs), в пределах §8 эстимата (~10ч).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
