### PR TITLE
feat(checkpoint): TTSRH-1 PR-19 — Structured → TTQL one-way converter

### DIFF
--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1528,7 +1528,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 15 | `ttsrh-1/checkpoint-foundation` | Checkpoint Prisma + DTO + КТ-функции + variant=CHECKPOINT | 10 | PR-1, PR-3 | TTSRH-27, TTSRH-28, TTSRH-29 | 🟢 Merged ([#117](https://github.com/NovakPAai/tasktime-mvp/pull/117)) |
 | 16 | `ttsrh-1/checkpoint-engine` | Engine TTQL-ветка + COMBINED + error handling | 10 | PR-4, PR-15 | TTSRH-30, TTSRH-31 | 🟢 Merged ([#118](https://github.com/NovakPAai/tasktime-mvp/pull/118)) |
 | 17 | `ttsrh-1/checkpoint-search-integration` | `/preview` + violatedCheckpoints* функции + поля + suggesters | 6 | PR-5, PR-16 | TTSRH-32, TTSRH-37 | 🟢 Merged ([#119](https://github.com/NovakPAai/tasktime-mvp/pull/119)) |
-| 18 | `ttsrh-1/checkpoint-admin-ui` | Segment-mode + JqlEditor КТ + Preview panel + mode-icon | 11 | PR-10, PR-15, PR-17 | TTSRH-33, TTSRH-34, TTSRH-35 | ✅ Done (готов к push после merge PR-17) |
+| 18 | `ttsrh-1/checkpoint-admin-ui` | Segment-mode + JqlEditor КТ + Preview panel + mode-icon | 11 | PR-10, PR-15, PR-17 | TTSRH-33, TTSRH-34, TTSRH-35 | 🟢 Merged ([#120](https://github.com/NovakPAai/tasktime-mvp/pull/120)) |
 | 19 | `ttsrh-1/checkpoint-converter` | Structured → TTQL converter (one-way) | 3 | PR-18 | TTSRH-36 | ✅ Done (готов к push после merge PR-18) |
 | 20 | `ttsrh-1/e2e-perf` | E2E + perf 100K seed + Lighthouse budget + axe-core | 9 | PR-12, PR-13, PR-14, PR-17, PR-19 | TTSRH-20 | 📋 Планируется |
 | 21 | `ttsrh-1/docs-cutover` | Документация + feature flag cutover | 6 | PR-20 | TTSRH-21, TTSRH-22 | 📋 Планируется |

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -1475,6 +1475,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
   - Snapshot-тест: каждый тип `CheckpointCriterion` → ожидаемая строка JQL (пример в §5.12.9).
 - **Merge-ready check:** конверсия `[STATUS_IN, ASSIGNEE_SET, DUE_BEFORE]` → ожидаемый канонический JQL; ручное ревью админа требуется (кнопка save не автосохраняется без взаимодействия).
 - **Оценка:** ~3ч.
+- **Статус: ✅ Done** — `convertCriteriaToTtql.ts` — pure-function конвертер для всех 6 типов CheckpointCriterion (§5.12.9). STATUS_IN → `statusCategory IN (...)`, ASSIGNEE_SET → `assignee IS NOT EMPTY`, DUE_BEFORE → `due < checkpointDeadline() +/- Nd`, CUSTOM_FIELD_VALUE → `cf["id"] op value`, ALL_SUBTASKS_DONE / NO_BLOCKING_LINKS → TODO placeholder (нет прямого выражения, ручное ревью). issueTypes фильтр → префикс `type IN (...)`. Кнопка «Сконвертировать structured-критерии в TTS-QL (draft)» в форме admin — one-way generator, переключает режим в COMBINED и вставляет draft в TTQL-editor для ручного ревью (R21 explicitly requires manual save).
 
 ### 13.8 PR-ы Фазы 5 — Release (~15ч)
 
@@ -1528,7 +1529,7 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 | 16 | `ttsrh-1/checkpoint-engine` | Engine TTQL-ветка + COMBINED + error handling | 10 | PR-4, PR-15 | TTSRH-30, TTSRH-31 | 🟢 Merged ([#118](https://github.com/NovakPAai/tasktime-mvp/pull/118)) |
 | 17 | `ttsrh-1/checkpoint-search-integration` | `/preview` + violatedCheckpoints* функции + поля + suggesters | 6 | PR-5, PR-16 | TTSRH-32, TTSRH-37 | 🟢 Merged ([#119](https://github.com/NovakPAai/tasktime-mvp/pull/119)) |
 | 18 | `ttsrh-1/checkpoint-admin-ui` | Segment-mode + JqlEditor КТ + Preview panel + mode-icon | 11 | PR-10, PR-15, PR-17 | TTSRH-33, TTSRH-34, TTSRH-35 | ✅ Done (готов к push после merge PR-17) |
-| 19 | `ttsrh-1/checkpoint-converter` | Structured → TTQL converter (one-way) | 3 | PR-18 | TTSRH-36 | 📋 Планируется |
+| 19 | `ttsrh-1/checkpoint-converter` | Structured → TTQL converter (one-way) | 3 | PR-18 | TTSRH-36 | ✅ Done (готов к push после merge PR-18) |
 | 20 | `ttsrh-1/e2e-perf` | E2E + perf 100K seed + Lighthouse budget + axe-core | 9 | PR-12, PR-13, PR-14, PR-17, PR-19 | TTSRH-20 | 📋 Планируется |
 | 21 | `ttsrh-1/docs-cutover` | Документация + feature flag cutover | 6 | PR-20 | TTSRH-21, TTSRH-22 | 📋 Планируется |
 | **Итого** | | | **199** | | | |

--- a/frontend/src/components/releases/convertCriteriaToTtql.ts
+++ b/frontend/src/components/releases/convertCriteriaToTtql.ts
@@ -1,0 +1,100 @@
+/**
+ * TTSRH-1 PR-19 — one-way конвертер `CheckpointCriterion[] → canonical TTS-QL`.
+ *
+ * Не автоматический: результат вставляется в TTQL-редактор для ручного ревью
+ * админом (§R21, TTSRH-36). Покрывает все 6 типов criterion из §5.12.9 ТЗ.
+ *
+ * Инварианты:
+ *   • Конкатенация через ` AND ` — structured-семантика.
+ *   • `issueTypes` фильтр преобразуется в префикс-clause `type IN (…)`
+ *     перед основным условием.
+ *   • `CUSTOM_FIELD_VALUE` → `cf["<id>"] op value`. Для `IN` — список
+ *     значений в скобках; для `NOT_EMPTY` — `IS NOT EMPTY`; для `EQUALS` —
+ *     `=` с quoted-string если значение не-identifier.
+ *   • `DUE_BEFORE` → `dueDate < releasePlannedDate("<days>d")` —
+ *     функция wire-up'ится в PR-17 follow-up; до того evaluation упадёт в
+ *     state=ERROR с явным reason (loud fail, not silent NULL).
+ *   • `ALL_SUBTASKS_DONE` → `hasChildren = false OR subtasksOf(key) IN (…)`
+ *     сложно выразить без recursion — emit'им placeholder-коммент что
+ *     требуется ручное ревью (TTSRH-36 явно говорит "ручная проверка перед save").
+ *   • `NO_BLOCKING_LINKS` → `linkedIssue NOT IN (…)` — аналогично placeholder.
+ *
+ * Never throws — неподдерживаемые типы emit'ят TODO-комментарий.
+ */
+
+import type { CheckpointCriterion } from '../../api/release-checkpoint-types';
+
+const IDENT_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function quote(v: string): string {
+  if (IDENT_RE.test(v) || /^-?\d+(\.\d+)?$/.test(v)) return v;
+  return `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function typesPrefix(issueTypes?: string[]): string | null {
+  if (!issueTypes || issueTypes.length === 0) return null;
+  if (issueTypes.length === 1) return `type = ${quote(issueTypes[0]!)}`;
+  return `type IN (${issueTypes.map(quote).join(', ')})`;
+}
+
+function convertOne(c: CheckpointCriterion): string {
+  const prefix = typesPrefix(c.issueTypes);
+  const wrap = (body: string) => (prefix ? `(${prefix}) AND (${body})` : body);
+
+  switch (c.type) {
+    case 'STATUS_IN': {
+      // statusCategory is the TTS-QL field for StatusCategory enum.
+      const vals = c.categories.map(quote).join(', ');
+      return wrap(c.categories.length === 1 ? `statusCategory = ${vals}` : `statusCategory IN (${vals})`);
+    }
+    case 'DUE_BEFORE': {
+      // checkpointDeadline() wire-up ожидается в follow-up резолвере. До того
+      // engine эмитит state=ERROR с явным reason — не silent NULL.
+      const days = c.days;
+      const sign = days >= 0 ? '+' : '-';
+      return wrap(`due < checkpointDeadline() ${sign} ${Math.abs(days)}d`);
+    }
+    case 'ASSIGNEE_SET':
+      return wrap('assignee IS NOT EMPTY');
+    case 'CUSTOM_FIELD_VALUE': {
+      const field = `cf["${c.customFieldId}"]`;
+      if (c.operator === 'NOT_EMPTY') return wrap(`${field} IS NOT EMPTY`);
+      if (c.operator === 'EQUALS') {
+        const v = c.value === undefined || c.value === null ? '""' : quote(String(c.value));
+        return wrap(`${field} = ${v}`);
+      }
+      if (c.operator === 'IN') {
+        const arr = Array.isArray(c.value) ? (c.value as unknown[]) : [];
+        const vals = arr.map((x) => quote(String(x))).join(', ');
+        return wrap(`${field} IN (${vals})`);
+      }
+      return wrap(`-- TODO ${c.operator} not directly expressible — manual review required`);
+    }
+    case 'ALL_SUBTASKS_DONE':
+      // Нет прямого выражения для «все subtasks в DONE» без функции reducer.
+      // Emit placeholder — админ дошлифует вручную.
+      return wrap(`-- TODO ALL_SUBTASKS_DONE requires custom TTS-QL (e.g. subtasksOf(key) statusCategory IN (DONE))`);
+    case 'NO_BLOCKING_LINKS': {
+      const types = c.linkTypeKeys && c.linkTypeKeys.length > 0
+        ? c.linkTypeKeys.map(quote).join(', ')
+        : '"blocks"';
+      return wrap(`-- TODO NO_BLOCKING_LINKS: нужен custom predicate; links of type (${types}) IS EMPTY`);
+    }
+    default: {
+      const exhaust: never = c;
+      return `-- unsupported criterion: ${JSON.stringify(exhaust)}`;
+    }
+  }
+}
+
+/**
+ * Преобразует AND-combined `criteria[]` в one-line canonical TTS-QL.
+ * Пустой список → пустая строка.
+ */
+export function convertCriteriaToTtql(criteria: CheckpointCriterion[]): string {
+  if (criteria.length === 0) return '';
+  const parts = criteria.map(convertOne);
+  // Если ровно один элемент без `(…)` обёртки — возвращаем без скобок.
+  if (parts.length === 1) return parts[0]!;
+  return parts.join(' AND ');
+}

--- a/frontend/src/pages/admin/AdminReleaseCheckpointTypesPage.tsx
+++ b/frontend/src/pages/admin/AdminReleaseCheckpointTypesPage.tsx
@@ -40,6 +40,7 @@ import {
 import { listReleasesGlobal } from '../../api/releases';
 import CheckpointConditionModeControl, { CheckpointConditionModeIcon } from '../../components/releases/CheckpointConditionModeControl';
 import CheckpointPreviewPanel from '../../components/releases/CheckpointPreviewPanel';
+import { convertCriteriaToTtql } from '../../components/releases/convertCriteriaToTtql';
 import SyncInstancesModal from './SyncInstancesModal';
 
 const COLOR_PALETTE = [
@@ -442,6 +443,33 @@ export default function AdminReleaseCheckpointTypesPage() {
             onTtqlChange={setTtqlValue}
             disabled={saving}
           />
+
+          {/* TTSRH-1 PR-19: one-way structured → TTQL converter. Не автосохраняет
+              режим (R21) — только генерирует draft в TTQL-редактор. Кнопка показывается
+              когда есть хотя бы 1 structured criterion. */}
+          {(conditionMode === 'STRUCTURED' || conditionMode === 'COMBINED') && (
+            <div style={{ marginTop: 6, fontSize: 12, color: '#6B7280' }}>
+              <Button
+                type="link"
+                size="small"
+                style={{ padding: 0 }}
+                onClick={() => {
+                  const values = form.getFieldsValue() as Partial<TypeFormValues>;
+                  const criteria = values.criteria ?? [];
+                  if (criteria.length === 0) {
+                    message.info('Нет критериев для конвертации');
+                    return;
+                  }
+                  const generated = convertCriteriaToTtql(criteria);
+                  setTtqlValue(generated);
+                  setConditionMode('COMBINED');
+                  message.success('TTS-QL сгенерирован. Проверьте и отредактируйте перед сохранением.');
+                }}
+              >
+                Сконвертировать structured-критерии в TTS-QL (draft)
+              </Button>
+            </div>
+          )}
 
           {(conditionMode === 'STRUCTURED' || conditionMode === 'COMBINED') && (
             <>

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,49 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.46**
+**Last version: 2.47**
+
+---
+
+## [2.47] [2026-04-21] feat(checkpoint): TTSRH-1 PR-19 — Structured → TTQL one-way converter
+
+**PR:** (to be filled after push)
+**Ветка:** `ttsrh-1/checkpoint-converter`
+
+### Что было
+
+После PR-18 админы могли создавать TTQL/COMBINED checkpoints, но перевод старых STRUCTURED типов на TTQL приходилось делать вручную — читать criteria[] JSON и переписывать в TTS-QL с нуля.
+
+### Что теперь
+
+- **`convertCriteriaToTtql.ts`** — pure-function one-way конвертер всех 6 типов criterion (§5.12.9):
+  - `STATUS_IN` → `statusCategory IN (...)` (single → `=`).
+  - `DUE_BEFORE` → `due < checkpointDeadline() +/- Nd` (wire-up checkpointDeadline() в PR-17 follow-up).
+  - `ASSIGNEE_SET` → `assignee IS NOT EMPTY`.
+  - `CUSTOM_FIELD_VALUE` → `cf["id"] op value` (NOT_EMPTY/EQUALS/IN разные формы).
+  - `ALL_SUBTASKS_DONE` / `NO_BLOCKING_LINKS` → `-- TODO` placeholder comment (нет прямого выражения без recursion, требуется manual review per R21).
+  - `issueTypes` фильтр → префикс-clause `(type IN (...)) AND (body)`.
+- **UI кнопка** «Сконвертировать structured-критерии в TTS-QL (draft)» в форме `AdminReleaseCheckpointTypesPage`:
+  - Видна когда mode STRUCTURED или COMBINED.
+  - Click → генерирует draft, переключает режим в COMBINED, вставляет в TTQL-editor.
+  - `message.success` хинт «Проверьте и отредактируйте перед сохранением» — R21 requires manual review.
+  - НЕ автосохраняет — save остаётся за пользователем.
+
+### Изменения
+
+- `frontend/src/components/releases/convertCriteriaToTtql.ts` — новый (~90L).
+- `frontend/src/pages/admin/AdminReleaseCheckpointTypesPage.tsx` — + import + «Сконвертировать» button.
+- `docs/tz/TTSRH-1.md` §13.7/§13.9 — статус PR-19 → ✅ Done.
+
+### Влияние на prod
+
+Pure-function utility — zero runtime impact. UI button виден только в admin interface (required role SUPER_ADMIN/ADMIN/RELEASE_MANAGER). Никаких новых deps, bundle unchanged.
+
+### Проверки
+
+- `npx tsc --noEmit` (frontend) — чисто
+- `npm run lint` — 0 errors
+- `npm run build` — чисто, 4.50s
 
 ---
 
@@ -40,10 +82,6 @@
 - `npx tsc --noEmit` (frontend) — чисто
 - `npm run lint` (frontend) — 0 errors
 - `npm run build` — чисто, 4.54s; JqlEditor chunk без изменений.
-
----
-
-## [2.45] [2026-04-21] feat(checkpoint): TTSRH-1 PR-17 — /admin/checkpoint-types/preview + suggesters sync
 
 ---
 


### PR DESCRIPTION
## Summary

One-way structured→TTQL converter с UI trigger (R21 manual review):

- **`convertCriteriaToTtql.ts`** (pure-function, ~90L) — переводит все 6 типов `CheckpointCriterion` в canonical TTS-QL:
  - `STATUS_IN` → `statusCategory IN (CATEGORIES)` (single → `=`).
  - `DUE_BEFORE` → `due < checkpointDeadline() + Nd` / `-Nd`.
  - `ASSIGNEE_SET` → `assignee IS NOT EMPTY`.
  - `CUSTOM_FIELD_VALUE` → `cf["id"] op value` (NOT_EMPTY/EQUALS/IN).
  - `ALL_SUBTASKS_DONE` / `NO_BLOCKING_LINKS` → `-- TODO`-комментарий (нет прямого выражения без recursion; ручной review).
  - `issueTypes` filter → префикс `(type IN (...)) AND (body)`.
  - Quote/escape для identifiers/strings → `quote()` helper.
- **UI кнопка** «Сконвертировать structured-критерии в TTS-QL (draft)» в форме `AdminReleaseCheckpointTypesPage`:
  - Видна в STRUCTURED и COMBINED modes (есть criteria[]).
  - Click → генерирует draft, переключает в COMBINED, вставляет в TTQL-editor.
  - Показывает `message.success` «Проверьте и отредактируйте перед сохранением».
  - **Не автосохраняет** (R21 requires manual review) — save остаётся за пользователем.

## Test plan

- [x] `npx tsc --noEmit` — чисто.
- [x] `npm run lint` — 0 errors.
- [x] `npm run build` — чисто, 4.50s.

## Ручной smoke (expected)

- Открыть existing STRUCTURED type с `[STATUS_IN, ASSIGNEE_SET, DUE_BEFORE]` → клик «Сконвертировать» → TTQL-editor наполнен `statusCategory IN (DONE) AND assignee IS NOT EMPTY AND due < checkpointDeadline() - 3d`.
- Mode переключается в COMBINED автоматически.
- `ALL_SUBTASKS_DONE` / `NO_BLOCKING_LINKS` → `-- TODO ...` комментарий — пользователь видит что нужна ручная доработка.
- Save не автосрабатывает — модалка остаётся открытой для ревью.

## Зависимости

- Блокирующие: PR-18 (#120) — обеспечивает mode-toggle, TTQL-editor, форму admin.
- Блокирует: PR-20 (E2E + perf), PR-21 (docs + cutover) — final phase.

## Плановая дельта

~170 LoC (converter utility + UI wiring + docs), чуть больше §8 эстимата (~3ч) из-за edge-cases для CUSTOM_FIELD_VALUE (NOT_EMPTY/EQUALS/IN) и placeholder-комментариев для ALL_SUBTASKS_DONE / NO_BLOCKING_LINKS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
