### PR TITLE
feat(bulk-ops): TTBULK-1 PR-11 — /operations page + retry UI + operation detail

### DIFF
--- a/docs/tz/TTBULK-1.md
+++ b/docs/tz/TTBULK-1.md
@@ -1051,7 +1051,7 @@ PR-12 ─► PR-13 (metrics + grafana + алёрты)
 | 9a | `ttbulk-1/wizard-modal-a`       | types + api client + wizard skeleton + Step1 + BulkActionsBar кнопка | 6 | PR-3 | types + api + skeleton | 🟢 Merged (#151) |
 | 9b | `ttbulk-1/wizard-modal-b`       | Step2 (config) + Step3 (preview/virtualized) + Step4 (confirm/submit) + conflicts + react-window | 8 | PR-9a | step components | 🟢 Merged (#152) |
 | 10 | `ttbulk-1/progress-drawer`      | ProgressDrawer + SSE hook + floating chip + zustand store    | 8    | PR-6, PR-9        | hook + drawer + chip | 🟢 Merged (#153) |
-| 11 | `ttbulk-1/operations-page`      | /operations page + retry UI + AuditLog badge in IssuePage    | 8    | PR-10             | page + badge       | 📋 Планируется |
+| 11 | `ttbulk-1/operations-page`      | /operations page + retry UI (AuditLog badge — deferred в PR-12) | 6 | PR-10 | page + detail | ✅ Done |
 | 12 | `ttbulk-1/e2e-docs-cutover`     | Playwright + k6 + docs + feature-flag flip + UAT             | 12   | PR-5, PR-7, PR-8, PR-11 | e2e + docs + cutover | 📋 Планируется |
 | 13 | `ttbulk-1/metrics`              | Prometheus metrics + grafana dashboard + алёрты              | 4    | PR-12             | metrics + alerts   | 📋 Планируется |
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,6 +56,8 @@ import AdminReleaseCheckpointTypesPage from './pages/admin/AdminReleaseCheckpoin
 import AdminReleaseCheckpointTemplatesPage from './pages/admin/AdminReleaseCheckpointTemplatesPage';
 import AdminCheckpointAuditPage from './pages/admin/AdminCheckpointAuditPage';
 import AdminSystemPage from './pages/admin/AdminSystemPage';
+import OperationsPage from './pages/OperationsPage';
+import OperationDetailPage from './pages/OperationDetailPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 import SettingsPage from './pages/SettingsPage';
 import LoadingSpinner from './components/common/LoadingSpinner';
@@ -260,6 +262,11 @@ export default function App() {
               element={<AdminGate allow={canViewCheckpointAudit}><AdminCheckpointAuditPage /></AdminGate>}
             />
             <Route path="admin/system" element={<AdminGate allow={canManageSystemSettings}><AdminSystemPage /></AdminGate>} />
+            {/* TTBULK-1 PR-11 — operations page (gated под features.bulkOps).
+                Роуты всегда mounted, но навигация из sidebar прячется под флагом;
+                direct URL работает всегда (безопасно: endpoints требуют auth). */}
+            <Route path="operations" element={<OperationsPage />} />
+            <Route path="operations/:id" element={<OperationDetailPage />} />
             <Route path="settings" element={<SettingsPage />} />
             <Route path="pipeline" element={<PipelineDashboardPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -413,6 +413,25 @@ export default function Sidebar({
             </>
           )}
 
+          {/* TTBULK-1 PR-11 — Massовые операции (/operations). Gated под
+              VITE_FEATURES_BULK_OPS; в PR-12 cutover флаг flip → ссылка видна. */}
+          {frontendFeatures.bulkOps && (
+            <div
+              data-testid="nav-operations"
+              style={itemStyle('/operations')}
+              onClick={() => onNavigate('/operations')}
+              onMouseEnter={() => setHovered('/operations')}
+              onMouseLeave={() => setHovered(null)}
+            >
+              <svg width="16" height="16" fill="none" viewBox="0 0 16 16" style={{ flexShrink: 0 }}>
+                <rect x="2" y="3" width="12" height="2" rx="0.5" stroke={itemColor('/operations')} strokeWidth="1.3" />
+                <rect x="2" y="7" width="12" height="2" rx="0.5" stroke={itemColor('/operations')} strokeWidth="1.3" />
+                <rect x="2" y="11" width="12" height="2" rx="0.5" stroke={itemColor('/operations')} strokeWidth="1.3" />
+              </svg>
+              <span style={textStyle('/operations')}>Массовые операции</span>
+            </div>
+          )}
+
           {/* Planning submenu */}
           <div
             style={{ ...itemStyle('planning-submenu'), backgroundColor: hovered === 'planning-submenu' ? tokens.itemHoverBg : 'transparent' }}

--- a/frontend/src/pages/OperationDetailPage.tsx
+++ b/frontend/src/pages/OperationDetailPage.tsx
@@ -9,7 +9,7 @@
  * См. docs/tz/TTBULK-1.md §3.4, §13.7 PR-11.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   Button,
@@ -26,7 +26,7 @@ import {
 import { DownloadOutlined, ReloadOutlined, RedoOutlined, LeftOutlined } from '@ant-design/icons';
 import { bulkOperationsApi } from '../api/bulkOperations';
 import type { BulkOperation } from '../types/bulk.types';
-import { OPERATION_LABELS, STATUS_COLORS } from '../types/bulk.types';
+import { OPERATION_LABELS, STATUS_COLORS, STATUS_LABELS } from '../types/bulk.types';
 import { useBulkOperationsStore } from '../store/bulkOperations.store';
 import { useBulkOperationStream } from '../components/bulk/useBulkOperationStream';
 import { saveBlob } from '../utils/saveBlob';
@@ -53,18 +53,30 @@ export default function OperationDetailPage() {
   const [retrying, setRetrying] = useState(false);
   const [cancelling, setCancelling] = useState(false);
 
+  // isMounted guard — handleCancel/Retry await'ят и могут завершиться после
+  // unmount'а (юзер back-кнопкой ушёл); без guard setState на mounted-null → warn.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   // Первоначальная выборка. Stream обновит counter'ы live; при полном refresh
   // страницы (F5) эта выборка тоже источник истины.
-  const load = async () => {
+  const load = useCallback(async () => {
     if (!id) return;
     setLoading(true);
     setLoadError(null);
     try {
       const fresh = await bulkOperationsApi.get(id);
+      if (!mountedRef.current) return;
       setOp(fresh);
       // Push в store — чтобы drawer при открытии сразу имел данные.
       addOperation({ id: fresh.id, status: fresh.status, snapshot: fresh });
     } catch (e: unknown) {
+      if (!mountedRef.current) return;
       const err = e as { response?: { status?: number; data?: { error?: string } } };
       setLoadError(
         err?.response?.status === 404
@@ -72,14 +84,13 @@ export default function OperationDetailPage() {
           : err?.response?.data?.error ?? 'Не удалось загрузить операцию',
       );
     } finally {
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
-  };
+  }, [id, addOperation]);
 
   useEffect(() => {
     void load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id]);
+  }, [load]);
 
   // Show the freshest view: stream snapshot (если пришло) или initial fetch.
   const view = trackedSnapshot ?? op;
@@ -159,7 +170,7 @@ export default function OperationDetailPage() {
         <Title level={4} style={{ margin: 0 }}>
           Операция #{view.id.slice(0, 8)}
         </Title>
-        <Tag color={STATUS_COLORS[view.status]}>{view.status}</Tag>
+        <Tag color={STATUS_COLORS[view.status]}>{STATUS_LABELS[view.status]}</Tag>
       </div>
 
       <Progress
@@ -217,7 +228,7 @@ export default function OperationDetailPage() {
         <Button icon={<ReloadOutlined />} onClick={() => void load()}>
           Обновить
         </Button>
-        {!isActive && (
+        {(view.status === 'SUCCEEDED' || view.status === 'PARTIAL') && (
           <Button icon={<DownloadOutlined />} onClick={() => void handleDownload()}>
             Скачать отчёт CSV
           </Button>

--- a/frontend/src/pages/OperationDetailPage.tsx
+++ b/frontend/src/pages/OperationDetailPage.tsx
@@ -1,0 +1,255 @@
+/**
+ * TTBULK-1 PR-11 — /operations/:id детальная страница одной операции.
+ *
+ * Показывает summary (type/scope/progress/status/timestamps), ссылку на Report
+ * CSV и кнопки Retry / Open in drawer / Cancel (если activec). Подключается
+ * к `useBulkOperationStream(id)` для live-обновлений — в частности, чтобы
+ * страницу не нужно было F5-ить для свежих counter'ов.
+ *
+ * См. docs/tz/TTBULK-1.md §3.4, §13.7 PR-11.
+ */
+
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  Button,
+  Descriptions,
+  Space,
+  Tag,
+  Typography,
+  message,
+  Popconfirm,
+  Spin,
+  Result,
+  Progress,
+} from 'antd';
+import { DownloadOutlined, ReloadOutlined, RedoOutlined, LeftOutlined } from '@ant-design/icons';
+import { bulkOperationsApi } from '../api/bulkOperations';
+import type { BulkOperation } from '../types/bulk.types';
+import { OPERATION_LABELS, STATUS_COLORS } from '../types/bulk.types';
+import { useBulkOperationsStore } from '../store/bulkOperations.store';
+import { useBulkOperationStream } from '../components/bulk/useBulkOperationStream';
+import { saveBlob } from '../utils/saveBlob';
+
+const { Title, Text } = Typography;
+
+export default function OperationDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const addOperation = useBulkOperationsStore((s) => s.addOperation);
+  const setDrawerOperationId = useBulkOperationsStore((s) => s.setDrawerOperationId);
+  // Сохраняем snapshot в store перед stream'ом — hook начнёт updates и drawer
+  // переиспользует данные без повторной выборки.
+  const trackedSnapshot = useBulkOperationsStore((s) =>
+    id ? s.operations[id]?.snapshot ?? null : null,
+  );
+
+  // Subscribe to live stream for this id (hook has its own null-guard).
+  useBulkOperationStream(id ?? null);
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [op, setOp] = useState<BulkOperation | null>(null);
+  const [retrying, setRetrying] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+
+  // Первоначальная выборка. Stream обновит counter'ы live; при полном refresh
+  // страницы (F5) эта выборка тоже источник истины.
+  const load = async () => {
+    if (!id) return;
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const fresh = await bulkOperationsApi.get(id);
+      setOp(fresh);
+      // Push в store — чтобы drawer при открытии сразу имел данные.
+      addOperation({ id: fresh.id, status: fresh.status, snapshot: fresh });
+    } catch (e: unknown) {
+      const err = e as { response?: { status?: number; data?: { error?: string } } };
+      setLoadError(
+        err?.response?.status === 404
+          ? 'Операция не найдена'
+          : err?.response?.data?.error ?? 'Не удалось загрузить операцию',
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  // Show the freshest view: stream snapshot (если пришло) или initial fetch.
+  const view = trackedSnapshot ?? op;
+
+  const handleDownload = async () => {
+    if (!id) return;
+    try {
+      const blob = await bulkOperationsApi.downloadReport(id);
+      saveBlob(blob, `bulk-operation-${id}.csv`);
+    } catch {
+      void message.error('Не удалось скачать отчёт');
+    }
+  };
+
+  const handleRetry = async () => {
+    if (!view) return;
+    setRetrying(true);
+    try {
+      const res = await bulkOperationsApi.retryFailed(view.id, crypto.randomUUID());
+      addOperation({ id: res.id, status: res.status });
+      setDrawerOperationId(res.id);
+      void message.success('Retry создан');
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { error?: string } } };
+      void message.error(err?.response?.data?.error ?? 'Не удалось создать retry');
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!view) return;
+    setCancelling(true);
+    try {
+      await bulkOperationsApi.cancel(view.id);
+      void message.info('Отмена запрошена');
+      await load();
+    } catch {
+      void message.error('Не удалось отменить операцию');
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div style={{ padding: 48, textAlign: 'center' }}>
+        <Spin />
+      </div>
+    );
+  }
+
+  if (loadError || !view) {
+    return (
+      <Result
+        status="warning"
+        title={loadError ?? 'Операция не найдена'}
+        extra={
+          <Button type="primary" onClick={() => navigate('/operations')}>
+            К списку операций
+          </Button>
+        }
+      />
+    );
+  }
+
+  const isActive = view.status === 'QUEUED' || view.status === 'RUNNING';
+  const processed = view.succeeded + view.failed + view.skipped;
+  const percent = view.total > 0 ? Math.round((processed / view.total) * 100) : 0;
+
+  return (
+    <div style={{ padding: 24, maxWidth: 900 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+        <Button icon={<LeftOutlined />} onClick={() => navigate('/operations')}>
+          К списку
+        </Button>
+        <Title level={4} style={{ margin: 0 }}>
+          Операция #{view.id.slice(0, 8)}
+        </Title>
+        <Tag color={STATUS_COLORS[view.status]}>{view.status}</Tag>
+      </div>
+
+      <Progress
+        percent={percent}
+        status={
+          isActive
+            ? 'active'
+            : view.status === 'FAILED' || view.status === 'PARTIAL'
+              ? 'exception'
+              : 'success'
+        }
+        format={() => `${processed} / ${view.total}`}
+        style={{ marginBottom: 16 }}
+      />
+
+      <Descriptions bordered size="small" column={1} style={{ marginBottom: 16 }}>
+        <Descriptions.Item label="Тип">
+          {OPERATION_LABELS[view.type]?.label ?? view.type}
+        </Descriptions.Item>
+        <Descriptions.Item label="Scope">
+          {view.scopeKind === 'jql' ? (
+            <Text code>{view.scopeJql}</Text>
+          ) : (
+            <Text>IDs × {view.total}</Text>
+          )}
+        </Descriptions.Item>
+        <Descriptions.Item label="Создана">
+          {new Date(view.createdAt).toLocaleString()}
+        </Descriptions.Item>
+        {view.startedAt && (
+          <Descriptions.Item label="Запущена">
+            {new Date(view.startedAt).toLocaleString()}
+          </Descriptions.Item>
+        )}
+        {view.finishedAt && (
+          <Descriptions.Item label="Завершена">
+            {new Date(view.finishedAt).toLocaleString()}
+          </Descriptions.Item>
+        )}
+        <Descriptions.Item label="Результат">
+          <Space>
+            <Tag color="green">Выполнено: {view.succeeded}</Tag>
+            <Tag color="red">Ошибок: {view.failed}</Tag>
+            <Tag color="orange">Пропущено: {view.skipped}</Tag>
+          </Space>
+        </Descriptions.Item>
+        {view.finalStatusReason && (
+          <Descriptions.Item label="Причина финального статуса">
+            {view.finalStatusReason}
+          </Descriptions.Item>
+        )}
+      </Descriptions>
+
+      <Space>
+        <Button icon={<ReloadOutlined />} onClick={() => void load()}>
+          Обновить
+        </Button>
+        {!isActive && (
+          <Button icon={<DownloadOutlined />} onClick={() => void handleDownload()}>
+            Скачать отчёт CSV
+          </Button>
+        )}
+        {view.failed > 0 && (
+          <Popconfirm
+            title="Повторить failed items?"
+            description={`${view.failed} задач будут пересозданы в новой операции.`}
+            onConfirm={() => void handleRetry()}
+            okText="Retry"
+            cancelText="Отмена"
+          >
+            <Button icon={<RedoOutlined />} loading={retrying}>
+              Retry failed
+            </Button>
+          </Popconfirm>
+        )}
+        {isActive && (
+          <Popconfirm
+            title="Отменить операцию?"
+            description="Уже обработанные задачи не откатываются."
+            onConfirm={() => void handleCancel()}
+            okText="Отменить"
+            okButtonProps={{ danger: true }}
+            cancelText="Оставить"
+          >
+            <Button danger loading={cancelling}>
+              Отменить
+            </Button>
+          </Popconfirm>
+        )}
+      </Space>
+    </div>
+  );
+}

--- a/frontend/src/pages/OperationsPage.tsx
+++ b/frontend/src/pages/OperationsPage.tsx
@@ -35,7 +35,12 @@ import type {
   BulkOperationStatus,
   BulkOperationType,
 } from '../types/bulk.types';
-import { BULK_OPERATION_TYPES, OPERATION_LABELS, STATUS_COLORS } from '../types/bulk.types';
+import {
+  BULK_OPERATION_TYPES,
+  OPERATION_LABELS,
+  STATUS_COLORS,
+  STATUS_LABELS,
+} from '../types/bulk.types';
 import { useBulkOperationsStore } from '../store/bulkOperations.store';
 
 const { Title, Text } = Typography;
@@ -139,10 +144,12 @@ export default function OperationsPage() {
       },
     },
     {
-      title: 'Status',
+      title: 'Статус',
       dataIndex: 'status',
-      width: 110,
-      render: (s: BulkOperationStatus) => <Tag color={STATUS_COLORS[s]}>{s}</Tag>,
+      width: 130,
+      render: (s: BulkOperationStatus) => (
+        <Tag color={STATUS_COLORS[s]}>{STATUS_LABELS[s]}</Tag>
+      ),
     },
     {
       title: '',
@@ -194,13 +201,13 @@ export default function OperationsPage() {
         <Select
           placeholder="Статус"
           allowClear
-          style={{ width: 160 }}
+          style={{ width: 180 }}
           value={filterStatus}
           onChange={(v) => {
             setStartAt(0);
             setFilterStatus(v);
           }}
-          options={STATUSES.map((s) => ({ value: s, label: s }))}
+          options={STATUSES.map((s) => ({ value: s, label: STATUS_LABELS[s] }))}
         />
         <Select
           placeholder="Тип"

--- a/frontend/src/pages/OperationsPage.tsx
+++ b/frontend/src/pages/OperationsPage.tsx
@@ -1,0 +1,238 @@
+/**
+ * TTBULK-1 PR-11 — /operations страница: таблица моих массовых операций.
+ *
+ * Показывает операции пользователя (API listMine) с фильтрами по status/type
+ * и пагинацией. Retry failed — создаёт новую операцию через retryFailed API;
+ * результат push'ается в store + drawer открывается.
+ *
+ * Admin filter «Все операции» (видим только для ADMIN/SUPER_ADMIN) — deferred
+ * в PR-12 polish (требует backend endpoint `/admin/bulk-operations` который не
+ * входит в scope PR-11; TZ §7.4 отмечает это как admin-view).
+ *
+ * CLAUDE.md правило modal-refresh не применимо (нет модалок).
+ *
+ * См. docs/tz/TTBULK-1.md §3.4, §5.4, §13.7 PR-11.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Button,
+  Select,
+  Space,
+  Table,
+  Tag,
+  Typography,
+  message,
+  Tooltip,
+  Popconfirm,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { ReloadOutlined, EyeOutlined, RedoOutlined } from '@ant-design/icons';
+import { bulkOperationsApi, type ListQuery } from '../api/bulkOperations';
+import type {
+  BulkOperation,
+  BulkOperationStatus,
+  BulkOperationType,
+} from '../types/bulk.types';
+import { BULK_OPERATION_TYPES, OPERATION_LABELS, STATUS_COLORS } from '../types/bulk.types';
+import { useBulkOperationsStore } from '../store/bulkOperations.store';
+
+const { Title, Text } = Typography;
+
+const STATUSES: readonly BulkOperationStatus[] = [
+  'QUEUED',
+  'RUNNING',
+  'SUCCEEDED',
+  'PARTIAL',
+  'FAILED',
+  'CANCELLED',
+];
+
+const PAGE_SIZE = 25;
+
+export default function OperationsPage() {
+  const navigate = useNavigate();
+  const addOperation = useBulkOperationsStore((s) => s.addOperation);
+  const setDrawerOperationId = useBulkOperationsStore((s) => s.setDrawerOperationId);
+
+  const [loading, setLoading] = useState(false);
+  const [items, setItems] = useState<BulkOperation[]>([]);
+  const [total, setTotal] = useState(0);
+  const [startAt, setStartAt] = useState(0);
+  const [filterStatus, setFilterStatus] = useState<BulkOperationStatus | undefined>();
+  const [filterType, setFilterType] = useState<BulkOperationType | undefined>();
+  const [retrying, setRetrying] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const query: ListQuery = {
+        limit: PAGE_SIZE,
+        startAt,
+        status: filterStatus,
+        type: filterType,
+      };
+      const res = await bulkOperationsApi.listMine(query);
+      setItems(res.items);
+      setTotal(res.total);
+    } catch {
+      void message.error('Не удалось загрузить операции');
+    } finally {
+      setLoading(false);
+    }
+  }, [startAt, filterStatus, filterType]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleRetry = async (op: BulkOperation) => {
+    setRetrying(op.id);
+    try {
+      const res = await bulkOperationsApi.retryFailed(op.id, crypto.randomUUID());
+      addOperation({ id: res.id, status: res.status });
+      setDrawerOperationId(res.id);
+      void message.success('Операция-ретрай создана — открываем progress drawer');
+      void load();
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { error?: string } } };
+      void message.error(err?.response?.data?.error ?? 'Не удалось создать retry');
+    } finally {
+      setRetrying(null);
+    }
+  };
+
+  const columns: ColumnsType<BulkOperation> = [
+    {
+      title: 'Создана',
+      dataIndex: 'createdAt',
+      width: 150,
+      render: (v: string) => new Date(v).toLocaleString(),
+    },
+    {
+      title: 'Тип',
+      dataIndex: 'type',
+      width: 180,
+      render: (t: BulkOperationType) => OPERATION_LABELS[t]?.label ?? t,
+    },
+    {
+      title: 'Scope',
+      dataIndex: 'scopeKind',
+      width: 100,
+      render: (kind: BulkOperation['scopeKind'], row) =>
+        kind === 'ids' ? `IDs × ${row.total}` : <Tooltip title={row.scopeJql}>JQL</Tooltip>,
+    },
+    {
+      title: 'Progress',
+      key: 'progress',
+      width: 160,
+      render: (_, row) => {
+        const processed = row.succeeded + row.failed + row.skipped;
+        const pct = row.total > 0 ? Math.round((processed / row.total) * 100) : 0;
+        return (
+          <Text style={{ fontSize: 12 }}>
+            {processed}/{row.total} ({pct}%){' '}
+            {row.failed > 0 && <Tag color="red" style={{ marginLeft: 4 }}>{row.failed} fail</Tag>}
+          </Text>
+        );
+      },
+    },
+    {
+      title: 'Status',
+      dataIndex: 'status',
+      width: 110,
+      render: (s: BulkOperationStatus) => <Tag color={STATUS_COLORS[s]}>{s}</Tag>,
+    },
+    {
+      title: '',
+      key: 'actions',
+      width: 140,
+      render: (_, row) => (
+        <Space size="small">
+          <Tooltip title="Открыть">
+            <Button
+              size="small"
+              icon={<EyeOutlined />}
+              onClick={() => navigate(`/operations/${row.id}`)}
+            />
+          </Tooltip>
+          {row.failed > 0 && (
+            <Popconfirm
+              title="Повторить failed items?"
+              description={`${row.failed} задач будут пересозданы в новой операции.`}
+              onConfirm={() => void handleRetry(row)}
+              okText="Retry"
+              cancelText="Отмена"
+            >
+              <Tooltip title="Retry failed">
+                <Button
+                  size="small"
+                  icon={<RedoOutlined />}
+                  loading={retrying === row.id}
+                />
+              </Tooltip>
+            </Popconfirm>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div style={{ padding: 24, maxWidth: 1200 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+        <Title level={4} style={{ margin: 0 }}>
+          Массовые операции
+        </Title>
+        <Button icon={<ReloadOutlined />} onClick={() => void load()} loading={loading}>
+          Обновить
+        </Button>
+      </div>
+
+      <Space style={{ marginBottom: 16 }} wrap>
+        <Select
+          placeholder="Статус"
+          allowClear
+          style={{ width: 160 }}
+          value={filterStatus}
+          onChange={(v) => {
+            setStartAt(0);
+            setFilterStatus(v);
+          }}
+          options={STATUSES.map((s) => ({ value: s, label: s }))}
+        />
+        <Select
+          placeholder="Тип"
+          allowClear
+          style={{ width: 220 }}
+          value={filterType}
+          onChange={(v) => {
+            setStartAt(0);
+            setFilterType(v);
+          }}
+          options={BULK_OPERATION_TYPES.map((t) => ({
+            value: t,
+            label: OPERATION_LABELS[t]?.label ?? t,
+          }))}
+        />
+      </Space>
+
+      <Table
+        rowKey="id"
+        loading={loading}
+        dataSource={items}
+        columns={columns}
+        size="small"
+        pagination={{
+          current: Math.floor(startAt / PAGE_SIZE) + 1,
+          pageSize: PAGE_SIZE,
+          total,
+          showSizeChanger: false,
+          onChange: (page) => setStartAt((page - 1) * PAGE_SIZE),
+        }}
+        locale={{ emptyText: 'Пока нет массовых операций' }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/types/bulk.types.ts
+++ b/frontend/src/types/bulk.types.ts
@@ -223,7 +223,17 @@ export const OPERATION_LABELS: Record<
   },
 };
 
-/** Cost-free status→color mapping used в UI preview/drawer (will expand в PR-10). */
+/** Russian labels для UI — consistent i18n с остальным интерфейсом. */
+export const STATUS_LABELS: Record<BulkOperationStatus, string> = {
+  QUEUED: 'В очереди',
+  RUNNING: 'Выполняется',
+  SUCCEEDED: 'Выполнено',
+  PARTIAL: 'Частично',
+  FAILED: 'Ошибка',
+  CANCELLED: 'Отменено',
+};
+
+/** Cost-free status→color mapping used в UI preview/drawer. */
 export const STATUS_COLORS: Record<BulkOperationStatus, string> = {
   QUEUED: 'default',
   RUNNING: 'processing',

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,42 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.63**
+**Last version: 2.64**
+
+---
+
+## [2.64] [2026-04-24] feat(bulk-ops): TTBULK-1 PR-11 — /operations page + retry UI + operation detail
+
+**PR:** _(будет заполнено после push'а)_
+**Ветка:** `ttbulk-1/operations-page` (branched from `ttbulk-1/progress-drawer`)
+
+### Что было
+
+После PR-9+10 wizard + progress drawer работали, но не было:
+- Списка прошлых операций (куда zoom'нуться после закрытия chip'а).
+- Детальной страницы операции с retry.
+- Возможности dispatch'нуть retry failed извне drawer'а.
+
+### Что теперь
+
+- **`pages/OperationsPage.tsx`** — таблица `listMine` с фильтрами Status/Type + пагинация. Retry → `retryFailed(id, uuid)` → store addOperation + setDrawerOperationId.
+- **`pages/OperationDetailPage.tsx`** — detail view `/operations/:id` с `useBulkOperationStream(id)` live-обновлениями. Descriptions + buttons (Обновить / Скачать CSV / Retry / Отменить).
+- **`App.tsx`** — routes `/operations` + `/operations/:id`.
+- **`Sidebar.tsx`** — nav link «Массовые операции» под `features.bulkOps`.
+
+### Не включено (deferred в PR-12)
+
+- IssueDetailPage AuditLog badge — требует investigation History-tab structure.
+- Admin filter «Все операции» — требует backend endpoint.
+
+### Проверки
+
+- `npx tsc --noEmit` frontend → 0 errors.
+- `npm run lint` → 0 errors, 0 новых warnings.
+
+### Связано
+
+- TTBULK-1 — см. `docs/tz/TTBULK-1.md` §3.4, §5.4, §7.4, §13.7 PR-11.
 
 ---
 


### PR DESCRIPTION
## Summary

После PR-9+10 wizard + drawer работали, но не было списка прошлых операций и retry UX извне drawer'а. Этот PR добавляет:

- **`pages/OperationsPage.tsx`** — таблица `listMine` с фильтрами Status/Type + пагинация (25/page). Колонки: дата/тип/scope/progress/status/actions. Retry через Popconfirm → `retryFailed(uuid)` → addOperation + setDrawerOperationId.
- **`pages/OperationDetailPage.tsx`** — detail view `/operations/:id` с `useBulkOperationStream(id)` live-обновлениями. Descriptions + Progress bar + buttons (Обновить / Download CSV / Retry / Отменить).
- **`App.tsx`** — routes `/operations` + `/operations/:id` (не gated — auth через backend).
- **`Sidebar.tsx`** — nav link «Массовые операции» gated под `frontendFeatures.bulkOps`.
- **`bulk.types.ts`** — `STATUS_LABELS` для русских подписей (В очереди / Выполняется / etc).

## Deferred в PR-12 polish

- **IssueDetailPage AuditLog badge** — TZ §7.4 говорит про «Массовая операция #N» бейдж в History tab IssuePage. У проекта `IssueDetailPage.tsx`; wiring бейджа требует investigation History-tab structure.
- **Admin filter «Все операции»** — требует backend `GET /admin/bulk-operations` endpoint (не в scope PR-11).

## Pre-push review counts

- 🟠 Critical (1) → **fixed**: `OperationDetailPage` — `useCallback(load)` + `isMounted` ref guard (без них stale-closure bug + state-after-unmount warns).
- 🟡 Should-fix (4) → **2 fixed / 2 skipped**:
  - ✅ Download CSV restricted to SUCCEEDED | PARTIAL (FAILED/CANCELLED 404'ил с generic message).
  - ✅ Russian STATUS_LABELS — consistent i18n.
  - ⏭ Sidebar active highlight при bulkOps=false — reviewer сам пометил "solid" (startsWith работает).
  - ⏭ `void load()` после retry — cosmetic UX, acceptable MVP.
- 🔵 (2) → 1 fixed (Russian labels), 1 skipped (scope×N rename — cosmetic).
- ⚪ (2) → skipped (view.id truncation / loadError).

## Test plan

- [x] `npx tsc --noEmit` frontend — 0 errors
- [x] `npm run lint` — 0 errors, 0 новых warnings
- [x] Pre-push review: 1🟠 + 4🟡 + 2🔵 + 2⚪ — критичные устранены
- [ ] Manual smoke (VITE_FEATURES_BULK_OPS=true): navigate `/operations` → список → filter Status=SUCCEEDED → click operation → detail page → Retry failed → drawer opens

## Зависимости

- **Base:** `ttbulk-1/progress-drawer` (PR-10 #153).
- **Blocks:** PR-12 (e2e + IssueDetailPage badge + Admin filter polish).

## Плановая дельта

- **LoC:** +556 / -2 (в бюджете 400-900).
- **Файлы:** 6 (2 новых page + App.tsx routes + Sidebar link + bulk.types + docs).

См. `docs/tz/TTBULK-1.md` §3.4, §5.4, §7.4, §13.7 PR-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
