### PR TITLE
feat(bulk-ops): TTBULK-1 PR-6 — SSE + Redis pub/sub + report.csv + retry-failed

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "@fast-csv/format": "^5.0.5",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@prisma/client": "^6.5.0",
         "bcryptjs": "^2.4.3",
@@ -774,24 +775,16 @@
       }
     },
     "node_modules/@fast-csv/format": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
-      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-5.0.5.tgz",
+      "integrity": "sha512-0P9SJXXnqKdmuWlLaTelqbrfdgN37Mvrb369J6eNmqL41IEIZQmV4sNM4GgAK2Dz3aH04J0HKGDMJFkYObThTw==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^14.0.1",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isboolean": "^3.0.3",
-        "lodash.isequal": "^4.5.0",
         "lodash.isfunction": "^3.0.9",
         "lodash.isnil": "^4.0.0"
       }
-    },
-    "node_modules/@fast-csv/format/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "license": "MIT"
     },
     "node_modules/@fast-csv/parse": {
       "version": "4.3.6",
@@ -4716,6 +4709,26 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/fast-csv/node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/fast-csv/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,13 +27,14 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts tests/search-functions.unit.test.ts tests/search-validator.unit.test.ts tests/search-compiler.unit.test.ts tests/search-pipeline-fuzz.unit.test.ts tests/search-suggest.unit.test.ts tests/checkpoint-dto.unit.test.ts tests/checkpoint-engine-ttql.unit.test.ts tests/effective-user-system-roles.unit.test.ts tests/bulk-operations-service.unit.test.ts tests/bulk-operations-processor.unit.test.ts tests/transition-executor.unit.test.ts tests/bulk-executors.unit.test.ts",
+    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts tests/search-functions.unit.test.ts tests/search-validator.unit.test.ts tests/search-compiler.unit.test.ts tests/search-pipeline-fuzz.unit.test.ts tests/search-suggest.unit.test.ts tests/checkpoint-dto.unit.test.ts tests/checkpoint-engine-ttql.unit.test.ts tests/effective-user-system-roles.unit.test.ts tests/bulk-operations-service.unit.test.ts tests/bulk-operations-processor.unit.test.ts tests/transition-executor.unit.test.ts tests/bulk-executors.unit.test.ts tests/bulk-operations-retry-report.unit.test.ts",
     "lint": "eslint src/ --ext .ts",
     "format": "prettier --write 'src/**/*.ts'",
     "mcp": "tsx src/mcp/server.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@fast-csv/format": "^5.0.5",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@prisma/client": "^6.5.0",
     "bcryptjs": "^2.4.3",

--- a/backend/src/modules/bulk-operations/bulk-operations.processor.ts
+++ b/backend/src/modules/bulk-operations/bulk-operations.processor.ts
@@ -333,28 +333,32 @@ async function publishEvents(
   items: Array<{ issueId: string; issueKey: string; outcome: BulkItemOutcome; errorCode: string; errorMessage: string }>,
 ): Promise<void> {
   const channel = eventsChannel(operationId);
-  await publishToChannel(channel, {
-    event: 'progress',
-    data: {
-      processed: op.processed,
-      succeeded: op.succeeded,
-      failed: op.failed,
-      skipped: op.skipped,
-      etaSeconds: estimateEta(op),
-    },
-  });
-  for (const item of items) {
-    await publishToChannel(channel, {
-      event: 'item',
+  // Fan-out параллельно: при batch=25 где все failed это 26 sequential publish
+  // round-trip'ов = ~130 мс на cross-AZ Redis. Promise.all — ~5 мс.
+  await Promise.all([
+    publishToChannel(channel, {
+      event: 'progress',
       data: {
-        issueId: item.issueId,
-        issueKey: item.issueKey,
-        outcome: item.outcome,
-        errorCode: item.errorCode,
-        errorMessage: item.errorMessage,
+        processed: op.processed,
+        succeeded: op.succeeded,
+        failed: op.failed,
+        skipped: op.skipped,
+        etaSeconds: estimateEta(op),
       },
-    });
-  }
+    }),
+    ...items.map((item) =>
+      publishToChannel(channel, {
+        event: 'item',
+        data: {
+          issueId: item.issueId,
+          issueKey: item.issueKey,
+          outcome: item.outcome,
+          errorCode: item.errorCode,
+          errorMessage: item.errorMessage,
+        },
+      }),
+    ),
+  ]);
 }
 
 // ────── Finalize ─────────────────────────────────────────────────────────────

--- a/backend/src/modules/bulk-operations/bulk-operations.processor.ts
+++ b/backend/src/modules/bulk-operations/bulk-operations.processor.ts
@@ -32,7 +32,7 @@ import type { BulkItemOutcome, BulkOperation, BulkOperationStatus, Prisma } from
 import type { ScheduledTask } from 'node-cron';
 import cron from 'node-cron';
 import { prisma } from '../../prisma/client.js';
-import { acquireLock, releaseLock, lpopListBatch } from '../../shared/redis.js';
+import { acquireLock, releaseLock, lpopListBatch, publishToChannel } from '../../shared/redis.js';
 import { runInBulkOperationContext } from '../../shared/bulk-operation-context.js';
 import { getEffectiveUserSystemRoles } from '../../shared/auth/roles.js';
 import { captureError } from '../../shared/utils/logger.js';
@@ -288,6 +288,11 @@ async function processOperationBatch(op: BulkOperation): Promise<TickResult> {
   // Если queue ещё не пуст и cancel не запрошен — следующий tick продолжит.
   // Иначе финализируем.
   const updated = await prisma.bulkOperation.findUniqueOrThrow({ where: { id: op.id } });
+
+  // TTBULK-1 PR-6: публикуем progress-event + каждый item в SSE-канал после
+  // каждого batch'а. Клиент видит инкремент счётчиков в live-режиме.
+  await publishEvents(op.id, updated, itemsToInsert);
+
   if (updated.cancelRequested) {
     return { kind: 'processed', operationId: op.id, batchSize: batch.length, finalized: await finalizeCancelled(updated) };
   }
@@ -295,6 +300,61 @@ async function processOperationBatch(op: BulkOperation): Promise<TickResult> {
     return { kind: 'processed', operationId: op.id, batchSize: batch.length, finalized: await finalize(updated) };
   }
   return { kind: 'processed', operationId: op.id, batchSize: batch.length, finalized: null };
+}
+
+// ────── SSE event publishing ────────────────────────────────────────────────
+
+function eventsChannel(operationId: string): string {
+  return `bulk-op:${operationId}:events`;
+}
+
+/** ETA rolling average — grubo оцениваем на основе processed / (now - startedAt). */
+function estimateEta(op: BulkOperation): number | null {
+  if (!op.startedAt || op.processed === 0) return null;
+  const elapsedMs = Date.now() - op.startedAt.getTime();
+  const remaining = Math.max(op.total - op.processed, 0);
+  if (remaining === 0) return 0;
+  const msPerItem = elapsedMs / op.processed;
+  return Math.round((msPerItem * remaining) / 1000);
+}
+
+/**
+ * Публикует SSE events после batch-обработки:
+ *   • один `progress` event со счётчиками;
+ *   • по одному `item` event на каждый записанный failed/skipped (succeeded
+ *     items не пишутся в `BulkOperationItem` — их trace в AuditLog).
+ *
+ * Каждая публикация — fire-and-forget; Redis down = null, SSE-клиент
+ * переживёт через polling-fallback.
+ */
+async function publishEvents(
+  operationId: string,
+  op: BulkOperation,
+  items: Array<{ issueId: string; issueKey: string; outcome: BulkItemOutcome; errorCode: string; errorMessage: string }>,
+): Promise<void> {
+  const channel = eventsChannel(operationId);
+  await publishToChannel(channel, {
+    event: 'progress',
+    data: {
+      processed: op.processed,
+      succeeded: op.succeeded,
+      failed: op.failed,
+      skipped: op.skipped,
+      etaSeconds: estimateEta(op),
+    },
+  });
+  for (const item of items) {
+    await publishToChannel(channel, {
+      event: 'item',
+      data: {
+        issueId: item.issueId,
+        issueKey: item.issueKey,
+        outcome: item.outcome,
+        errorCode: item.errorCode,
+        errorMessage: item.errorMessage,
+      },
+    });
+  }
 }
 
 // ────── Finalize ─────────────────────────────────────────────────────────────
@@ -331,6 +391,11 @@ async function finalize(op: BulkOperation): Promise<BulkOperationStatus> {
         skipped: op.skipped,
       } as Prisma.InputJsonValue,
     },
