### PR TITLE
feat(bulk-ops): TTBULK-1 PR-7 — runtime System settings + AdminSystemPage UI

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts tests/search-functions.unit.test.ts tests/search-validator.unit.test.ts tests/search-compiler.unit.test.ts tests/search-pipeline-fuzz.unit.test.ts tests/search-suggest.unit.test.ts tests/checkpoint-dto.unit.test.ts tests/checkpoint-engine-ttql.unit.test.ts tests/effective-user-system-roles.unit.test.ts tests/bulk-operations-service.unit.test.ts tests/bulk-operations-processor.unit.test.ts tests/transition-executor.unit.test.ts tests/bulk-executors.unit.test.ts tests/bulk-operations-retry-report.unit.test.ts",
+    "test:parser": "vitest run --config vitest.parser-only.config.ts tests/search-tokenizer.unit.test.ts tests/search-parser.unit.test.ts tests/search-parser-goldenset.unit.test.ts tests/search-parser-fuzz.unit.test.ts tests/search-functions.unit.test.ts tests/search-validator.unit.test.ts tests/search-compiler.unit.test.ts tests/search-pipeline-fuzz.unit.test.ts tests/search-suggest.unit.test.ts tests/checkpoint-dto.unit.test.ts tests/checkpoint-engine-ttql.unit.test.ts tests/effective-user-system-roles.unit.test.ts tests/bulk-operations-service.unit.test.ts tests/bulk-operations-processor.unit.test.ts tests/transition-executor.unit.test.ts tests/bulk-executors.unit.test.ts tests/bulk-operations-retry-report.unit.test.ts tests/bulk-operations-settings.unit.test.ts",
     "lint": "eslint src/ --ext .ts",
     "format": "prettier --write 'src/**/*.ts'",
     "mcp": "tsx src/mcp/server.ts"

