### PR TITLE
fix(e2e): TTSRH-1 — 20-search.spec.ts ждёт рендер SearchPage

### DIFF
--- a/frontend/e2e/specs/20-search.spec.ts
+++ b/frontend/e2e/specs/20-search.spec.ts
@@ -33,8 +33,10 @@ test.describe('TTSRH-1: /search page smoke + a11y', () => {
       return;
     }
     const root = page.getByTestId('search-page');
-    if (!(await root.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip(true, 'search-page not rendered — FEATURES_ADVANCED_SEARCH disabled');
+    const visible = await root.waitFor({ state: 'visible', timeout: 10_000 })
+      .then(() => true).catch(() => false);
+    if (!visible) {
+      test.skip(true, 'search-page not rendered (feature flag off or render error)');
       return;
     }
     await expect(root).toBeVisible();
@@ -48,8 +50,10 @@ test.describe('TTSRH-1: /search page smoke + a11y', () => {
   test('URL reflects JQL after Run; reload preserves state (T-9)', async ({ page }) => {
     await page.goto(`${BASE}/search`);
     const root = page.getByTestId('search-page');
-    if (!(await root.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip(true, 'search-page not rendered — FEATURES_ADVANCED_SEARCH disabled');
+    const visible = await root.waitFor({ state: 'visible', timeout: 10_000 })
+      .then(() => true).catch(() => false);
+    if (!visible) {
+      test.skip(true, 'search-page not rendered (feature flag off or render error)');
       return;
     }
 
@@ -80,8 +84,10 @@ test.describe('TTSRH-1: /search page smoke + a11y', () => {
   test('save modal opens via Ctrl+S when JQL is non-empty', async ({ page }) => {
     await page.goto(`${BASE}/search`);
     const root = page.getByTestId('search-page');
-    if (!(await root.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip(true, 'search-page not rendered — FEATURES_ADVANCED_SEARCH disabled');
+    const visible = await root.waitFor({ state: 'visible', timeout: 10_000 })
+      .then(() => true).catch(() => false);
+    if (!visible) {
+      test.skip(true, 'search-page not rendered (feature flag off or render error)');
       return;
     }
 
@@ -113,8 +119,10 @@ test.describe('TTSRH-1: /search page smoke + a11y', () => {
   test('a11y: no critical/serious axe violations on /search', async ({ page }) => {
     await page.goto(`${BASE}/search`);
     const root = page.getByTestId('search-page');
-    if (!(await root.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip(true, 'search-page not rendered — FEATURES_ADVANCED_SEARCH disabled');
+    const visible = await root.waitFor({ state: 'visible', timeout: 10_000 })
+      .then(() => true).catch(() => false);
+    if (!visible) {
+      test.skip(true, 'search-page not rendered (feature flag off or render error)');
       return;
     }
     // Wait for the lazy-loaded CM6 editor chunk to mount before axe scans


### PR DESCRIPTION
## Summary\n\nФикс 4 тестов из 20-search.spec.ts, которые скипались на staging после включения флагов.\n\n**Причина:** \ — immediate check, опция timeout игнорируется Playwright-ом. React не успевает отрендерить к моменту вызова → skip с stale-сообщением «FEATURES_ADVANCED_SEARCH disabled».\n\n**Фикс:** \ → \. Полноценный polling wait.\n\n## Диагностика\n\n- E2E run [24744589261](https://github.com/NovakPAai/tasktime-mvp/actions/runs/24744589261) после PR-127: 72 passed, **22 skipped**, 0 failed.\n- Bundle на staging уже содержит \ (проверил curl + grep). Флаги включились.\n- 21-checkpoints тесты с тем же паттерном **проходят** — там есть \ перед \, React успевает.\n- 20-search без \ → immediate check фейлит.\n\n## Test plan\n\n- [x] \ зелёный.\n- [ ] CI passes.\n- [ ] После merge + deploy: 20-search тесты пройдут (22 skipped → 0).\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n