+  });
+  // Финальный status-event — SSE-клиент закрывает соединение после этого.
+  await publishToChannel(eventsChannel(op.id), {
+    event: 'status',
+    data: { status, finishedAt: new Date().toISOString() },
   });
   return status;
 }
@@ -387,6 +452,10 @@ async function finalizeCancelled(op: BulkOperation): Promise<BulkOperationStatus
       bulkOperationId: op.id,
       details: { drainedFromQueue: drained } as Prisma.InputJsonValue,
     },
+  });
+  await publishToChannel(eventsChannel(op.id), {
+    event: 'status',
+    data: { status: 'CANCELLED', finishedAt: new Date().toISOString() },
   });
   return 'CANCELLED';
 }

--- a/backend/src/modules/bulk-operations/bulk-operations.router.ts
+++ b/backend/src/modules/bulk-operations/bulk-operations.router.ts
@@ -30,6 +30,8 @@
 
 import { Router, type Response, type NextFunction } from 'express';
 import { z } from 'zod';
+import { format } from '@fast-csv/format';
+import { randomUUID } from 'node:crypto';
 import { authenticate } from '../../shared/middleware/auth.js';
 import { requireRole } from '../../shared/middleware/rbac.js';
 import { validate } from '../../shared/middleware/validate.js';
@@ -37,6 +39,8 @@ import { rateLimit } from '../../shared/middleware/rate-limit.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
 import { hasGlobalProjectReadAccess } from '../../shared/auth/roles.js';
 import { prisma } from '../../prisma/client.js';
+import { createSubscriber } from '../../shared/redis.js';
+import { captureError } from '../../shared/utils/logger.js';
 import type { AuthRequest } from '../../shared/types/index.js';
 import {
   previewBulkOperationDto,
@@ -177,6 +181,136 @@ router.post(
     }
   },
 );
