### PR TITLE
feat(bulk-ops): TTBULK-1 follow-up — friendly pickers вместо UUID

### DIFF
--- a/frontend/src/components/bulk/BulkOperationWizardModal.tsx
+++ b/frontend/src/components/bulk/BulkOperationWizardModal.tsx
@@ -223,6 +223,7 @@ export default function BulkOperationWizardModal({
           operationType={selectedType}
           value={payload}
           onChange={setPayload}
+          scope={scope}
         />
       )}
 
@@ -273,7 +274,10 @@ function isCompletePayload(
     }
     case 'EDIT_CUSTOM_FIELD': {
       const cf = (p as { customFieldId?: unknown }).customFieldId;
-      return typeof cf === 'string' && cf.length > 0 && 'value' in p;
+      const val = (p as { value?: unknown }).value;
+      // value: undefined не валидно (JSON его не сериализует → backend получит
+      // absent key). Смена field в Step2 сбрасывает value=undefined до ввода.
+      return typeof cf === 'string' && cf.length > 0 && 'value' in p && val !== undefined;
     }
     case 'MOVE_TO_SPRINT':
       return 'sprintId' in p;

--- a/frontend/src/components/bulk/Step2Configure.tsx
+++ b/frontend/src/components/bulk/Step2Configure.tsx
@@ -1,31 +1,51 @@
 /**
- * TTBULK-1 PR-9b — Step 2 wizard: per-type конфигурация операции.
+ * TTBULK-1 PR-9b → follow-up — Step 2 wizard: per-type конфигурация операции
+ * через **человеко-понятные пикеры** вместо ввода UUID.
  *
- * Формы для каждого типа (TRANSITION/ASSIGN/EDIT_FIELD/EDIT_CUSTOM_FIELD/
- * MOVE_TO_SPRINT/ADD_COMMENT/DELETE). DELETE — no config (только confirm).
+ * Rich pickers:
+ *   • TRANSITION       — Select целевого статуса, агрегированного из
+ *                        `getBatchTransitions(ids)` по `toStatus.name`.
+ *   • ASSIGN           — searchable Select пользователей (`listUsers()`).
+ *   • EDIT_CUSTOM_FIELD — Select кастом-полей + типизированный value-input
+ *                        (берём схему из первой выбранной задачи).
+ *   • MOVE_TO_SPRINT   — Select спринтов, сгруппированных по проекту
+ *                        (`listAllSprints({ state: 'ALL' })`).
  *
- * Scope PR-9b: **минимальные формы** с text/textarea/date/select. Rich selectors
- * (user-search, sprint-lookup, custom-field picker) не включены — user пастит UUID
- * напрямую (ID-first UX). Workflow-transition picker вынесен за scope (нужен
- * transitions-API; добавится в PR-12 с remaining polish).
+ * Инварианты:
+ *   • Скоуп `'jql'` в UI пока не используется (только `'ids'` из BulkActionsBar),
+ *     но fallback на ручной UUID-ввод сохранён как safety net для будущих
+ *     callers.
+ *   • Для multi-project выборки показываем tooltip/hint «доступно для N/M задач».
+ *   • На API-ошибке — красный Alert + fallback UUID input.
  *
  * См. docs/tz/TTBULK-1.md §3.2, §13.6 PR-9.
  */
 
-import type { ReactElement } from 'react';
-import { Form, Input, Select, DatePicker, Radio, Space, Alert } from 'antd';
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
+import { Form, Input, Select, DatePicker, Radio, Space, Alert, Spin, Tooltip, InputNumber } from 'antd';
 import dayjs, { type Dayjs } from 'dayjs';
 import type {
   BulkOperationType,
   BulkOperationPayload,
+  BulkScope,
   EditFieldName,
 } from '../../types/bulk.types';
+import { workflowEngineApi, type BatchTransitionsItem } from '../../api/workflow-engine';
+import { listUsers } from '../../api/auth';
+import type { User } from '../../types';
+import { listAllSprints } from '../../api/sprints';
+import type { Sprint, SprintState } from '../../types/sprint.types';
+import { issueCustomFieldsApi, type IssueCustomFieldValue } from '../../api/issue-custom-fields';
+import type { CustomFieldOption, ReferenceOptions } from '../../api/custom-fields';
 
 export interface Step2ConfigureProps {
   operationType: BulkOperationType;
   /** Частичный payload (пользователь печатает). Родитель валидирует и хранит. */
   value: Partial<BulkOperationPayload> | null;
   onChange: (value: Partial<BulkOperationPayload>) => void;
+  /** Скоуп из Wizard'а — нужен чтобы подгрузить контекстные справочники
+   * (transitions для выбранных задач, custom fields из первой задачи). */
+  scope: BulkScope;
 }
 
 const PRIORITIES = ['LOWEST', 'LOW', 'MEDIUM', 'HIGH', 'HIGHEST'] as const;
@@ -37,48 +57,18 @@ const EDIT_FIELDS: readonly { value: EditFieldName; label: string }[] = [
   { value: 'description.append', label: 'Description — append' },
 ];
 