--- a/backend/src/modules/admin/admin.dto.ts
+++ b/backend/src/modules/admin/admin.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MAX_ITEMS_HARD_LIMIT } from '../bulk-operations/bulk-operations.dto.js';
 
 export const createUserDto = z.object({
   email: z.string().email(),
@@ -37,10 +38,13 @@ export const updateSystemSettingsDto = z.object({
 });
 
 // TTBULK-1 PR-7 — bulk operations runtime limits.
+// maxItems max = MAX_ITEMS_HARD_LIMIT (10k), чтобы устранить silent-clamp
+// между DTO-валидацией и service-clamp'ом. Если в будущем hard-cap расширят —
+// поднимется и этот bound.
 export const updateBulkOpsSettingsDto = z
   .object({
     maxConcurrentPerUser: z.number().int().min(1).max(20).optional(),
-    maxItems: z.number().int().min(100).max(50_000).optional(),
+    maxItems: z.number().int().min(100).max(MAX_ITEMS_HARD_LIMIT).optional(),
   })
   .refine(
     (v) => v.maxConcurrentPerUser !== undefined || v.maxItems !== undefined,

--- a/backend/src/modules/admin/admin.dto.ts
+++ b/backend/src/modules/admin/admin.dto.ts
@@ -36,7 +36,19 @@ export const updateSystemSettingsDto = z.object({
   sessionLifetimeMinutes: z.number().int().min(5).max(10080),
 });
 
+// TTBULK-1 PR-7 — bulk operations runtime limits.
+export const updateBulkOpsSettingsDto = z
+  .object({
+    maxConcurrentPerUser: z.number().int().min(1).max(20).optional(),
+    maxItems: z.number().int().min(100).max(50_000).optional(),
+  })
+  .refine(
+    (v) => v.maxConcurrentPerUser !== undefined || v.maxItems !== undefined,
+    { message: 'Нужно передать хотя бы одно поле (maxConcurrentPerUser или maxItems)' },
+  );
+
 export type CreateUserDto = z.infer<typeof createUserDto>;
 export type UpdateUserAdminDto = z.infer<typeof updateUserAdminDto>;
 export type AssignProjectRoleDto = z.infer<typeof assignProjectRoleDto>;
 export type UpdateSystemSettingsDto = z.infer<typeof updateSystemSettingsDto>;
+export type UpdateBulkOpsSettingsDto = z.infer<typeof updateBulkOpsSettingsDto>;

--- a/backend/src/modules/admin/admin.router.ts
+++ b/backend/src/modules/admin/admin.router.ts
@@ -3,7 +3,11 @@ import { authenticate } from '../../shared/middleware/auth.js';
 import { requireRole, requireSuperAdmin } from '../../shared/middleware/rbac.js';
 import { validate } from '../../shared/middleware/validate.js';
 import * as adminService from './admin.service.js';
-import { createUserDto, updateUserAdminDto, assignProjectRoleDto, updateSystemSettingsDto } from './admin.dto.js';
+import { createUserDto, updateUserAdminDto, assignProjectRoleDto, updateSystemSettingsDto, updateBulkOpsSettingsDto } from './admin.dto.js';
+import {
+  getBulkOpsSettings,
+  setBulkOpsSettings,
+} from '../bulk-operations/bulk-operations-settings.service.js';
 import { logAudit } from '../../shared/middleware/audit.js';
 import { rotateUserPassword } from '../users/password-rotation.service.js';
 import type { UatRole } from './uat-tests.data.js';
@@ -168,6 +172,23 @@ router.patch('/admin/settings/system', requireSuperAdmin(), validate(updateSyste
   const settings = await adminService.getSystemSettings();
   res.json(settings);
 }));
+
+// TTBULK-1 PR-7 — runtime limits for bulk operations (SUPER_ADMIN only).
+router.get('/admin/system-settings/bulk-operations', requireSuperAdmin(), asyncHandler(async (_req, res) => {
+  const settings = await getBulkOpsSettings();
+  res.json(settings);
+}));
+
+router.patch(
+  '/admin/system-settings/bulk-operations',
+  requireSuperAdmin(),
+  validate(updateBulkOpsSettingsDto),
+  authHandler(async (req, res) => {
+    const patch = req.body as { maxConcurrentPerUser?: number; maxItems?: number };
+    const updated = await setBulkOpsSettings(req.user!.userId, patch);
+    res.json(updated);
+  }),
+);
 
 router.get('/admin/uat-tests', requireRole('ADMIN', 'USER', 'AUDITOR', 'RELEASE_MANAGER'), asyncHandler(async (req, res) => {
   const { role } = req.query as { role?: UatRole };

--- a/backend/src/modules/bulk-operations/bulk-operations-settings.service.ts
+++ b/backend/src/modules/bulk-operations/bulk-operations-settings.service.ts
@@ -147,6 +147,10 @@ export async function setBulkOpsSettings(
   actorId: string,
   patch: Partial<BulkOpsSettings>,
 ): Promise<BulkOpsSettings> {
+  // Drop memo before reading `current` — иначе при конкурентных SA-сессиях
+  // в `details.before` audit log'а попадёт stale значение первого запроса
+  // (memo hit), а не реальное DB-состояние на момент второго setBulkOpsSettings.
+  memo = null;
   const current = await getBulkOpsSettings();
   const next: BulkOpsSettings = {
     maxConcurrentPerUser:
@@ -163,6 +167,15 @@ export async function setBulkOpsSettings(
     update: { value: JSON.stringify(next) },
   });
 
+  // Инвалидация ДО audit.create: если audit упадёт, кэш всё равно очищен,
+  // иначе получили бы stale 60s с уже-обновлённым DB-row.
+  memo = null;
+  try {
+    await delCachedJson(CACHE_KEY);
+  } catch (err) {
+    captureError(err, { fn: 'setBulkOpsSettings.delCache' });
+  }
+
   await prisma.auditLog.create({
     data: {
       action: 'system.bulk_operations_settings_changed',
@@ -172,14 +185,6 @@ export async function setBulkOpsSettings(
       details: { before: current, after: next },
     },
   });
-
-  // Инвалидация — оба слоя синхронно.
-  memo = null;
-  try {
-    await delCachedJson(CACHE_KEY);
-  } catch (err) {
-    captureError(err, { fn: 'setBulkOpsSettings.delCache' });
-  }
 
   return next;
 }

--- a/backend/src/modules/bulk-operations/bulk-operations-settings.service.ts
+++ b/backend/src/modules/bulk-operations/bulk-operations-settings.service.ts
@@ -1,0 +1,199 @@
+/**
+ * TTBULK-1 PR-7 — Runtime-настройки массовых операций (System settings).
+ *
+ * Публичный API (см. §11.1 ТЗ):
+ *   • getBulkOpsSettings() — текущие значения { maxConcurrentPerUser, maxItems }
+ *     с in-memory + 60s-Redis-кэшем. Никогда не бросает: fallback на ENV/hardcode
+ *     при любых ошибках (Redis down / malformed JSON / invalid range).
+ *
+ *   • setBulkOpsSettings(actorId, patch) — валидирует + upsert в `SystemSetting.key='bulk_operations'`,
+ *     инвалидирует кэш (both layers), пишет audit_log. Неизвестные поля игнорируются
+ *     на уровне DTO выше (Zod strict в admin.dto).
+ *
+ * Инварианты:
+ *   • maxConcurrentPerUser ∈ [1..20], maxItems ∈ [100..50000]. Clamp на read,
+ *     reject на write (400).
+ *   • ENV-default = `BULK_OP_MAX_CONCURRENT_PER_USER` / `BULK_OP_MAX_ITEMS`
+ *     (обратная совместимость с PR-3..PR-6 значениями).
+ *   • Hard-ceiling maxItems ≤ MAX_ITEMS_HARD_LIMIT (10k из DTO) — сохраняем
+ *     иначе `issueIds.max` в DTO всё равно обрежет до 10k, создав скрытый
+ *     truncate. 50k из ТЗ — только roadmap'овый потолок для расширения DTO;
+ *     текущий runtime clamp'ит до MAX_ITEMS_HARD_LIMIT.
+ *   • Кэш: 60s Redis TTL + 60s in-memory (per-process). На setBulkOpsSettings
+ *     оба инвалидируются синхронно.
+ *
+ * См. docs/tz/TTBULK-1.md §11.1, §13.6 (PR-7).
+ */
+
+import { prisma } from '../../prisma/client.js';
+import {
+  getCachedJson,
+  setCachedJson,
+  delCachedJson,
+} from '../../shared/redis.js';
+import { captureError } from '../../shared/utils/logger.js';
+import { MAX_ITEMS_HARD_LIMIT } from './bulk-operations.dto.js';
+
+// ────── Публичные константы (используются DTO и UI) ──────────────────────────
+
+export const BULK_OPS_MAX_CONCURRENT_MIN = 1;
+export const BULK_OPS_MAX_CONCURRENT_MAX = 20;
+export const BULK_OPS_MAX_ITEMS_MIN = 100;
+/**
+ * UI и DTO принимают значения до 50000 (roadmap), но runtime clamp'ит до
+ * MAX_ITEMS_HARD_LIMIT — иначе Zod `issueIds.max` в DTO всё равно срежет scope.
+ */
+export const BULK_OPS_MAX_ITEMS_MAX = 50_000;
+
+export const SETTING_KEY = 'bulk_operations';
+const CACHE_KEY = 'settings:bulk_operations';
+const CACHE_TTL_SECONDS = 60;
+
+const DEFAULT_MAX_CONCURRENT = Number(process.env.BULK_OP_MAX_CONCURRENT_PER_USER ?? 3);
+const DEFAULT_MAX_ITEMS = Number(process.env.BULK_OP_MAX_ITEMS ?? MAX_ITEMS_HARD_LIMIT);
+
+export type BulkOpsSettings = {
+  maxConcurrentPerUser: number;
+  maxItems: number;
+};
+
+// ────── In-memory кэш (для hot-path createBulkOperation / resolveScope) ─────
+
+type MemoEntry = { value: BulkOpsSettings; expiresAt: number };
+let memo: MemoEntry | null = null;
+
+/** @internal — для тестов. */
+export function __resetMemoCache(): void {
+  memo = null;
+}
+
+// ────── Clamp helpers ────────────────────────────────────────────────────────
+
+function clampConcurrent(n: number): number {
+  if (!Number.isFinite(n)) return DEFAULT_MAX_CONCURRENT;
+  const i = Math.trunc(n);
+  if (i < BULK_OPS_MAX_CONCURRENT_MIN) return BULK_OPS_MAX_CONCURRENT_MIN;
+  if (i > BULK_OPS_MAX_CONCURRENT_MAX) return BULK_OPS_MAX_CONCURRENT_MAX;
+  return i;
+}
+
+function clampItems(n: number): number {
+  if (!Number.isFinite(n)) return DEFAULT_MAX_ITEMS;
+  const i = Math.trunc(n);
+  // Runtime ceiling — MAX_ITEMS_HARD_LIMIT, иначе DTO срежет scope молча.
+  const ceiling = Math.min(BULK_OPS_MAX_ITEMS_MAX, MAX_ITEMS_HARD_LIMIT);
+  if (i < BULK_OPS_MAX_ITEMS_MIN) return BULK_OPS_MAX_ITEMS_MIN;
+  if (i > ceiling) return ceiling;
+  return i;
+}
+
+function envDefaults(): BulkOpsSettings {
+  return {
+    maxConcurrentPerUser: clampConcurrent(DEFAULT_MAX_CONCURRENT),
+    maxItems: clampItems(DEFAULT_MAX_ITEMS),
+  };
+}
+
+// ────── Public API ───────────────────────────────────────────────────────────
+
+export async function getBulkOpsSettings(): Promise<BulkOpsSettings> {
+  const now = Date.now();
+  if (memo && memo.expiresAt > now) {
+    return memo.value;
+  }
+
+  try {
+    const cached = await getCachedJson<BulkOpsSettings>(CACHE_KEY);
+    if (cached && typeof cached === 'object') {
+      const resolved: BulkOpsSettings = {
+        maxConcurrentPerUser: clampConcurrent(cached.maxConcurrentPerUser),
+        maxItems: clampItems(cached.maxItems),
+      };
+      memo = { value: resolved, expiresAt: now + CACHE_TTL_SECONDS * 1000 };
+      return resolved;
+    }
+  } catch (err) {
+    captureError(err, { fn: 'getBulkOpsSettings.redis' });
+  }
+
+  let resolved: BulkOpsSettings;
+  try {
+    const row = await prisma.systemSetting.findUnique({ where: { key: SETTING_KEY } });
+    if (row) {
+      const parsed = parseSettingJson(row.value);
+      resolved = {
+        maxConcurrentPerUser: clampConcurrent(parsed?.maxConcurrentPerUser ?? DEFAULT_MAX_CONCURRENT),
+        maxItems: clampItems(parsed?.maxItems ?? DEFAULT_MAX_ITEMS),
+      };
+    } else {
+      resolved = envDefaults();
+    }
+  } catch (err) {
+    captureError(err, { fn: 'getBulkOpsSettings.prisma' });
+    resolved = envDefaults();
+  }
+
+  try {
+    await setCachedJson(CACHE_KEY, resolved, CACHE_TTL_SECONDS);
+  } catch (err) {
+    captureError(err, { fn: 'getBulkOpsSettings.setCache' });
+  }
+
+  memo = { value: resolved, expiresAt: now + CACHE_TTL_SECONDS * 1000 };
+  return resolved;
+}
+
+export async function setBulkOpsSettings(
+  actorId: string,
+  patch: Partial<BulkOpsSettings>,
+): Promise<BulkOpsSettings> {
+  const current = await getBulkOpsSettings();
+  const next: BulkOpsSettings = {
+    maxConcurrentPerUser:
+      patch.maxConcurrentPerUser !== undefined
+        ? clampConcurrent(patch.maxConcurrentPerUser)
+        : current.maxConcurrentPerUser,
+    maxItems:
+      patch.maxItems !== undefined ? clampItems(patch.maxItems) : current.maxItems,
+  };
+
+  await prisma.systemSetting.upsert({
+    where: { key: SETTING_KEY },
+    create: { key: SETTING_KEY, value: JSON.stringify(next) },
+    update: { value: JSON.stringify(next) },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      action: 'system.bulk_operations_settings_changed',
+      entityType: 'system',
+      entityId: SETTING_KEY,
+      userId: actorId,
+      details: { before: current, after: next },
+    },
+  });
+
+  // Инвалидация — оба слоя синхронно.
+  memo = null;
+  try {
+    await delCachedJson(CACHE_KEY);
+  } catch (err) {
+    captureError(err, { fn: 'setBulkOpsSettings.delCache' });
+  }
+
+  return next;
+}
+
+// ────── Internal helpers ─────────────────────────────────────────────────────
+
+function parseSettingJson(raw: string): Partial<BulkOpsSettings> | null {
+  try {
+    const j = JSON.parse(raw);
+    if (j && typeof j === 'object') {
+      return j as Partial<BulkOpsSettings>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/modules/bulk-operations/bulk-operations.service.ts
+++ b/backend/src/modules/bulk-operations/bulk-operations.service.ts
@@ -49,19 +49,13 @@ import {
 } from '../../shared/redis.js';
 import { searchIssues } from '../search/search.service.js';
 import type { OperationPayload } from './bulk-operations.dto.js';
-import { MAX_ITEMS_HARD_LIMIT } from './bulk-operations.dto.js';
+import { getBulkOpsSettings } from './bulk-operations-settings.service.js';
 import type { BulkExecutorActor } from './bulk-operations.types.js';
 
 // ────── Константы / конфигурация ─────────────────────────────────────────────
 
 /** TTL preview-токена в Redis. Пользователь обязан подтвердить submit до истечения. */
 const PREVIEW_TOKEN_TTL_SECONDS = Number(process.env.BULK_OP_PREVIEW_TTL_SECONDS ?? 15 * 60);
-
-/** Default concurrency quota per user (runtime может переопределить в PR-7 через System settings). */
-const DEFAULT_MAX_CONCURRENT_PER_USER = Number(process.env.BULK_OP_MAX_CONCURRENT_PER_USER ?? 3);
-
-/** Hard-cap on items per operation (DTO уже clamp'ит на 10k; SystemSettings (PR-7) может <= этого). */
-const DEFAULT_MAX_ITEMS = Number(process.env.BULK_OP_MAX_ITEMS ?? MAX_ITEMS_HARD_LIMIT);
 
 const PREVIEW_KEY_PREFIX = 'bulk-op:preview:';
 const PENDING_KEY_PREFIX = 'bulk-op:';
@@ -248,6 +242,19 @@ export async function createBulkOperation(
     throw new AppError(400, 'No eligible items in preview', { code: 'NO_ELIGIBLE_ITEMS' });
   }
 
+  // Runtime-limits из System settings (PR-7). Читаем один раз на create.
+  const { maxConcurrentPerUser, maxItems } = await getBulkOpsSettings();
+
+  // Safety check: админ мог понизить maxItems между preview и create — отклоняем
+  // submit со старым (большим) scope'ом, чтобы избежать обхода нового лимита.
+  if (preview.eligibleIds.length > maxItems) {
+    throw new AppError(400, 'Too many items in scope', {
+      code: 'TOO_MANY_ITEMS',
+      limit: maxItems,
+      received: preview.eligibleIds.length,
+    });
+  }
+
   // Concurrency-quota per user.
   const activeCount = await prisma.bulkOperation.count({
     where: {
@@ -255,11 +262,11 @@ export async function createBulkOperation(
       status: { in: ['QUEUED', 'RUNNING'] },
     },
   });
-  if (activeCount >= DEFAULT_MAX_CONCURRENT_PER_USER) {
+  if (activeCount >= maxConcurrentPerUser) {
     throw new AppError(429, 'Too many concurrent bulk operations', {
       code: 'TOO_MANY_CONCURRENT',
       retryAfter: 60,
-      limit: DEFAULT_MAX_CONCURRENT_PER_USER,
+      limit: maxConcurrentPerUser,
       active: activeCount,
     });
   }
@@ -593,12 +600,16 @@ async function resolveScope(
   scope: { kind: 'ids'; issueIds: string[] } | { kind: 'jql'; jql: string },
   ctx: BulkExecutorContext,
 ): Promise<{ issueIds: string[]; totalMatched: number; warnings: string[] }> {
+  // Runtime maxItems из System settings (PR-7). Читаем один раз на preview —
+  // внутри цикла и в обеих ветках используем одно и то же значение, чтобы
+  // половина scope'а не отсекалась новым лимитом в середине.
+  const { maxItems } = await getBulkOpsSettings();
+
   if (scope.kind === 'ids') {
-    // Hard-cap уже применён DTO (MAX_ITEMS_HARD_LIMIT = 10k). Runtime-lim может быть <= этого.
-    if (scope.issueIds.length > DEFAULT_MAX_ITEMS) {
+    if (scope.issueIds.length > maxItems) {
       throw new AppError(400, 'Too many items in scope', {
         code: 'TOO_MANY_ITEMS',
-        limit: DEFAULT_MAX_ITEMS,
+        limit: maxItems,
         received: scope.issueIds.length,
       });
     }
@@ -618,7 +629,7 @@ async function resolveScope(
   const issueIds: string[] = [];
   let totalMatched = 0;
   let startAt = 0;
-  while (issueIds.length < DEFAULT_MAX_ITEMS) {
+  while (issueIds.length < maxItems) {
     const result = await searchIssues(
       { jql: scope.jql, startAt, limit: SEARCH_PAGE_SIZE },
       {
@@ -633,16 +644,16 @@ async function resolveScope(
     totalMatched = result.total;
     for (const i of result.issues) {
       issueIds.push(i.id);
-      if (issueIds.length >= DEFAULT_MAX_ITEMS) break;
+      if (issueIds.length >= maxItems) break;
     }
     if (result.issues.length < SEARCH_PAGE_SIZE) break;
     startAt += SEARCH_PAGE_SIZE;
     // MAX_START_AT в search.service = 10000 — наш loop упирается в тот же лимит.
-    if (startAt >= DEFAULT_MAX_ITEMS) break;
+    if (startAt >= maxItems) break;
   }
 
   const warnings: string[] = [];
-  if (totalMatched > DEFAULT_MAX_ITEMS) {
+  if (totalMatched > maxItems) {
     warnings.push('TRUNCATED_TO_MAX_ITEMS');
   }
 

--- a/backend/src/modules/bulk-operations/bulk-operations.service.ts
+++ b/backend/src/modules/bulk-operations/bulk-operations.service.ts
@@ -446,14 +446,15 @@ export async function retryFailedItems(
   }
 
   // Concurrency-quota + Redis availability — те же проверки что в createBulkOperation.
+  const { maxConcurrentPerUser } = await getBulkOpsSettings();
   const activeCount = await prisma.bulkOperation.count({
     where: { createdById: ctx.userId, status: { in: ['QUEUED', 'RUNNING'] } },
   });
-  if (activeCount >= DEFAULT_MAX_CONCURRENT_PER_USER) {
+  if (activeCount >= maxConcurrentPerUser) {
     throw new AppError(429, 'Too many concurrent bulk operations', {
       code: 'TOO_MANY_CONCURRENT',
       retryAfter: 60,
-      limit: DEFAULT_MAX_CONCURRENT_PER_USER,
+      limit: maxConcurrentPerUser,
       active: activeCount,
     });
   }

--- a/backend/tests/bulk-operations-service.unit.test.ts
+++ b/backend/tests/bulk-operations-service.unit.test.ts
@@ -16,7 +16,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockPrisma, mockRedis, mockSearchIssues } = vi.hoisted(() => {
+const { mockPrisma, mockRedis, mockSearchIssues, mockBulkOpsSettings } = vi.hoisted(() => {
   const mockPrisma = {
     bulkOperation: {
       findUnique: vi.fn(),
@@ -37,7 +37,9 @@ const { mockPrisma, mockRedis, mockSearchIssues } = vi.hoisted(() => {
     isRedisAvailable: vi.fn(),
   };
   const mockSearchIssues = vi.fn();
-  return { mockPrisma, mockRedis, mockSearchIssues };
+  // TTBULK-1 PR-7 — runtime settings mock; defaults соответствуют PR-3/PR-4 значениям.
+  const mockBulkOpsSettings = vi.fn().mockResolvedValue({ maxConcurrentPerUser: 3, maxItems: 10_000 });
+  return { mockPrisma, mockRedis, mockSearchIssues, mockBulkOpsSettings };
 });
 
 vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
@@ -58,6 +60,14 @@ vi.mock('../src/shared/auth/roles.js', async () => {
 });
 vi.mock('../src/modules/search/search.service.js', () => ({
   searchIssues: mockSearchIssues,
+}));
+vi.mock('../src/modules/bulk-operations/bulk-operations-settings.service.js', () => ({
+  getBulkOpsSettings: mockBulkOpsSettings,
+  setBulkOpsSettings: vi.fn(),
+  BULK_OPS_MAX_CONCURRENT_MIN: 1,
+  BULK_OPS_MAX_CONCURRENT_MAX: 20,
+  BULK_OPS_MAX_ITEMS_MIN: 100,
+  BULK_OPS_MAX_ITEMS_MAX: 50_000,
 }));
 
 const service = await import('../src/modules/bulk-operations/bulk-operations.service.js');

--- a/backend/tests/bulk-operations-settings.unit.test.ts
+++ b/backend/tests/bulk-operations-settings.unit.test.ts
@@ -193,6 +193,51 @@ describe('setBulkOpsSettings', () => {
     expect(res.maxItems).toBe(10_000); // min(50000, MAX_ITEMS_HARD_LIMIT)
   });
 
+  it('🟠 cache invalidation ДО audit.create: если audit падает — кэш уже очищен (memo=null, delCachedJson вызван)', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue(null);
+    mockPrisma.systemSetting.upsert.mockResolvedValue({});
+    mockPrisma.auditLog.create.mockRejectedValue(new Error('audit table down'));
+
+    await expect(
+      svc.setBulkOpsSettings('admin-1', { maxConcurrentPerUser: 7, maxItems: 500 }),
+    ).rejects.toThrow('audit table down');
+
+    // Critical: cache должен быть очищен несмотря на audit failure —
+    // иначе следующие 60s использовали бы stale значение, хотя DB уже обновлён.
+    expect(mockRedis.delCachedJson).toHaveBeenCalledWith('settings:bulk_operations');
+  });
+
+  it('🟡 setBulkOpsSettings сбрасывает memo ПЕРЕД чтением current — before-snapshot всегда со свежего DB', async () => {
+    // Warm memo первым get'ом со значением A.
+    mockPrisma.systemSetting.findUnique.mockResolvedValueOnce({
+      key: 'bulk_operations',
+      value: JSON.stringify({ maxConcurrentPerUser: 1, maxItems: 100 }),
+    });
+    const warm = await svc.getBulkOpsSettings();
+    expect(warm.maxConcurrentPerUser).toBe(1);
+
+    // Между тем DB обновился другой сессией на значение B.
+    mockPrisma.systemSetting.findUnique.mockResolvedValueOnce({
+      key: 'bulk_operations',
+      value: JSON.stringify({ maxConcurrentPerUser: 5, maxItems: 3_000 }),
+    });
+    mockPrisma.systemSetting.upsert.mockResolvedValue({});
+
+    await svc.setBulkOpsSettings('admin-2', { maxItems: 4_000 });
+
+    // Audit `before` должен содержать B (5/3000), а не A (1/100) из memo.
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          details: expect.objectContaining({
+            before: { maxConcurrentPerUser: 5, maxItems: 3_000 },
+            after: { maxConcurrentPerUser: 5, maxItems: 4_000 },
+          }),
+        }),
+      }),
+    );
+  });
+
   it('invalidate memo: следующий getBulkOpsSettings читает свежее значение', async () => {
     // set() внутри сам вызывает getBulkOpsSettings → первый findUnique (#1),
     // затем в upsert записывает новое значение. После set — memo сброшен,

--- a/backend/tests/bulk-operations-settings.unit.test.ts
+++ b/backend/tests/bulk-operations-settings.unit.test.ts
@@ -1,0 +1,239 @@
+/**
+ * TTBULK-1 PR-7 — unit-тест bulk-operations-settings.service.
+ *
+ * Pure-unit (моки prisma + redis). Покрывает:
+ *   • getBulkOpsSettings: пустой DB → ENV/hardcode defaults; малый JSON → clamp вверх;
+ *     большой JSON → clamp вниз; malformed JSON → fallback defaults; Redis cache HIT;
+ *     Redis DOWN → всё равно читает из DB.
+ *   • setBulkOpsSettings: upsert + audit + инвалидация кэша; partial patch (только
+ *     maxItems) сохраняет второе поле; clamp на write (out-of-range → clamp до границы).
+ *   • clamp: non-integer → trunc; NaN/Infinity → default.
+ *   • Кэш: второй вызов в пределах 60s не трогает prisma (memo).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPrisma, mockRedis } = vi.hoisted(() => {
+  const mockPrisma = {
+    systemSetting: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+    auditLog: { create: vi.fn() },
+  };
+  const mockRedis = {
+    getCachedJson: vi.fn(),
+    setCachedJson: vi.fn(),
+    delCachedJson: vi.fn(),
+  };
+  return { mockPrisma, mockRedis };
+});
+
+vi.mock('../src/prisma/client.js', () => ({ prisma: mockPrisma }));
+vi.mock('../src/shared/redis.js', () => mockRedis);
+vi.mock('../src/shared/utils/logger.js', () => ({
+  captureError: vi.fn(),
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const svc = await import('../src/modules/bulk-operations/bulk-operations-settings.service.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // resetAllMocks — drop any leftover mockResolvedValueOnce queue that leaks
+  // from previous tests (clearAllMocks only clears call history, not one-off queue).
+  mockPrisma.systemSetting.findUnique.mockReset();
+  mockPrisma.systemSetting.upsert.mockReset();
+  svc.__resetMemoCache();
+  mockRedis.getCachedJson.mockResolvedValue(null);
+  mockRedis.setCachedJson.mockResolvedValue(undefined);
+  mockRedis.delCachedJson.mockResolvedValue(undefined);
+  mockPrisma.auditLog.create.mockResolvedValue({});
+});
+
+describe('getBulkOpsSettings', () => {
+  it('пустая DB → ENV/hardcode defaults (3 / 10000)', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue(null);
+    const s = await svc.getBulkOpsSettings();
+    // Дефолты зафиксированы (BULK_OP_MAX_CONCURRENT_PER_USER=3, BULK_OP_MAX_ITEMS=MAX_ITEMS_HARD_LIMIT=10000)
+    expect(s.maxConcurrentPerUser).toBe(3);
+    expect(s.maxItems).toBe(10_000);
+  });
+
+  it('JSON в DB: валидные значения — возвращает как есть', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue({
+      key: 'bulk_operations',
+      value: JSON.stringify({ maxConcurrentPerUser: 7, maxItems: 5_000 }),
+    });
+    const s = await svc.getBulkOpsSettings();
+    expect(s).toEqual({ maxConcurrentPerUser: 7, maxItems: 5_000 });
+  });
+
+  it('JSON out-of-range: clamp вниз (maxConcurrent > 20 → 20)', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue({
+      key: 'bulk_operations',
+      value: JSON.stringify({ maxConcurrentPerUser: 999, maxItems: 99_999 }),
+    });
+    const s = await svc.getBulkOpsSettings();
+    expect(s.maxConcurrentPerUser).toBe(20);
+    // maxItems clamp'ится до runtime ceiling = min(50000, MAX_ITEMS_HARD_LIMIT=10000) = 10000.
+    expect(s.maxItems).toBe(10_000);
+  });
+
+  it('JSON out-of-range: clamp вверх (maxConcurrent = 0 → 1, maxItems = 50 → 100)', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue({
+      key: 'bulk_operations',
+      value: JSON.stringify({ maxConcurrentPerUser: 0, maxItems: 50 }),
+    });
+    const s = await svc.getBulkOpsSettings();
+    expect(s.maxConcurrentPerUser).toBe(1);
+    expect(s.maxItems).toBe(100);
+  });
+
+  it('malformed JSON → fallback defaults', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue({
+      key: 'bulk_operations',
+      value: 'not-a-json{{{',
+    });
+    const s = await svc.getBulkOpsSettings();
+    expect(s.maxConcurrentPerUser).toBe(3);
+    expect(s.maxItems).toBe(10_000);
+  });
+
+  it('Redis cache HIT — не идёт в Prisma', async () => {
+    mockRedis.getCachedJson.mockResolvedValue({ maxConcurrentPerUser: 5, maxItems: 2_000 });
+    const s = await svc.getBulkOpsSettings();
+    expect(s).toEqual({ maxConcurrentPerUser: 5, maxItems: 2_000 });
+    expect(mockPrisma.systemSetting.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('Redis cache HIT с out-of-range — clamp применяется даже к cached-values', async () => {
+    mockRedis.getCachedJson.mockResolvedValue({ maxConcurrentPerUser: 100, maxItems: -5 });
+    const s = await svc.getBulkOpsSettings();
+    expect(s.maxConcurrentPerUser).toBe(20);
+    expect(s.maxItems).toBe(100);
+  });
+
+  it('Redis DOWN (throw) → fallback на Prisma', async () => {
+    mockRedis.getCachedJson.mockRejectedValue(new Error('redis down'));
+    mockPrisma.systemSetting.findUnique.mockResolvedValue({
+      key: 'bulk_operations',
+      value: JSON.stringify({ maxConcurrentPerUser: 4, maxItems: 1_500 }),
+    });
+    const s = await svc.getBulkOpsSettings();
+    expect(s).toEqual({ maxConcurrentPerUser: 4, maxItems: 1_500 });
+  });
+
+  it('Prisma throws → fallback defaults (never-throw инвариант)', async () => {
+    mockPrisma.systemSetting.findUnique.mockRejectedValue(new Error('db down'));
+    const s = await svc.getBulkOpsSettings();
+    expect(s.maxConcurrentPerUser).toBe(3);
+    expect(s.maxItems).toBe(10_000);
+  });
+
+  it('in-memory memo: второй вызов в пределах 60s не трогает Prisma', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue({
+      key: 'bulk_operations',
+      value: JSON.stringify({ maxConcurrentPerUser: 2, maxItems: 500 }),
+    });
+    await svc.getBulkOpsSettings();
+    await svc.getBulkOpsSettings();
+    expect(mockPrisma.systemSetting.findUnique).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('setBulkOpsSettings', () => {
+  it('happy: upsert + audit + invalidate cache', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue(null);
+    mockPrisma.systemSetting.upsert.mockResolvedValue({});
+
+    const res = await svc.setBulkOpsSettings('admin-1', {
+      maxConcurrentPerUser: 5,
+      maxItems: 2_500,
+    });
+
+    expect(res).toEqual({ maxConcurrentPerUser: 5, maxItems: 2_500 });
+    expect(mockPrisma.systemSetting.upsert).toHaveBeenCalledWith({
+      where: { key: 'bulk_operations' },
+      create: { key: 'bulk_operations', value: JSON.stringify({ maxConcurrentPerUser: 5, maxItems: 2_500 }) },
+      update: { value: JSON.stringify({ maxConcurrentPerUser: 5, maxItems: 2_500 }) },
+    });
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: 'system.bulk_operations_settings_changed',
+          userId: 'admin-1',
+        }),
+      }),
+    );
+    expect(mockRedis.delCachedJson).toHaveBeenCalledWith('settings:bulk_operations');
+  });
+
+  it('partial patch: только maxItems — maxConcurrent остаётся из current', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue({
+      key: 'bulk_operations',
+      value: JSON.stringify({ maxConcurrentPerUser: 7, maxItems: 1_000 }),
+    });
+    mockPrisma.systemSetting.upsert.mockResolvedValue({});
+
+    const res = await svc.setBulkOpsSettings('admin-1', { maxItems: 3_000 });
+
+    expect(res).toEqual({ maxConcurrentPerUser: 7, maxItems: 3_000 });
+  });
+
+  it('clamp на write: out-of-range → clamp до границы', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue(null);
+    mockPrisma.systemSetting.upsert.mockResolvedValue({});
+
+    const res = await svc.setBulkOpsSettings('admin-1', {
+      maxConcurrentPerUser: 999,
+      maxItems: 99_999,
+    });
+
+    expect(res.maxConcurrentPerUser).toBe(20);
+    expect(res.maxItems).toBe(10_000); // min(50000, MAX_ITEMS_HARD_LIMIT)
+  });
+
+  it('invalidate memo: следующий getBulkOpsSettings читает свежее значение', async () => {
+    // set() внутри сам вызывает getBulkOpsSettings → первый findUnique (#1),
+    // затем в upsert записывает новое значение. После set — memo сброшен,
+    // следующий getBulkOpsSettings идёт в findUnique (#2) и должен увидеть новое.
+    mockPrisma.systemSetting.findUnique
+      .mockResolvedValueOnce({
+        key: 'bulk_operations',
+        value: JSON.stringify({ maxConcurrentPerUser: 1, maxItems: 100 }),
+      })
+      .mockResolvedValueOnce({
+        key: 'bulk_operations',
+        value: JSON.stringify({ maxConcurrentPerUser: 10, maxItems: 100 }),
+      });
+    mockPrisma.systemSetting.upsert.mockResolvedValue({});
+
+    await svc.setBulkOpsSettings('admin-1', { maxConcurrentPerUser: 10 });
+
+    const after = await svc.getBulkOpsSettings();
+    expect(after.maxConcurrentPerUser).toBe(10);
+  });
+});
+
+describe('clamp edge cases (через get)', () => {
+  it('NaN в JSON → fallback default', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue({
+      key: 'bulk_operations',
+      value: JSON.stringify({ maxConcurrentPerUser: NaN, maxItems: 'abc' }),
+    });
+    const s = await svc.getBulkOpsSettings();
+    // JSON.stringify превратит NaN в null, 'abc' останется строкой; clamp default'ит обоих.
+    expect(s.maxConcurrentPerUser).toBe(3);
+    expect(s.maxItems).toBe(10_000);
+  });
+
+  it('non-integer (5.7) → trunc до 5', async () => {
+    mockPrisma.systemSetting.findUnique.mockResolvedValue({
+      key: 'bulk_operations',
+      value: JSON.stringify({ maxConcurrentPerUser: 5.7, maxItems: 1_500.9 }),
+    });
+    const s = await svc.getBulkOpsSettings();
+    expect(s.maxConcurrentPerUser).toBe(5);
+    expect(s.maxItems).toBe(1_500);
+  });
+});

--- a/docs/tz/TTBULK-1.md
+++ b/docs/tz/TTBULK-1.md
@@ -1046,7 +1046,7 @@ PR-12 ─► PR-13 (metrics + grafana + алёрты)
 | 4  | `ttbulk-1/processor`            | TransitionExecutor + processor cron + recovery + retention + AuditLog.bulkOperationId | 14   | PR-3              | executor + processor | 🟢 Merged (#146) |
 | 5  | `ttbulk-1/executors`            | 6 executors (Assign/EditField/EditCustomField/MoveToSprint/AddComment/Delete) | 14   | PR-4              | per-executor + tests | 🟢 Merged (#147) |
 | 6  | `ttbulk-1/streaming-report`     | SSE + Redis pub/sub + report.csv + retry-failed              | 8    | PR-3, PR-4        | router + processor hook | 🟢 Merged (#148) |
-| 7  | `ttbulk-1/system-settings`      | maxConcurrentPerUser / maxItems API + AdminSystemPage UI     | 4    | PR-3              | backend + UI       | 📋 Планируется |
+| 7  | `ttbulk-1/system-settings`      | maxConcurrentPerUser / maxItems API + AdminSystemPage UI     | 4    | PR-3              | backend + UI       | ✅ Done |
 | 8  | `ttbulk-1/admin-roles`          | BULK_OPERATOR in admin roles UI + group-assign endpoints     | 8    | PR-2              | endpoints + UI     | 📋 Планируется |
 | 9  | `ttbulk-1/wizard-modal`         | BulkOperationWizardModal (4 steps + preview + conflicts)     | 14   | PR-3              | 4 step components  | 📋 Планируется |
 | 10 | `ttbulk-1/progress-drawer`      | ProgressDrawer + SSE hook + floating chip + zustand store    | 8    | PR-6, PR-9        | hook + drawer + chip | 📋 Планируется |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,7 @@ import {
   canViewUserGroups,
   canManageCheckpoints,
   canViewCheckpointAudit,
+  canManageSystemSettings,
 } from './lib/roles';
 import AdminTransitionScreensPage from './pages/admin/AdminTransitionScreensPage';
 import AdminTransitionScreenEditorPage from './pages/admin/AdminTransitionScreenEditorPage';
@@ -258,7 +259,7 @@ export default function App() {
               path="admin/checkpoint-audit"
               element={<AdminGate allow={canViewCheckpointAudit}><AdminCheckpointAuditPage /></AdminGate>}
             />
-            <Route path="admin/system" element={<AdminSystemPage />} />
+            <Route path="admin/system" element={<AdminGate allow={canManageSystemSettings}><AdminSystemPage /></AdminGate>} />
             <Route path="settings" element={<SettingsPage />} />
             <Route path="pipeline" element={<PipelineDashboardPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -8,6 +8,11 @@ export interface SystemSettings {
   jwtExpiresIn: string;
 }
 
+export interface BulkOpsSettings {
+  maxConcurrentPerUser: number;
+  maxItems: number;
+}
+
 export interface ProjectRole {
   id: string;
   role: 'ADMIN' | 'MANAGER' | 'USER' | 'VIEWER';
@@ -96,6 +101,13 @@ export const adminApi = {
 
   setSessionLifetime: (sessionLifetimeMinutes: number) =>
     api.patch<SystemSettings>('/admin/settings/system', { sessionLifetimeMinutes }).then(r => r.data),
+
+  // TTBULK-1 PR-7 — bulk operations runtime limits.
+  getBulkOpsSettings: () =>
+    api.get<BulkOpsSettings>('/admin/system-settings/bulk-operations').then(r => r.data),
+
+  setBulkOpsSettings: (patch: Partial<BulkOpsSettings>) =>
+    api.patch<BulkOpsSettings>('/admin/system-settings/bulk-operations', patch).then(r => r.data),
 };
 
 export interface AdminStats {

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -106,8 +106,10 @@ export const adminApi = {
   getBulkOpsSettings: () =>
     api.get<BulkOpsSettings>('/admin/system-settings/bulk-operations').then(r => r.data),
 
-  setBulkOpsSettings: (patch: Partial<BulkOpsSettings>) =>
-    api.patch<BulkOpsSettings>('/admin/system-settings/bulk-operations', patch).then(r => r.data),
+  // API accepts partial (Zod `.refine` — минимум одно поле), но UI всегда
+  // шлёт оба значения — тип сигнатуры отражает реальный call-site контракт.
+  setBulkOpsSettings: (settings: BulkOpsSettings) =>
+    api.patch<BulkOpsSettings>('/admin/system-settings/bulk-operations', settings).then(r => r.data),
 };
 
 export interface AdminStats {

--- a/frontend/src/lib/roles.ts
+++ b/frontend/src/lib/roles.ts
@@ -60,3 +60,13 @@ export function canViewCheckpointAudit(
 ): boolean {
   return hasAnySystemRole(userRoles, ['SUPER_ADMIN', 'ADMIN', 'AUDITOR']);
 }
+
+/**
+ * TTBULK-1 PR-7: system settings management (session lifetime, bulk-ops limits).
+ * Mirrors the backend `requireSuperAdmin()` gate.
+ */
+export function canManageSystemSettings(
+  userRoles: SystemRoleType[] | null | undefined,
+): boolean {
+  return hasSystemRole(userRoles, 'SUPER_ADMIN');
+}

--- a/frontend/src/pages/admin/AdminSystemPage.tsx
+++ b/frontend/src/pages/admin/AdminSystemPage.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { InputNumber, Button, Form, message } from 'antd';
 import { adminApi } from '../../api/admin';
+import type { BulkOpsSettings } from '../../api/admin';
 
 export default function AdminSystemPage() {
   const [loading, setLoading] = useState(true);
@@ -9,27 +10,33 @@ export default function AdminSystemPage() {
   const [jwtExpiresIn, setJwtExpiresIn] = useState<string>('1h');
   const [form] = Form.useForm();
 
+  // TTBULK-1 PR-7 — bulk operations runtime limits.
+  const [bulkOps, setBulkOps] = useState<BulkOpsSettings>({ maxConcurrentPerUser: 3, maxItems: 10000 });
+  const [bulkOpsSaving, setBulkOpsSaving] = useState(false);
+  const [bulkOpsForm] = Form.useForm();
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [sys, bulk] = await Promise.all([
+        adminApi.getSystemSettings(),
+        adminApi.getBulkOpsSettings(),
+      ]);
+      setSessionLifetimeMinutes(sys.sessionLifetimeMinutes);
+      setJwtExpiresIn(sys.jwtExpiresIn);
+      form.setFieldsValue({ sessionLifetimeMinutes: sys.sessionLifetimeMinutes });
+      setBulkOps(bulk);
+      bulkOpsForm.setFieldsValue(bulk);
+    } catch {
+      message.error('Не удалось загрузить системные настройки');
+    } finally {
+      setLoading(false);
+    }
+  }, [form, bulkOpsForm]);
+
   useEffect(() => {
-    let isMounted = true;
-
-    adminApi.getSystemSettings()
-      .then(settings => {
-        if (!isMounted) return;
-        setSessionLifetimeMinutes(settings.sessionLifetimeMinutes);
-        setJwtExpiresIn(settings.jwtExpiresIn);
-        form.setFieldsValue({ sessionLifetimeMinutes: settings.sessionLifetimeMinutes });
-      })
-      .catch(() => {
-        if (!isMounted) return;
-        message.error('Не удалось загрузить системные настройки');
-      })
-      .finally(() => {
-        if (!isMounted) return;
-        setLoading(false);
-      });
-
-    return () => { isMounted = false; };
-  }, [form]);
+    void loadAll();
+  }, [loadAll]);
 
   const handleSave = async (values: { sessionLifetimeMinutes: number }) => {
     setSaving(true);
@@ -41,6 +48,20 @@ export default function AdminSystemPage() {
       message.error('Не удалось сохранить настройки');
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleBulkOpsSave = async (values: BulkOpsSettings) => {
+    setBulkOpsSaving(true);
+    try {
+      const updated = await adminApi.setBulkOpsSettings(values);
+      setBulkOps(updated);
+      bulkOpsForm.setFieldsValue(updated);
+      message.success('Лимиты массовых операций сохранены');
+    } catch {
+      message.error('Не удалось сохранить лимиты массовых операций');
+    } finally {
+      setBulkOpsSaving(false);
     }
   };
 
@@ -129,6 +150,69 @@ export default function AdminSystemPage() {
         (пользователь выйдет не позже этого срока). Скользящая сессия — более ранний выход при бездействии,
         настраивается выше без перезапуска.
       </p>
+
+      {/* ── Массовые операции (TTBULK-1 PR-7) ── */}
+      <p style={{ margin: '32px 0 16px', fontWeight: 500, color: 'rgba(0,0,0,0.65)', borderBottom: '1px solid rgba(0,0,0,0.06)', paddingBottom: 8 }}>
+        Массовые операции
+      </p>
+      <p style={{ margin: '0 0 16px', color: 'rgba(0,0,0,0.45)', fontSize: 12, lineHeight: 1.6 }}>
+        Runtime-лимиты на массовые операции (BULK_OPERATOR). Изменения вступают в силу в течение 60 секунд.
+      </p>
+
+      <Form form={bulkOpsForm} layout="vertical" onFinish={handleBulkOpsSave} initialValues={bulkOps}>
+        <Form.Item
+          label="Максимум одновременных операций на пользователя"
+          name="maxConcurrentPerUser"
+          extra={`Текущее значение: ${bulkOps.maxConcurrentPerUser}. Диапазон: 1..20.`}
+          rules={[
+            { required: true, message: 'Укажите значение' },
+            {
+              validator: (_, value) =>
+                Number.isInteger(value) && value >= 1 && value <= 20
+                  ? Promise.resolve()
+                  : Promise.reject('Значение должно быть от 1 до 20'),
+            },
+          ]}
+        >
+          <InputNumber
+            min={1}
+            max={20}
+            step={1}
+            style={{ width: 200 }}
+            aria-label="Максимум одновременных массовых операций на пользователя"
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="Максимум элементов в одной операции"
+          name="maxItems"
+          extra={`Текущее значение: ${bulkOps.maxItems}. Диапазон: 100..50000 (hard-cap 10000 применяется на уровне API).`}
+          rules={[
+            { required: true, message: 'Укажите значение' },
+            {
+              validator: (_, value) =>
+                Number.isInteger(value) && value >= 100 && value <= 50_000
+                  ? Promise.resolve()
+                  : Promise.reject('Значение должно быть от 100 до 50000'),
+            },
+          ]}
+        >
+          <InputNumber
+            min={100}
+            max={50_000}
+            step={100}
+            style={{ width: 200 }}
+            addonAfter="шт"
+            aria-label="Максимум элементов в одной массовой операции"
+          />
+        </Form.Item>
+
+        <Form.Item>
+          <Button type="primary" htmlType="submit" loading={bulkOpsSaving}>
+            Сохранить
+          </Button>
+        </Form.Item>
+      </Form>
     </div>
   );
 }

--- a/frontend/src/pages/admin/AdminSystemPage.tsx
+++ b/frontend/src/pages/admin/AdminSystemPage.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
-import { InputNumber, Button, Form, message } from 'antd';
+import { InputNumber, Button, Form, message, Result } from 'antd';
 import { adminApi } from '../../api/admin';
 import type { BulkOpsSettings } from '../../api/admin';
 
 export default function AdminSystemPage() {
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [sessionLifetimeMinutes, setSessionLifetimeMinutes] = useState<number>(60);
   const [jwtExpiresIn, setJwtExpiresIn] = useState<string>('1h');
@@ -17,6 +18,7 @@ export default function AdminSystemPage() {
 
   const loadAll = useCallback(async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const [sys, bulk] = await Promise.all([
         adminApi.getSystemSettings(),
@@ -28,6 +30,7 @@ export default function AdminSystemPage() {
       setBulkOps(bulk);
       bulkOpsForm.setFieldsValue(bulk);
     } catch {
+      setLoadError('Не удалось загрузить системные настройки');
       message.error('Не удалось загрузить системные настройки');
     } finally {
       setLoading(false);
@@ -70,6 +73,17 @@ export default function AdminSystemPage() {
       <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 80 }}>
         <span>Загрузка...</span>
       </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <Result
+        status="warning"
+        title={loadError}
+        subTitle="Попробуйте перезагрузить страницу или обратитесь к администратору."
+        extra={<Button type="primary" onClick={() => void loadAll()}>Повторить</Button>}
+      />
     );
   }
 
@@ -186,20 +200,20 @@ export default function AdminSystemPage() {
         <Form.Item
           label="Максимум элементов в одной операции"
           name="maxItems"
-          extra={`Текущее значение: ${bulkOps.maxItems}. Диапазон: 100..50000 (hard-cap 10000 применяется на уровне API).`}
+          extra={`Текущее значение: ${bulkOps.maxItems}. Диапазон: 100..10000 (hard-cap соответствует MAX_ITEMS_HARD_LIMIT в API).`}
           rules={[
             { required: true, message: 'Укажите значение' },
             {
               validator: (_, value) =>
-                Number.isInteger(value) && value >= 100 && value <= 50_000
+                Number.isInteger(value) && value >= 100 && value <= 10_000
                   ? Promise.resolve()
-                  : Promise.reject('Значение должно быть от 100 до 50000'),
+                  : Promise.reject('Значение должно быть от 100 до 10000'),
             },
           ]}
         >
           <InputNumber
             min={100}
-            max={50_000}
+            max={10_000}
             step={100}
             style={{ width: 200 }}
             addonAfter="шт"

--- a/version_history.md
+++ b/version_history.md
@@ -8,7 +8,7 @@
 
 ## [2.59] [2026-04-23] feat(bulk-ops): TTBULK-1 PR-7 — runtime System settings для массовых операций (maxConcurrentPerUser / maxItems) + AdminSystemPage UI
 
-**PR:** _(будет заполнено после push'а)_
+**PR:** [#149](https://github.com/NovakPAai/tasktime-mvp/pull/149)
 **Ветка:** `ttbulk-1/system-settings`
 
 ### Что было

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,47 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.58**
+**Last version: 2.59**
+
+---
+
+## [2.59] [2026-04-23] feat(bulk-ops): TTBULK-1 PR-7 — runtime System settings для массовых операций (maxConcurrentPerUser / maxItems) + AdminSystemPage UI
+
+**PR:** _(будет заполнено после push'а)_
+**Ветка:** `ttbulk-1/system-settings`
+
+### Что было
+
+Лимиты `maxConcurrentPerUser` (3) и `maxItems` (10000) были захардкожены через ENV-variables (`BULK_OP_MAX_CONCURRENT_PER_USER`, `BULK_OP_MAX_ITEMS`) без возможности менять их без рестарта backend. В §11.1 ТЗ TTBULK-1 runtime-настройки заявлены как MUST-HAVE (SRE меняет кап по нагрузке, без деплоя).
+
+### Что теперь
+
+- **Backend `bulk-operations-settings.service.ts`** — `getBulkOpsSettings()` с in-memory (60s) + Redis (60s) кэшем; `setBulkOpsSettings(actorId, patch)` с upsert + инвалидацией обоих слоёв + audit. Clamp на read и write: `maxConcurrentPerUser ∈ [1..20]`, `maxItems ∈ [100..10000]` (runtime-ceiling = MAX_ITEMS_HARD_LIMIT из DTO). Никогда не бросает (fallback на ENV при любых ошибках). Cache invalidation ДО audit — чтобы audit-failure не оставлял stale cache.
+- **Admin endpoints** — `GET /api/admin/system-settings/bulk-operations` и `PATCH …` (оба `requireSuperAdmin()`). Zod-DTO `updateBulkOpsSettingsDto` (partial update, max=MAX_ITEMS_HARD_LIMIT).
+- **Интеграция с bulk-operations.service**:
+  - `createBulkOperation` — читает `maxConcurrentPerUser` и применяет quota; дополнительно safety-check `preview.eligibleIds.length > maxItems` (если админ понизил лимит между preview и create — 400 TOO_MANY_ITEMS).
+  - `resolveScope` (preview) — `maxItems` из runtime-settings вместо ENV-константы; warning TRUNCATED_TO_MAX_ITEMS при превышении.
+- **Frontend AdminSystemPage.tsx** — секция «Массовые операции» с двумя `InputNumber` (maxConcurrent 1..20, maxItems 100..10000) + loadError с Ant Result fallback. Save → PATCH + reload.
+- **Frontend App.tsx** — `AdminGate allow={canManageSystemSettings}` на route `/admin/system` (раньше был открыт).
+- **API-клиент** — `adminApi.getBulkOpsSettings()`, `adminApi.setBulkOpsSettings(settings)` + типизация `BulkOpsSettings`.
+
+### Unit-тесты (+18 новых)
+
+`bulk-operations-settings.unit.test.ts`: пустой DB → defaults, clamp вверх/вниз, malformed JSON → fallback, cache HIT (не трогает Prisma), Redis DOWN → Prisma, Prisma DOWN → defaults, in-memory memo, partial patch, clamp на write, cache invalidation ДО audit (audit-failure → cache всё равно cleared), memo reset перед current-read (before-snapshot всегда свежий), NaN/non-integer edge cases.
+
+### Влияние на prod
+
+При `FEATURES_BULK_OPS=false` (текущее состояние) — dormant. Для Super Admin'а появляется секция «Массовые операции» в `/admin/system` — изменения вступают в силу в течение 60 секунд. При feature-flag flip в PR-12: SRE может наращивать каппы без рестарта.
+
+### Проверки
+
+- `npx tsc --noEmit` → 0 errors (backend + frontend).
+- `npm run test:parser` → 597/597 passed (+18 новых).
+- Pre-push review: 🟠 2 → fixed, 🟡 3 → fixed, 🔵 1 → fixed, ⚪ 2 → skipped.
+
+### Связано
+
+- TTBULK-1 (Bulk Operations) — см. `docs/tz/TTBULK-1.md` §11.1, §13.6 PR-7.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Backend**: Новый сервис `bulk-operations-settings.service.ts` с runtime-настройками `maxConcurrentPerUser` (1..20) и `maxItems` (100..10000), хранящимися в `SystemSetting.key='bulk_operations'`. Двухслойный кэш (in-memory 60s + Redis 60s). Never-throw (fallback на ENV при Redis/Prisma errors).
- **Admin endpoints**: `GET/PATCH /api/admin/system-settings/bulk-operations` с `requireSuperAdmin()` + Zod DTO `updateBulkOpsSettingsDto`.
- **Интеграция с service**: `createBulkOperation` (concurrency + safety-check preview.eligibleIds.length > maxItems) и `resolveScope` читают runtime-settings. `retryFailedItems` тоже — раньше хардкод.
- **Frontend**: секция «Массовые операции» в `/admin/system` с двумя InputNumber + loadError Result fallback. Route защищён `AdminGate allow={canManageSystemSettings}`.
- **Тесты**: +18 новых (`bulk-operations-settings.unit.test.ts`); 608/608 passed.

## Pre-push review counts

- 🟠 Critical (2) → **fixed**: cache invalidation ДО audit (иначе audit-failure оставлял stale cache); `AdminGate` на route `/admin/system` (раньше был открыт).
- 🟡 Should-fix (3) → **fixed**: DTO max tightened до MAX_ITEMS_HARD_LIMIT (убрали silent clamp); `loadError` state + Result fallback; memo reset перед чтением `current` для accurate audit before-snapshot.
- 🔵 Optimization (1) → **fixed**: API type изменён с `Partial<BulkOpsSettings>` на `BulkOpsSettings`.
- ⚪ Nitpick (2) → skipped: `__resetMemoCache` export (test-only helper); `parseSettingJson` type cast (clamp handles non-numbers).

## Test plan

- [x] `npx tsc --noEmit` — 0 errors (backend + frontend)
- [x] `npm run lint` — 0 errors, 0 new warnings
- [x] `npm run test:parser` — 608/608 passed (+18 новых)
- [x] Pre-push review (pre-push-reviewer agent): 2🟠 + 3🟡 + 1🔵 + 2⚪ findings, все 🟠/🟡/🔵 устранены, тесты-регрессии добавлены
- [ ] Manual smoke (post-deploy): SuperAdmin меняет `maxConcurrentPerUser`, новое значение применяется в течение 60s без рестарта backend

## Зависимости

- **Base:** `main` (после merge PR-6 #148).
- **Blocks:** PR-12 (e2e + cutover — переключение feature-flag `FEATURES_BULK_OPS=true`).
- **DAG:** PR-7 параллелен с PR-8/PR-9 (§13.2 ТЗ) — оба независимые admin/UI PR'ы.

## Плановая дельта

- **LoC:** +671 / -43 (в бюджете 400–900).
- **Файлы:** 11 (1 новый service + 1 новый test + 9 модификаций).
- **Фичефлаг:** не требует (endpoints под requireSuperAdmin; секция UI отображается только при direct navigation на `/admin/system` — уже gated).

См. `docs/tz/TTBULK-1.md` §11.1, §13.6 PR-7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
