### PR TITLE
fix(ttsrh-1): post-release — reference values + suggest routing + custom columns

### DIFF
--- a/backend/src/modules/releases/checkpoints/checkpoint-ttql-evaluator.service.ts
+++ b/backend/src/modules/releases/checkpoints/checkpoint-ttql-evaluator.service.ts
@@ -26,6 +26,7 @@ import { compile } from '../../search/search.compiler.js';
 import { executeCustomFieldPredicates } from '../../search/search.custom-field.executor.js';
 import { resolveFunctions } from '../../search/search.function-resolver.js';
 import { parse } from '../../search/search.parser.js';
+import { resolveReferenceValues } from '../../search/search.reference-resolver.js';
 import { loadCustomFields } from '../../search/search.schema.loader.js';
 import { createValidatorContext, validate } from '../../search/search.validator.js';
 
@@ -87,8 +88,12 @@ export async function resolveTtqlMatchedIds(
       });
 
       // Phase 4: compile to Prisma where.
+      const referenceValues = await resolveReferenceValues(parseResult.ast, {
+        accessibleProjectIds: ctx.accessibleProjectIds,
+      });
       const compiled = compile(parseResult.ast, {
         accessibleProjectIds: ctx.accessibleProjectIds,
+        referenceValues,
         customFields,
         resolved,
         now: ctx.now,

--- a/backend/src/modules/search/search.compile-context.ts
+++ b/backend/src/modules/search/search.compile-context.ts
@@ -58,6 +58,25 @@ export interface CompileContext {
    * produces a where-clause that matches nothing.
    */
   accessibleProjectIds: readonly string[];
+  /**
+   * Pre-resolved `user-facing value → row id` lookups for reference-type system
+   * fields. Keyed by the TTS-QL field's canonical name (e.g. `project`,
+   * `assignee`, `sprint`, `release`, `type`, `parent`, `epic`, `issue`, `key`).
+   *
+   * The inner map is case-insensitive (keys must be lowercased on insertion):
+   *   - `project`       → project key (`TTMP` → uuid)
+   *   - `assignee`/`reporter` → email OR full name (`alice@x.com` / `alice` → uuid)
+   *   - `sprint`        → sprint name (`Sprint 1` → uuid)
+   *   - `release`       → release name (`v1.0` → uuid)
+   *   - `type`          → issue-type `systemKey` OR name (`BUG` / `bug` → uuid)
+   *   - `parent`/`epic`/`issue`/`key` → issue key (`ttmp-123` → uuid)
+   *
+   * The compiler substitutes the RHS of a clause via this map. Unknown values
+   * fall through unchanged — the top-level scope filter then yields zero rows
+   * (matching JIRA behaviour on unknown keys). Populated by
+   * `search.reference-resolver.ts` in the caller, so the compiler stays DB-free.
+   */
+  referenceValues: ReadonlyMap<string, ReadonlyMap<string, string>>;
   /** Custom-field registry (already loaded in the caller, typically via Redis cache). */
   customFields: readonly CustomFieldDef[];
   /** Pre-resolved DB-dependent function outputs. */

--- a/backend/src/modules/search/search.compiler.ts
+++ b/backend/src/modules/search/search.compiler.ts
@@ -421,11 +421,12 @@ function compileCompare(
     return MATCH_NONE;
   }
 
-  const value = evaluateValue(valueExpr, field.type, ctx);
-  if (value.kind === 'error') {
-    ctx.errors.push({ code: 'UNRESOLVED_VALUE', message: value.message, field: field.name });
+  const rawValue = evaluateValue(valueExpr, field.type, ctx);
+  if (rawValue.kind === 'error') {
+    ctx.errors.push({ code: 'UNRESOLVED_VALUE', message: rawValue.message, field: field.name });
     return MATCH_NONE;
   }
+  const value = resolveReferenceEvaluated(field.name, rawValue, ctx);
 
   // Text fields with `~` / `!~`
   if (op === '~' || op === '!~') {
@@ -476,8 +477,8 @@ function compileIn(
     ctx.errors.push({ code: 'UNRESOLVED_FIELD', message: `No column for \`${field.name}\`.`, field: field.name });
     return MATCH_NONE;
   }
-  const resolved = values.map((v) => evaluateValue(v, field.type, ctx));
-  const erroring = resolved.filter((r) => r.kind === 'error');
+  const resolvedRaw = values.map((v) => evaluateValue(v, field.type, ctx));
+  const erroring = resolvedRaw.filter((r) => r.kind === 'error');
   if (erroring.length > 0) {
     for (const e of erroring) {
       if (e.kind === 'error') ctx.errors.push({ code: 'UNRESOLVED_VALUE', message: e.message, field: field.name });
@@ -485,6 +486,7 @@ function compileIn(
     return MATCH_NONE;
   }
 
+  const resolved = resolvedRaw.map((r) => resolveReferenceEvaluated(field.name, r, ctx));
   const primitives = resolved.flatMap((r) => flattenResolvedValue(r));
   if (primitives.length === 0) return MATCH_NONE;
 
@@ -521,6 +523,43 @@ function compileIsEmpty(field: { name: string; type: TtqlType }, negated: boolea
   if (!col) return MATCH_NONE;
   const rhs = negated ? { not: null } : null;
   return wrapColumn(col, rhs);
+}
+
+// ─── Reference-value translation (user-facing name/key/email → row id) ──────
+
+/**
+ * Reference-type system fields whose Prisma column is a UUID, not the
+ * user-facing identifier. The suggest endpoint inserts `TTMP` (project key),
+ * `"alice@x.com"` (user email), `"Sprint 1"` (sprint name), `BUG`
+ * (issue-type systemKey), `TTMP-123` (issue key) — so every clause on these
+ * fields has to be rewritten before the where-clause reaches Prisma, else the
+ * compare runs UUID = "human text" and always matches nothing.
+ *
+ * The caller pre-resolves the referenced literals into
+ * `CompileContext.referenceValues` (see `search.reference-resolver.ts`); this
+ * helper looks up and substitutes. Unknown values fall through unchanged so
+ * the top-level scope filter (or simple id-mismatch) yields zero rows — same
+ * as JIRA's behaviour on non-existent keys.
+ *
+ * Substitutes only `string` values; `scalar-id` / `id-list` already contain
+ * ids produced by the function resolver.
+ */
+const REFERENCE_FIELDS: ReadonlySet<string> = new Set([
+  'project', 'assignee', 'reporter', 'sprint', 'release',
+  'type', 'parent', 'epic', 'issue', 'key',
+]);
+
+function resolveReferenceEvaluated(
+  fieldName: string,
+  value: EvaluatedValue,
+  ctx: SystemContext,
+): EvaluatedValue {
+  if (!REFERENCE_FIELDS.has(fieldName)) return value;
+  if (value.kind !== 'string') return value;
+  const lookup = ctx.ctx.referenceValues.get(fieldName);
+  if (!lookup) return value;
+  const mapped = lookup.get(value.value.toLowerCase());
+  return mapped ? { kind: 'string', value: mapped } : value;
 }
 
 // ─── Value evaluator ────────────────────────────────────────────────────────

--- a/backend/src/modules/search/search.export.ts
+++ b/backend/src/modules/search/search.export.ts
@@ -37,6 +37,7 @@ import { compile, type CompileIssue } from './search.compiler.js';
 import { executeCustomFieldPredicates } from './search.custom-field.executor.js';
 import { resolveFunctions } from './search.function-resolver.js';
 import { parse } from './search.parser.js';
+import { resolveReferenceValues } from './search.reference-resolver.js';
 import { SYSTEM_FIELDS } from './search.schema.js';
 import { loadCustomFields } from './search.schema.loader.js';
 import { createValidatorContext, validate, type ValidationIssue } from './search.validator.js';
@@ -174,8 +175,12 @@ export async function prepareExport(input: ExportInput, ctx: ExportContext): Pro
     variant: 'default',
   });
 
+  const referenceValues = await resolveReferenceValues(ast, {
+    accessibleProjectIds: ctx.accessibleProjectIds,
+  });
   const compiled = compile(ast, {
     accessibleProjectIds: ctx.accessibleProjectIds,
+    referenceValues,
     customFields,
     resolved,
     now,

--- a/backend/src/modules/search/search.reference-resolver.ts
+++ b/backend/src/modules/search/search.reference-resolver.ts
@@ -1,0 +1,318 @@
+/**
+ * Pre-compile resolver for reference-type system-field literals.
+ *
+ * The compiler maps every TTS-QL system field to a Prisma column, but for
+ * `project`, `assignee`, `reporter`, `sprint`, `release`, `type`, `parent`,
+ * `epic`, `issue`, `key` that column is a UUID while the user types a
+ * human-readable identifier (project key, email, sprint name, issue-type
+ * `systemKey`, issue key `TTMP-123`, …). Without translation, the compiled
+ * query becomes `uuid = "TTMP"` and always returns zero rows.
+ *
+ * This module walks the AST, groups the literals by field, and runs one
+ * batched Prisma query per field-kind. The result plugs into
+ * `CompileContext.referenceValues`. Unknown values are dropped from the map
+ * (the compiler passes them through unchanged, so the scope filter or
+ * id-mismatch yields zero rows — matching JIRA's behaviour on unknown keys).
+ */
+
+import { prisma } from '../../prisma/client.js';
+import type { BoolExpr, Expr, QueryNode } from './search.ast.js';
+
+type Literals = Map<string, Set<string>>;
+
+type ReferenceValues = Map<string, Map<string, string>>;
+
+export interface ReferenceResolverContext {
+  accessibleProjectIds: readonly string[];
+}
+
+export async function resolveReferenceValues(
+  ast: QueryNode,
+  ctx: ReferenceResolverContext,
+): Promise<ReferenceValues> {
+  const out: ReferenceValues = new Map();
+  const literals = collectReferenceLiterals(ast);
+  if (literals.size === 0) return out;
+
+  const tasks: Array<Promise<void>> = [];
+
+  const project = literals.get('project');
+  if (project && project.size > 0) {
+    tasks.push(resolveProjects(project, ctx, out));
+  }
+  const assignee = literals.get('assignee');
+  const reporter = literals.get('reporter');
+  const userLiterals = new Set<string>([...(assignee ?? []), ...(reporter ?? [])]);
+  if (userLiterals.size > 0) {
+    tasks.push(resolveUsers(userLiterals, ctx, out, {
+      fillAssignee: !!assignee && assignee.size > 0,
+      fillReporter: !!reporter && reporter.size > 0,
+    }));
+  }
+  const sprint = literals.get('sprint');
+  if (sprint && sprint.size > 0) {
+    tasks.push(resolveSprints(sprint, ctx, out));
+  }
+  const release = literals.get('release');
+  if (release && release.size > 0) {
+    tasks.push(resolveReleases(release, ctx, out));
+  }
+  const type = literals.get('type');
+  if (type && type.size > 0) {
+    tasks.push(resolveIssueTypes(type, out));
+  }
+  const issueLiterals = new Set<string>([
+    ...(literals.get('issue') ?? []),
+    ...(literals.get('key') ?? []),
+    ...(literals.get('parent') ?? []),
+    ...(literals.get('epic') ?? []),
+  ]);
+  if (issueLiterals.size > 0) {
+    tasks.push(resolveIssueKeys(issueLiterals, ctx, out, literals));
+  }
+
+  await Promise.all(tasks);
+  return out;
+}
+
+// ─── Field-specific resolvers ──────────────────────────────────────────────
+
+async function resolveProjects(
+  values: Set<string>,
+  ctx: ReferenceResolverContext,
+  out: ReferenceValues,
+): Promise<void> {
+  if (ctx.accessibleProjectIds.length === 0) return;
+  const rows = await prisma.project.findMany({
+    where: {
+      id: { in: [...ctx.accessibleProjectIds] },
+      key: { in: [...values].map(upper) },
+    },
+    select: { id: true, key: true },
+  });
+  const map = ensureField(out, 'project');
+  for (const r of rows) map.set(r.key.toLowerCase(), r.id);
+}
+
+async function resolveUsers(
+  values: Set<string>,
+  ctx: ReferenceResolverContext,
+  out: ReferenceValues,
+  fill: { fillAssignee: boolean; fillReporter: boolean },
+): Promise<void> {
+  if (ctx.accessibleProjectIds.length === 0) return;
+  const lower = [...values].map((v) => v.toLowerCase());
+  const rows = await prisma.user.findMany({
+    where: {
+      isActive: true,
+      projectRoles: {
+        some: { projectId: { in: [...ctx.accessibleProjectIds] } },
+      },
+      OR: [
+        { email: { in: lower, mode: 'insensitive' } },
+        { name: { in: lower, mode: 'insensitive' } },
+      ],
+    },
+    select: { id: true, email: true, name: true },
+  });
+  const entries: Array<[string, string]> = [];
+  for (const r of rows) {
+    entries.push([r.email.toLowerCase(), r.id]);
+    entries.push([r.name.toLowerCase(), r.id]);
+  }
+  if (fill.fillAssignee) {
+    const m = ensureField(out, 'assignee');
+    for (const [k, v] of entries) m.set(k, v);
+  }
+  if (fill.fillReporter) {
+    const m = ensureField(out, 'reporter');
+    for (const [k, v] of entries) m.set(k, v);
+  }
+}
+
+async function resolveSprints(
+  values: Set<string>,
+  ctx: ReferenceResolverContext,
+  out: ReferenceValues,
+): Promise<void> {
+  if (ctx.accessibleProjectIds.length === 0) return;
+  const rows = await prisma.sprint.findMany({
+    where: {
+      projectId: { in: [...ctx.accessibleProjectIds] },
+      name: { in: [...values], mode: 'insensitive' },
+    },
+    select: { id: true, name: true },
+  });
+  const map = ensureField(out, 'sprint');
+  for (const r of rows) map.set(r.name.toLowerCase(), r.id);
+}
+
+async function resolveReleases(
+  values: Set<string>,
+  ctx: ReferenceResolverContext,
+  out: ReferenceValues,
+): Promise<void> {
+  if (ctx.accessibleProjectIds.length === 0) return;
+  const rows = await prisma.release.findMany({
+    where: {
+      projectId: { in: [...ctx.accessibleProjectIds] },
+      name: { in: [...values], mode: 'insensitive' },
+    },
+    select: { id: true, name: true },
+  });
+  const map = ensureField(out, 'release');
+  for (const r of rows) map.set(r.name.toLowerCase(), r.id);
+}
+
+async function resolveIssueTypes(
+  values: Set<string>,
+  out: ReferenceValues,
+): Promise<void> {
+  const upperValues = [...values].map(upper);
+  const rows = await prisma.issueTypeConfig.findMany({
+    where: {
+      OR: [
+        { systemKey: { in: upperValues } },
+        { name: { in: [...values], mode: 'insensitive' } },
+      ],
+    },
+    select: { id: true, name: true, systemKey: true },
+  });
+  const map = ensureField(out, 'type');
+  for (const r of rows) {
+    if (r.systemKey) map.set(r.systemKey.toLowerCase(), r.id);
+    map.set(r.name.toLowerCase(), r.id);
+  }
+}
+
+async function resolveIssueKeys(
+  values: Set<string>,
+  ctx: ReferenceResolverContext,
+  out: ReferenceValues,
+  literals: Literals,
+): Promise<void> {
+  if (ctx.accessibleProjectIds.length === 0) return;
+  // Parse `TTMP-123` → { projectKey: 'TTMP', number: 123 }. Malformed values
+  // are dropped silently — they will miss the lookup and fall through.
+  const parsed: Array<{ raw: string; projectKey: string; number: number }> = [];
+  for (const v of values) {
+    const m = /^([A-Za-z][A-Za-z0-9]*)-(\d+)$/.exec(v.trim());
+    if (!m) continue;
+    parsed.push({ raw: v, projectKey: m[1]!.toUpperCase(), number: Number.parseInt(m[2]!, 10) });
+  }
+  if (parsed.length === 0) return;
+
+  const projectKeys = [...new Set(parsed.map((p) => p.projectKey))];
+  const projects = await prisma.project.findMany({
+    where: { id: { in: [...ctx.accessibleProjectIds] }, key: { in: projectKeys } },
+    select: { id: true, key: true },
+  });
+  const keyToProjectId = new Map(projects.map((p) => [p.key, p.id] as const));
+
+  const numbersByProject = new Map<string, number[]>();
+  for (const p of parsed) {
+    const projId = keyToProjectId.get(p.projectKey);
+    if (!projId) continue;
+    const list = numbersByProject.get(projId) ?? [];
+    list.push(p.number);
+    numbersByProject.set(projId, list);
+  }
+  if (numbersByProject.size === 0) return;
+
+  const issues = await prisma.issue.findMany({
+    where: {
+      OR: [...numbersByProject.entries()].map(([projectId, numbers]) => ({
+        projectId,
+        number: { in: numbers },
+      })),
+    },
+    select: { id: true, number: true, projectId: true },
+  });
+  const projectIdToKey = new Map([...keyToProjectId.entries()].map(([k, v]) => [v, k] as const));
+  const entries: Array<[string, string]> = [];
+  for (const i of issues) {
+    const projKey = projectIdToKey.get(i.projectId);
+    if (!projKey) continue;
+    entries.push([`${projKey}-${i.number}`.toLowerCase(), i.id]);
+  }
+  // Mirror into every issue-typed reference field that was referenced in the AST.
+  for (const field of ['issue', 'key', 'parent', 'epic'] as const) {
+    if (!literals.has(field)) continue;
+    const map = ensureField(out, field);
+    for (const [k, v] of entries) map.set(k, v);
+  }
+}
+
+// ─── AST walker ────────────────────────────────────────────────────────────
+
+/**
+ * Collect string-ish literals per reference field name. Case is preserved so
+ * downstream resolvers can treat `systemKey` (case-sensitive) and `name`
+ * (case-insensitive) differently.
+ */
+export function collectReferenceLiterals(ast: QueryNode): Literals {
+  const out: Literals = new Map();
+  const push = (field: string, value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    const set = out.get(field) ?? new Set<string>();
+    set.add(trimmed);
+    out.set(field, set);
+  };
+  const visitExpr = (field: string, e: Expr) => {
+    if (e.kind === 'String' || e.kind === 'Ident') {
+      push(field, e.kind === 'String' ? e.value : e.name);
+    }
+    // Functions + other literal shapes (Number, Bool, etc.) contribute nothing
+    // here — they don't map onto the `user-string → row id` translation path.
+  };
+  const visitBool = (n: BoolExpr) => {
+    switch (n.kind) {
+      case 'And':
+      case 'Or':
+        n.children.forEach(visitBool);
+        return;
+      case 'Not':
+        visitBool(n.child);
+        return;
+      case 'Clause': {
+        const fieldName = fieldNameOf(n);
+        if (!fieldName) return;
+        switch (n.op.kind) {
+          case 'Compare':
+            visitExpr(fieldName, n.op.value);
+            return;
+          case 'In':
+            n.op.values.forEach((v) => visitExpr(fieldName, v));
+            return;
+          default:
+            return;
+        }
+      }
+    }
+  };
+  if (ast.where) visitBool(ast.where);
+  return out;
+}
+
+function fieldNameOf(clause: { field: { kind: string; name?: string } }): string | null {
+  const f = clause.field;
+  if (f.kind === 'Ident' && typeof f.name === 'string') return f.name.toLowerCase();
+  if (f.kind === 'QuotedField' && typeof f.name === 'string') return f.name.toLowerCase();
+  return null;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function ensureField(map: ReferenceValues, field: string): Map<string, string> {
+  let inner = map.get(field);
+  if (!inner) {
+    inner = new Map();
+    map.set(field, inner);
+  }
+  return inner;
+}
+
+function upper(v: string): string {
+  return v.toUpperCase();
+}

--- a/backend/src/modules/search/search.service.ts
+++ b/backend/src/modules/search/search.service.ts
@@ -17,6 +17,7 @@ import { compile } from './search.compiler.js';
 import { executeCustomFieldPredicates } from './search.custom-field.executor.js';
 import { resolveFunctions } from './search.function-resolver.js';
 import { parse } from './search.parser.js';
+import { resolveReferenceValues } from './search.reference-resolver.js';
 import { loadCustomFields } from './search.schema.loader.js';
 import { createValidatorContext, validate } from './search.validator.js';
 import type { ParseError } from './search.ast.js';
@@ -38,14 +39,17 @@ export interface SearchIssuesContext {
 
 /**
  * Shape of a single issue in the `/search/issues` response. Mirrors the fixed
- * Prisma `include` below. When PR-9+ adds a user-configurable column set, this
- * type will need to become generic over the include payload.
+ * Prisma `include` below. `customFieldValues` is included unconditionally so
+ * the ResultsTable can render user-configured custom-field columns without a
+ * second round-trip; the payload is bounded by (issues × configured CFs),
+ * which for MVP (50 rows × ~20 CFs) is well under any row-size limit.
  */
 export type IssueSearchResult = Prisma.IssueGetPayload<{
   include: {
     assignee: { select: { id: true; name: true; email: true } };
     project: { select: { id: true; key: true; name: true } };
     workflowStatus: { select: { id: true; name: true; category: true; color: true; systemKey: true } };
+    customFieldValues: { select: { customFieldId: true; value: true } };
   };
 }>;
 
@@ -130,8 +134,12 @@ export async function searchIssues(
   });
 
   // Phase 4 — compile AST to Prisma where.
+  const referenceValues = await resolveReferenceValues(ast, {
+    accessibleProjectIds: ctx.accessibleProjectIds,
+  });
   const compiled = compile(ast, {
     accessibleProjectIds: ctx.accessibleProjectIds,
+    referenceValues,
     customFields,
     resolved,
     now,
@@ -172,6 +180,7 @@ export async function searchIssues(
               assignee: { select: { id: true, name: true, email: true } },
               project: { select: { id: true, key: true, name: true } },
               workflowStatus: { select: { id: true, name: true, category: true, color: true, systemKey: true } },
+              customFieldValues: { select: { customFieldId: true, value: true } },
             },
           }),
           prisma.issue.count({ where: exec.where }),

--- a/backend/src/modules/search/search.suggest.ts
+++ b/backend/src/modules/search/search.suggest.ts
@@ -45,10 +45,15 @@ export async function suggest(
   ctx: SuggestContext,
   customFields: readonly CustomFieldDef[],
 ): Promise<SuggestResponse> {
-  // Basic-builder path: caller passes field/operator/prefix directly.
-  if (ctx.field || ctx.operator || ctx.prefix !== undefined) {
+  // Basic-builder path: caller pinned the clause context by passing `field`.
+  // The CM6 editor sends `prefix` on every keystroke (for its own filtering),
+  // so we cannot treat `prefix` alone as an opt-in to this shortcut — doing so
+  // routes every in-editor completion through `completionsForField('', '=', …)`,
+  // which falls through to `suggestFunctions` and hides the real suggestions.
+  // Require `field` to be explicit; `operator`/`prefix` only modulate the result.
+  if (ctx.field) {
     const completions = await completionsForField(
-      ctx.field ?? '',
+      ctx.field,
       ctx.operator ?? '=',
       ctx.prefix ?? '',
       ctx,
@@ -59,13 +64,16 @@ export async function suggest(
       completions,
       context: {
         expectedField: ctx.field,
-        expectedType: typeFor(ctx.field ?? '', customFields),
+        expectedType: typeFor(ctx.field, customFields),
         inValueList: false,
       },
     };
   }
 
-  // Text-editor path: analyse cursor position in the raw JQL.
+  // Text-editor path: analyse cursor position in the raw JQL. The tokenizer
+  // derives its own prefix from the token at the cursor, so `ctx.prefix`
+  // (when sent by the CM6 editor) is ignored here — the editor uses it only
+  // for its local filtering display.
   const pos = analysePosition(source, cursor);
   switch (pos.expected) {
     case 'field':

--- a/backend/tests/search-compiler.unit.test.ts
+++ b/backend/tests/search-compiler.unit.test.ts
@@ -20,6 +20,7 @@ const PROJECTS: readonly string[] = ['proj-a', 'proj-b', 'proj-c'];
 function makeCtx(overrides: Partial<CompileContext> = {}): CompileContext {
   return {
     accessibleProjectIds: PROJECTS,
+    referenceValues: new Map(),
     customFields: [],
     resolved: { currentUserId: 'user-1', calls: new Map() },
     now: ANCHOR,
@@ -62,6 +63,67 @@ describe('compiler — scope filter (R3)', () => {
   it('no accessible projects → scope is empty; query matches nothing', () => {
     const r = compileFromSource('priority = HIGH', makeCtx({ accessibleProjectIds: [] }));
     expect(topScope(r)).toEqual({ projectId: { in: [] } });
+  });
+});
+
+// ─── reference value → id translation ──────────────────────────────────────
+
+describe('compiler — reference fields translate user-facing values to row ids', () => {
+  const refs = (entries: Record<string, Record<string, string>>): Map<string, Map<string, string>> =>
+    new Map(Object.entries(entries).map(([k, v]) => [k, new Map(Object.entries(v))]));
+
+  it('project = "TTMP" → projectId = <uuid>', () => {
+    const r = compileFromSource('project = "TTMP"', makeCtx({
+      referenceValues: refs({ project: { ttmp: 'proj-a' } }),
+    }));
+    expect(innerWhere(r)).toEqual({ projectId: 'proj-a' });
+  });
+
+  it('assignee = "alice@x.com" → assigneeId = <uuid>', () => {
+    const r = compileFromSource('assignee = "alice@x.com"', makeCtx({
+      referenceValues: refs({ assignee: { 'alice@x.com': 'user-1' } }),
+    }));
+    expect(innerWhere(r)).toEqual({ assigneeId: 'user-1' });
+  });
+
+  it('sprint IN ("Sprint 1", "Sprint 2") → sprintId IN [<uuids>]', () => {
+    const r = compileFromSource('sprint IN ("Sprint 1", "Sprint 2")', makeCtx({
+      referenceValues: refs({ sprint: { 'sprint 1': 's-1', 'sprint 2': 's-2' } }),
+    }));
+    expect(innerWhere(r)).toEqual({ sprintId: { in: ['s-1', 's-2'] } });
+  });
+
+  it('type = BUG (ident) → issueTypeConfigId = <uuid>', () => {
+    const r = compileFromSource('type = BUG', makeCtx({
+      referenceValues: refs({ type: { bug: 'type-bug' } }),
+    }));
+    expect(innerWhere(r)).toEqual({ issueTypeConfigId: 'type-bug' });
+  });
+
+  it('parent = "TTMP-123" → parentId = <uuid>', () => {
+    const r = compileFromSource('parent = "TTMP-123"', makeCtx({
+      referenceValues: refs({ parent: { 'ttmp-123': 'issue-1' } }),
+    }));
+    expect(innerWhere(r)).toEqual({ parentId: 'issue-1' });
+  });
+
+  it('release = "v1.0" → releaseId = <uuid>', () => {
+    const r = compileFromSource('release = "v1.0"', makeCtx({
+      referenceValues: refs({ release: { 'v1.0': 'rel-1' } }),
+    }));
+    expect(innerWhere(r)).toEqual({ releaseId: 'rel-1' });
+  });
+
+  it('unknown value falls through (scope filter then yields zero rows)', () => {
+    const r = compileFromSource('project = "UNKNOWN"', makeCtx({
+      referenceValues: refs({ project: { ttmp: 'proj-a' } }),
+    }));
+    expect(innerWhere(r)).toEqual({ projectId: 'UNKNOWN' });
+  });
+
+  it('UUID literal passes through unchanged (empty map, backward compat)', () => {
+    const r = compileFromSource('assignee = "user-42"', makeCtx());
+    expect(innerWhere(r)).toEqual({ assigneeId: 'user-42' });
   });
 });
 

--- a/backend/tests/search-pipeline-fuzz.unit.test.ts
+++ b/backend/tests/search-pipeline-fuzz.unit.test.ts
@@ -62,6 +62,7 @@ function makeCtx(): CompileContext {
   const resolved: ResolvedFunctions = { currentUserId: 'u-1', calls: new Map() };
   return {
     accessibleProjectIds: PROJECTS,
+    referenceValues: new Map(),
     customFields: [],
     resolved,
     now: ANCHOR,

--- a/backend/tests/search-suggest.unit.test.ts
+++ b/backend/tests/search-suggest.unit.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from 'vitest';
 import { analysePosition } from '../src/modules/search/search.suggest.position.js';
 import { rankByPrefix } from '../src/modules/search/search.suggest.rank.js';
+import { suggest } from '../src/modules/search/search.suggest.js';
 import {
   suggestBool,
   suggestDateShortcuts,
@@ -226,5 +227,34 @@ describe('suggestOperators', () => {
   it('maps TtqlOpKind to display operators', () => {
     const c = suggestOperators(['EQ', 'NEQ', 'IS_EMPTY', 'IS_NOT_EMPTY'], '');
     expect(c.map((x) => x.insert).sort()).toEqual(['!=', '=', 'IS EMPTY', 'IS NOT EMPTY']);
+  });
+});
+
+// ─── Orchestrator routing ───────────────────────────────────────────────────
+
+describe('suggest() — routing between basic-builder and text-editor paths', () => {
+  const baseCtx = {
+    userId: 'u1',
+    accessibleProjectIds: [] as string[],
+    variant: 'default' as const,
+  };
+
+  it('prefix alone (no field) does not trigger the basic-builder shortcut — editor path fires', async () => {
+    // Regression guard: the CM6 completion source sends `prefix` on every
+    // keystroke. If the backend treats `prefix !== undefined` as an opt-in to
+    // the basic-builder shortcut, every in-editor request falls through to
+    // `suggestFunctions()` (because the field is unknown), and the user sees
+    // function suggestions instead of fields/operators/values.
+    const r = await suggest('prior', 5, { ...baseCtx, prefix: 'prior' }, []);
+    expect(r.completions.some((c) => c.kind === 'field' && c.insert === 'priority')).toBe(true);
+    // And we must NOT be drowning in function suggestions.
+    const funcOnly = r.completions.every((c) => c.kind === 'function');
+    expect(funcOnly).toBe(false);
+  });
+
+  it('explicit field param routes via basic-builder (operator suggestions for a field)', async () => {
+    const r = await suggest('', 0, { ...baseCtx, field: 'priority' }, []);
+    // Priority type → enum values; confirm we get them, not function list.
+    expect(r.completions.some((c) => c.insert === 'HIGH')).toBe(true);
   });
 });

--- a/docs/tz/TTSRH-1.md
+++ b/docs/tz/TTSRH-1.md
@@ -236,22 +236,32 @@ CUSTOM_FIELD   ::= "cf" "[" UUID "]" | '"' NAME '"'
 
 ### 5.2 Поля TTS-QL — реестр (system)
 
+> **Reference-value resolution (post-release 2026-04-22).** Все reference-поля
+> (`project`, `assignee`, `reporter`, `sprint`, `release`, `type`, `parent`,
+> `epic`, `issue`, `key`) принимают user-facing идентификатор, а не UUID.
+> Препроцессор `search.reference-resolver.ts` перед компиляцией обходит AST,
+> собирает литералы по каждому полю и пакетно резолвит их в row-id через
+> Prisma. Без этого шага compiler сравнивал бы UUID-колонку с человеко-читаемой
+> строкой и всегда возвращал бы пустой результат. Неизвестные значения
+> пропускаются без изменений — top-level scope-фильтр (R3) даёт 0 строк, что
+> совпадает с поведением JIRA на несуществующих ключах.
+
 | Поле | Синонимы | Тип | Операторы | Прим. |
 |------|----------|-----|-----------|-------|
-| `project` | `proj` | Project-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | по `key` или `id` |
-| `key`, `issuekey` | — | Issue-ref | `=`, `!=`, `IN`, `NOT IN` | `PRJ-123` |
+| `project` | `proj` | Project-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | `TTMP` (key) или UUID; key → id резолвится препроцессором |
+| `key`, `issuekey` | — | Issue-ref | `=`, `!=`, `IN`, `NOT IN` | `PRJ-123` — резолвится препроцессором в `Issue.id` |
 | `summary` | `title` | TEXT | `~`, `!~`, `=`, `!=`, `IS [NOT] EMPTY` | ILIKE |
 | `description` | — | TEXT | `~`, `!~`, `IS [NOT] EMPTY` | |
 | `status` | — | Status-ref | `=`, `!=`, `IN`, `NOT IN`, `CHANGED*`, `WAS*` | имя WorkflowStatus или systemKey (OPEN/IN_PROGRESS/REVIEW/DONE/CANCELLED) |
 | `statusCategory` | `category` | Enum | `=`, `!=`, `IN`, `NOT IN` | `TODO`/`IN_PROGRESS`/`DONE` |
 | `priority` | — | Enum | `=`, `!=`, `IN`, `NOT IN` | CRITICAL/HIGH/MEDIUM/LOW |
-| `type`, `issuetype` | — | Type-ref | `=`, `!=`, `IN`, `NOT IN` | systemKey (TASK/EPIC/…) или UUID |
-| `assignee` | — | User-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | email / id / `currentUser()` |
-| `reporter`, `creator` | — | User-ref | то же | |
-| `sprint` | — | Sprint-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | имя / id / функции |
-| `release`, `fixVersion` | — | Release-ref | то же | |
-| `parent` | — | Issue-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | |
-| `epic` | — | Issue-ref | `=`, `IN` | parent, если type=EPIC |
+| `type`, `issuetype` | — | Type-ref | `=`, `!=`, `IN`, `NOT IN` | `BUG` (systemKey) / `"Bug"` (name) / UUID — резолвится препроцессором |
+| `assignee` | — | User-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | email / name / id / `currentUser()` — резолвится препроцессором (scope по `UserProjectRole`, `isActive=true`) |
+| `reporter`, `creator` | — | User-ref | то же | то же |
+| `sprint` | — | Sprint-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | name / id / функции — резолвится препроцессором (scope по `accessibleProjectIds`) |
+| `release`, `fixVersion` | — | Release-ref | то же | name / id / функции — резолвится препроцессором (scope по `accessibleProjectIds`) |
+| `parent` | — | Issue-ref | `=`, `!=`, `IN`, `NOT IN`, `IS [NOT] EMPTY` | `PRJ-123` (key) или UUID — резолвится препроцессором |
+| `epic` | — | Issue-ref | `=`, `IN` | `PRJ-123` (key) или UUID; parent, если type=EPIC |
 | `due`, `dueDate` | — | DATE | `=`, `!=`, `>`, `<`, `>=`, `<=`, `IS [NOT] EMPTY` | + relative: `due <= "7d"` |
 | `created` | — | DATETIME | то же | |
 | `updated` | — | DATETIME | то же | |
@@ -363,20 +373,22 @@ hasCheckpointViolation = true                 -- булев-аналог без 
 jql text
   │
   ▼
-┌────────────┐    ┌───────────┐    ┌────────────────┐    ┌────────────────────┐
-│ Tokenizer  │───▶│  Parser   │───▶│   Validator    │───▶│  Compiler          │
-│  (regex-   │    │ (recursive│    │ (resolve field │    │ (AST → Prisma where│
-│   lexer)   │    │  descent) │    │  + type check) │    │  + raw SQL для CF) │
-└────────────┘    └───────────┘    └────────────────┘    └─────────┬──────────┘
-                                                                    │
-                                                                    ▼
-                                                   prisma.issue.findMany({where, orderBy, ...})
+┌────────────┐    ┌───────────┐    ┌────────────────┐    ┌────────────────┐    ┌────────────────────┐
+│ Tokenizer  │───▶│  Parser   │───▶│   Validator    │───▶│ Reference      │───▶│  Compiler          │
+│  (regex-   │    │ (recursive│    │ (resolve field │    │ resolver       │    │ (AST → Prisma where│
+│   lexer)   │    │  descent) │    │  + type check) │    │ (key/email/... │    │  + raw SQL для CF) │
+│            │    │           │    │                │    │  → row id)     │    │                    │
+└────────────┘    └───────────┘    └────────────────┘    └────────────────┘    └─────────┬──────────┘
+                                                                                          │
+                                                                                          ▼
+                                                                   prisma.issue.findMany({where, orderBy, ...})
 ```
 
 - **Tokenizer**: поддерживает `STRING` с escape, `NUMBER`, `IDENT`, `KEYWORD`, `LPAREN/RPAREN`, `COMMA`, `OP` (`=/!=/>/<=/>=/<=/~/!~`), `RELATIVE_DATE`. Возвращает массив `{type, value, start, end}` — позиции для error reporting.
 - **Parser**: recursive descent. На каждой ноде хранит `span: {start, end}` для инлайн-подчёркивания ошибок в редакторе.
 - **Validator**: семантика — поле существует? тип значения совместим с оператором? функция зарегистрирована? Ошибки накапливает в `errors: ValidationError[]`, не прерывая (для UX автодополнения).
-- **Compiler**: строит Prisma `WhereInput`. Для кастомных полей — `Prisma.sql\`SELECT id FROM issue_custom_field_values WHERE ...\`` с `id IN` под-запросом. Для связей — под-запрос по `IssueLink`. Агрегатные поля (`timeSpent`) — `HAVING`-клауза через `$queryRaw` или материализованное поле. Верхний AND всегда добавляет scope: `projectId IN (:accessibleProjectIds)`.
+- **Reference resolver** *(добавлено 2026-04-22)*: обходит AST, группирует строковые литералы по reference-полям (`project`, `assignee`/`reporter`, `sprint`, `release`, `type`, `parent`/`epic`/`issue`/`key`) и одним батчем на каждое семейство полей резолвит их через Prisma в row-id. Результат кладётся в `CompileContext.referenceValues: Map<fieldName, Map<lc-value, id>>`. Неизвестные значения пропускаются как есть — scope-фильтр гарантирует 0 строк вместо ложного false-positive. Без этой стадии compiler сравнивал бы UUID-колонку с литералом `"TTMP"` / `"alice@x.com"` и запрос всегда бы возвращал пустой набор. Compiler остаётся чистой функцией (DB-free), async-часть изолирована в resolver'е.
+- **Compiler**: строит Prisma `WhereInput`. Для кастомных полей — `Prisma.sql\`SELECT id FROM issue_custom_field_values WHERE ...\`` с `id IN` под-запросом. Для связей — под-запрос по `IssueLink`. Агрегатные поля (`timeSpent`) — `HAVING`-клауза через `$queryRaw` или материализованное поле. Верхний AND всегда добавляет scope: `projectId IN (:accessibleProjectIds)`. Для reference-полей — lookup в `ctx.referenceValues[fieldName]`; если значение не найдено (unknown), литерал передаётся в Prisma как есть и отсекается scope-фильтром.
 
 #### Пример компиляции
 
@@ -388,13 +400,13 @@ project = "TTMP" AND assignee = currentUser() AND status IN (OPEN, IN_PROGRESS)
 ORDER BY priority DESC, updated DESC
 ```
 
-Выход:
+Выход (после reference-resolver'а `"TTMP"` → `<uuid>`):
 ```ts
 prisma.issue.findMany({
   where: {
     AND: [
       { projectId: { in: accessibleProjectIds } },  // scope
-      { project: { key: 'TTMP' } },
+      { projectId: '<uuid-of-TTMP>' },              // preresolved из ctx.referenceValues.project
       { assigneeId: ctx.userId },
       { OR: [{ status: 'OPEN' }, { status: 'IN_PROGRESS' }] },
       { priority: 'HIGH' },
@@ -481,6 +493,14 @@ prisma.issue.findMany({
   - в рамках текущего фильтра — в `SavedFilter.columns`;
   - как дефолт пользователя — в `User.preferences.searchDefaults.columns`.
 - Сортировка — клик по заголовку колонки переписывает `ORDER BY` в JQL (с сохранением остального).
+
+**Custom fields в результатах (post-release 2026-04-22):**
+- Backend `POST /search/issues` возвращает `issue.customFieldValues: [{customFieldId, value}]` (add в Prisma `include`). Frontend `ResultsTable` распаковывает JSON-обёртку `{v: ...}` и форматирует arrays/booleans/objects для отображения.
+- Результаты могут содержать задачи из разных проектов, поэтому список кастомных полей в конфигураторе — **глобальный каталог** (`/search/schema`), не scope'нутый на текущий результат: иначе пользователь не смог бы добавить колонку для поля, которого нет в первой странице выдачи, но есть в следующих.
+- Чтобы глобальный каталог кастомных полей не превращал picker в нечитаемую свалку при большом числе полей, «Доступные» панель имеет **поисковую строку** (JIRA-style):
+  - пустой ввод → показываются только «primary» (system) поля + подсказка `«Ещё N полей — начните вводить для поиска»`;
+  - любой набранный префикс → фильтр работает по всему `available` (system + custom), case-insensitive, сопоставляет имя и label.
+- Конфигуратор принимает новые пропсы: `primary?: string[]` (что показывать по умолчанию) и `getLabel?: (name) => string` (human-readable подпись, для custom-полей — из `SchemaField.label`).
 
 ### 5.9 Безопасность и RBAC
 
@@ -572,6 +592,10 @@ GET /api/search/suggest?jql=<text>&cursor=<offset>
 - Tab / Enter — вставить выбранное (для Enum — без кавычек; для User — с форматом `"email@host"`).
 - Esc — закрыть без вставки.
 - Клавиши ↑/↓ — навигация, Home/End — границы.
+
+**Routing `/suggest` — default vs basic-mode (post-release 2026-04-22):**
+- CM6 CompletionSource отправляет параметр `prefix` на каждый keystroke — это его собственное поле фильтрации, не сигнал «Basic-mode». Backend **не** берёт Basic-builder shortcut только потому что `prefix !== undefined`: триггером остаётся только явный `field` (опционально с `operator`/`prefix`).
+- Иначе любой in-editor запрос падал в `completionsForField('', '=', prefix, …)` → `typeFor('')` = undefined → fallback на `suggestFunctions(prefix)`, и пользователь вместо field/operator/value suggestions видел только список функций. Guard в `search.suggest.ts` требует `ctx.field`, иначе идёт cursor-analysis path (editor mode).
 
 **Basic-mode интеграция:**
 - Chip для поля `assignee` открывает Popover, который рендерится тем же компонентом `ValueSuggesterPopup`, что и для Advanced, но с `mode=multi` для IN-clause (чекбоксы) и с preview выбранных chip'ов внизу.
@@ -1559,6 +1583,23 @@ PR-20 ─► PR-21 (docs + feature flag cutover)
 - **Composite-индексы** по profiling (§3.3) — follow-up миграция после запуска в prod.
 
 **Дельта к §8 (278ч):** план покрывает ~199ч. Недостающие ~79ч — это (a) code review + фиксы (~8ч per §8), (b) security review + фиксы (~4ч), (c) докуметация JQL полная (~6ч уже в PR-21, ~0ч дополнительно), (d) профайлинг + composite-index tuning (~4ч в PR-20), (e) fuzz-harness extended (~4ч в PR-5); остальное — buffer на unknown unknowns и Phase-2-проникновение. Реалистичный календарный план — 8–10 недель при одном fullstack-разработчике или 5–6 недель при параллельной работе двоих (backend + frontend после PR-5).
+
+### 13.9.2 Post-release фиксы — 2026-04-22
+
+После старта UAT на staging всплыли три корреляционных класса багов: (a) compiler никогда не матчил reference-поля по user-facing идентификаторам, (b) value-suggest в in-editor mode всегда показывал function suggestions, (c) ColumnConfigurator не видел кастомных полей.
+
+| # | Проблема | Симптом | Корень | Фикс |
+|---|----------|---------|--------|------|
+| 1 | `project = "TTMP"` возвращает пусто (а также `assignee`, `reporter`, `sprint`, `release`, `type`, `parent`, `epic`, `issue`, `key`) | UI Results area показывает «Всего: 0» на заведомо валидный JQL | Compiler клал строковый литерал напрямую в Prisma-фильтр на UUID-колонку; suggest вставляет `key`/`email`/`name`/`systemKey`, а не UUID | Новый модуль `search.reference-resolver.ts` — обход AST, сбор литералов по reference-полям, батчевые Prisma-lookup'ы, результат в `CompileContext.referenceValues`. Compiler подменяет литералы на row-id перед `wrapColumn(...)`. Unknown значения → scope-фильтр даёт 0 строк (как в JIRA). Обновлены §5.2 и §5.5. |
+| 2 | Suggestions в редакторе не зависят от позиции курсора / набранного текста | Пользователь печатает `proj` — popup показывает `now()`, `today()`, `currentUser()`… | CM6 CompletionSource на каждый keystroke шлёт параметр `prefix` (своё локальное поле фильтрации), а backend trigger-ил Basic-builder shortcut по условию `prefix !== undefined`, попадая в `completionsForField('', '=', prefix)` → fallback `suggestFunctions(prefix)`. | Guard в `search.suggest.ts` требует `ctx.field` для Basic-builder пути; только `prefix` → cursor-analysis path (editor mode). Обновлён §5.11. Unit-тест-регрессия в `search-suggest.unit.test.ts`. |
+| 3 | Custom fields нельзя добавить как колонку | `ColumnConfigurator` показывает только system-колонки | (a) `AVAILABLE_COLUMNS` в `SearchPage.tsx` — хардкод без schema-fetch; (b) backend `searchIssues` не включал `customFieldValues` в Prisma payload; (c) добавление всех CF в список одной пачкой перегружает picker. | (a) `SearchPage` делает `getSearchSchema()` на mount и мёржит custom-имена в `AVAILABLE_COLUMNS`; (b) Prisma `include` в `search.service.ts` добавил `customFieldValues: { select: { customFieldId, value } }`, `ResultsTable` распаковывает `{v: ...}` envelope; (c) `ColumnConfigurator` получил search-box + новый prop `primary` — при пустом вводе показывает только primary (system), при наборе — фильтр по всему `available`. Обновлён §5.8. |
+
+**Покрытие тестами:** 487 backend tests pass (parser suite, включая 7 новых в compiler и 2 новых в suggest). Frontend — typecheck clean. Интеграционные/e2e fixtures для новой column-picker UX — follow-up (см. TTSRH-39 ниже).
+
+**Follow-ups (не входят в TTSRH-1):**
+- **TTSRH-? (WorkflowStatus по имени):** `status = "In Review"` по-прежнему мапится на `IssueStatus` enum (OPEN/IN_PROGRESS/REVIEW/DONE/CANCELLED), а не на `workflow_status_id`. Denormalised-колонка `Issue.status` сохранена для обратной совместимости; полный переход требует либо миграции join'а в compiler, либо маппинга name → systemKey. Out-of-scope для данного хот-фикса.
+- **TTSRH-? (`linkedIssue` clause):** поле зарегистрировано в `SYSTEM_FIELDS` как ISSUE-ref, но отсутствует в `SYSTEM_FIELD_COLUMN` — сейчас возвращает `UNRESOLVED_FIELD`. Pre-existing, вне scope фикса.
+- **TTSRH-39 (column-picker E2E):** добавить e2e-сценарий, чтобы пользователь мог найти кастомное поле через search-box и добавить в результаты.
 
 ### 13.10 Phase 2 (не включена в TTSRH-1)
 

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -19,6 +19,12 @@ import api from './client';
 // returned by the API under arbitrary string keys — an intersection with a
 // Record keeps them accessible (as `unknown`) without suppressing typos on the
 // named fields (a bare `[key: string]: unknown` index signature would).
+export interface IssueCustomFieldValueRow {
+  customFieldId: string;
+  /** JSON envelope — values are wrapped as `{ v: <payload> }`. */
+  value: unknown;
+}
+
 export type IssueSearchRow = {
   id: string;
   projectId: string;
@@ -30,6 +36,7 @@ export type IssueSearchRow = {
   project: { id: string; key: string; name: string };
   assignee: { id: string; name: string; email: string } | null;
   workflowStatus: { id: string; name: string; category: string; color: string | null; systemKey: string | null } | null;
+  customFieldValues?: IssueCustomFieldValueRow[];
 } & Record<string, unknown>;
 
 export interface SearchIssuesResponse {

--- a/frontend/src/components/search/ColumnConfigurator.tsx
+++ b/frontend/src/components/search/ColumnConfigurator.tsx
@@ -6,6 +6,11 @@
  *
  * Публичный API:
  *   • available — имена всех доступных колонок (system + custom).
+ *   • primary — подмножество `available`, которое показывается по умолчанию
+ *     (обычно — системные поля). Нужен, чтобы при большом каталоге
+ *     кастомных полей не выгружать весь список; JIRA-подобный UX: пустой
+ *     поисковый ввод = только primary, ввод → фильтр по всем `available`.
+ *   • getLabel — опциональный human-readable label для отображения.
  *   • selected — текущие selected columns.
  *   • onChange(selected) — новый порядок/набор.
  *   • onClose — закрыть popover.
@@ -16,10 +21,17 @@
  *   • `available` (left list) всегда показывается в фиксированном order'е.
  *   • Duplicate guard: drop одного имени дважды в Selected — игнорируется.
  */
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 export interface ColumnConfiguratorProps {
   available: string[];
+  /**
+   * Подмножество `available`, показываемое при пустом поиске. Если не задано
+   * — показываются все `available` (старое поведение). При наборе в поисковом
+   * поле фильтр работает поверх всего `available`.
+   */
+  primary?: string[];
+  getLabel?: (name: string) => string;
   selected: string[];
   onChange: (next: string[]) => void;
   onClose?: () => void;
@@ -30,12 +42,15 @@ type DragFrom = 'available' | { list: 'selected'; index: number };
 
 export default function ColumnConfigurator({
   available,
+  primary,
+  getLabel,
   selected,
   onChange,
   onClose,
   isLight = false,
 }: ColumnConfiguratorProps) {
   const [dragData, setDragData] = useState<{ name: string; from: DragFrom } | null>(null);
+  const [query, setQuery] = useState('');
 
   const c = isLight
     ? { text: '#1F2328', border: '#D0D7DE', muted: '#656D76', hover: '#F6F8FA', selected: '#EFF4FF' }
@@ -102,38 +117,95 @@ export default function ColumnConfigurator({
     gap: 6,
   };
 
+  const labelFor = useCallback(
+    (name: string): string => getLabel?.(name) ?? name,
+    [getLabel],
+  );
+  const trimmed = query.trim().toLowerCase();
+  // Empty query + primary set defined → only show primary names, so a huge
+  // custom-field catalogue (could be 100+ fields across all projects in the
+  // search results) doesn't dump into the UI. Typing widens the search to
+  // all `available`, matching JIRA's column-picker behaviour.
+  const visibleAvailable = useMemo(() => {
+    const base = trimmed === '' && primary ? primary : available;
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const name of base) {
+      if (selectedSet.has(name)) continue;
+      if (seen.has(name)) continue;
+      if (trimmed !== '') {
+        const hay = `${name} ${labelFor(name)}`.toLowerCase();
+        if (!hay.includes(trimmed)) continue;
+      }
+      seen.add(name);
+      out.push(name);
+    }
+    return out;
+  }, [trimmed, primary, available, selectedSet, labelFor]);
+  const hiddenCount =
+    trimmed === '' && primary
+      ? available.filter((n) => !primary.includes(n) && !selectedSet.has(n)).length
+      : 0;
+
   return (
     <div data-testid="column-configurator" style={{ display: 'flex', gap: 12, minWidth: 400 }}>
       <div style={{ flex: 1 }}>
         <div style={{ fontSize: 11, color: c.muted, marginBottom: 6, textTransform: 'uppercase' }}>
           Доступные
         </div>
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Поиск поля…"
+          data-testid="col-search"
+          style={{
+            width: '100%',
+            boxSizing: 'border-box',
+            marginBottom: 6,
+            padding: '4px 8px',
+            fontSize: 12,
+            border: `1px solid ${c.border}`,
+            borderRadius: 4,
+            background: 'transparent',
+            color: c.text,
+            fontFamily: 'inherit',
+          }}
+        />
         <div
           onDragOver={(e) => e.preventDefault()}
           onDrop={onDropToAvailable}
           style={{ minHeight: 120, maxHeight: 300, overflowY: 'auto' }}
         >
-          {available
-            .filter((n) => !selectedSet.has(n))
-            .map((name) => (
-              <div
-                key={name}
-                draggable
-                onDragStart={onDragStart(name, 'available')}
-                style={cellStyle}
-                data-testid={`col-available-${name}`}
+          {visibleAvailable.map((name) => (
+            <div
+              key={name}
+              draggable
+              onDragStart={onDragStart(name, 'available')}
+              style={cellStyle}
+              data-testid={`col-available-${name}`}
+            >
+              <span>{labelFor(name)}</span>
+              <button
+                type="button"
+                onClick={() => onChange([...selected, name])}
+                aria-label={`Add ${name}`}
+                style={{ background: 'transparent', border: 'none', color: c.muted, cursor: 'pointer', fontSize: 13 }}
               >
-                <span>{name}</span>
-                <button
-                  type="button"
-                  onClick={() => onChange([...selected, name])}
-                  aria-label={`Add ${name}`}
-                  style={{ background: 'transparent', border: 'none', color: c.muted, cursor: 'pointer', fontSize: 13 }}
-                >
-                  →
-                </button>
-              </div>
-            ))}
+                →
+              </button>
+            </div>
+          ))}
+          {visibleAvailable.length === 0 && (
+            <div style={{ color: c.muted, fontSize: 11, padding: 8 }}>
+              {trimmed ? 'Ничего не найдено' : 'Все поля уже добавлены'}
+            </div>
+          )}
+          {hiddenCount > 0 && (
+            <div style={{ color: c.muted, fontSize: 11, padding: '6px 2px' }}>
+              Ещё {hiddenCount} {pluralize(hiddenCount, 'поле', 'поля', 'полей')} — начните вводить для поиска
+            </div>
+          )}
         </div>
       </div>
       <div style={{ flex: 1 }}>
@@ -157,7 +229,7 @@ export default function ColumnConfigurator({
             >
               <span>
                 <span style={{ color: c.muted, marginRight: 6 }}>⋮⋮</span>
-                {name}
+                {labelFor(name)}
               </span>
               <button
                 type="button"
@@ -196,4 +268,12 @@ export default function ColumnConfigurator({
       </div>
     </div>
   );
+}
+
+function pluralize(n: number, one: string, few: string, many: string): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return one;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return few;
+  return many;
 }

--- a/frontend/src/components/search/ResultsTable.tsx
+++ b/frontend/src/components/search/ResultsTable.tsx
@@ -21,11 +21,19 @@
 import { useMemo } from 'react';
 import { Table, Tag, type TableProps } from 'antd';
 
-import type { IssueSearchRow } from '../../api/search';
+import type { IssueSearchRow, SchemaField } from '../../api/search';
 
 export interface ResultsTableProps {
   issues: IssueSearchRow[];
   columns: string[];
+  /**
+   * Custom-field metadata from `/search/schema`. Used to resolve column names
+   * that aren't system fields — the compiler stores values under
+   * `issue.customFieldValues[]` keyed by `customFieldId`, so the table needs
+   * the `{ id, name }` mapping to find them. Optional so the legacy prop
+   * shape (system-only columns) keeps working.
+   */
+  customFields?: SchemaField[];
   total: number;
   page: number;
   pageSize: number;
@@ -91,7 +99,34 @@ function rewriteOrderBy(jql: string, field: string, dir: SortState): string {
   return `${withoutOrderBy.trim()} ORDER BY ${field} ${kw}`.trim();
 }
 
-function renderCell(col: string, issue: IssueSearchRow): React.ReactNode {
+/**
+ * Unwrap the JSON envelope `{ v: ... }` used for custom-field values in
+ * Postgres. Backend stores every CF value under the `v` key so queries can
+ * target a stable path; when rendering we transparently drop the wrapper.
+ */
+function extractCustomFieldValue(raw: unknown): unknown {
+  if (raw && typeof raw === 'object' && 'v' in raw) {
+    return (raw as { v: unknown }).v;
+  }
+  return raw;
+}
+
+function formatCustomFieldValue(v: unknown): React.ReactNode {
+  if (v === null || v === undefined) return '—';
+  if (Array.isArray(v)) {
+    if (v.length === 0) return '—';
+    return v.map((x) => (x === null || x === undefined ? '' : String(x))).join(', ');
+  }
+  if (typeof v === 'boolean') return v ? 'Да' : 'Нет';
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+function renderCell(
+  col: string,
+  issue: IssueSearchRow,
+  customFieldsByName: Map<string, SchemaField>,
+): React.ReactNode {
   switch (col) {
     case 'key':
       return (
@@ -126,13 +161,23 @@ function renderCell(col: string, issue: IssueSearchRow): React.ReactNode {
       return (issue as unknown as { sprint?: { name: string } }).sprint?.name ?? '—';
     case 'release':
       return (issue as unknown as { release?: { name: string } }).release?.name ?? '—';
-    default:
-      // Custom fields / unknown — render raw value as string.
+    default: {
+      // Custom fields — look up by configured name (case-insensitive to match
+      // the backend schema loader), then extract the `{ v: ... }` envelope.
+      const cf = customFieldsByName.get(col.toLowerCase());
+      if (cf?.uuid && issue.customFieldValues) {
+        const row = issue.customFieldValues.find((r) => r.customFieldId === cf.uuid);
+        if (!row) return '—';
+        return formatCustomFieldValue(extractCustomFieldValue(row.value));
+      }
+      // Unknown column — attempt the legacy flat-key lookup so older
+      // integrations (exported rows with flat keys) don't silently render '—'.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const v = (issue as any)[col];
       if (v === null || v === undefined) return '—';
       if (typeof v === 'object') return JSON.stringify(v);
       return String(v);
+    }
   }
 }
 
@@ -149,6 +194,7 @@ function priorityColor(p: string): string {
 export default function ResultsTable({
   issues,
   columns,
+  customFields,
   total,
   page,
   pageSize,
@@ -159,14 +205,22 @@ export default function ResultsTable({
   selectedIds,
 }: ResultsTableProps) {
   const currentSort = useMemo(() => parseOrderBy(currentJql), [currentJql]);
+  // Case-insensitive name → SchemaField index. Built once per customFields
+  // change so renderCell can resolve custom-field columns in O(1).
+  const customFieldsByName = useMemo(() => {
+    const map = new Map<string, SchemaField>();
+    for (const cf of customFields ?? []) map.set(cf.name.toLowerCase(), cf);
+    return map;
+  }, [customFields]);
 
   const tableCols: TableProps<IssueSearchRow>['columns'] = columns.map((col) => {
     const isSortable = SORTABLE.has(col);
     const sortOrder: SortState =
       currentSort?.field === col.toLowerCase() ? currentSort.dir : null;
+    const cf = customFieldsByName.get(col.toLowerCase());
     return {
       key: col,
-      title: COLUMN_LABELS[col] ?? col,
+      title: COLUMN_LABELS[col] ?? cf?.label ?? col,
       dataIndex: col,
       // `compare: false` suppresses Ant Table client-side sort — we rewrite
       // JQL's ORDER BY on onChange and let the backend re-order. Without this,
@@ -174,7 +228,7 @@ export default function ResultsTable({
       sorter: isSortable ? { compare: () => 0, multiple: 0 } : false,
       sortOrder,
       showSorterTooltip: isSortable ? undefined : false,
-      render: (_: unknown, issue: IssueSearchRow) => renderCell(col, issue),
+      render: (_: unknown, issue: IssueSearchRow) => renderCell(col, issue, customFieldsByName),
     };
   });
 

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -24,7 +24,7 @@ import { useParams } from 'react-router-dom';
 import { Button, Popover } from 'antd';
 import { SettingOutlined } from '@ant-design/icons';
 
-import { searchIssues, type IssueSearchRow } from '../api/search';
+import { getSearchSchema, searchIssues, type IssueSearchRow, type SchemaField } from '../api/search';
 import { getSavedFilter, markSavedFilterUsed, type SavedFilter } from '../api/savedFilters';
 import BasicFilterBuilder from '../components/search/BasicFilterBuilder';
 import { canBasicize } from '../components/search/basic-filter-model';
@@ -66,13 +66,31 @@ export default function SearchPage() {
     () => ['key', 'summary', 'type', 'status', 'priority', 'assignee', 'sprint', 'updated'],
     [],
   );
-  const AVAILABLE_COLUMNS = useMemo(
+  const SYSTEM_COLUMNS = useMemo(
     () => [
       'key', 'summary', 'type', 'status', 'priority', 'assignee', 'creator',
       'project', 'projectKey', 'sprint', 'release', 'due', 'created', 'updated',
       'description',
     ],
     [],
+  );
+  const [customFields, setCustomFields] = useState<SchemaField[]>([]);
+  // Fetch the field schema once per mount so the column picker can offer
+  // custom fields. Failures degrade silently — the user still sees the
+  // hard-coded system columns, same as before schema integration.
+  useEffect(() => {
+    let cancelled = false;
+    void getSearchSchema('default')
+      .then((schema) => {
+        if (cancelled) return;
+        setCustomFields(schema.fields.filter((f) => f.custom));
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+  const AVAILABLE_COLUMNS = useMemo(
+    () => [...SYSTEM_COLUMNS, ...customFields.map((f) => f.name)],
+    [SYSTEM_COLUMNS, customFields],
   );
   const displayedColumns = state.columns.length > 0 ? state.columns : DEFAULT_COLUMNS;
 
@@ -364,6 +382,8 @@ export default function SearchPage() {
                       content={
                         <ColumnConfigurator
                           available={AVAILABLE_COLUMNS}
+                          primary={SYSTEM_COLUMNS}
+                          getLabel={(name) => customFields.find((f) => f.name === name)?.label ?? name}
                           selected={displayedColumns}
                           onChange={(next) => updateUrl({ columns: next }, { push: false })}
                           onClose={() => setColumnConfigOpen(false)}
@@ -391,6 +411,7 @@ export default function SearchPage() {
                 <ResultsTable
                   issues={load.issues}
                   columns={displayedColumns}
+                  customFields={customFields}
                   total={load.total}
                   page={state.page}
                   pageSize={PAGE_SIZE}

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,37 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.49**
+**Last version: 2.50**
+
+---
+
+## [2.50] [2026-04-22] fix(ttsrh-1): post-release — reference values + suggest routing + custom-field columns
+
+**PR:** (to be filled after push)
+**Ветка:** `fix/ttsrh-1-post-release-references-suggest-columns`
+
+### Что было
+
+После merge эпика TTSRH-1 и включения UAT на staging всплыли три класса багов:
+1. **Reference-поля возвращали пустой результат** — `project = "TTMP"`, `assignee = "alice@x.com"`, `sprint = "Sprint 1"`, `type = BUG`, `parent = "TTMP-123"` и т.д. Compiler клал строковый литерал напрямую в Prisma-фильтр на UUID-колонку; suggest при этом вставляет key / email / name / systemKey / issue-key — не UUID.
+2. **Suggestions в редакторе игнорировали контекст курсора** — пользователь печатает `proj`, popup показывает `now()`, `today()`, `currentUser()` вместо полей. Backend trigger-ил Basic-builder shortcut по `prefix !== undefined` — а CM6 шлёт `prefix` на каждый keystroke для своей локальной фильтрации.
+3. **Кастомные поля недоступны в ColumnConfigurator** — `AVAILABLE_COLUMNS` хардкод без schema-fetch; backend не включал `customFieldValues` в payload; добавление всех CF в список — плохой UX при большом каталоге.
+
+### Что теперь
+
+- **Reference resolver** — новый модуль `backend/src/modules/search/search.reference-resolver.ts`. Обходит AST, собирает литералы по reference-полям, одним батчем на каждое семейство (User / Sprint / Release / IssueTypeConfig / Issue / Project) резолвит через Prisma. Результат → `CompileContext.referenceValues`. Compiler подменяет литералы на row-id перед `wrapColumn(...)`. Неизвестные значения — scope-фильтр даёт 0 строк.
+- **Suggest routing guard** — `backend/src/modules/search/search.suggest.ts` требует `ctx.field` для Basic-builder пути; только `prefix` → cursor-analysis path (editor mode).
+- **Custom-field columns end-to-end**:
+  - backend `searchIssues` Prisma `include` добавил `customFieldValues: { select: { customFieldId, value } }`;
+  - `SearchPage.tsx` делает `getSearchSchema()` на mount и мёржит custom-имена в `AVAILABLE_COLUMNS`;
+  - `ResultsTable.tsx` распаковывает `{v: ...}` envelope;
+  - `ColumnConfigurator.tsx` — search-box + новый prop `primary` (при пустом вводе показываются только system, при наборе — фильтр по всему каталогу, JIRA-style).
+- **Документация** — §5.2 / §5.5 / §5.8 / §5.11 обновлены; добавлен §13.9.2 «Post-release фиксы» с таблицей симптом → корень → фикс.
+- **Тесты** — 7 новых в `search-compiler.unit.test.ts` (reference-value translation), 2 новых в `search-suggest.unit.test.ts` (routing guard). 487 backend tests pass.
+
+### Связано
+
+- TTSRH-1 (Advanced Search) — post-release hardening.
 
 ---
 


### PR DESCRIPTION
## Summary

Three post-release hardening fixes for the Advanced Search epic (TTSRH-1) after UAT on staging surfaced regressions across the compiler, suggest pipeline, and column picker.

**1. Reference-value resolution.** `project = "TTMP"`, `assignee = "alice@x.com"`, `sprint = "Sprint 1"`, `type = BUG`, `parent = "TTMP-123"` — all returned 0 rows. The compiler compared UUID columns to human-readable literals that the `suggest` endpoint inserts (project key / email / sprint name / systemKey / issue key). New `backend/src/modules/search/search.reference-resolver.ts` walks the AST, batches Prisma lookups per field kind, and plugs the result into `CompileContext.referenceValues`. Compiler substitutes literals → row ids before `wrapColumn(...)`. Unknown values fall through unchanged — the scope filter yields 0 rows (matches JIRA).

**2. Suggest routing guard.** The CM6 completion source sends `prefix` on every keystroke for local filtering. The backend treated `prefix !== undefined` as a Basic-builder opt-in, so every in-editor request went through `completionsForField('', '=', prefix, …)` → `typeFor('') = undefined` → `suggestFunctions()`. Users saw only function suggestions regardless of position. Now `ctx.field` is required for the shortcut; bare `prefix` drops to the cursor-analysis path.

**3. Custom-field columns end-to-end.** Backend `searchIssues` include now adds `customFieldValues`; `SearchPage` fetches `/search/schema` on mount and merges custom names into `AVAILABLE_COLUMNS`; `ResultsTable` unwraps the `{ v: ... }` JSON envelope; `ColumnConfigurator` gets a JIRA-style search-box with a new `primary` prop so empty input shows only system columns and typing widens the filter across a potentially 100+ custom-field catalogue.

Docs: §5.2 / §5.5 / §5.8 / §5.11 updated; §13.9.2 post-release fix log added. version_history bumped to 2.50.

## Test plan

- [x] Backend parser-only test suite (487 tests, incl. +7 compiler + +2 suggest regressions) — `npm --prefix backend run test:parser` → pass
- [x] Backend `typecheck` → pass
- [x] Frontend `typecheck` → pass
- [ ] Staging UAT: `project = "TTMP"` returns rows; `assignee = "<email>"` returns rows; `sprint = "<name>"` returns rows
- [ ] Staging UAT: inline editor suggestions match the typed prefix (field / operator / value by cursor context)
- [ ] Staging UAT: `ColumnConfigurator` shows empty-search state with only system columns + «Ещё N полей — начните вводить»; typing filters across all fields; adding a custom-field column renders cell values correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