+
+// ────── GET /:id/stream (SSE) ────────────────────────────────────────────────
+
+/**
+ * Server-Sent Events для live-progress массовой операции.
+ * События: `progress`, `item`, `status`, `heartbeat` (keep-alive 20s).
+ *
+ * Клиент закрывает соединение по `status` event или через timeout/heartbeat miss;
+ * сервер закрывает при отсутствии Redis subscriber'а (Redis down → 503 перед
+ * стартом SSE-handshake'а; фронт fall-back на polling).
+ */
+router.get('/bulk-operations/:id/stream', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const actor = requireActor(req);
+    const operationId = req.params.id as string;
+
+    // Ownership check до раскрытия канала.
+    await service.getBulkOperation(operationId, {
+      userId: actor.userId,
+      systemRoles: req.user!.systemRoles,
+    });
+
+    const subscriber = await createSubscriber();
+    if (!subscriber) {
+      // Redis недоступен — клиент fall-back'ает на polling GET /:id.
+      throw new AppError(503, 'Event stream unavailable, use polling', { code: 'STREAM_UNAVAILABLE' });
+    }
+
+    // SSE headers — отключаем compression (nginx X-Accel-Buffering) для мгновенной доставки.
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.flushHeaders?.();
+
+    const channel = `bulk-op:${operationId}:events`;
+    await subscriber.subscribe(channel, (message) => {
+      try {
+        const parsed = JSON.parse(message) as { event: string; data: unknown };
+        res.write(`event: ${parsed.event}\n`);
+        res.write(`data: ${JSON.stringify(parsed.data)}\n\n`);
+      } catch (err) {
+        captureError(err, { fn: 'SSE message handler', operationId });
+      }
+    });
+
+    // Keep-alive heartbeat каждые 20с (прокси обычно закрывают idle на 30-60с).
+    const heartbeat = setInterval(() => {
+      res.write(`: ping\n\n`);
+    }, 20_000);
+
+    // Cleanup при disconnect клиента / ошибке.
+    const cleanup = async () => {
+      clearInterval(heartbeat);
+      try {
+        await subscriber.quit();
+      } catch (err) {
+        captureError(err, { fn: 'SSE cleanup', operationId });
+      }
+    };
+    req.on('close', () => void cleanup());
+    req.on('error', () => void cleanup());
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ────── GET /:id/report.csv ──────────────────────────────────────────────────
+
+/**
+ * Stream-CSV отчёт по всем failed/skipped items'ам операции (succeeded items не
+ * персистятся — §5.0 minimization; их трейс в AuditLog). Cursor-based пагинация
+ * по 1000 строк, чтобы не держать всё в памяти.
+ */
+router.get('/bulk-operations/:id/report.csv', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const actor = requireActor(req);
+    const operationId = req.params.id as string;
+
+    // Ownership check.
+    await service.getBulkOperation(operationId, {
+      userId: actor.userId,
+      systemRoles: req.user!.systemRoles,
+    });
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="bulk-op-${operationId}.csv"`);
+
+    const csv = format({ headers: ['issueKey', 'outcome', 'errorCode', 'errorMessage', 'processedAt'], writeBOM: true });
+    csv.pipe(res);
+    for await (const row of service.streamReportItems(operationId)) {
+      csv.write({
+        issueKey: row.issueKey,
+        outcome: row.outcome,
+        errorCode: row.errorCode,
+        errorMessage: row.errorMessage,
+        processedAt: row.processedAt.toISOString(),
+      });
+    }
+    csv.end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ────── POST /:id/retry-failed ───────────────────────────────────────────────
+
+router.post('/bulk-operations/:id/retry-failed', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const actor = requireActor(req);
+    const operationId = req.params.id as string;
+    // Idempotency-Key: для retry header обязателен так же как для create.
+    // Если клиент не передал — генерируем новый (retry обычно инициируется из UI,
+    // и юзер ожидает "каждый клик — новая попытка"; при желании reuse клиент
+    // явно передаст тот же Idempotency-Key).
+    const idempotencyKeyRaw = req.header('Idempotency-Key') ?? randomUUID();
+    const idempotencyKey = idempotencyKeySchema.parse(idempotencyKeyRaw);
+    const result = await service.retryFailedItems(operationId, {
+      userId: actor.userId,
+      systemRoles: req.user!.systemRoles,
+    }, idempotencyKey);
+    const { alreadyExisted, ...body } = result;
+    res.status(alreadyExisted ? 200 : 201).json(body);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return next(new AppError(400, 'Invalid Idempotency-Key (must be UUID)', { code: 'IDEMPOTENCY_KEY_INVALID' }));
+    }
+    next(err);
+  }
+});
 
 // ────── GET / (list mine) ────────────────────────────────────────────────────
 

--- a/backend/src/modules/bulk-operations/bulk-operations.router.ts
+++ b/backend/src/modules/bulk-operations/bulk-operations.router.ts
@@ -232,8 +232,12 @@ router.get('/bulk-operations/:id/stream', async (req: AuthRequest, res: Response
       res.write(`: ping\n\n`);
     }, 20_000);
 
-    // Cleanup при disconnect клиента / ошибке.
+    // Cleanup при disconnect клиента / ошибке — одноразовый, иначе
+    // subscriber.quit() может вызваться дважды (close + error events).
+    let cleanedUp = false;
     const cleanup = async () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
       clearInterval(heartbeat);
       try {
         await subscriber.quit();
@@ -266,21 +270,35 @@ router.get('/bulk-operations/:id/report.csv', async (req: AuthRequest, res: Resp
       systemRoles: req.user!.systemRoles,
     });
 
+    // operationId — UUID (только [a-z0-9-]), filename safe без RFC 5987 quoting.
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');
     res.setHeader('Content-Disposition', `attachment; filename="bulk-op-${operationId}.csv"`);
 
     const csv = format({ headers: ['issueKey', 'outcome', 'errorCode', 'errorMessage', 'processedAt'], writeBOM: true });
+    csv.on('error', (csvErr) => {
+      captureError(csvErr, { fn: 'CSV stream error', operationId });
+      if (!res.headersSent) next(csvErr);
+      else res.destroy(csvErr);
+    });
     csv.pipe(res);
-    for await (const row of service.streamReportItems(operationId)) {
-      csv.write({
-        issueKey: row.issueKey,
-        outcome: row.outcome,
-        errorCode: row.errorCode,
-        errorMessage: row.errorMessage,
-        processedAt: row.processedAt.toISOString(),
-      });
+    try {
+      for await (const row of service.streamReportItems(operationId)) {
+        csv.write({
+          issueKey: row.issueKey,
+          outcome: row.outcome,
+          errorCode: row.errorCode,
+          errorMessage: row.errorMessage,
+          processedAt: row.processedAt.toISOString(),
+        });
+      }
+      csv.end();
+    } catch (streamErr) {
+      // Ошибка после pipe: headers уже отправлены, next(err) не поможет.
+      // Разрушаем stream, чтобы клиент получил abrupt close а не молчаливо
+      // truncated CSV.
+      captureError(streamErr, { fn: 'CSV iterate error', operationId });
+      csv.destroy(streamErr as Error);
     }
-    csv.end();
   } catch (err) {
     next(err);
   }

--- a/backend/src/modules/bulk-operations/bulk-operations.service.ts
+++ b/backend/src/modules/bulk-operations/bulk-operations.service.ts
@@ -411,8 +411,16 @@ export async function retryFailedItems(
   }
 
   // Собираем items для повтора (retention ≤ 30 дней — после зачистки 410 Gone).
+  // CANCELLED_BY_USER намеренно исключаем: юзер отменил эти items, ретраить их
+  // без явного нового запуска = игнорирование его решения. Прочие SKIPPED
+  // (ALREADY_IN_TARGET_STATE, NO_ACCESS) тоже retry'ятся в scope — processor
+  // повторно их SKIP'нет, user-facing это дешево. STALE_STATUS — legitimate retry.
   const failedItems = await prisma.bulkOperationItem.findMany({
-    where: { operationId, outcome: { in: ['FAILED', 'SKIPPED'] } },
+    where: {
+      operationId,
+      outcome: { in: ['FAILED', 'SKIPPED'] },
+      errorCode: { not: 'CANCELLED_BY_USER' },
+    },
     select: { issueId: true },
   });
   if (failedItems.length === 0) {
@@ -498,6 +506,10 @@ export async function retryFailedItems(
 /**
  * Async iterator через BulkOperationItem для CSV-стрима report.csv. Читаем
  * cursor-based пагинацией по 1000 строк, чтобы не держать все items в памяти.
+ *
+ * @internal Caller ОБЯЗАН пройти authorization-check через `getBulkOperation`
+ * до вызова — функция сама по себе доверяет operationId и не разделяет
+ * ownership. В router'е это делается до `streamReportItems`.
  */
 export async function* streamReportItems(operationId: string): AsyncIterable<{
   issueKey: string;

--- a/backend/src/modules/bulk-operations/bulk-operations.service.ts
+++ b/backend/src/modules/bulk-operations/bulk-operations.service.ts
@@ -381,6 +381,170 @@ export async function cancelBulkOperation(
 
 // ────── list ─────────────────────────────────────────────────────────────────
 
+// ────── retry-failed (PR-6) ─────────────────────────────────────────────────
+
+/**
+ * Создаёт новую операцию со scope=failed items исходной операции.
+ * Требования:
+ *   • Исходная op должна быть в терминальном статусе (не QUEUED/RUNNING).
+ *   • Failed/skipped items ещё не зачищены retention-cron'ом.
+ *   • Юзер — owner исходной op (404 на чужую).
+ *
+ * Новая op имеет тот же payload и scope.kind='ids' с issueIds из
+ * BulkOperationItem WHERE outcome IN ('FAILED','SKIPPED'). Полный цикл
+ * create (concurrency-quota, idempotency, RPUSH) — через createBulkOperation.
+ */
+export async function retryFailedItems(
+  operationId: string,
+  ctx: BulkExecutorActor,
+  idempotencyKey: string,
+): Promise<{ id: string; status: BulkOperationStatus; alreadyExisted: boolean }> {
+  const source = await prisma.bulkOperation.findUnique({
+    where: { id: operationId },
+    select: { id: true, createdById: true, status: true, type: true, scopeKind: true, scopeJql: true, payload: true },
+  });
+  if (!source || source.createdById !== ctx.userId) {
+    throw new AppError(404, 'Bulk operation not found');
+  }
+  if (source.status === 'QUEUED' || source.status === 'RUNNING') {
+    throw new AppError(409, 'Source operation still in progress', { code: 'SOURCE_NOT_TERMINAL' });
+  }
+
+  // Собираем items для повтора (retention ≤ 30 дней — после зачистки 410 Gone).
+  const failedItems = await prisma.bulkOperationItem.findMany({
+    where: { operationId, outcome: { in: ['FAILED', 'SKIPPED'] } },
+    select: { issueId: true },
+  });
+  if (failedItems.length === 0) {
+    throw new AppError(410, 'No failed/skipped items to retry (or retention cleanup already happened)', {
+      code: 'NO_RETRY_ITEMS',
+    });
+  }
+
+  // Идемпотентность — проверяем существующий retry по (userId, idempotencyKey).
+  const existing = await prisma.bulkOperation.findUnique({
+    where: { createdById_idempotencyKey: { createdById: ctx.userId, idempotencyKey } },
+    select: { id: true, status: true },
+  });
+  if (existing) {
+    return { id: existing.id, status: existing.status, alreadyExisted: true };
+  }
+
+  // Concurrency-quota + Redis availability — те же проверки что в createBulkOperation.
+  const activeCount = await prisma.bulkOperation.count({
+    where: { createdById: ctx.userId, status: { in: ['QUEUED', 'RUNNING'] } },
+  });
+  if (activeCount >= DEFAULT_MAX_CONCURRENT_PER_USER) {
+    throw new AppError(429, 'Too many concurrent bulk operations', {
+      code: 'TOO_MANY_CONCURRENT',
+      retryAfter: 60,
+      limit: DEFAULT_MAX_CONCURRENT_PER_USER,
+      active: activeCount,
+    });
+  }
+  if (!(await isRedisAvailable())) {
+    throw new AppError(503, 'Backend queue unavailable', { code: 'QUEUE_UNAVAILABLE' });
+  }
+
+  const issueIds = failedItems.map((i) => i.issueId);
+  let operation: { id: string; status: BulkOperationStatus };
+  try {
+    operation = await prisma.bulkOperation.create({
+      data: {
+        createdById: ctx.userId,
+        type: source.type,
+        status: 'QUEUED',
+        // Retry всегда scope=ids (снапшот предыдущих failed/skipped ID'ов), даже
+        // если исходная op была scope=jql — TZ §4.1 POST /:id/retry-failed.
+        scopeKind: 'ids',
+        scopeJql: null,
+        payload: source.payload as Prisma.InputJsonValue,
+        idempotencyKey,
+        total: issueIds.length,
+      },
+      select: { id: true, status: true },
+    });
+  } catch (err) {
+    if (isUniqueViolation(err, 'idempotency_key')) {
+      const raced = await prisma.bulkOperation.findUnique({
+        where: { createdById_idempotencyKey: { createdById: ctx.userId, idempotencyKey } },
+        select: { id: true, status: true },
+      });
+      if (raced) return { id: raced.id, status: raced.status, alreadyExisted: true };
+    }
+    throw err;
+  }
+
+  const pushed = await rpushList(pendingQueueKey(operation.id), issueIds);
+  if (pushed === null) {
+    await prisma.bulkOperation.delete({ where: { id: operation.id } });
+    throw new AppError(503, 'Backend queue unavailable', { code: 'QUEUE_UNAVAILABLE' });
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      action: 'bulk_operation.retry_failed',
+      entityType: 'bulk_operation',
+      entityId: operation.id,
+      userId: ctx.userId,
+      bulkOperationId: operation.id,
+      details: { sourceOperationId: operationId, retryItemCount: issueIds.length },
+    },
+  });
+
+  return { id: operation.id, status: operation.status, alreadyExisted: false };
+}
+
+/**
+ * Async iterator через BulkOperationItem для CSV-стрима report.csv. Читаем
+ * cursor-based пагинацией по 1000 строк, чтобы не держать все items в памяти.
+ */
+export async function* streamReportItems(operationId: string): AsyncIterable<{
+  issueKey: string;
+  outcome: string;
+  errorCode: string;
+  errorMessage: string;
+  processedAt: Date;
+}> {
+  const PAGE = 1000;
+  let cursor: string | null = null;
+  while (true) {
+    const items: Array<{
+      id: string;
+      issueKey: string;
+      outcome: string;
+      errorCode: string;
+      errorMessage: string;
+      processedAt: Date;
+    }> = await prisma.bulkOperationItem.findMany({
+      where: { operationId },
+      take: PAGE,
+      orderBy: { id: 'asc' },
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      select: {
+        id: true,
+        issueKey: true,
+        outcome: true,
+        errorCode: true,
+        errorMessage: true,
+        processedAt: true,
+      },
+    });
+    if (items.length === 0) break;
+    for (const row of items) {
+      yield {
+        issueKey: row.issueKey,
+        outcome: row.outcome,
+        errorCode: row.errorCode,
+        errorMessage: row.errorMessage,
+        processedAt: row.processedAt,
+      };
+    }
+    if (items.length < PAGE) break;
+    cursor = items[items.length - 1].id;
+  }
+}
+
 export async function listBulkOperations(
   ctx: BulkExecutorActor,
   query: { limit?: number; startAt?: number; status?: BulkOperationStatus; type?: BulkOperationType },

--- a/backend/src/shared/redis.ts
+++ b/backend/src/shared/redis.ts
@@ -163,6 +163,53 @@ export async function lpopListBatch(key: string, count: number): Promise<string[
 }
 
 /**
+ * TTBULK-1 PR-6: Pub/Sub для SSE-стрима прогресса массовых операций.
+ *
+ * `publishToChannel` — processor публикует события (progress/status/item/heartbeat)
+ * на канале `bulk-op:{id}:events`, SSE-роут подписан через duplicate-client и
+ * форвардит в поток клиенту.
+ *
+ * Важно: node-redis v5 переводит connection в эксклюзивный subscribe-режим,
+ * поэтому subscriber должен быть отдельным клиентом (не shared singleton'ом).
+ * `createSubscriber()` возвращает свежий `client.duplicate()` под каждого
+ * SSE-consumer'а (long-lived connection = closed on client disconnect).
+ */
+export async function publishToChannel(channel: string, payload: unknown): Promise<boolean> {
+  const redis = await getRedisClientInternal();
+  if (!redis) return false;
+  try {
+    await redis.publish(channel, JSON.stringify(payload));
+    return true;
+  } catch (err) {
+    captureError(err, { fn: 'publishToChannel', channel });
+    return false;
+  }
+}
+
+/**
+ * Создаёт dedicated subscriber-client для SSE endpoint'а. Caller ОБЯЗАН
+ * вызвать `.quit()` при закрытии stream'а (cleanup на 'close' event).
+ *
+ * Возвращает null если Redis unavailable — caller должен fall-back на
+ * polling (клиент сам переключается через eventsource polyfill).
+ */
+export async function createSubscriber(): Promise<RedisClient | null> {
+  if (process.env.NODE_ENV === 'test') return null;
+  if (!config.REDIS_URL) return null;
+  const main = await getRedisClientInternal();
+  if (!main) return null;
+  try {
+    const sub = main.duplicate() as RedisClient;
+    sub.on('error', (err) => captureError(err, { fn: 'createSubscriber', event: 'subscriber-error' }));
+    await sub.connect();
+    return sub;
+  } catch (err) {
+    captureError(err, { fn: 'createSubscriber', event: 'connect-failed' });
+    return null;
+  }
+}
+
+/**
  * TTBULK-1: атомарный GET+DEL одним round-trip'ом (node-redis v4/v5 `getDel`).
  * Используется для one-shot previewToken'ов: две одновременные create-запроса
  * с одним token'ом не должны обе увидеть данные (double-consume race).

--- a/backend/tests/bulk-operations-processor.unit.test.ts
+++ b/backend/tests/bulk-operations-processor.unit.test.ts
@@ -33,6 +33,7 @@ const { mockPrisma, mockRedis, mockTransitionExecutor, mockContext } = vi.hoiste
     acquireLock: vi.fn(),
     releaseLock: vi.fn(),
     lpopListBatch: vi.fn(),
+    publishToChannel: vi.fn().mockResolvedValue(true),
   };
   const mockTransitionExecutor = {
     type: 'TRANSITION',
@@ -50,6 +51,7 @@ vi.mock('../src/shared/redis.js', () => ({
   acquireLock: mockRedis.acquireLock,
   releaseLock: mockRedis.releaseLock,
   lpopListBatch: mockRedis.lpopListBatch,
+  publishToChannel: mockRedis.publishToChannel,
 }));
 vi.mock('../src/shared/bulk-operation-context.js', () => mockContext);
 vi.mock('../src/shared/auth/roles.js', () => ({
@@ -177,6 +179,15 @@ describe('runTickOnce — batch processing', () => {
           heartbeatAt: expect.any(Date),
         }),
       }),
+    );
+    // PR-6: SSE progress event + финальный status event (SUCCEEDED).
+    expect(mockRedis.publishToChannel).toHaveBeenCalledWith(
+      'bulk-op:op-1:events',
+      expect.objectContaining({ event: 'progress' }),
+    );
+    expect(mockRedis.publishToChannel).toHaveBeenCalledWith(
+      'bulk-op:op-1:events',
+      expect.objectContaining({ event: 'status', data: expect.objectContaining({ status: 'SUCCEEDED' }) }),
     );
   });
 

--- a/backend/tests/bulk-operations-retry-report.unit.test.ts
+++ b/backend/tests/bulk-operations-retry-report.unit.test.ts
@@ -85,6 +85,23 @@ describe('retryFailedItems', () => {
     await expect(retryFailedItems('op-1', actor, KEY)).rejects.toMatchObject({ statusCode: 410 });
   });
 
+  it('query для retry items исключает CANCELLED_BY_USER errorCode', async () => {
+    mockPrisma.bulkOperation.findUnique.mockResolvedValue({
+      id: 'op-1', createdById: 'u1', status: 'CANCELLED', type: 'TRANSITION',
+      scopeKind: 'ids', scopeJql: null, payload: {},
+    });
+    mockPrisma.bulkOperationItem.findMany.mockResolvedValue([]);
+    await expect(retryFailedItems('op-1', actor, KEY)).rejects.toMatchObject({ statusCode: 410 });
+    expect(mockPrisma.bulkOperationItem.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          errorCode: { not: 'CANCELLED_BY_USER' },
+          outcome: { in: ['FAILED', 'SKIPPED'] },
+        }),
+      }),
+    );
+  });
+
   it('happy: создаёт новую op с scope=ids, RPUSH pending, audit', async () => {
     mockPrisma.bulkOperation.findUnique
       .mockResolvedValueOnce({

--- a/backend/tests/bulk-operations-retry-report.unit.test.ts
+++ b/backend/tests/bulk-operations-retry-report.unit.test.ts
@@ -1,0 +1,188 @@
+/**
+ * TTBULK-1 PR-6 — unit-тесты retry-failed + streamReportItems.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPrisma, mockRedis } = vi.hoisted(() => {
+  const mockPrisma = {
+    bulkOperation: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      count: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+    bulkOperationItem: { findMany: vi.fn() },
+    auditLog: { create: vi.fn() },
+  };
+  const mockRedis = {
+    atomicGetDelJson: vi.fn(),
+    setCachedJson: vi.fn(),
+    rpushList: vi.fn().mockResolvedValue(1),
+    isRedisAvailable: vi.fn().mockResolvedValue(true),
+    publishToChannel: vi.fn().mockResolvedValue(true),
+  };
+  return { mockPrisma, mockRedis };
+});
+
+vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
+vi.mock('../src/shared/redis.js', () => mockRedis);
+vi.mock('../src/shared/auth/roles.js', () => ({
+  hasGlobalProjectReadAccess: vi.fn().mockReturnValue(false),
+  getEffectiveUserSystemRoles: vi.fn(),
+  invalidateUserSystemRolesCache: vi.fn(),
+  invalidateUserSystemRolesCacheForUsers: vi.fn(),
+  computeEffectiveUserSystemRoles: vi.fn(),
+  sysRolesCacheKey: (id: string) => `user:sysroles:${id}`,
+  isSuperAdmin: vi.fn().mockReturnValue(false),
+  hasSystemRole: vi.fn().mockReturnValue(false),
+  hasAnySystemRole: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../src/modules/search/search.service.js', () => ({ searchIssues: vi.fn() }));
+
+const { retryFailedItems, streamReportItems } = await import(
+  '../src/modules/bulk-operations/bulk-operations.service.js'
+);
+
+const actor = { userId: 'u1', systemRoles: ['BULK_OPERATOR'] };
+const KEY = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRedis.rpushList.mockResolvedValue(1);
+  mockRedis.isRedisAvailable.mockResolvedValue(true);
+  mockPrisma.auditLog.create.mockResolvedValue({});
+});
+
+describe('retryFailedItems', () => {
+  it('404 если source op не существует', async () => {
+    mockPrisma.bulkOperation.findUnique.mockResolvedValue(null);
+    await expect(retryFailedItems('op-missing', actor, KEY)).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('404 если source op принадлежит другому юзеру', async () => {
+    mockPrisma.bulkOperation.findUnique.mockResolvedValue({
+      id: 'op-1', createdById: 'u-other', status: 'PARTIAL', type: 'TRANSITION',
+      scopeKind: 'ids', scopeJql: null, payload: {},
+    });
+    await expect(retryFailedItems('op-1', actor, KEY)).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('409 если source op ещё RUNNING/QUEUED', async () => {
+    mockPrisma.bulkOperation.findUnique.mockResolvedValue({
+      id: 'op-1', createdById: 'u1', status: 'RUNNING', type: 'TRANSITION',
+      scopeKind: 'ids', scopeJql: null, payload: {},
+    });
+    await expect(retryFailedItems('op-1', actor, KEY)).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it('410 если failed/skipped items уже зачищены по retention', async () => {
+    mockPrisma.bulkOperation.findUnique.mockResolvedValue({
+      id: 'op-1', createdById: 'u1', status: 'PARTIAL', type: 'TRANSITION',
+      scopeKind: 'ids', scopeJql: null, payload: {},
+    });
+    mockPrisma.bulkOperationItem.findMany.mockResolvedValue([]);
+    await expect(retryFailedItems('op-1', actor, KEY)).rejects.toMatchObject({ statusCode: 410 });
+  });
+
+  it('happy: создаёт новую op с scope=ids, RPUSH pending, audit', async () => {
+    mockPrisma.bulkOperation.findUnique
+      .mockResolvedValueOnce({
+        id: 'op-1', createdById: 'u1', status: 'PARTIAL', type: 'TRANSITION',
+        scopeKind: 'ids', scopeJql: null, payload: { type: 'TRANSITION', transitionId: 't1' },
+      })
+      .mockResolvedValueOnce(null); // no existing retry
+    mockPrisma.bulkOperationItem.findMany.mockResolvedValue([
+      { issueId: 'i1' }, { issueId: 'i2' },
+    ]);
+    mockPrisma.bulkOperation.count.mockResolvedValue(0);
+    mockPrisma.bulkOperation.create.mockResolvedValue({ id: 'op-retry', status: 'QUEUED' });
+
+    const res = await retryFailedItems('op-1', actor, KEY);
+    expect(res).toEqual({ id: 'op-retry', status: 'QUEUED', alreadyExisted: false });
+    expect(mockPrisma.bulkOperation.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        scopeKind: 'ids', scopeJql: null, total: 2, idempotencyKey: KEY, type: 'TRANSITION',
+      }),
+    }));
+    expect(mockRedis.rpushList).toHaveBeenCalledWith('bulk-op:op-retry:pending', ['i1', 'i2']);
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ action: 'bulk_operation.retry_failed' }),
+    }));
+  });
+
+  it('idempotency: повторный ключ возвращает existing', async () => {
+    mockPrisma.bulkOperation.findUnique
+      .mockResolvedValueOnce({
+        id: 'op-1', createdById: 'u1', status: 'PARTIAL', type: 'TRANSITION',
+        scopeKind: 'ids', scopeJql: null, payload: {},
+      })
+      .mockResolvedValueOnce({ id: 'op-retry-existing', status: 'RUNNING' });
+    mockPrisma.bulkOperationItem.findMany.mockResolvedValue([{ issueId: 'i1' }]);
+
+    const res = await retryFailedItems('op-1', actor, KEY);
+    expect(res).toEqual({ id: 'op-retry-existing', status: 'RUNNING', alreadyExisted: true });
+    expect(mockPrisma.bulkOperation.create).not.toHaveBeenCalled();
+  });
+
+  it('429 при concurrency-quota', async () => {
+    mockPrisma.bulkOperation.findUnique
+      .mockResolvedValueOnce({
+        id: 'op-1', createdById: 'u1', status: 'PARTIAL', type: 'TRANSITION',
+        scopeKind: 'ids', scopeJql: null, payload: {},
+      })
+      .mockResolvedValueOnce(null);
+    mockPrisma.bulkOperationItem.findMany.mockResolvedValue([{ issueId: 'i1' }]);
+    mockPrisma.bulkOperation.count.mockResolvedValue(3);
+    await expect(retryFailedItems('op-1', actor, KEY)).rejects.toMatchObject({ statusCode: 429 });
+  });
+
+  it('503 + rollback DELETE при Redis RPUSH failure', async () => {
+    mockPrisma.bulkOperation.findUnique
+      .mockResolvedValueOnce({
+        id: 'op-1', createdById: 'u1', status: 'PARTIAL', type: 'TRANSITION',
+        scopeKind: 'ids', scopeJql: null, payload: {},
+      })
+      .mockResolvedValueOnce(null);
+    mockPrisma.bulkOperationItem.findMany.mockResolvedValue([{ issueId: 'i1' }]);
+    mockPrisma.bulkOperation.count.mockResolvedValue(0);
+    mockPrisma.bulkOperation.create.mockResolvedValue({ id: 'op-retry', status: 'QUEUED' });
+    mockRedis.rpushList.mockResolvedValue(null); // Redis died
+
+    await expect(retryFailedItems('op-1', actor, KEY)).rejects.toMatchObject({ statusCode: 503 });
+    expect(mockPrisma.bulkOperation.delete).toHaveBeenCalledWith({ where: { id: 'op-retry' } });
+  });
+});
+
+describe('streamReportItems', () => {
+  it('итерирует items пачками по 1000 с cursor-пагинацией', async () => {
+    const page1 = Array.from({ length: 1000 }, (_, i) => ({
+      id: `i-${i}`, issueKey: `TT-${i}`, outcome: 'FAILED',
+      errorCode: 'X', errorMessage: 'err', processedAt: new Date(),
+    }));
+    const page2 = Array.from({ length: 42 }, (_, i) => ({
+      id: `j-${i}`, issueKey: `TT-${1000 + i}`, outcome: 'SKIPPED',
+      errorCode: 'Y', errorMessage: 'skip', processedAt: new Date(),
+    }));
+    mockPrisma.bulkOperationItem.findMany
+      .mockResolvedValueOnce(page1)
+      .mockResolvedValueOnce(page2);
+
+    const rows: Array<{ issueKey: string; outcome: string }> = [];
+    for await (const r of streamReportItems('op-1')) rows.push(r);
+    expect(rows.length).toBe(1042);
+    expect(rows[0].issueKey).toBe('TT-0');
+    expect(rows[1041].issueKey).toBe('TT-1041');
+    // Cursor задан после первой страницы.
+    expect(mockPrisma.bulkOperationItem.findMany).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      cursor: { id: 'i-999' }, skip: 1,
+    }));
+  });
+
+  it('пустой dataset → 0 iterations', async () => {
+    mockPrisma.bulkOperationItem.findMany.mockResolvedValueOnce([]);
+    const rows: unknown[] = [];
+    for await (const r of streamReportItems('op-empty')) rows.push(r);
+    expect(rows).toEqual([]);
+  });
+});

--- a/docs/tz/TTBULK-1.md
+++ b/docs/tz/TTBULK-1.md
@@ -1045,7 +1045,7 @@ PR-12 ─► PR-13 (metrics + grafana + алёрты)
 | 3  | `ttbulk-1/service-core`         | DTO + preview/create/get/cancel + Redis pending queue + previewToken | 12   | PR-2              | service + router   | 🟢 Merged (#145) |
 | 4  | `ttbulk-1/processor`            | TransitionExecutor + processor cron + recovery + retention + AuditLog.bulkOperationId | 14   | PR-3              | executor + processor | 🟢 Merged (#146) |
 | 5  | `ttbulk-1/executors`            | 6 executors (Assign/EditField/EditCustomField/MoveToSprint/AddComment/Delete) | 14   | PR-4              | per-executor + tests | 🟢 Merged (#147) |
-| 6  | `ttbulk-1/streaming-report`     | SSE + Redis pub/sub + report.csv + retry-failed              | 8    | PR-3, PR-4        | router + processor hook | 📋 Планируется |
+| 6  | `ttbulk-1/streaming-report`     | SSE + Redis pub/sub + report.csv + retry-failed              | 8    | PR-3, PR-4        | router + processor hook | ✅ Done        |
 | 7  | `ttbulk-1/system-settings`      | maxConcurrentPerUser / maxItems API + AdminSystemPage UI     | 4    | PR-3              | backend + UI       | 📋 Планируется |
 | 8  | `ttbulk-1/admin-roles`          | BULK_OPERATOR in admin roles UI + group-assign endpoints     | 8    | PR-2              | endpoints + UI     | 📋 Планируется |
 | 9  | `ttbulk-1/wizard-modal`         | BulkOperationWizardModal (4 steps + preview + conflicts)     | 14   | PR-3              | 4 step components  | 📋 Планируется |

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,33 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.57**
+**Last version: 2.58**
+
+---
+
+## [2.58] [2026-04-23] feat(bulk-ops): TTBULK-1 PR-6 — SSE + Redis pub/sub + report.csv + retry-failed
+
+**PR:** (to be filled after push)
+**Ветка:** `ttbulk-1/streaming-report`
+
+### Что было
+
+После PR-1..5 backend полностью работоспособен, но клиент не мог отслеживать прогресс live. Не было `/stream`, `/report.csv`, `/retry-failed`.
+
+### Что теперь
+
+- **Redis Pub/Sub helpers** в `shared/redis.ts`: `publishToChannel` + `createSubscriber` (duplicate-client для subscribe-mode node-redis v5).
+- **Processor публикует events** после каждого batch'а: `progress` + per-item `item` + финальный `status`.
+- **Router:** `GET /:id/stream` (SSE, heartbeat 20s, dedicated subscriber), `GET /:id/report.csv` (fast-csv streaming, cursor 1000/page), `POST /:id/retry-failed`.
+- **`@fast-csv/format`** добавлен. **10 новых unit-тестов**.
+
+### Проверки
+
+- tsc ✅, lint 0 errors ✅, test:parser 589/589 (+10 новых).
+
+### Связано
+
+- TTBULK-1 — см. `docs/tz/TTBULK-1.md` §4.5, §6.6, §13.6 PR-6.
 
 ---
 


### PR DESCRIPTION
## Summary

PR-6 закрывает оставшиеся backend endpoints: клиент может live-следить за прогрессом через SSE, скачивать CSV-отчёт, ретраить упавшие items.

### Scope (10 файлов)

- **Redis helpers (shared/redis.ts):** `publishToChannel` + `createSubscriber` (duplicate-client для node-redis v5 subscribe-mode).
- **Processor publishes events:** progress + per-item (failed/skipped) + finalize status. Fan-out через `Promise.all`.
- **Router endpoints:**
  - `GET /:id/stream` — SSE, heartbeat 20s, dedicated subscriber, double-cleanup guard.
  - `GET /:id/report.csv` — @fast-csv/format streaming с BOM, cursor-based 1000/page, proper error handling после pipe.
  - `POST /:id/retry-failed` — scope=ids из failed/skipped (кроме CANCELLED_BY_USER), P2002 catch, DELETE rollback.
- **Dep:** `@fast-csv/format` ^5.0.5.
- **11 новых unit-тестов** (retry-failed 8 + streamReportItems 2 + CANCELLED_BY_USER exclude 1).

## Pre-push review (Opus 4.7) — 2 🟠 + 3 🟡 + 1 🔵 + 1 ⚪

Все применены (`425476e`):
- 🟠 SSE double-cleanup guard (`cleanedUp` boolean).
- 🟠 CSV stream error handling после pipe (csv.destroy если headersSent).
- 🟡 retry-failed исключает CANCELLED_BY_USER errorCode.
- 🟡 streamReportItems @internal JSDoc (caller owns authorization).
- 🟡 publishEvents Promise.all fan-out (26 RT → 1 RT на cross-AZ Redis).
- 🔵 Content-Disposition comment о UUID safety.
- ⚪ Skipped: `delCacheByPrefix` SCAN cursor bug в shared/redis.ts — pre-existing (node-redis v5 `reply.cursor` — number не string), scope отдельного fix.

## Test plan

- [x] tsc → 0 errors
- [x] lint → 0 errors, 0 new warnings
- [x] test:parser → 590/590 passed (+11 новых в PR-6)
- [ ] Staging: curl `/api/bulk-operations/:id/stream` получает `event: progress` + `event: status`
- [ ] Staging: `/report.csv` скачивается, открывается в Excel с русским BOM
- [ ] Staging: retry-failed после PARTIAL — создаёт новую op с failed items, CANCELLED не попадают

## Зависимости

- **Base:** `main` (branch от PR-5 `ttbulk-1/executors`, #147 CI pending). После merge #147 сделаю rebase.
- **Downstream:** PR-10 (ProgressDrawer frontend) подписывается через этот SSE endpoint.

## Плановая дельта

§13.9 row 6 → 🟢 Merged после merge (сейчас ✅ Done).

См. [docs/tz/TTBULK-1.md §4.5, §6.6, §13.6 PR-6](docs/tz/TTBULK-1.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
