### PR TITLE
feat(bulk-ops): TTBULK-1 PR-9a — wizard skeleton + API client + types

### DIFF
--- a/docs/tz/TTBULK-1.md
+++ b/docs/tz/TTBULK-1.md
@@ -1048,7 +1048,8 @@ PR-12 ─► PR-13 (metrics + grafana + алёрты)
 | 6  | `ttbulk-1/streaming-report`     | SSE + Redis pub/sub + report.csv + retry-failed              | 8    | PR-3, PR-4        | router + processor hook | 🟢 Merged (#148) |
 | 7  | `ttbulk-1/system-settings`      | maxConcurrentPerUser / maxItems API + AdminSystemPage UI     | 4    | PR-3              | backend + UI       | 🟢 Merged (#149) |
 | 8  | `ttbulk-1/admin-roles`          | BULK_OPERATOR in admin roles UI + group-assign endpoints     | 8    | PR-2              | endpoints + UI     | 🟢 Merged (#150) |
-| 9  | `ttbulk-1/wizard-modal`         | BulkOperationWizardModal (4 steps + preview + conflicts)     | 14   | PR-3              | 4 step components  | 📋 Планируется |
+| 9a | `ttbulk-1/wizard-modal-a`       | types + api client + wizard skeleton + Step1 + BulkActionsBar кнопка | 6 | PR-3 | types + api + skeleton | ✅ Done |
+| 9b | `ttbulk-1/wizard-modal-b`       | Step2 (config) + Step3 (preview/virtualized) + Step4 (confirm/submit) + conflicts + react-window | 8 | PR-9a | step components | 📋 Планируется |
 | 10 | `ttbulk-1/progress-drawer`      | ProgressDrawer + SSE hook + floating chip + zustand store    | 8    | PR-6, PR-9        | hook + drawer + chip | 📋 Планируется |
 | 11 | `ttbulk-1/operations-page`      | /operations page + retry UI + AuditLog badge in IssuePage    | 8    | PR-10             | page + badge       | 📋 Планируется |
 | 12 | `ttbulk-1/e2e-docs-cutover`     | Playwright + k6 + docs + feature-flag flip + UAT             | 12   | PR-5, PR-7, PR-8, PR-11 | e2e + docs + cutover | 📋 Планируется |

--- a/frontend/src/api/bulkOperations.ts
+++ b/frontend/src/api/bulkOperations.ts
@@ -1,0 +1,97 @@
+/**
+ * TTBULK-1 PR-9a — typed API client для массовых операций.
+ *
+ * Публичный API (зеркалит backend router):
+ *   • preview(input)         → POST /bulk-operations/preview
+ *   • create(input)          → POST /bulk-operations
+ *   • get(id)                → GET  /bulk-operations/:id
+ *   • cancel(id)             → POST /bulk-operations/:id/cancel
+ *   • listMine(query)        → GET  /bulk-operations
+ *   • retryFailed(id, key)   → POST /bulk-operations/:id/retry-failed
+ *   • downloadReport(id)     → GET  /bulk-operations/:id/report.csv (Blob)
+ *   • streamUrl(id)          → URL для EventSource (PR-10 hook).
+ *
+ * Инварианты:
+ *   • `idempotencyKey` — обязателен на create/retryFailed; поставщик (caller)
+ *     должен генерить uuid v4 per user-action (wizard submit / retry button).
+ *   • `downloadReport` возвращает Blob (не parse'ится как JSON) — caller должен
+ *     использовать `saveBlob`. Response type = 'blob'.
+ *
+ * См. docs/tz/TTBULK-1.md §13.6 PR-9.
+ */
+
+import api from './client';
+import type {
+  BulkCreateResponse,
+  BulkOperation,
+  BulkOperationListResponse,
+  BulkOperationPayload,
+  BulkOperationStatus,
+  BulkOperationType,
+  BulkPreviewResponse,
+  BulkScope,
+} from '../types/bulk.types';
+
+export interface PreviewInput {
+  scope: BulkScope;
+  payload: BulkOperationPayload;
+}
+
+export interface CreateInput {
+  previewToken: string;
+  idempotencyKey: string;
+}
+
+export interface ListQuery {
+  limit?: number;
+  startAt?: number;
+  status?: BulkOperationStatus;
+  type?: BulkOperationType;
+}
+
+export const bulkOperationsApi = {
+  preview: (input: PreviewInput) =>
+    api
+      .post<BulkPreviewResponse>('/bulk-operations/preview', input)
+      .then((r) => r.data),
+
+  create: (input: CreateInput) =>
+    api
+      .post<BulkCreateResponse>('/bulk-operations', input, {
+        // idempotencyKey goes в body — НЕ как header. Backend DTO ожидает его
+        // в body (см. createBulkOperationDto: previewToken + idempotencyKey оба
+        // в json). Header-based idempotency не реализован в PR-3.
+      })
+      .then((r) => r.data),
+
+  get: (id: string) =>
+    api.get<BulkOperation>(`/bulk-operations/${id}`).then((r) => r.data),
+
+  cancel: (id: string) =>
+    api
+      .post<BulkOperation>(`/bulk-operations/${id}/cancel`)
+      .then((r) => r.data),
+
+  listMine: (query?: ListQuery) =>
+    api
+      .get<BulkOperationListResponse>('/bulk-operations', { params: query })
+      .then((r) => r.data),
+
+  retryFailed: (id: string, idempotencyKey: string) =>
+    api
+      .post<BulkCreateResponse>(`/bulk-operations/${id}/retry-failed`, {
+        idempotencyKey,
+      })
+      .then((r) => r.data),
+
+  downloadReport: (id: string) =>
+    api
+      .get<Blob>(`/bulk-operations/${id}/report.csv`, { responseType: 'blob' })
+      .then((r) => r.data),
+
+  /**
+   * Относительный URL для EventSource (native browser API не принимает
+   * Authorization header — в PR-10 hook добавит polling fallback).
+   */
+  streamUrl: (id: string) => `/api/bulk-operations/${id}/stream`,
+};

--- a/frontend/src/api/bulkOperations.ts
+++ b/frontend/src/api/bulkOperations.ts
@@ -3,7 +3,7 @@
  *
  * Публичный API (зеркалит backend router):
  *   • preview(input)         → POST /bulk-operations/preview
- *   • create(input)          → POST /bulk-operations
+ *   • create(input)          → POST /bulk-operations  (Idempotency-Key в header)
  *   • get(id)                → GET  /bulk-operations/:id
  *   • cancel(id)             → POST /bulk-operations/:id/cancel
  *   • listMine(query)        → GET  /bulk-operations
@@ -12,10 +12,13 @@
  *   • streamUrl(id)          → URL для EventSource (PR-10 hook).
  *
  * Инварианты:
- *   • `idempotencyKey` — обязателен на create/retryFailed; поставщик (caller)
- *     должен генерить uuid v4 per user-action (wizard submit / retry button).
+ *   • `Idempotency-Key` передаётся **в HTTP-заголовке** (не body), UUID v4.
+ *     Backend: `req.header('Idempotency-Key')` в `bulk-operations.router.ts:126`.
  *   • `downloadReport` возвращает Blob (не parse'ится как JSON) — caller должен
  *     использовать `saveBlob`. Response type = 'blob'.
+ *
+ * Transport contract (header/body split): backend/src/modules/bulk-operations/bulk-operations.router.ts
+ * DTO зеркало:                            backend/src/modules/bulk-operations/bulk-operations.dto.ts
  *
  * См. docs/tz/TTBULK-1.md §13.6 PR-9.
  */
@@ -39,6 +42,7 @@ export interface PreviewInput {
 
 export interface CreateInput {
   previewToken: string;
+  /** Передаётся как HTTP-заголовок `Idempotency-Key` (не в body). UUID v4. */
   idempotencyKey: string;
 }
 
@@ -57,11 +61,11 @@ export const bulkOperationsApi = {
 
   create: (input: CreateInput) =>
     api
-      .post<BulkCreateResponse>('/bulk-operations', input, {
-        // idempotencyKey goes в body — НЕ как header. Backend DTO ожидает его
-        // в body (см. createBulkOperationDto: previewToken + idempotencyKey оба
-        // в json). Header-based idempotency не реализован в PR-3.
-      })
+      .post<BulkCreateResponse>(
+        '/bulk-operations',
+        { previewToken: input.previewToken },
+        { headers: { 'Idempotency-Key': input.idempotencyKey } },
+      )
       .then((r) => r.data),
 
   get: (id: string) =>
@@ -79,9 +83,11 @@ export const bulkOperationsApi = {
 
   retryFailed: (id: string, idempotencyKey: string) =>
     api
-      .post<BulkCreateResponse>(`/bulk-operations/${id}/retry-failed`, {
-        idempotencyKey,
-      })
+      .post<BulkCreateResponse>(
+        `/bulk-operations/${id}/retry-failed`,
+        {},
+        { headers: { 'Idempotency-Key': idempotencyKey } },
+      )
       .then((r) => r.data),
 
   downloadReport: (id: string) =>

--- a/frontend/src/components/bulk/BulkOperationWizardModal.tsx
+++ b/frontend/src/components/bulk/BulkOperationWizardModal.tsx
@@ -1,0 +1,127 @@
+/**
+ * TTBULK-1 PR-9a — WizardModal, 4-step flow массовых операций.
+ *
+ * PR-9a (этот): скелет modal + Step1 (выбор операции) + placeholder'ы
+ * Step2/3/4. PR-9b добавит реальные Step2 (config), Step3 (preview с
+ * virtualized-списками), Step4 (confirm + submit + conflicts resolution).
+ *
+ * Публичный API:
+ *   • props `{ open, scope, total, allowedOperations, onClose, onSubmitted }`
+ *   • onClose → родитель должен вызвать refresh (CLAUDE.md правило —
+ *     SearchPage `runQuery(jql, page)`).
+ *
+ * Инварианты:
+ *   • Reset state на mount (useEffect(open)): step=1, type=undefined.
+ *     Без reset — повторное открытие показывало бы stale selection.
+ *   • Destructive операции (DELETE) остаются disabled до Step4 confirm
+ *     phrase (ENTER "DELETE"), который реализуется в PR-9b.
+ *
+ * См. docs/tz/TTBULK-1.md §3.2, §8.1, §13.6 PR-9.
+ */
+
+import { useState, useEffect } from 'react';
+import { Modal, Steps, Button, Space, Alert } from 'antd';
+import type { BulkOperationType, BulkScope } from '../../types/bulk.types';
+import { OPERATION_LABELS } from '../../types/bulk.types';
+import Step1PickOperation from './Step1PickOperation';
+
+export interface BulkOperationWizardModalProps {
+  open: boolean;
+  /** Scope — `ids` (из выделенных) или `jql` (вся результат-выборка). */
+  scope: BulkScope;
+  /** Для заголовка + footer stats ("Выбрано: N"). */
+  total: number;
+  /** Ограничение типов операций, показываемых в Step1 (опц). */
+  allowedOperations?: readonly BulkOperationType[];
+  /** Close — родитель должен refresh'нуть данные (CLAUDE.md). */
+  onClose: () => void;
+  /** После успешного submit (Step4 → create) — дёрнется с operationId
+   * для collapse в progress drawer (PR-10). В PR-9a не вызывается. */
+  onSubmitted?: (operationId: string) => void;
+}
+
+const STEPS = [
+  { title: 'Операция' },
+  { title: 'Настройка' },
+  { title: 'Предпросмотр' },
+  { title: 'Подтверждение' },
+];
+
+export default function BulkOperationWizardModal({
+  open,
+  scope,
+  total,
+  allowedOperations,
+  onClose,
+  // onSubmitted — unused в PR-9a (будет в PR-9b).
+}: BulkOperationWizardModalProps) {
+  const [step, setStep] = useState(0);
+  const [selectedType, setSelectedType] = useState<BulkOperationType | undefined>();
+
+  // Reset state когда wizard открывают заново. Без этого повторное открытие
+  // с другим scope'ом показывало бы предыдущий selection.
+  useEffect(() => {
+    if (open) {
+      setStep(0);
+      setSelectedType(undefined);
+    }
+  }, [open]);
+
+  const scopeLabel =
+    scope.kind === 'ids'
+      ? `${total} выбран${total === 1 ? 'а' : total < 5 ? 'ы' : 'о'} задача`.replace(/а$/, 'а')
+      : `JQL-выборка (${total} задач)`;
+
+  const canNext = step === 0 ? selectedType !== undefined : false; // Step2+ в PR-9b
+
+  return (
+    <Modal
+      title={`Массовые операции — ${scopeLabel}`}
+      open={open}
+      width={720}
+      onCancel={onClose}
+      destroyOnClose
+      footer={
+        <Space>
+          <Button onClick={onClose}>Отмена</Button>
+          <Button
+            disabled={step === 0}
+            onClick={() => setStep((s) => Math.max(0, s - 1))}
+          >
+            Назад
+          </Button>
+          <Button
+            type="primary"
+            disabled={!canNext || step >= STEPS.length - 1}
+            onClick={() => setStep((s) => Math.min(STEPS.length - 1, s + 1))}
+          >
+            Далее
+          </Button>
+        </Space>
+      }
+    >
+      <Steps current={step} items={STEPS} size="small" style={{ marginBottom: 24 }} />
+
+      {step === 0 && (
+        <Step1PickOperation
+          value={selectedType}
+          onSelect={setSelectedType}
+          allowedOperations={allowedOperations}
+        />
+      )}
+
+      {step > 0 && (
+        <Alert
+          message="Дальнейшие шаги — в PR-9b"
+          description={
+            selectedType
+              ? `Выбранная операция: ${OPERATION_LABELS[selectedType].label}. Конфигурация, preview и confirm добавятся следующим PR'ом.`
+              : 'Сначала выберите операцию на шаге 1.'
+          }
+          type="info"
+          showIcon
+        />
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/components/bulk/BulkOperationWizardModal.tsx
+++ b/frontend/src/components/bulk/BulkOperationWizardModal.tsx
@@ -67,10 +67,20 @@ export default function BulkOperationWizardModal({
     }
   }, [open]);
 
+  // Русская плюрализация: 1 → "задача", 2-4 → "задачи", 5+ → "задач".
+  // Для 11-14 — всегда "задач" (исключение стандартного правила).
+  const pluralizeTasks = (n: number): string => {
+    const mod100 = n % 100;
+    if (mod100 >= 11 && mod100 <= 14) return 'задач';
+    const mod10 = n % 10;
+    if (mod10 === 1) return 'задача';
+    if (mod10 >= 2 && mod10 <= 4) return 'задачи';
+    return 'задач';
+  };
   const scopeLabel =
     scope.kind === 'ids'
-      ? `${total} выбран${total === 1 ? 'а' : total < 5 ? 'ы' : 'о'} задача`.replace(/а$/, 'а')
-      : `JQL-выборка (${total} задач)`;
+      ? `Выбрано: ${total} ${pluralizeTasks(total)}`
+      : `JQL-выборка (${total} ${pluralizeTasks(total)})`;
 
   const canNext = step === 0 ? selectedType !== undefined : false; // Step2+ в PR-9b
 

--- a/frontend/src/components/bulk/Step1PickOperation.tsx
+++ b/frontend/src/components/bulk/Step1PickOperation.tsx
@@ -1,0 +1,72 @@
+/**
+ * TTBULK-1 PR-9a — Step 1 wizard'а: выбор типа операции.
+ *
+ * Рендер: список из 7 типов `BulkOperationType` с radio-выбором; destructive
+ * (DELETE) помечена warning-badge'ом. Disabled опции — если operation не
+ * входит в `allowedOperations` (переданный из BulkActionsBar через wizard).
+ *
+ * onSelect(type) → родитель (`BulkOperationWizardModal`) продвигает step → 2.
+ *
+ * См. docs/tz/TTBULK-1.md §3.2, §13.6 PR-9.
+ */
+
+import { Radio, Space, Tag } from 'antd';
+import { WarningOutlined } from '@ant-design/icons';
+import type { BulkOperationType } from '../../types/bulk.types';
+import { BULK_OPERATION_TYPES, OPERATION_LABELS } from '../../types/bulk.types';
+
+export interface Step1PickOperationProps {
+  value?: BulkOperationType;
+  onSelect: (type: BulkOperationType) => void;
+  /** Подмножество разрешённых операций (например, если в scope нет subtask'ов). */
+  allowedOperations?: readonly BulkOperationType[];
+}
+
+export default function Step1PickOperation({
+  value,
+  onSelect,
+  allowedOperations,
+}: Step1PickOperationProps) {
+  const allowed = new Set(allowedOperations ?? BULK_OPERATION_TYPES);
+
+  return (
+    <Radio.Group
+      value={value}
+      onChange={(e) => onSelect(e.target.value as BulkOperationType)}
+      style={{ width: '100%' }}
+    >
+      <Space direction="vertical" size="small" style={{ width: '100%' }}>
+        {BULK_OPERATION_TYPES.map((t) => {
+          const meta = OPERATION_LABELS[t];
+          const disabled = !allowed.has(t);
+          return (
+            <Radio
+              key={t}
+              value={t}
+              disabled={disabled}
+              style={{
+                padding: '8px 12px',
+                border: '1px solid rgba(0,0,0,0.06)',
+                borderRadius: 6,
+                width: '100%',
+                opacity: disabled ? 0.5 : 1,
+              }}
+            >
+              <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                <strong>{meta.label}</strong>
+                {meta.destructive && (
+                  <Tag color="red" icon={<WarningOutlined />} style={{ marginLeft: 4 }}>
+                    Необратимо
+                  </Tag>
+                )}
+              </div>
+              <div style={{ fontSize: 12, color: 'rgba(0,0,0,0.45)', marginTop: 2 }}>
+                {meta.description}
+              </div>
+            </Radio>
+          );
+        })}
+      </Space>
+    </Radio.Group>
+  );
+}

--- a/frontend/src/components/search/BulkActionsBar.tsx
+++ b/frontend/src/components/search/BulkActionsBar.tsx
@@ -27,11 +27,8 @@ export interface BulkActionsBarProps {
   selectedIds: string[];
   onCleared: () => void;
   isLight?: boolean;
-  /** Current JQL expression. When provided + `features.bulkOps` on, wizard can
-   *  operate on full JQL scope (not just `selectedIds`). */
-  jql?: string;
-  /** Total matched (by JQL) — отображается в wizard если scope=jql. */
-  total?: number;
+  // PR-9b добавит `jql?: string` + `total?: number` для JQL-scope варианта
+  // bulk-операций (без обязательного selection).
 }
 
 async function bulkDelete(ids: string[]): Promise<{ succeeded: number; failed: number }> {
@@ -49,8 +46,6 @@ export default function BulkActionsBar({
   selectedIds,
   onCleared,
   isLight = false,
-  jql,
-  total,
 }: BulkActionsBarProps) {
   const [busy, setBusy] = useState(false);
   // TTBULK-1 PR-9a — wizard. Gated под `features.bulkOps`; в PR-12 cutover флаг
@@ -149,15 +144,12 @@ export default function BulkActionsBar({
       {features.bulkOps && (
         <BulkOperationWizardModal
           open={wizardOpen}
-          // Scope — если пользователь кликнул «Массовые операции» c selection,
-          // передаём ids. JQL-вариант будет в PR-9b через доп. кнопку «Применить
-          // ко всей выборке», либо пользователь снимет selection и снова откроет.
-          scope={
-            jql && selectedIds.length === 0
-              ? { kind: 'jql', jql }
-              : { kind: 'ids', issueIds: selectedIds }
-          }
-          total={jql && selectedIds.length === 0 ? total ?? 0 : selectedIds.length}
+          // PR-9a: scope всегда = ids (компонент early-return'ит при пустом
+          // selectedIds, так что selection гарантирован). JQL-вариант (bulk
+          // «ко всей выборке» без selection) добавится в PR-9b через отдельную
+          // кнопку, которая рендерится ВНЕ этого early-return ветки.
+          scope={{ kind: 'ids', issueIds: selectedIds }}
+          total={selectedIds.length}
           onClose={() => {
             // CLAUDE.md: modal close → refresh parent. onCleared зовёт
             // runQuery в SearchPage (selectedIds reset + re-fetch).

--- a/frontend/src/components/search/BulkActionsBar.tsx
+++ b/frontend/src/components/search/BulkActionsBar.tsx
@@ -14,17 +14,24 @@
  */
 import { useState } from 'react';
 import { Button, Dropdown, Popconfirm, message, type MenuProps } from 'antd';
-import { DownOutlined, DeleteOutlined, DownloadOutlined } from '@ant-design/icons';
+import { DownOutlined, DeleteOutlined, DownloadOutlined, ThunderboltOutlined } from '@ant-design/icons';
 
 import api from '../../api/client';
 import { exportIssues } from '../../api/search';
 import { saveBlob } from '../../utils/saveBlob';
+import { features } from '../../lib/features';
+import BulkOperationWizardModal from '../bulk/BulkOperationWizardModal';
 
 export interface BulkActionsBarProps {
   /** UUID strings — come from `issue.id` via ResultsTable rowKey. */
   selectedIds: string[];
   onCleared: () => void;
   isLight?: boolean;
+  /** Current JQL expression. When provided + `features.bulkOps` on, wizard can
+   *  operate on full JQL scope (not just `selectedIds`). */
+  jql?: string;
+  /** Total matched (by JQL) — отображается в wizard если scope=jql. */
+  total?: number;
 }
 
 async function bulkDelete(ids: string[]): Promise<{ succeeded: number; failed: number }> {
@@ -38,8 +45,17 @@ async function bulkDelete(ids: string[]): Promise<{ succeeded: number; failed: n
   return { succeeded, failed };
 }
 
-export default function BulkActionsBar({ selectedIds, onCleared, isLight = false }: BulkActionsBarProps) {
+export default function BulkActionsBar({
+  selectedIds,
+  onCleared,
+  isLight = false,
+  jql,
+  total,
+}: BulkActionsBarProps) {
   const [busy, setBusy] = useState(false);
+  // TTBULK-1 PR-9a — wizard. Gated под `features.bulkOps`; в PR-12 cutover флаг
+  // включается и кнопка «Массовые операции» становится видна всем.
+  const [wizardOpen, setWizardOpen] = useState(false);
 
   if (selectedIds.length === 0) return null;
 
@@ -100,6 +116,17 @@ export default function BulkActionsBar({ selectedIds, onCleared, isLight = false
       }}
     >
       <span>Выбрано: <strong>{selectedIds.length}</strong></span>
+      {features.bulkOps && (
+        <Button
+          size="small"
+          type="primary"
+          icon={<ThunderboltOutlined />}
+          onClick={() => setWizardOpen(true)}
+          disabled={busy}
+        >
+          Массовые операции
+        </Button>
+      )}
       <Dropdown menu={menu} disabled={busy}>
         <Button size="small" disabled={busy}>
           Экспорт <DownOutlined />
@@ -119,6 +146,26 @@ export default function BulkActionsBar({ selectedIds, onCleared, isLight = false
       <Button size="small" onClick={onCleared} disabled={busy}>
         Снять выделение
       </Button>
+      {features.bulkOps && (
+        <BulkOperationWizardModal
+          open={wizardOpen}
+          // Scope — если пользователь кликнул «Массовые операции» c selection,
+          // передаём ids. JQL-вариант будет в PR-9b через доп. кнопку «Применить
+          // ко всей выборке», либо пользователь снимет selection и снова откроет.
+          scope={
+            jql && selectedIds.length === 0
+              ? { kind: 'jql', jql }
+              : { kind: 'ids', issueIds: selectedIds }
+          }
+          total={jql && selectedIds.length === 0 ? total ?? 0 : selectedIds.length}
+          onClose={() => {
+            // CLAUDE.md: modal close → refresh parent. onCleared зовёт
+            // runQuery в SearchPage (selectedIds reset + re-fetch).
+            setWizardOpen(false);
+            onCleared();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -414,8 +414,6 @@ export default function SearchPage() {
                         void runQuery(state.jql, state.page);
                       }}
                       isLight={isLight}
-                      jql={state.jql}
-                      total={load.total}
                     />
                   </div>
                 )}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -414,6 +414,8 @@ export default function SearchPage() {
                         void runQuery(state.jql, state.page);
                       }}
                       isLight={isLight}
+                      jql={state.jql}
+                      total={load.total}
                     />
                   </div>
                 )}

--- a/frontend/src/types/bulk.types.ts
+++ b/frontend/src/types/bulk.types.ts
@@ -1,10 +1,15 @@
 /**
  * TTBULK-1 PR-9a — types и enum'ы массовых операций.
  *
- * Зеркало backend `bulk-operations.dto.ts`. Wizard и downstream-компоненты
- * (PR-9b Step2/3, PR-10 ProgressDrawer, PR-11 OperationsPage) импортируют
- * отсюда. При изменении backend DTO — синхронизировать руками; compile-time
- * проверка обеспечивается только structural compatibility ответов API.
+ * Зеркало backend DTO. Wizard и downstream-компоненты (PR-9b Step2/3, PR-10
+ * ProgressDrawer, PR-11 OperationsPage) импортируют отсюда. При изменении
+ * backend — синхронизировать руками; compile-time проверка обеспечивается
+ * только structural compatibility ответов API.
+ *
+ * Canonical sources:
+ *   • DTO schemas:        backend/src/modules/bulk-operations/bulk-operations.dto.ts
+ *   • Transport contract: backend/src/modules/bulk-operations/bulk-operations.router.ts
+ *     (header Idempotency-Key, response shape / strip и т.д.)
  *
  * См. docs/tz/TTBULK-1.md §13.6 PR-9.
  */
@@ -167,10 +172,14 @@ export interface BulkOperationListResponse {
   limit: number;
 }
 
+/**
+ * Router: `alreadyExisted` стрипается перед `res.json(...)` (используется только
+ * для HTTP-кода: 200 на replay, 201 на create-new). Caller различает по статусу
+ * ответа, не по полю. См. bulk-operations.router.ts:138-139.
+ */
 export interface BulkCreateResponse {
   id: string;
   status: BulkOperationStatus;
-  alreadyExisted: boolean;
 }
 
 // ────── UI helpers ──────────────────────────────────────────────────────────
@@ -223,3 +232,17 @@ export const STATUS_COLORS: Record<BulkOperationStatus, string> = {
   FAILED: 'error',
   CANCELLED: 'default',
 };
+
+/**
+ * Runtime narrowing для `BulkOperation.payload`: Prisma Json → typed union.
+ *
+ * Поле возвращается бэкендом как opaque JSON (migrations могли изменить форму
+ * в прошлом). Callers обязаны проверить через этот guard перед доступом к
+ * type-specific полям (e.g. `.transitionId`) — иначе TS молчит, а runtime
+ * получит undefined.
+ */
+export function isBulkOperationPayload(v: unknown): v is BulkOperationPayload {
+  if (typeof v !== 'object' || v === null) return false;
+  const t = (v as Record<string, unknown>).type;
+  return typeof t === 'string' && (BULK_OPERATION_TYPES as readonly string[]).includes(t);
+}

--- a/frontend/src/types/bulk.types.ts
+++ b/frontend/src/types/bulk.types.ts
@@ -1,0 +1,225 @@
+/**
+ * TTBULK-1 PR-9a — types и enum'ы массовых операций.
+ *
+ * Зеркало backend `bulk-operations.dto.ts`. Wizard и downstream-компоненты
+ * (PR-9b Step2/3, PR-10 ProgressDrawer, PR-11 OperationsPage) импортируют
+ * отсюда. При изменении backend DTO — синхронизировать руками; compile-time
+ * проверка обеспечивается только structural compatibility ответов API.
+ *
+ * См. docs/tz/TTBULK-1.md §13.6 PR-9.
+ */
+
+// ────── Enums (mirror Prisma BulkOperation{Type,Status}) ────────────────────
+
+export type BulkOperationType =
+  | 'TRANSITION'
+  | 'ASSIGN'
+  | 'EDIT_FIELD'
+  | 'EDIT_CUSTOM_FIELD'
+  | 'MOVE_TO_SPRINT'
+  | 'ADD_COMMENT'
+  | 'DELETE';
+
+export type BulkOperationStatus =
+  | 'QUEUED'
+  | 'RUNNING'
+  | 'SUCCEEDED'
+  | 'PARTIAL'
+  | 'FAILED'
+  | 'CANCELLED';
+
+export const BULK_OPERATION_TYPES: readonly BulkOperationType[] = [
+  'TRANSITION',
+  'ASSIGN',
+  'EDIT_FIELD',
+  'EDIT_CUSTOM_FIELD',
+  'MOVE_TO_SPRINT',
+  'ADD_COMMENT',
+  'DELETE',
+] as const;
+
+/** Hard-cap from backend DTO (MAX_ITEMS_HARD_LIMIT). UI hints ≤ runtime setting. */
+export const BULK_OPS_MAX_ITEMS_HARD_LIMIT = 10_000;
+
+// ────── Scope + payload (discriminated unions) ──────────────────────────────
+
+export type BulkScope =
+  | { kind: 'ids'; issueIds: string[] }
+  | { kind: 'jql'; jql: string };
+
+export type TransitionPayload = {
+  type: 'TRANSITION';
+  transitionId: string;
+  fieldOverrides?: Record<string, unknown>;
+};
+
+export type AssignPayload = {
+  type: 'ASSIGN';
+  assigneeId: string | null;
+};
+
+export type EditFieldName =
+  | 'priority'
+  | 'dueDate'
+  | 'labels.add'
+  | 'labels.remove'
+  | 'description.append';
+
+export type EditFieldPayload = {
+  type: 'EDIT_FIELD';
+  field: EditFieldName;
+  value: unknown;
+};
+
+export type EditCustomFieldPayload = {
+  type: 'EDIT_CUSTOM_FIELD';
+  customFieldId: string;
+  value: unknown;
+};
+
+export type MoveToSprintPayload = {
+  type: 'MOVE_TO_SPRINT';
+  sprintId: string | null;
+};
+
+export type AddCommentPayload = {
+  type: 'ADD_COMMENT';
+  body: string;
+};
+
+export type DeletePayload = {
+  type: 'DELETE';
+  /** Anti-accidental gate: пользователь должен ввести «DELETE» (wizard Step4). */
+  confirmPhrase: 'DELETE';
+};
+
+export type BulkOperationPayload =
+  | TransitionPayload
+  | AssignPayload
+  | EditFieldPayload
+  | EditCustomFieldPayload
+  | MoveToSprintPayload
+  | AddCommentPayload
+  | DeletePayload;
+
+// ────── Preview response ────────────────────────────────────────────────────
+
+export interface BulkEligibleItem {
+  issueId: string;
+  issueKey: string;
+  title: string;
+  projectId: string;
+  projectKey: string;
+  preview?: Record<string, unknown>;
+}
+
+export interface BulkSkippedItem {
+  issueId: string;
+  issueKey: string;
+  title: string;
+  reasonCode: string;
+  reason: string;
+}
+
+export interface BulkConflictItem {
+  issueId: string;
+  issueKey: string;
+  title: string;
+  code: string;
+  message: string;
+  requiredFields?: string[];
+}
+
+export interface BulkPreviewResponse {
+  previewToken: string;
+  totalMatched: number;
+  eligible: BulkEligibleItem[];
+  skipped: BulkSkippedItem[];
+  conflicts: BulkConflictItem[];
+  warnings: string[];
+}
+
+// ────── Operation summary (list / detail / stream init) ─────────────────────
+
+export interface BulkOperation {
+  id: string;
+  createdById: string;
+  createdAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  type: BulkOperationType;
+  status: BulkOperationStatus;
+  scopeKind: 'ids' | 'jql';
+  scopeJql: string | null;
+  payload: BulkOperationPayload;
+  total: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+  cancelRequested: boolean;
+  finalStatusReason: string | null;
+}
+
+export interface BulkOperationListResponse {
+  items: BulkOperation[];
+  total: number;
+  startAt: number;
+  limit: number;
+}
+
+export interface BulkCreateResponse {
+  id: string;
+  status: BulkOperationStatus;
+  alreadyExisted: boolean;
+}
+
+// ────── UI helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Человекочитаемые подписи операций для wizard Step1.
+ * Ключ = backend BulkOperationType, значение = { label, description }.
+ */
+export const OPERATION_LABELS: Record<
+  BulkOperationType,
+  { label: string; description: string; destructive?: boolean }
+> = {
+  TRANSITION: {
+    label: 'Перевести статус',
+    description: 'Применить workflow-transition к выбранным задачам',
+  },
+  ASSIGN: {
+    label: 'Назначить исполнителя',
+    description: 'Изменить Assignee (или снять)',
+  },
+  EDIT_FIELD: {
+    label: 'Редактировать поле',
+    description: 'priority / dueDate / labels / description.append',
+  },
+  EDIT_CUSTOM_FIELD: {
+    label: 'Редактировать кастомное поле',
+    description: 'Значение схемного кастомного поля',
+  },
+  MOVE_TO_SPRINT: {
+    label: 'Переместить в спринт',
+    description: 'Назначить или снять спринт',
+  },
+  ADD_COMMENT: {
+    label: 'Добавить комментарий',
+    description: 'К каждой задаче — один и тот же текст',
+  },
+  DELETE: {
+    label: 'Удалить задачи',
+    description: 'Необратимое удаление — требует подтверждения «DELETE»',
+    destructive: true,
+  },
+};
+
+/** Cost-free status→color mapping used в UI preview/drawer (will expand в PR-10). */
+export const STATUS_COLORS: Record<BulkOperationStatus, string> = {
+  QUEUED: 'default',
+  RUNNING: 'processing',
+  SUCCEEDED: 'success',
+  PARTIAL: 'warning',
+  FAILED: 'error',
+  CANCELLED: 'default',
+};

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,40 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.60**
+**Last version: 2.61**
+
+---
+
+## [2.61] [2026-04-24] feat(bulk-ops): TTBULK-1 PR-9a — wizard skeleton + API client + types + BulkActionsBar кнопка
+
+**PR:** [#151](https://github.com/NovakPAai/tasktime-mvp/pull/151)
+**Ветка:** `ttbulk-1/wizard-modal-a`
+
+### Что было
+
+Backend массовых операций полностью готов (PR-1..8: schema, auth, service, processor, 7 executors, SSE, runtime settings, admin-roles). Фронтенд пока не имел ни типов, ни клиента, ни UI — пользователь не мог запустить операцию из UI; всё вызывалось вручную через curl.
+
+### Что теперь
+
+- **`frontend/src/types/bulk.types.ts`** — зеркало backend DTO: `BulkOperationType` (7), `BulkOperationStatus` (6), `BulkScope` (ids/jql), `BulkOperationPayload` (discriminated union по type), `BulkPreviewResponse`, `BulkOperation`, `BulkOperationListResponse`, `BulkCreateResponse` + UI-хелперы `OPERATION_LABELS`, `STATUS_COLORS`, `BULK_OPS_MAX_ITEMS_HARD_LIMIT`, `isBulkOperationPayload` type-guard.
+- **`frontend/src/api/bulkOperations.ts`** — typed client: `preview / create / get / cancel / listMine / retryFailed / downloadReport` + `streamUrl(id)` helper для PR-10 SSE hook. `Idempotency-Key` в HTTP-заголовке (match backend router contract).
+- **`BulkOperationWizardModal.tsx`** — скелет 4-step Ant `Steps` + Modal, state reset на mount. Step1 реализован; Step2-4 — placeholder Alert.
+- **`Step1PickOperation.tsx`** — Radio-список 7 типов с description'ами + DELETE warning tag.
+- **Integration в `BulkActionsBar.tsx`**: кнопка «Массовые операции» gated под `features.bulkOps`. Modal close → `onCleared()`.
+
+### Влияние на prod
+
+Gated под `VITE_FEATURES_BULK_OPS=false` — кнопка не видна до cutover (PR-12).
+
+### Проверки
+
+- `npx tsc --noEmit` (frontend) → 0 errors.
+- `npm run lint` — 0 новых warnings.
+- Pre-push review: 🟠 2 → fixed (Idempotency-Key header drift, alreadyExisted stripped field), 🟡 3 → fixed.
+
+### Связано
+
+- TTBULK-1 — см. `docs/tz/TTBULK-1.md` §3.2, §8.1, §13.6 PR-9.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Split from original PR-9** (14h → 9a/9b): infrastructure only. PR-9b добавит Step2/3/4 + virtualized preview + conflicts UI.
- **Frontend types** (`bulk.types.ts`): discriminated unions для `BulkScope` и `BulkOperationPayload` зеркало backend DTO. Включает `BULK_OPERATION_TYPES`, `OPERATION_LABELS`, `STATUS_COLORS` + `isBulkOperationPayload` runtime type-guard.
- **API client** (`bulkOperations.ts`): `preview/create/get/cancel/listMine/retryFailed/downloadReport` + `streamUrl` helper для PR-10 SSE hook. `Idempotency-Key` в HTTP-заголовке (совпадает с backend `req.header('Idempotency-Key')`).
- **WizardModal скелет**: 4-step Ant `Steps` + Modal; state reset на open (без stale selection); Step1 реализован; Step2-4 placeholder.
- **Step1PickOperation**: Radio-список 7 типов с description'ами; DELETE с warning-тэгом "Необратимо".
- **BulkActionsBar интеграция**: при `features.bulkOps=true` кнопка «Массовые операции» → открывает wizard со scope=ids. Modal close → `onCleared()` (CLAUDE.md правило).

## Pre-push review counts

- 🟠 Critical (2) → **fixed**:
  - `Idempotency-Key` в body → header (drift вызвал бы 400 на первом submit).
  - `BulkCreateResponse.alreadyExisted` удалён из типа (router стрипает поле перед res.json; caller различает по status code 200/201).
- 🟡 Should-fix (3) → **fixed**:
  - Pluralization "задача" (1/2-4/5+/11-14).
  - Dead code path: scope=jql ветка + unused props `jql`/`total` убраны (вернутся в PR-9b).
  - `isBulkOperationPayload` type-guard добавлен для narrowing Prisma Json.
- 🔵 Optimization (2) → skipped (codebase consistency на `destroyOnClose`; addressed через JSDoc cross-refs).
- ⚪ Nitpick (2) → one addressed (cross-reference комментарии на backend files).

## Test plan

- [x] `npx tsc --noEmit` frontend — 0 errors
- [x] `npm run lint` frontend — 0 новых warnings (9 pre-existing, не связаны)
- [x] Pre-push review: 2🟠 + 3🟡 + 2🔵 + 2⚪ — все критичные устранены
- [ ] Manual smoke (post-deploy с `VITE_FEATURES_BULK_OPS=true`): SearchPage → выделить задачи → кнопка «Массовые операции» → Step1 select DELETE → «Далее» → Step2 Alert placeholder. Закрыть → SearchPage refresh.
- [ ] Frontend unit-тесты — инфраструктуры vitest нет; Playwright e2e в PR-12

## Зависимости

- **Base:** `main` (после merge PR-7 #149).
- **Blocks:** PR-9b (step components), PR-10 (SSE hook), PR-11 (operations page), PR-12 (cutover e2e).
- **Parallel:** PR-8 #150 (admin roles — пересечения нет).

## Плановая дельта

- **LoC:** +676 / -4 (внутри бюджета 400–900).
- **Файлы:** 8 (4 новых: 3 TS компонента + types; 4 модификации).
- **Фичефлаг:** `VITE_FEATURES_BULK_OPS` (уже существует с PR-1); кнопка скрыта в prod до cutover (PR-12).

См. `docs/tz/TTBULK-1.md` §3.2, §8.1, §13.6 PR-9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
