### PR TITLE
fix(a11y): TTSRH-1 — underline на «справка» link в SearchPage

### DIFF
--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -183,7 +183,7 @@ export default function SearchPage() {
       <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
         <h1 style={{ fontSize: 18, fontWeight: 600, margin: 0 }}>Поиск задач</h1>
         <div style={{ color: c.t3, fontSize: 12 }}>
-          TTS-QL · <a href="https://github.com/NovakPAai/tasktime-mvp/blob/main/docs/tz/TTSRH-1.md" target="_blank" rel="noreferrer" style={{ color: c.acc }}>справка</a>
+          TTS-QL · <a href="https://github.com/NovakPAai/tasktime-mvp/blob/main/docs/tz/TTSRH-1.md" target="_blank" rel="noreferrer" style={{ color: c.acc, textDecoration: 'underline' }}>справка</a>
         </div>
       </header>
 


### PR DESCRIPTION
E2E staging: 75 passed / 18 skipped / 1 failed — последний fail = axe \ + \ на ссылке «справка» в header SearchPage. Color alone недостаточен для a11y — нужен secondary distinguisher.\n\nДобавлен textDecoration: underline. После merge + rebuild + deploy → e2e должен дать 76/18/0.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n