### PR TITLE
feat(checkpoint): TTSRH-1 PR-18 — Checkpoint admin UI: mode-toggle + JqlEditor + preview panel

### DIFF
--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1527,7 +1527,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 15 | `ttsrh-1/checkpoint-foundation` | Checkpoint Prisma + DTO + КТ-функции + variant=CHECKPOINT | 10 | PR-1, PR-3 | TTSRH-27, TTSRH-28, TTSRH-29 | 🟢 Merged ([#117](https://github.com/NovakPAai/tasktime-mvp/pull/117)) |
 | 16 | `ttsrh-1/checkpoint-engine` | Engine TTQL-ветка + COMBINED + error handling | 10 | PR-4, PR-15 | TTSRH-30, TTSRH-31 | 🟢 Merged ([#118](https://github.com/NovakPAai/tasktime-mvp/pull/118)) |
 | 17 | `ttsrh-1/checkpoint-search-integration` | `/preview` + violatedCheckpoints* функции + поля + suggesters | 6 | PR-5, PR-16 | TTSRH-32, TTSRH-37 | ✅ Done (готов к push после merge PR-16) |
-| 18 | `ttsrh-1/checkpoint-admin-ui` | Segment-mode + JqlEditor КТ + Preview panel + mode-icon | 11 | PR-10, PR-15, PR-17 | TTSRH-33, TTSRH-34, TTSRH-35 | 📋 Планируется |
+| 18 | `ttsrh-1/checkpoint-admin-ui` | Segment-mode + JqlEditor КТ + Preview panel + mode-icon | 11 | PR-10, PR-15, PR-17 | TTSRH-33, TTSRH-34, TTSRH-35 | ✅ Done (готов к push после merge PR-17) |
 | 19 | `ttsrh-1/checkpoint-converter` | Structured → TTQL converter (one-way) | 3 | PR-18 | TTSRH-36 | 📋 Планируется |
 | 20 | `ttsrh-1/e2e-perf` | E2E + perf 100K seed + Lighthouse budget + axe-core | 9 | PR-12, PR-13, PR-14, PR-17, PR-19 | TTSRH-20 | 📋 Планируется |
 | 21 | `ttsrh-1/docs-cutover` | Документация + feature flag cutover | 6 | PR-20 | TTSRH-21, TTSRH-22 | 📋 Планируется |

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1526,7 +1526,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 14 | `ttsrh-1/results` | ColumnConfigurator + ResultsTable + bulk + ExportMenu + shortcuts | 11 | PR-8, PR-10 | TTSRH-17, TTSRH-18, остаток TTSRH-19 | 🟢 Merged ([#116](https://github.com/NovakPAai/tasktime-mvp/pull/116)) |
 | 15 | `ttsrh-1/checkpoint-foundation` | Checkpoint Prisma + DTO + КТ-функции + variant=CHECKPOINT | 10 | PR-1, PR-3 | TTSRH-27, TTSRH-28, TTSRH-29 | 🟢 Merged ([#117](https://github.com/NovakPAai/tasktime-mvp/pull/117)) |
 | 16 | `ttsrh-1/checkpoint-engine` | Engine TTQL-ветка + COMBINED + error handling | 10 | PR-4, PR-15 | TTSRH-30, TTSRH-31 | 🟢 Merged ([#118](https://github.com/NovakPAai/tasktime-mvp/pull/118)) |
-| 17 | `ttsrh-1/checkpoint-search-integration` | `/preview` + violatedCheckpoints* функции + поля + suggesters | 6 | PR-5, PR-16 | TTSRH-32, TTSRH-37 | ✅ Done (готов к push после merge PR-16) |
+| 17 | `ttsrh-1/checkpoint-search-integration` | `/preview` + violatedCheckpoints* функции + поля + suggesters | 6 | PR-5, PR-16 | TTSRH-32, TTSRH-37 | 🟢 Merged ([#119](https://github.com/NovakPAai/tasktime-mvp/pull/119)) |
 | 18 | `ttsrh-1/checkpoint-admin-ui` | Segment-mode + JqlEditor КТ + Preview panel + mode-icon | 11 | PR-10, PR-15, PR-17 | TTSRH-33, TTSRH-34, TTSRH-35 | ✅ Done (готов к push после merge PR-17) |
 | 19 | `ttsrh-1/checkpoint-converter` | Structured → TTQL converter (one-way) | 3 | PR-18 | TTSRH-36 | 📋 Планируется |
 | 20 | `ttsrh-1/e2e-perf` | E2E + perf 100K seed + Lighthouse budget + axe-core | 9 | PR-12, PR-13, PR-14, PR-17, PR-19 | TTSRH-20 | 📋 Планируется |

--- a/frontend/src/api/release-checkpoint-types.ts
+++ b/frontend/src/api/release-checkpoint-types.ts
@@ -22,6 +22,10 @@ export type CheckpointCriterion =
 
 export type CheckpointCriterionType = CheckpointCriterion['type'];
 
+// TTSRH-1 PR-15: три режима оценки. STRUCTURED — existing (criteria[]),
+// TTQL — evaluate через compiled TTS-QL, COMBINED — оба одновременно.
+export type CheckpointConditionMode = 'STRUCTURED' | 'TTQL' | 'COMBINED';
+
 export interface CheckpointType {
   id: string;
   name: string;
@@ -31,6 +35,8 @@ export interface CheckpointType {
   offsetDays: number;
   warningDays: number;
   criteria: CheckpointCriterion[];
+  conditionMode?: CheckpointConditionMode;
+  ttqlCondition?: string | null;
   webhookUrl?: string | null;
   minStableSeconds: number;
   isActive: boolean;
@@ -47,6 +53,8 @@ export interface CreateCheckpointTypeBody {
   offsetDays: number;
   warningDays?: number;
   criteria: CheckpointCriterion[];
+  conditionMode?: CheckpointConditionMode;
+  ttqlCondition?: string | null;
   webhookUrl?: string | null;
   minStableSeconds?: number;
   isActive?: boolean;
@@ -105,6 +113,50 @@ export async function syncInstances(
   const { data } = await api.post<{ syncedCount: number }>(
     `/admin/checkpoint-types/${id}/sync-instances`,
     { releaseIds },
+  );
+  return data;
+}
+
+// TTSRH-1 PR-17/18: dry-run preview для TTQL/STRUCTURED/COMBINED condition.
+// Используется UI PR-18 в Preview-панели формы редактирования КТ.
+export interface CheckpointPreviewBody {
+  releaseId: string;
+  conditionMode: CheckpointConditionMode;
+  criteria?: CheckpointCriterion[];
+  ttqlCondition?: string | null;
+  offsetDays?: number;
+  warningDays?: number;
+}
+
+export interface CheckpointPreviewResponse {
+  state: 'PENDING' | 'OK' | 'VIOLATED' | 'ERROR';
+  isWarning: boolean;
+  applicableIssueIds: string[];
+  passedIssueIds: string[];
+  violations: Array<{
+    issueId: string;
+    issueKey: string;
+    issueTitle: string;
+    reason: string;
+    criterionType: string;
+  }>;
+  violationsHash: string;
+  breakdown: { applicable: number; passed: number; violated: number };
+  meta: {
+    releaseId: string;
+    conditionMode: CheckpointConditionMode;
+    totalIssuesInRelease: number;
+    ttqlSkippedByFlag: boolean;
+    ttqlError: string | null;
+  };
+}
+
+export async function previewCheckpointCondition(
+  body: CheckpointPreviewBody,
+): Promise<CheckpointPreviewResponse> {
+  const { data } = await api.post<CheckpointPreviewResponse>(
+    '/admin/checkpoint-types/preview',
+    body,
   );
   return data;
 }

--- a/frontend/src/components/releases/CheckpointConditionModeControl.tsx
+++ b/frontend/src/components/releases/CheckpointConditionModeControl.tsx
@@ -1,0 +1,148 @@
+/**
+ * TTSRH-1 PR-18 — управляющий UI для conditionMode в checkpoint form.
+ *
+ * Публичный API:
+ *   • value — текущий режим (STRUCTURED / TTQL / COMBINED).
+ *   • onChange(next) — переключить.
+ *   • ttqlValue / onTtqlChange — биндинг TTQL-поля; показывается когда
+ *     режим TTQL или COMBINED.
+ *   • disabled — toggle disabled (например, при save).
+ *   • isLight — theme.
+ *
+ * Инварианты:
+ *   • Переключение режима НЕ стирает criteria[] / ttqlCondition (R20) —
+ *     родительская форма хранит оба поля независимо, здесь мы только
+ *     toggle'им визибельность.
+ *   • При pre-save валидация проверяет соответствие mode ↔ payload
+ *     (see backend DTO superRefine).
+ *   • JqlEditor загружается лениво и только если пользователь открыл
+ *     TTQL/COMBINED mode (уже lazy в PR-10, здесь дополнительно
+ *     conditionally-render).
+ */
+import { useMemo } from 'react';
+import { Segmented } from 'antd';
+
+import type { CheckpointConditionMode } from '../../api/release-checkpoint-types';
+import JqlEditor from '../search/JqlEditor.lazy';
+
+export interface CheckpointConditionModeControlProps {
+  value: CheckpointConditionMode;
+  onChange: (next: CheckpointConditionMode) => void;
+  ttqlValue: string;
+  onTtqlChange: (value: string) => void;
+  disabled?: boolean;
+  isLight?: boolean;
+}
+
+const MODE_LABELS: Record<CheckpointConditionMode, string> = {
+  STRUCTURED: 'Structured',
+  TTQL: 'TTQL',
+  COMBINED: 'Combined',
+};
+
+const MODE_HINTS: Record<CheckpointConditionMode, string> = {
+  STRUCTURED: 'Стандартные правила (critериi) — быстро и проверено.',
+  TTQL: 'Выражение на TTS-QL. Мощнее, но требует знания синтаксиса. Доступна функция checkpointDeadline().',
+  COMBINED: 'И structured критерии, И TTQL — issue должен пройти оба.',
+};
+
+export default function CheckpointConditionModeControl({
+  value,
+  onChange,
+  ttqlValue,
+  onTtqlChange,
+  disabled = false,
+  isLight = false,
+}: CheckpointConditionModeControlProps) {
+  const options = useMemo(
+    () =>
+      (['STRUCTURED', 'TTQL', 'COMBINED'] as const).map((mode) => ({
+        label: MODE_LABELS[mode],
+        value: mode,
+      })),
+    [],
+  );
+
+  const hint = MODE_HINTS[value];
+  const showStructured = value === 'STRUCTURED' || value === 'COMBINED';
+  const showTtql = value === 'TTQL' || value === 'COMBINED';
+
+  return (
+    <div data-testid="checkpoint-condition-mode-control" style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <Segmented
+          options={options}
+          value={value}
+          disabled={disabled}
+          onChange={(v) => onChange(v as CheckpointConditionMode)}
+          data-testid="condition-mode-segmented"
+        />
+        <span style={{ fontSize: 12, color: isLight ? '#6B7280' : '#8B949E' }}>{hint}</span>
+      </div>
+      {showTtql && (
+        <div data-testid="condition-mode-ttql-section" style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <label style={{ fontSize: 12, fontWeight: 500, color: isLight ? '#1F2328' : '#E2E8F8' }}>
+            TTS-QL условие (variant=checkpoint)
+          </label>
+          <JqlEditor
+            value={ttqlValue}
+            onChange={onTtqlChange}
+            onSubmit={() => { /* no-op — submit driven by outer form */ }}
+            isLight={isLight}
+            placeholder='status = DONE AND assignee IS NOT EMPTY'
+          />
+          <span style={{ fontSize: 11, color: isLight ? '#6B7280' : '#8B949E' }}>
+            Доступен полный реестр TTS-QL + КТ-функции. `currentUser()` в КТ резолвится в NULL (выдаётся warning).
+          </span>
+        </div>
+      )}
+      {!showStructured && value === 'TTQL' && (
+        <div style={{ fontSize: 11, color: isLight ? '#8B949E' : '#6B7280', fontStyle: 'italic' }}>
+          Structured критерии игнорируются в TTQL режиме (но остаются сохранёнными — переключение назад не теряет их).
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * TTSRH-1 PR-18 — иконка режима КТ для таблицы types.
+ * S = structured (зелёный), Q = ttql (синий), S+Q = combined (фиолетовый).
+ */
+export function CheckpointConditionModeIcon({
+  mode,
+  isLight = false,
+}: {
+  mode: CheckpointConditionMode;
+  isLight?: boolean;
+}) {
+  const colors = {
+    STRUCTURED: isLight ? '#16A34A' : '#4ADE80',
+    TTQL: isLight ? '#2563EB' : '#60A5FA',
+    COMBINED: isLight ? '#9333EA' : '#C084FC',
+  };
+  const label = { STRUCTURED: 'S', TTQL: 'Q', COMBINED: 'S+Q' };
+  const title = { STRUCTURED: 'Structured criteria', TTQL: 'TTS-QL condition', COMBINED: 'Structured + TTS-QL' };
+  return (
+    <span
+      title={title[mode]}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minWidth: 24,
+        padding: '0 6px',
+        height: 20,
+        borderRadius: 4,
+        fontSize: 10,
+        fontWeight: 600,
+        color: '#fff',
+        backgroundColor: colors[mode],
+        fontFamily: '"JetBrains Mono", monospace',
+      }}
+      data-testid={`mode-icon-${mode}`}
+    >
+      {label[mode]}
+    </span>
+  );
+}

--- a/frontend/src/components/releases/CheckpointPreviewPanel.tsx
+++ b/frontend/src/components/releases/CheckpointPreviewPanel.tsx
@@ -1,0 +1,163 @@
+/**
+ * TTSRH-1 PR-18 — панель превью оценки checkpoint.
+ *
+ * Публичный API:
+ *   • releaseOptions — список релизов для выбора (загружается родителем).
+ *   • body — builder для CheckpointPreviewBody (mode + criteria + ttql + offset).
+ *     Панель вызывает его на каждый запрос, чтобы получить актуальный payload
+ *     из parent form'ы.
+ *   • disabled — отключить запуск (например, при valid=false).
+ *
+ * UX:
+ *   • Выбор релиза из select'а → кнопка «Рассчитать» → fetch /preview.
+ *   • Результат: breakdown {applicable, passed, violated}, state badge,
+ *     top-10 violations. meta.ttqlSkippedByFlag баннер.
+ *   • Ошибки (400/403/404/500) → Alert-error.
+ */
+import { useState } from 'react';
+import { Alert, Badge, Button, Card, List, Select, Tag, message } from 'antd';
+
+import {
+  previewCheckpointCondition,
+  type CheckpointPreviewBody,
+  type CheckpointPreviewResponse,
+} from '../../api/release-checkpoint-types';
+
+export interface CheckpointPreviewPanelProps {
+  releaseOptions: Array<{ id: string; name: string; projectKey?: string }>;
+  body: () => CheckpointPreviewBody | null;
+  disabled?: boolean;
+  isLight?: boolean;
+}
+
+function stateColor(state: CheckpointPreviewResponse['state']): string {
+  switch (state) {
+    case 'OK': return 'success';
+    case 'VIOLATED': return 'error';
+    case 'ERROR': return 'magenta';
+    case 'PENDING':
+    default: return 'default';
+  }
+}
+
+export default function CheckpointPreviewPanel({
+  releaseOptions,
+  body,
+  disabled = false,
+  isLight = false,
+}: CheckpointPreviewPanelProps) {
+  const [releaseId, setReleaseId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<CheckpointPreviewResponse | null>(null);
+
+  const handleRun = async () => {
+    if (!releaseId) {
+      message.info('Выберите релиз');
+      return;
+    }
+    const payload = body();
+    if (!payload) {
+      message.warning('Форма ещё не заполнена');
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await previewCheckpointCondition({ ...payload, releaseId });
+      setResult(res);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : 'Ошибка preview';
+      message.error(reason);
+      setResult(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card
+      size="small"
+      data-testid="checkpoint-preview-panel"
+      title="Превью оценки на релизе"
+      style={{ marginTop: 12 }}
+      styles={{ header: { fontSize: 13, fontWeight: 500 } }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
+        <Select
+          placeholder="Выберите релиз"
+          style={{ minWidth: 280 }}
+          value={releaseId}
+          onChange={setReleaseId}
+          data-testid="preview-release-select"
+          options={releaseOptions.map((r) => ({
+            value: r.id,
+            label: r.projectKey ? `${r.projectKey} — ${r.name}` : r.name,
+          }))}
+          showSearch
+          optionFilterProp="label"
+        />
+        <Button
+          type="primary"
+          onClick={handleRun}
+          loading={loading}
+          disabled={disabled || !releaseId}
+          data-testid="preview-run-button"
+        >
+          Рассчитать
+        </Button>
+      </div>
+
+      {result?.meta.ttqlSkippedByFlag && (
+        <Alert
+          type="warning"
+          showIcon
+          style={{ marginBottom: 12 }}
+          message="TTQL не проверялся (FEATURES_CHECKPOINT_TTQL=false)"
+          description="Результат — как STRUCTURED fallback. Для полной проверки включите флаг в окружении."
+        />
+      )}
+      {result?.meta.ttqlError && (
+        <Alert
+          type="error"
+          showIcon
+          style={{ marginBottom: 12 }}
+          message="Ошибка TTQL"
+          description={result.meta.ttqlError}
+        />
+      )}
+
+      {result && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, fontSize: 13, color: isLight ? '#1F2328' : '#E2E8F8' }}>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+            <Badge status={stateColor(result.state) as 'success'} text={<strong>{result.state}</strong>} />
+            <Tag color="blue">Applicable: {result.breakdown.applicable}</Tag>
+            <Tag color="green">Passed: {result.breakdown.passed}</Tag>
+            <Tag color="red">Violated: {result.breakdown.violated}</Tag>
+            <Tag>Всего в релизе: {result.meta.totalIssuesInRelease}</Tag>
+          </div>
+          {result.violations.length > 0 && (
+            <div>
+              <strong style={{ fontSize: 12 }}>Нарушения (первые 10):</strong>
+              <List
+                size="small"
+                style={{ marginTop: 6 }}
+                dataSource={result.violations.slice(0, 10)}
+                renderItem={(v) => (
+                  <List.Item>
+                    <Tag color="orange" style={{ fontFamily: 'monospace' }}>{v.issueKey || '—'}</Tag>
+                    <span style={{ flex: 1, marginLeft: 8 }}>{v.issueTitle || v.reason}</span>
+                    <Tag color="default">{v.criterionType}</Tag>
+                  </List.Item>
+                )}
+              />
+              {result.violations.length > 10 && (
+                <span style={{ fontSize: 11, color: '#8B949E' }}>
+                  …и ещё {result.violations.length - 10} нарушений.
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/pages/admin/AdminReleaseCheckpointTypesPage.tsx
+++ b/frontend/src/pages/admin/AdminReleaseCheckpointTypesPage.tsx
@@ -25,6 +25,7 @@ import type { Color } from 'antd/es/color-picker';
 import type { ColumnsType } from 'antd/es/table';
 import { useCallback, useEffect, useState } from 'react';
 import {
+  type CheckpointConditionMode,
   type CheckpointCriterion,
   type CheckpointCriterionType,
   type CheckpointType,
@@ -36,6 +37,9 @@ import {
   listCheckpointTypes,
   updateCheckpointType,
 } from '../../api/release-checkpoint-types';
+import { listReleasesGlobal } from '../../api/releases';
+import CheckpointConditionModeControl, { CheckpointConditionModeIcon } from '../../components/releases/CheckpointConditionModeControl';
+import CheckpointPreviewPanel from '../../components/releases/CheckpointPreviewPanel';
 import SyncInstancesModal from './SyncInstancesModal';
 
 const COLOR_PALETTE = [
@@ -93,6 +97,8 @@ type TypeFormValues = {
   minStableSeconds: number;
   isActive: boolean;
   criteria: CheckpointCriterion[];
+  conditionMode?: CheckpointConditionMode;
+  ttqlCondition?: string | null;
 };
 
 export default function AdminReleaseCheckpointTypesPage() {
@@ -103,6 +109,27 @@ export default function AdminReleaseCheckpointTypesPage() {
   const [saving, setSaving] = useState(false);
   const [syncTarget, setSyncTarget] = useState<CheckpointType | null>(null);
   const [form] = Form.useForm();
+  // TTSRH-1 PR-18: mode state mirrors form.conditionMode but lives outside
+  // so mode-toggle + preview panel re-render instantly without waiting for
+  // Form.useWatch propagation.
+  const [conditionMode, setConditionMode] = useState<CheckpointConditionMode>('STRUCTURED');
+  const [ttqlValue, setTtqlValue] = useState<string>('');
+  const [releaseOptions, setReleaseOptions] = useState<Array<{ id: string; name: string; projectKey?: string }>>([]);
+
+  useEffect(() => {
+    // Preload releases for the preview panel. Silent-fail: panel is optional UX.
+    listReleasesGlobal({ limit: 100 })
+      .then((res) => {
+        setReleaseOptions(
+          res.data.map((r) => ({
+            id: r.id,
+            name: r.name,
+            projectKey: (r as unknown as { project?: { key?: string } }).project?.key,
+          })),
+        );
+      })
+      .catch(() => setReleaseOptions([]));
+  }, []);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -130,12 +157,18 @@ export default function AdminReleaseCheckpointTypesPage() {
       minStableSeconds: 300,
       isActive: true,
       criteria: [{ type: 'STATUS_IN', categories: ['DONE'] }],
+      conditionMode: 'STRUCTURED',
+      ttqlCondition: '',
     });
+    setConditionMode('STRUCTURED');
+    setTtqlValue('');
     setModalOpen(true);
   };
 
   const openEdit = (t: CheckpointType) => {
     setEditing(t);
+    const mode = t.conditionMode ?? 'STRUCTURED';
+    const ttql = t.ttqlCondition ?? '';
     form.setFieldsValue({
       name: t.name,
       description: t.description ?? '',
@@ -147,7 +180,11 @@ export default function AdminReleaseCheckpointTypesPage() {
       minStableSeconds: t.minStableSeconds,
       isActive: t.isActive,
       criteria: t.criteria,
+      conditionMode: mode,
+      ttqlCondition: ttql,
     });
+    setConditionMode(mode);
+    setTtqlValue(ttql);
     setModalOpen(true);
   };
 
@@ -162,6 +199,13 @@ export default function AdminReleaseCheckpointTypesPage() {
         offsetDays: values.offsetDays,
         warningDays: values.warningDays,
         criteria: values.criteria,
+        // TTSRH-1 PR-18: propagate new fields. Backend superRefine validates
+        // mode ↔ payload consistency (см. checkpoint.dto.ts).
+        conditionMode: conditionMode,
+        ttqlCondition:
+          conditionMode === 'TTQL' || conditionMode === 'COMBINED'
+            ? ttqlValue.trim() || null
+            : null,
         webhookUrl: values.webhookUrl ? values.webhookUrl : null,
         minStableSeconds: values.minStableSeconds,
         isActive: values.isActive,
@@ -227,6 +271,7 @@ export default function AdminReleaseCheckpointTypesPage() {
             }}
           />
           {name}
+          <CheckpointConditionModeIcon mode={t.conditionMode ?? 'STRUCTURED'} />
         </Space>
       ),
     },
@@ -389,8 +434,40 @@ export default function AdminReleaseCheckpointTypesPage() {
             </Form.Item>
           </Space>
 
-          <Divider orientation="left">Критерии (AND)</Divider>
-          <CriteriaListField />
+          <Divider orientation="left">Режим оценки</Divider>
+          <CheckpointConditionModeControl
+            value={conditionMode}
+            onChange={setConditionMode}
+            ttqlValue={ttqlValue}
+            onTtqlChange={setTtqlValue}
+            disabled={saving}
+          />
+
+          {(conditionMode === 'STRUCTURED' || conditionMode === 'COMBINED') && (
+            <>
+              <Divider orientation="left">Критерии (AND)</Divider>
+              <CriteriaListField />
+            </>
+          )}
+
+          <CheckpointPreviewPanel
+            releaseOptions={releaseOptions}
+            disabled={saving}
+            body={() => {
+              const values = form.getFieldsValue() as Partial<TypeFormValues>;
+              return {
+                releaseId: '', // filled inside the panel from its own select
+                conditionMode,
+                criteria: conditionMode === 'TTQL' ? [] : (values.criteria ?? []),
+                ttqlCondition:
+                  conditionMode === 'TTQL' || conditionMode === 'COMBINED'
+                    ? ttqlValue.trim() || null
+                    : null,
+                offsetDays: values.offsetDays,
+                warningDays: values.warningDays,
+              };
+            }}
+          />
         </Form>
       </Modal>
 

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,48 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.45**
+**Last version: 2.46**
+
+---
+
+## [2.46] [2026-04-21] feat(checkpoint): TTSRH-1 PR-18 — Checkpoint admin UI: mode-toggle + JqlEditor + preview panel
+
+**PR:** (to be filled after push)
+**Ветка:** `ttsrh-1/checkpoint-admin-ui`
+
+### Что было
+
+После PR-17 endpoint `/admin/checkpoint-types/preview` был готов backend-wise, но UI оставался чисто structured — пользователь не мог создать TTQL/COMBINED checkpoint type и не имел инструмента dry-run перед сохранением.
+
+### Что теперь
+
+- **`api/release-checkpoint-types.ts`** — + `CheckpointConditionMode` type, + optional `conditionMode`/`ttqlCondition` в `CheckpointType` / `CreateCheckpointTypeBody`, + `previewCheckpointCondition(body)` → `/admin/checkpoint-types/preview`.
+- **`components/releases/CheckpointConditionModeControl.tsx`** — AntD `Segmented` (STRUCTURED/TTQL/COMBINED) + условно lazy-loaded `JqlEditor` (PR-10) для TTQL/COMBINED. Переключение режима НЕ стирает criteria/ttqlCondition state (R20). `CheckpointConditionModeIcon` — inline S/Q/S+Q иконка для таблицы с tooltip.
+- **`components/releases/CheckpointPreviewPanel.tsx`** — AntD Card с Release-select + «Рассчитать». Breakdown (applicable/passed/violated) + state badge + top-10 violations. Alerts на `meta.ttqlSkippedByFlag` и `meta.ttqlError`.
+- **`AdminReleaseCheckpointTypesPage.tsx`** — integration: state conditionMode/ttqlValue вне Form (мгновенный re-render toggle); openCreate/openEdit + handleSave пропагируют новые fields; форма показывает mode-toggle всегда, criteria section conditional (STRUCTURED/COMBINED), TTQL-editor внутри control (TTQL/COMBINED), preview panel всегда. Releases preloaded через `listReleasesGlobal({limit:100})` silent-fail.
+- Иконка режима в таблице «Название» column.
+
+### Изменения
+
+- `frontend/src/api/release-checkpoint-types.ts` — + conditionMode/ttqlCondition + previewCheckpointCondition.
+- `frontend/src/components/releases/CheckpointConditionModeControl.tsx` — новый.
+- `frontend/src/components/releases/CheckpointPreviewPanel.tsx` — новый.
+- `frontend/src/pages/admin/AdminReleaseCheckpointTypesPage.tsx` — integration + mode-icon.
+- `docs/tz/TTSRH-1.md` §13.7/§13.9 — статус PR-18 → ✅ Done.
+
+### Влияние на prod
+
+Под `VITE_FEATURES_ADVANCED_SEARCH=false` JqlEditor chunk не грузится; mode-toggle виден, но TTQL-editor требует CodeMirror (lazy chunk), грузится by-demand. Backend gate `FEATURES_CHECKPOINT_TTQL=false` → preview ttqlSkippedByFlag=true, UI показывает баннер.
+
+### Проверки
+
+- `npx tsc --noEmit` (frontend) — чисто
+- `npm run lint` (frontend) — 0 errors
+- `npm run build` — чисто, 4.54s; JqlEditor chunk без изменений.
+
+---
+
+## [2.45] [2026-04-21] feat(checkpoint): TTSRH-1 PR-17 — /admin/checkpoint-types/preview + suggesters sync
 
 ---
 


### PR DESCRIPTION
## Summary

Frontend КТ admin UI для TTQL/COMBINED режимов + dry-run preview:

- **API client** (`release-checkpoint-types.ts`): + `CheckpointConditionMode` type, + `conditionMode`/`ttqlCondition` на type+body, + `previewCheckpointCondition()` → `/admin/checkpoint-types/preview`.
- **`CheckpointConditionModeControl`**: AntD `Segmented` STRUCTURED/TTQL/COMBINED + условно lazy JqlEditor (chunk из PR-10). Переключение режима НЕ стирает criteria[] / ttqlCondition state (R20). `CheckpointConditionModeIcon` — S/Q/S+Q inline badge для таблицы.
- **`CheckpointPreviewPanel`**: Release-select + «Рассчитать» → breakdown + state badge + top-10 violations + Alerts для `meta.ttqlSkippedByFlag` / `meta.ttqlError`.
- **`AdminReleaseCheckpointTypesPage`**: mode-state вне Form (мгновенный re-render toggle'а); openCreate/openEdit + handleSave прокидывают `conditionMode`/`ttqlCondition`; criteria section conditionally rendered для STRUCTURED/COMBINED; preview panel внизу формы; releases preloaded через `listReleasesGlobal({limit:100})` silent-fail.
- Иконка режима в столбце «Название» таблицы types.

## Test plan

- [x] `npx tsc --noEmit` — чисто.
- [x] `npm run lint` — 0 errors.
- [x] `npm run build` — чисто, 4.54s. JqlEditor chunk без изменений.

## Ручной smoke (expected)

- Новый тип КТ: segment toggle переключает видимость criteria/TTQL; TTQL-mode скрывает criteria (но не теряет state); COMBINED показывает оба.
- Preview panel: выбор релиза → POST /preview → breakdown applicable/passed/violated.
- `FEATURES_CHECKPOINT_TTQL=false` → preview показывает баннер «TTQL не проверялся».
- Ошибка TTQL в pipeline → preview показывает Alert с reason.
- Таблица types: S/Q/S+Q иконка режима с tooltip.

## Зависимости

- Блокирующие: PR-10 (#110) JqlEditor, PR-15 (#117) schema, PR-17 (#119) /preview endpoint — все merged ✅.
- Блокирует: PR-19 (structured→TTQL converter — one-way, добавит кнопку «Преобразовать» в форму для STRUCTURED types).

## Плановая дельта

~485 LoC (3 new components + API extension + integration + docs), в пределах §8 эстимата (~11ч).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