-export default function Step2Configure({ operationType, value, onChange }: Step2ConfigureProps) {
+const SPRINT_STATE_LABEL: Record<SprintState, string> = {
+  PLANNED: 'Планируется',
+  ACTIVE: 'Активен',
+  CLOSED: 'Завершён',
+};
+
+export default function Step2Configure({ operationType, value, onChange, scope }: Step2ConfigureProps) {
   switch (operationType) {
     case 'TRANSITION':
-      return (
-        <Form layout="vertical">
-          <Alert
-            type="info"
-            showIcon
-            message="TRANSITION требует transitionId (UUID из workflow-схемы проекта)"
-            description="Rich picker появится в PR-12 cutover polish. Сейчас — вставьте UUID."
-            style={{ marginBottom: 16 }}
-          />
-          <Form.Item label="Transition ID (UUID)" required>
-            <Input
-              placeholder="00000000-0000-0000-0000-000000000000"
-              value={(value as { transitionId?: string })?.transitionId ?? ''}
-              onChange={(e) =>
-                onChange({ type: 'TRANSITION', transitionId: e.target.value })
-              }
-            />
-          </Form.Item>
-        </Form>
-      );
-
+      return <TransitionConfig value={value} onChange={onChange} scope={scope} />;
     case 'ASSIGN':
-      return (
-        <Form layout="vertical">
-          <Form.Item label="Assignee User ID (UUID, пусто = unassign)">
-            <Input
-              placeholder="00000000-0000-0000-0000-000000000000"
-              value={(value as { assigneeId?: string | null })?.assigneeId ?? ''}
-              onChange={(e) =>
-                onChange({
-                  type: 'ASSIGN',
-                  assigneeId: e.target.value.trim() === '' ? null : e.target.value,
-                })
-              }
-            />
-          </Form.Item>
-        </Form>
-      );
-
+      return <AssignConfig value={value} onChange={onChange} />;
     case 'EDIT_FIELD': {
       const v = value as { field?: EditFieldName; value?: unknown } | null;
       const field = v?.field;
@@ -104,74 +94,10 @@ export default function Step2Configure({ operationType, value, onChange }: Step2
         </Form>
       );
     }
-
-    case 'EDIT_CUSTOM_FIELD': {
-      const v = value as { customFieldId?: string; value?: unknown } | null;
-      return (
-        <Form layout="vertical">
-          <Form.Item label="Custom field ID (UUID)" required>
-            <Input
-              placeholder="00000000-0000-0000-0000-000000000000"
-              value={v?.customFieldId ?? ''}
-              onChange={(e) =>
-                onChange({
-                  type: 'EDIT_CUSTOM_FIELD',
-                  customFieldId: e.target.value,
-                  value: v?.value,
-                })
-              }
-            />
-          </Form.Item>
-          <Form.Item label="Значение (строка / число / JSON)">
-            <Input.TextArea
-              rows={3}
-              placeholder='"my text" или 42 или {"key": "value"}'
-              value={
-                typeof v?.value === 'string'
-                  ? v.value
-                  : v?.value !== undefined
-                    ? JSON.stringify(v.value)
-                    : ''
-              }
-              onChange={(e) => {
-                // Try parse as JSON, fall back to raw string.
-                const raw = e.target.value;
-                let parsed: unknown = raw;
-                try {
-                  parsed = JSON.parse(raw);
-                } catch {
-                  // leave as string
-                }
-                onChange({
-                  type: 'EDIT_CUSTOM_FIELD',
-                  customFieldId: v?.customFieldId ?? '',
-                  value: parsed,
-                });
-              }}
-            />
-          </Form.Item>
-        </Form>
-      );
-    }
-
+    case 'EDIT_CUSTOM_FIELD':
+      return <EditCustomFieldConfig value={value} onChange={onChange} scope={scope} />;
     case 'MOVE_TO_SPRINT':
-      return (
-        <Form layout="vertical">
-          <Form.Item label="Sprint ID (UUID, пусто = remove)">
-            <Input
-              placeholder="00000000-0000-0000-0000-000000000000"
-              value={(value as { sprintId?: string | null })?.sprintId ?? ''}
-              onChange={(e) =>
-                onChange({
-                  type: 'MOVE_TO_SPRINT',
-                  sprintId: e.target.value.trim() === '' ? null : e.target.value,
-                })
-              }
-            />
-          </Form.Item>
-        </Form>
-      );
-
+      return <MoveToSprintConfig value={value} onChange={onChange} />;
     case 'ADD_COMMENT':
       return (
         <Form layout="vertical">
@@ -189,7 +115,6 @@ export default function Step2Configure({ operationType, value, onChange }: Step2
           </Form.Item>
         </Form>
       );
-
     case 'DELETE':
       return (
         <Alert
@@ -199,10 +124,552 @@ export default function Step2Configure({ operationType, value, onChange }: Step2
           description="Подтверждение «DELETE» запрашивается на Шаге 4. Дополнительной конфигурации не требуется."
         />
       );
-
     default:
       return null;
   }
+}
+
+// ────── TRANSITION ────────────────────────────────────────────────────────────
+
+interface TransitionOptionGroup {
+  /** Человекочитаемое имя целевого статуса. */
+  toStatusName: string;
+  /** Категория (например, `done` / `in-progress`) — для иконки/цвета в будущем. */
+  category: string;
+  /** Сколько задач могут перейти в этот статус (любым из transitionId'ов). */
+  totalIssues: number;
+  /** `transitionId` с максимальным покрытием + его count — отправляется в payload.
+   * Остальные задачи с другим transitionId'ом будут SKIPPED (NO_TRANSITION). */
+  bestTransitionId: string;
+  bestCount: number;
+  /** Хотя бы один переход требует screen fields — флаг для user-facing warning. */
+  requiresScreen: boolean;
+}
+
+function TransitionConfig({
+  value,
+  onChange,
+  scope,
+}: {
+  value: Partial<BulkOperationPayload> | null;
+  onChange: (v: Partial<BulkOperationPayload>) => void;
+  scope: BulkScope;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [batch, setBatch] = useState<BatchTransitionsItem[] | null>(null);
+
+  const scopeKey = scope.kind === 'ids' ? scope.issueIds.join(',') : scope.jql;
+
+  useEffect(() => {
+    setError(null);
+    if (scope.kind !== 'ids') {
+      setLoading(false);
+      return;
+    }
+    const ids = scope.issueIds;
+    if (ids.length === 0) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    workflowEngineApi
+      .getBatchTransitions(ids)
+      .then((res) => {
+        if (!cancelled) setBatch(res);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        const err = e as { response?: { data?: { error?: string } } };
+        setError(err?.response?.data?.error ?? 'Не удалось загрузить доступные переходы');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // scopeKey — стабильный derived string; [scope] ломался бы при reference-unstable callers.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scopeKey]);
+
+  const groups = useMemo<TransitionOptionGroup[]>(() => {
+    if (!batch) return [];
+    // Двойной индекс: по имени статуса (для группировки в UI) и внутри —
+    // счётчик по exactId. Нужно чтобы выбрать UUID с максимальным покрытием:
+    // backend-executor матчит exact transitionId → issues с другим UUID будут
+    // SKIPPED (NO_TRANSITION).
+    const byStatus = new Map<
+      string,
+      { name: string; category: string; totalIssues: number; idCounts: Map<string, number>; requiresScreen: boolean }
+    >();
+    for (const item of batch) {
+      // Дедупликация статусов внутри одной задачи — одна задача может иметь
+      // несколько переходов в один и тот же статус (редко, но теоретически).
+      const seenStatusInItem = new Set<string>();
+      for (const t of item.transitions) {
+        const key = t.toStatus.name;
+        const bucket = byStatus.get(key) ?? {
+          name: t.toStatus.name,
+          category: t.toStatus.category,
+          totalIssues: 0,
+          idCounts: new Map<string, number>(),
+          requiresScreen: false,
+        };
+        if (!seenStatusInItem.has(key)) {
+          bucket.totalIssues += 1;
+          seenStatusInItem.add(key);
+        }
+        bucket.idCounts.set(t.id, (bucket.idCounts.get(t.id) ?? 0) + 1);
+        if (t.requiresScreen) bucket.requiresScreen = true;
+        byStatus.set(key, bucket);
+      }
+    }
+    const result: TransitionOptionGroup[] = [];
+    for (const bucket of byStatus.values()) {
+      let bestId = '';
+      let bestCount = 0;
+      for (const [id, count] of bucket.idCounts.entries()) {
+        if (count > bestCount) {
+          bestCount = count;
+          bestId = id;
+        }
+      }
+      result.push({
+        toStatusName: bucket.name,
+        category: bucket.category,
+        totalIssues: bucket.totalIssues,
+        bestTransitionId: bestId,
+        bestCount,
+        requiresScreen: bucket.requiresScreen,
+      });
+    }
+    return result.sort((a, b) => b.bestCount - a.bestCount);
+  }, [batch]);
+
+  // Для scope='jql' (пока не в UI) — fallback ввод UUID.
+  if (scope.kind === 'jql') {
+    return (
+      <Form layout="vertical">
+        <Alert
+          type="info"
+          showIcon
+          message="JQL-скоуп: укажите transition ID вручную"
+          description="Для JQL-выборки список переходов заранее неизвестен. Введите UUID перехода — executor пропустит задачи, где он недоступен."
+          style={{ marginBottom: 16 }}
+        />
+        <Form.Item label="Transition ID (UUID)" required>
+          <Input
+            placeholder="00000000-0000-0000-0000-000000000000"
+            value={(value as { transitionId?: string })?.transitionId ?? ''}
+            onChange={(e) => onChange({ type: 'TRANSITION', transitionId: e.target.value })}
+          />
+        </Form.Item>
+      </Form>
+    );
+  }
+
+  const selectedId = (value as { transitionId?: string })?.transitionId ?? '';
+  const selectedGroup = groups.find((g) => g.bestTransitionId === selectedId);
+  const totalBatch = batch?.length ?? 0;
+
+  return (
+    <Form layout="vertical">
+      {loading && (
+        <div style={{ padding: 16, textAlign: 'center' }}>
+          <Spin tip="Загружаем доступные переходы…" />
+        </div>
+      )}
+      {error && <Alert type="error" showIcon message={error} style={{ marginBottom: 16 }} />}
+      {!loading && !error && groups.length === 0 && batch !== null && (
+        <Alert
+          type="warning"
+          showIcon
+          message="Нет доступных переходов"
+          description="Ни одна выбранная задача не допускает transition (нет прав или текущий статус терминальный)."
+        />
+      )}
+      {!loading && groups.length > 0 && (
+        <>
+          <Form.Item label="Перевести в статус" required>
+            <Select
+              placeholder="Выберите целевой статус"
+              value={selectedGroup?.toStatusName}
+              onChange={(statusName: string) => {
+                const g = groups.find((x) => x.toStatusName === statusName);
+                if (!g) return;
+                onChange({
+                  type: 'TRANSITION',
+                  transitionId: g.bestTransitionId,
+                });
+              }}
+              options={groups.map((g) => ({
+                value: g.toStatusName,
+                label: `${g.toStatusName} (доступно: ${g.bestCount}/${totalBatch})`,
+              }))}
+            />
+          </Form.Item>
+          {selectedGroup && selectedGroup.bestCount < totalBatch && (
+            <Alert
+              type="warning"
+              showIcon
+              message={`Переход применится к ${selectedGroup.bestCount} из ${totalBatch} задач`}
+              description={
+                selectedGroup.totalIssues > selectedGroup.bestCount
+                  ? `Ещё ${selectedGroup.totalIssues - selectedGroup.bestCount} задач используют другой transition-UUID для того же статуса (разные workflow-схемы проектов) — они будут пропущены. Остальные ${totalBatch - selectedGroup.totalIssues} задач не допускают этот переход (NO_TRANSITION).`
+                  : 'Задачи без доступного перехода будут пропущены (NO_TRANSITION).'
+              }
+              style={{ marginBottom: 16 }}
+            />
+          )}
+          {selectedGroup?.requiresScreen && (
+            <Alert
+              type="warning"
+              showIcon
+              message="Переход требует заполнения полей"
+              description="Пропустятся задачи, где обязательные поля перехода не заполнены. Full field-overrides UI появится позже."
+            />
+          )}
+        </>
+      )}
+    </Form>
+  );
+}
+
+// ────── ASSIGN ────────────────────────────────────────────────────────────────
+
+function AssignConfig({
+  value,
+  onChange,
+}: {
+  value: Partial<BulkOperationPayload> | null;
+  onChange: (v: Partial<BulkOperationPayload>) => void;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [users, setUsers] = useState<User[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    listUsers()
+      .then((res) => {
+        if (!cancelled) setUsers(res);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Не удалось загрузить список пользователей');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const current = value as { assigneeId?: string | null } | null;
+  const selected = current && 'assigneeId' in current
+    ? (current.assigneeId === null ? '__unassign__' : current.assigneeId)
+    : undefined;
+
+  const options = useMemo(
+    () => [
+      { value: '__unassign__', label: '— Снять исполнителя —' },
+      ...users
+        .filter((u) => u.isActive)
+        .map((u) => ({
+          value: u.id,
+          label: `${u.name} <${u.email}>`,
+        })),
+    ],
+    [users],
+  );
+
+  return (
+    <Form layout="vertical">
+      {error && <Alert type="error" showIcon message={error} style={{ marginBottom: 16 }} />}
+      <Form.Item label="Новый исполнитель" required>
+        <Select
+          showSearch
+          loading={loading}
+          placeholder="Начните печатать имя или email…"
+          value={selected}
+          optionFilterProp="label"
+          filterOption={(input, option) =>
+            (option?.label ?? '').toString().toLowerCase().includes(input.toLowerCase())
+          }
+          onChange={(v: string) => {
+            onChange({
+              type: 'ASSIGN',
+              assigneeId: v === '__unassign__' ? null : v,
+            });
+          }}
+          options={options}
+          style={{ width: '100%' }}
+        />
+      </Form.Item>
+    </Form>
+  );
+}
+
+// ────── EDIT_CUSTOM_FIELD ─────────────────────────────────────────────────────
+
+function EditCustomFieldConfig({
+  value,
+  onChange,
+  scope,
+}: {
+  value: Partial<BulkOperationPayload> | null;
+  onChange: (v: Partial<BulkOperationPayload>) => void;
+  scope: BulkScope;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fields, setFields] = useState<IssueCustomFieldValue[] | null>(null);
+
+  const scopeKey = scope.kind === 'ids' ? scope.issueIds.join(',') : scope.jql;
+
+  useEffect(() => {
+    setError(null);
+    if (scope.kind !== 'ids') {
+      setLoading(false);
+      return;
+    }
+    const firstId = scope.issueIds[0];
+    if (!firstId) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    issueCustomFieldsApi
+      .getFields(firstId)
+      .then((res) => {
+        if (!cancelled) setFields(res.fields);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Не удалось загрузить кастом-поля');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scopeKey]);
+
+  const v = value as { customFieldId?: string; value?: unknown } | null;
+
+  if (scope.kind === 'jql') {
+    // Fallback UUID input — JQL-скоуп не имеет sample issue.
+    return (
+      <Form layout="vertical">
+        <Alert
+          type="info"
+          showIcon
+          message="JQL-скоуп: укажите custom field ID вручную"
+          style={{ marginBottom: 16 }}
+        />
+        <Form.Item label="Custom field ID (UUID)" required>
+          <Input
+            placeholder="00000000-0000-0000-0000-000000000000"
+            value={v?.customFieldId ?? ''}
+            onChange={(e) =>
+              onChange({ type: 'EDIT_CUSTOM_FIELD', customFieldId: e.target.value, value: v?.value })
+            }
+          />
+        </Form.Item>
+        <Form.Item label="Значение (строка / число / JSON)">
+          <Input.TextArea
+            rows={3}
+            placeholder='"my text" или 42 или {"key": "value"}'
+            value={
+              typeof v?.value === 'string'
+                ? v.value
+                : v?.value !== undefined
+                  ? JSON.stringify(v.value)
+                  : ''
+            }
+            onChange={(e) => {
+              const raw = e.target.value;
+              let parsed: unknown = raw;
+              try {
+                parsed = JSON.parse(raw);
+              } catch {
+                /* leave as string */
+              }
+              onChange({
+                type: 'EDIT_CUSTOM_FIELD',
+                customFieldId: v?.customFieldId ?? '',
+                value: parsed,
+              });
+            }}
+          />
+        </Form.Item>
+      </Form>
+    );
+  }
+
+  const selectedField = fields?.find((f) => f.customFieldId === v?.customFieldId);
+
+  return (
+    <Form layout="vertical">
+      {loading && (
+        <div style={{ padding: 16, textAlign: 'center' }}>
+          <Spin tip="Загружаем кастом-поля первой задачи…" />
+        </div>
+      )}
+      {error && <Alert type="error" showIcon message={error} style={{ marginBottom: 16 }} />}
+      {!loading && fields !== null && fields.length === 0 && (
+        <Alert
+          type="warning"
+          showIcon
+          message="У первой выбранной задачи нет кастом-полей"
+          description="Схема first-issue определяет доступные поля. Если в выборке есть задачи с другой схемой, используйте JQL-скоуп (будет добавлен позже)."
+        />
+      )}
+      {!loading && fields && fields.length > 0 && (
+        <>
+          <Form.Item label="Кастом-поле" required>
+            <Select
+              placeholder="Выберите поле"
+              value={v?.customFieldId}
+              onChange={(cfId: string) => {
+                onChange({ type: 'EDIT_CUSTOM_FIELD', customFieldId: cfId, value: undefined });
+              }}
+              options={fields.map((f) => ({
+                value: f.customFieldId,
+                label: `${f.name} (${f.fieldType})`,
+              }))}
+            />
+          </Form.Item>
+          {selectedField && (
+            <Form.Item label="Значение" required>
+              {renderCustomFieldValueInput(selectedField, v?.value, (nv) =>
+                onChange({
+                  type: 'EDIT_CUSTOM_FIELD',
+                  customFieldId: selectedField.customFieldId,
+                  value: nv,
+                }),
+              )}
+            </Form.Item>
+          )}
+          <Alert
+            type="info"
+            showIcon
+            message="Задачи с другой схемой кастом-полей будут пропущены при выполнении."
+          />
+        </>
+      )}
+    </Form>
+  );
+}
+
+// ────── MOVE_TO_SPRINT ────────────────────────────────────────────────────────
+
+function MoveToSprintConfig({
+  value,
+  onChange,
+}: {
+  value: Partial<BulkOperationPayload> | null;
+  onChange: (v: Partial<BulkOperationPayload>) => void;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sprints, setSprints] = useState<Sprint[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    listAllSprints({ state: 'ALL' }, { limit: 500 })
+      .then((res) => {
+        if (!cancelled) setSprints(res.data ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Не удалось загрузить спринты');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const current = value as { sprintId?: string | null } | null;
+  const selected = current && 'sprintId' in current
+    ? (current.sprintId === null ? '__remove__' : current.sprintId)
+    : undefined;
+
+  // Группировка по проекту — useMemo'ится чтобы не пересоздавать на каждый
+  // keystroke в `showSearch` (перестройка ~500 sprints на рендер).
+  const groupedOptions = useMemo(() => {
+    const byProject = new Map<string, Sprint[]>();
+    for (const s of sprints) {
+      const key = s.project?.name ?? s.projectId;
+      const arr = byProject.get(key) ?? [];
+      arr.push(s);
+      byProject.set(key, arr);
+    }
+    const result: { label: string; options: { value: string; label: string }[] }[] = [];
+    result.push({
+      label: 'Специальные',
+      options: [{ value: '__remove__', label: '— Убрать из спринта —' }],
+    });
+    for (const [projectName, projectSprints] of byProject.entries()) {
+      result.push({
+        label: projectName,
+        options: projectSprints
+          .sort((a, b) => stateOrder(a.state) - stateOrder(b.state))
+          .map((s) => ({
+            value: s.id,
+            label: `${s.name} · ${SPRINT_STATE_LABEL[s.state]}`,
+          })),
+      });
+    }
+    return result;
+  }, [sprints]);
+
+  return (
+    <Form layout="vertical">
+      {error && <Alert type="error" showIcon message={error} style={{ marginBottom: 16 }} />}
+      <Form.Item label="Целевой спринт" required>
+        <Select
+          showSearch
+          loading={loading}
+          placeholder="Начните печатать имя спринта или проекта…"
+          value={selected}
+          optionFilterProp="label"
+          filterOption={(input, option) =>
+            (option?.label ?? '').toString().toLowerCase().includes(input.toLowerCase())
+          }
+          onChange={(v: string) => {
+            onChange({
+              type: 'MOVE_TO_SPRINT',
+              sprintId: v === '__remove__' ? null : v,
+            });
+          }}
+          options={groupedOptions}
+          style={{ width: '100%' }}
+        />
+      </Form.Item>
+      <Alert
+        type="info"
+        showIcon
+        message="Задачи из других проектов будут пропущены (нельзя переместить между проектами)."
+      />
+    </Form>
+  );
+}
+
+function stateOrder(state: SprintState): number {
+  if (state === 'ACTIVE') return 0;
+  if (state === 'PLANNED') return 1;
+  return 2;
 }
 
 // ────── helpers ──────────────────────────────────────────────────────────────
@@ -254,4 +721,120 @@ function renderEditFieldInput(
     );
   }
   return <Space>Unsupported field</Space>;
+}
+
+/**
+ * Рендер input'а под тип кастом-поля. Основные `fieldType` из Prisma:
+ * TEXT/TEXTAREA → строка, NUMBER → число, DATE → ISO-дата, SELECT → выпадашка,
+ * MULTI_SELECT → multi, USER/REFERENCE → fallback на строку (UUID/ключ).
+ */
+function renderCustomFieldValueInput(
+  field: IssueCustomFieldValue,
+  current: unknown,
+  onChange: (v: unknown) => void,
+): ReactElement {
+  const ft = field.fieldType;
+
+  if (ft === 'TEXT') {
+    return (
+      <Input
+        value={typeof current === 'string' ? current : ''}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  }
+  if (ft === 'TEXTAREA') {
+    return (
+      <Input.TextArea
+        rows={3}
+        value={typeof current === 'string' ? current : ''}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  }
+  if (ft === 'NUMBER') {
+    return (
+      <InputNumber
+        style={{ width: '100%' }}
+        value={typeof current === 'number' ? current : undefined}
+        onChange={(v) => onChange(v)}
+      />
+    );
+  }
+  if (ft === 'DATE') {
+    return (
+      <DatePicker
+        style={{ width: '100%' }}
+        value={typeof current === 'string' && current ? dayjs(current) : null}
+        onChange={(d: Dayjs | null) => onChange(d ? d.format('YYYY-MM-DD') : null)}
+      />
+    );
+  }
+  if (ft === 'SELECT' || ft === 'MULTI_SELECT') {
+    const opts = Array.isArray(field.options) ? (field.options as CustomFieldOption[]) : [];
+    const options = opts.map((o) => ({ value: o.value, label: o.label ?? o.value }));
+    if (ft === 'SELECT') {
+      return (
+        <Select
+          allowClear
+          style={{ width: '100%' }}
+          value={typeof current === 'string' ? current : undefined}
+          onChange={(v) => onChange(v ?? null)}
+          options={options}
+          placeholder="Выберите значение"
+        />
+      );
+    }
+    return (
+      <Select
+        mode="multiple"
+        allowClear
+        style={{ width: '100%' }}
+        value={Array.isArray(current) ? (current as string[]) : []}
+        onChange={(v) => onChange(v)}
+        options={options}
+        placeholder="Выберите значения"
+      />
+    );
+  }
+  if (ft === 'CHECKBOX') {
+    return (
+      <Radio.Group
+        value={current}
+        onChange={(e) => onChange(e.target.value)}
+        options={[
+          { value: true, label: 'Да' },
+          { value: false, label: 'Нет' },
+        ]}
+      />
+    );
+  }
+  // REFERENCE / USER / URL / unknown — fallback на строковое значение с хинтом.
+  const ref = field.options as ReferenceOptions | null;
+  const hint = ref && 'entity' in ref ? `Введите ID ${ref.entity}` : 'Введите значение (строку или JSON)';
+  return (
+    <Tooltip title={hint}>
+      <Input.TextArea
+        rows={2}
+        placeholder={hint}
+        value={
+          typeof current === 'string'
+            ? current
+            : current !== undefined && current !== null
+              ? JSON.stringify(current)
+              : ''
+        }
+        onChange={(e) => {
+          const raw = e.target.value;
+          let parsed: unknown = raw;
+          try {
+            parsed = JSON.parse(raw);
+          } catch {
+            /* leave as string */
+          }
+          onChange(parsed);
+        }}
+      />
+    </Tooltip>
+  );
 }

--- a/frontend/src/components/bulk/Step4Confirm.tsx
+++ b/frontend/src/components/bulk/Step4Confirm.tsx
@@ -1,13 +1,18 @@
 /**
- * TTBULK-1 PR-9b — Step 4 wizard: подтверждение и submit.
+ * TTBULK-1 PR-9b → follow-up — Step 4 wizard: подтверждение и submit.
  *
  * Рендерит summary (operation + scope + count eligible) + для DELETE —
  * confirm-phrase gate (текст "DELETE" должен быть введён дословно). Submit
  * button → родитель вызывает `bulkOperationsApi.create`.
  *
+ * Follow-up to PR-9b: UUID'ы в payload resolve'ятся в имена пользователей,
+ * названия спринтов/статусов/кастом-полей через те же API что и Step2Configure.
+ * API-вызовы дешёвые (listUsers/listAllSprints ~однажды на сессию).
+ *
  * См. docs/tz/TTBULK-1.md §3.2 (R11-confirmation), §13.6 PR-9.
  */
 
+import { useEffect, useState } from 'react';
 import { Alert, Input, Space, Tag, Typography } from 'antd';
 import type {
   BulkOperationPayload,
@@ -16,6 +21,12 @@ import type {
   BulkScope,
 } from '../../types/bulk.types';
 import { OPERATION_LABELS } from '../../types/bulk.types';
+import { listUsers } from '../../api/auth';
+import type { User } from '../../types';
+import { listAllSprints } from '../../api/sprints';
+import type { Sprint } from '../../types/sprint.types';
+import { workflowEngineApi, type BatchTransitionsItem } from '../../api/workflow-engine';
+import { issueCustomFieldsApi, type IssueCustomFieldValue } from '../../api/issue-custom-fields';
 
 const { Text } = Typography;
 
@@ -77,7 +88,7 @@ export default function Step4Confirm({
         </div>
       </div>
 
-      <PayloadSummary payload={payload} />
+      <PayloadSummary payload={payload} scope={scope} />
 
       {destructive && (
         <Alert
@@ -105,20 +116,26 @@ export default function Step4Confirm({
   );
 }
 
-function PayloadSummary({ payload }: { payload: BulkOperationPayload | null }) {
+function PayloadSummary({
+  payload,
+  scope,
+}: {
+  payload: BulkOperationPayload | null;
+  scope: BulkScope;
+}) {
   if (!payload) return null;
 
   let summary: React.ReactNode = null;
   switch (payload.type) {
     case 'ASSIGN':
       summary = payload.assigneeId ? (
-        <Text>Assignee: <Text code>{payload.assigneeId}</Text></Text>
+        <AssigneeName userId={payload.assigneeId} />
       ) : (
-        <Text>Unassign (очистить исполнителя)</Text>
+        <Text>Снять исполнителя</Text>
       );
       break;
     case 'TRANSITION':
-      summary = <Text>Transition ID: <Text code>{payload.transitionId}</Text></Text>;
+      summary = <TransitionName transitionId={payload.transitionId} scope={scope} />;
       break;
     case 'EDIT_FIELD':
       summary = (
@@ -129,16 +146,18 @@ function PayloadSummary({ payload }: { payload: BulkOperationPayload | null }) {
       break;
     case 'EDIT_CUSTOM_FIELD':
       summary = (
-        <Text>
-          Custom field <Text code>{payload.customFieldId}</Text> = {formatValue(payload.value)}
-        </Text>
+        <CustomFieldSummary
+          customFieldId={payload.customFieldId}
+          value={payload.value}
+          scope={scope}
+        />
       );
       break;
     case 'MOVE_TO_SPRINT':
       summary = payload.sprintId ? (
-        <Text>Sprint: <Text code>{payload.sprintId}</Text></Text>
+        <SprintName sprintId={payload.sprintId} />
       ) : (
-        <Text>Remove from sprint</Text>
+        <Text>Убрать из спринта</Text>
       );
       break;
     case 'ADD_COMMENT':
@@ -152,7 +171,7 @@ function PayloadSummary({ payload }: { payload: BulkOperationPayload | null }) {
       );
       break;
     case 'DELETE':
-      return null; // summary не нужен для DELETE — всё в Alert ниже
+      return null;
   }
 
   return (
@@ -160,6 +179,145 @@ function PayloadSummary({ payload }: { payload: BulkOperationPayload | null }) {
       <Text type="secondary">Payload:</Text>
       <div style={{ marginTop: 4 }}>{summary}</div>
     </div>
+  );
+}
+
+// ────── resolver-компоненты ──────────────────────────────────────────────────
+
+function AssigneeName({ userId }: { userId: string }) {
+  const [user, setUser] = useState<User | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    listUsers()
+      .then((list) => {
+        if (!cancelled) setUser(list.find((u) => u.id === userId) ?? null);
+      })
+      .catch(() => {
+        /* silent — fallback на UUID */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+  return (
+    <Text>
+      Назначить: {user ? <Text strong>{user.name} ({user.email})</Text> : <Text code>{userId}</Text>}
+    </Text>
+  );
+}
+
+function SprintName({ sprintId }: { sprintId: string }) {
+  const [sprint, setSprint] = useState<Sprint | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    listAllSprints({ state: 'ALL' }, { limit: 500 })
+      .then((res) => {
+        if (cancelled) return;
+        setSprint((res.data ?? []).find((s) => s.id === sprintId) ?? null);
+      })
+      .catch(() => {
+        /* silent */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sprintId]);
+  return (
+    <Text>
+      Переместить в спринт:{' '}
+      {sprint ? (
+        <Text strong>
+          {sprint.name}
+          {sprint.project ? ` · ${sprint.project.name}` : ''}
+        </Text>
+      ) : (
+        <Text code>{sprintId}</Text>
+      )}
+    </Text>
+  );
+}
+
+function TransitionName({ transitionId, scope }: { transitionId: string; scope: BulkScope }) {
+  const [statusName, setStatusName] = useState<string | null>(null);
+  const scopeKey = scope.kind === 'ids' ? scope.issueIds.join(',') : scope.jql;
+  useEffect(() => {
+    if (scope.kind !== 'ids' || scope.issueIds.length === 0) return;
+    let cancelled = false;
+    workflowEngineApi
+      .getBatchTransitions(scope.issueIds)
+      .then((batch: BatchTransitionsItem[]) => {
+        if (cancelled) return;
+        // Step2 stores bestTransitionId из одной workflow-схемы. В multi-project
+        // выборке другие issue'и могут иметь тот же toStatus.name, но другой UUID —
+        // резолвим имя статуса через exact UUID match ИЛИ через любую задачу,
+        // где stored UUID присутствует.
+        for (const it of batch) {
+          for (const t of it.transitions) {
+            if (t.id === transitionId) {
+              setStatusName(t.toStatus.name);
+              return;
+            }
+          }
+        }
+      })
+      .catch(() => {
+        /* silent */
+      });
+    return () => {
+      cancelled = true;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [transitionId, scopeKey]);
+  return (
+    <Text>
+      Перевести в статус:{' '}
+      {statusName ? <Text strong>{statusName}</Text> : <Text code>{transitionId}</Text>}
+    </Text>
+  );
+}
+
+function CustomFieldSummary({
+  customFieldId,
+  value,
+  scope,
+}: {
+  customFieldId: string;
+  value: unknown;
+  scope: BulkScope;
+}) {
+  const [field, setField] = useState<IssueCustomFieldValue | null>(null);
+  const scopeKey = scope.kind === 'ids' ? scope.issueIds.join(',') : scope.jql;
+  useEffect(() => {
+    if (scope.kind !== 'ids' || scope.issueIds.length === 0) return;
+    const firstId = scope.issueIds[0];
+    if (!firstId) return;
+    let cancelled = false;
+    issueCustomFieldsApi
+      .getFields(firstId)
+      .then((res) => {
+        if (cancelled) return;
+        setField(res.fields.find((f) => f.customFieldId === customFieldId) ?? null);
+      })
+      .catch(() => {
+        /* silent */
+      });
+    return () => {
+      cancelled = true;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [customFieldId, scopeKey]);
+  return (
+    <Text>
+      Поле:{' '}
+      {field ? (
+        <Text strong>
+          {field.name} <Text type="secondary">({field.fieldType})</Text>
+        </Text>
+      ) : (
+        <Text code>{customFieldId}</Text>
+      )}{' '}
+      = {formatValue(value)}
+    </Text>
   );
 }
 

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,44 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.66**
+**Last version: 2.67**
+
+---
+
+## [2.67] [2026-04-24] feat(bulk-ops): TTBULK-1 follow-up — friendly pickers (замена UUID-вводов)
+
+**PR:** _(будет заполнено после push'а)_
+**Ветка:** `ttbulk-1/friendly-pickers`
+
+### Что было
+
+После cutover в PR-12 BULK_OPERATOR-пользователь при настройке операций на Step 2 должен был вводить UUID'ы руками (transitionId, assigneeId, customFieldId, sprintId) — ID-first UX, изначально отложенный в §13.6 PR-9b как «rich selectors deferred». На Step 4 confirm тоже отображались только UUID'ы — непрозрачно перед submit'ом.
+
+### Что теперь
+
+**Step2Configure** — человеко-понятные пикеры вместо UUID-input'ов:
+
+- **TRANSITION** — Select целевого статуса. Фетчит `workflowEngineApi.getBatchTransitions(scope.issueIds)` на входе, агрегирует переходы по `toStatus.name` с count'ом «доступно для N/M задач». Выбор ведёт в один из `transitionId`'ов группы — executor per-issue проверяет availability (issues с недоступным переходом будут SKIPPED с `NO_TRANSITION`).
+- **ASSIGN** — searchable Select из `listUsers()` (публичный endpoint `/users`), фильтр по имени и email, опция «— Снять исполнителя —» эквивалентна `assigneeId: null`.
+- **EDIT_CUSTOM_FIELD** — Select кастом-полей из `issueCustomFieldsApi.getFields(firstIssueId)`. Input под значение — типизированный по `fieldType` (TEXT/TEXTAREA/NUMBER/DATE/SELECT/MULTI_SELECT/CHECKBOX/REFERENCE). Показывает warning'и про multi-schema.
+- **MOVE_TO_SPRINT** — Select из `listAllSprints({ state: 'ALL' }, { limit: 500 })` сгруппированный по проекту, с меткой статуса спринта (Планируется/Активен/Завершён). Опция «— Убрать из спринта —» → `sprintId: null`.
+
+**Step4Confirm** — PayloadSummary резолвит UUID'ы в человеко-читаемые имена через те же API (lazy-fetch per resolver-компонент). Fallback на Text code с UUID при ошибке.
+
+### Инварианты
+
+- JQL-скоуп (пока не в UI): fallback на UUID-ввод — сохранён как safety net.
+- При multi-project выборке TRANSITION группирует по `toStatus.name`, так как transition-UUID'ы могут отличаться между проектами. EDIT_CUSTOM_FIELD использует схему первой задачи (warning'и показаны).
+- Все новые API-вызовы защищены try/catch → silent fallback на UUID при ошибке (не блокирует submit).
+
+### Проверки
+
+- `npx tsc --noEmit` → 0 errors.
+- `npm run lint` → 0 новых warnings (все existing — из других файлов).
+
+### Связано
+
+- TTBULK-1 — см. `docs/tz/TTBULK-1.md` §3.2, §13.6 PR-9b (deferred rich selectors).
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up к эпику TTBULK-1: заменяет ручной ввод UUID в Step2 wizard'а массовых операций на human-friendly пикеры.

- **TRANSITION** — Select целевого статуса, агрегирует `getBatchTransitions(scope.issueIds)` по `toStatus.name`, выбирает transitionId с максимальным покрытием, показывает точный count "применится к N/M задач" + warning для multi-project workflow schemes.
- **ASSIGN** — searchable Select из `listUsers()` (публичный /users), фильтр по имени и email, опция «Снять исполнителя» → `assigneeId: null`.
- **EDIT_CUSTOM_FIELD** — Select полей из `getFields(firstIssueId)` + типизированный input по `fieldType` (TEXT/TEXTAREA/NUMBER/DATE/SELECT/MULTI_SELECT/CHECKBOX/REFERENCE).
- **MOVE_TO_SPRINT** — Select из `listAllSprints({state:'ALL'})`, сгруппировано по проекту, метки статуса спринта, опция «Убрать из спринта» → `sprintId: null`.

Step4 Confirm резолвит UUID в имена через те же API (lazy-fetch per resolver).

JQL-скоуп (пока не в UI) сохраняет UUID fallback.

## Pre-push review — counts

- 🟠: 2 / 1 applied, 1 false-alarm (listUsers pagination — backend не пагинирует)
- 🟡: 4 applied
- 🔵: 2 applied (1 skipped — AssignConfig options visibility trivial)
- ⚪: 2 noted

## Test plan

- [ ] `/search` → выбрать задачи → «Массовые операции» → каждый из 7 типов:
  - [ ] TRANSITION: dropdown показывает имена статусов с count, warning на multi-project
  - [ ] ASSIGN: searchable dropdown с именами+email, «Снять» работает
  - [ ] EDIT_FIELD: без изменений (не требовал UUID)
  - [ ] EDIT_CUSTOM_FIELD: dropdown полей, типизированный value-input по fieldType
  - [ ] MOVE_TO_SPRINT: grouped dropdown, «Убрать» работает
  - [ ] ADD_COMMENT: textarea (без UUID)
  - [ ] DELETE: confirm-phrase
- [ ] Step4 показывает имена вместо UUID
- [ ] Fallback на UUID при API-ошибке (silent)

## Плановая дельта

- Frontend: ~780 LoC (+913 / -131)
- Backend: 0
- Tests: none (frontend vitest infra отсутствует — задокументировано в v2.65)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
