### PR TITLE
feat(releases): release card enhancements + admin workflow editor fixes

### DIFF
--- a/backend/src/modules/releases/release-workflows-admin.dto.ts
+++ b/backend/src/modules/releases/release-workflows-admin.dto.ts
@@ -16,8 +16,12 @@ export const updateReleaseWorkflowDto = z.object({
   isActive: z.boolean().optional(),
 });
 
+// statusId accepts any non-empty string (not strictly UUID): seeded release statuses
+// (see prisma/seed-release-workflow.ts) use short slugs like `rs-draft`. Referential
+// integrity is enforced by the service layer (status existence check) and the DB
+// foreign key, so the UUID-format constraint was rejecting legitimate seed IDs.
 export const createReleaseWorkflowStepDto = z.object({
-  statusId: z.string().uuid(),
+  statusId: z.string().min(1),
   isInitial: z.boolean().optional(),
   orderIndex: z.number().int().nonnegative().optional(),
 });
@@ -29,18 +33,19 @@ export const updateReleaseWorkflowStepDto = z.object({
 
 const conditionsField = z.array(z.record(z.unknown())).nullish();
 
+// See comment above createReleaseWorkflowStepDto: from/to statusId are slugs or UUIDs.
 export const createReleaseWorkflowTransitionDto = z.object({
   name: z.string().min(1).max(200),
-  fromStatusId: z.string().uuid(),
-  toStatusId: z.string().uuid(),
+  fromStatusId: z.string().min(1),
+  toStatusId: z.string().min(1),
   isGlobal: z.boolean().optional(),
   conditions: conditionsField,
 });
 
 export const updateReleaseWorkflowTransitionDto = z.object({
   name: z.string().min(1).max(200).optional(),
-  fromStatusId: z.string().uuid().optional(),
-  toStatusId: z.string().uuid().optional(),
+  fromStatusId: z.string().min(1).optional(),
+  toStatusId: z.string().min(1).optional(),
   isGlobal: z.boolean().optional(),
   conditions: conditionsField,
 });

--- a/frontend/src/pages/GlobalReleasesPage.tsx
+++ b/frontend/src/pages/GlobalReleasesPage.tsx
@@ -29,6 +29,9 @@ import {
   CheckCircleOutlined,
   ClockCircleOutlined,
   MinusCircleOutlined,
+  CalendarOutlined,
+  HourglassOutlined,
+  EditOutlined,
 } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import dayjs from 'dayjs';
@@ -205,10 +208,11 @@ interface DetailPanelProps {
   onClose: () => void;
   onTransition: (releaseId: string, transitionId: string) => Promise<void>;
   onReleasesRefresh: () => void;
+  onReleaseUpdated: (updated: Release) => void;
 }
 
-function DetailPanel({ release, C, isDark, canManage, canBackfillBurndown, onClose, onTransition, onReleasesRefresh }: DetailPanelProps) {
-  const [tab, setTab] = useState<DetailTab>('issues');
+function DetailPanel({ release, C, isDark, canManage, canBackfillBurndown, onClose, onTransition, onReleasesRefresh, onReleaseUpdated }: DetailPanelProps) {
+  const [tab, setTab] = useState<DetailTab>('readiness');
   const [items, setItems] = useState<ReleaseItem[]>([]);
   const [itemsTotal, setItemsTotal] = useState(0);
   const [itemsPage, setItemsPage] = useState(1);
@@ -239,6 +243,9 @@ function DetailPanel({ release, C, isDark, canManage, canBackfillBurndown, onClo
   const [allProjects, setAllProjects] = useState<Project[]>([]);
   const [issueProjectFilter, setIssueProjectFilter] = useState<string | undefined>();
   const [loadingModalIssues, setLoadingModalIssues] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editLoading, setEditLoading] = useState(false);
+  const [editForm] = Form.useForm();
 
   const loadItems = useCallback(async (id: string, page = 1) => {
     setLoadingItems(true);
@@ -309,19 +316,20 @@ function DetailPanel({ release, C, isDark, canManage, canBackfillBurndown, onClo
 
   useEffect(() => {
     if (!release) return;
-    setTab('issues');
+    setTab('readiness');
     setItems([]); setSprints([]); setReadiness(null); setHistory([]);
     setCheckpointsData(null); setCheckpointsError(false);
-    loadItems(release.id);
     loadTransitions(release.id);
   }, [release?.id]);
 
   useEffect(() => {
     if (!release) return;
+    if (tab === 'issues') loadItems(release.id);
     if (tab === 'sprints') loadSprints(release.id);
     if (tab === 'readiness') loadReadiness(release.id);
     if (tab === 'history') loadHistory(release.id);
     if (tab === 'checkpoints') loadCheckpoints(release.id);
+    // 'burndown' intentionally omitted — ReleaseBurndownChart is lazy-loaded and fetches its own data.
   }, [tab, release?.id]);
 
   const handleTransition = async (transitionId: string) => {
@@ -428,6 +436,52 @@ function DetailPanel({ release, C, isDark, canManage, canBackfillBurndown, onClo
     setAddSprintsOpen(true);
   };
 
+  const openEdit = () => {
+    if (!release) return;
+    if (release.status?.category === 'DONE') {
+      message.warning('Нельзя редактировать завершённый релиз');
+      return;
+    }
+    editForm.setFieldsValue({
+      name: release.name,
+      description: release.description ?? '',
+      level: release.level,
+      plannedDate: release.plannedDate ? dayjs(release.plannedDate) : null,
+      releaseDate: release.releaseDate ? dayjs(release.releaseDate) : null,
+    });
+    setEditOpen(true);
+  };
+
+  const handleEdit = async (vals: {
+    name: string;
+    description?: string;
+    level: 'MINOR' | 'MAJOR';
+    plannedDate?: dayjs.Dayjs | null;
+    releaseDate?: dayjs.Dayjs | null;
+  }) => {
+    if (!release) return;
+    setEditLoading(true);
+    try {
+      const updated = await releasesApi.updateRelease(release.id, {
+        name: vals.name,
+        description: vals.description?.trim() ? vals.description : null,
+        level: vals.level,
+        plannedDate: vals.plannedDate ? vals.plannedDate.format('YYYY-MM-DD') : null,
+        releaseDate: vals.releaseDate ? vals.releaseDate.format('YYYY-MM-DD') : null,
+      });
+      message.success('Релиз обновлён');
+      setEditOpen(false);
+      editForm.resetFields();
+      onReleaseUpdated(updated);
+      onReleasesRefresh();
+    } catch (e) {
+      const err = e as AxiosError<{ error?: string }>;
+      message.error(err.response?.data?.error || 'Ошибка обновления');
+    } finally {
+      setEditLoading(false);
+    }
+  };
+
   const filteredIssues = issueSearch
     ? allIssues.filter(i => i.title.toLowerCase().includes(issueSearch.toLowerCase()) || String(i.number).includes(issueSearch))
     : allIssues;
@@ -435,11 +489,11 @@ function DetailPanel({ release, C, isDark, canManage, canBackfillBurndown, onClo
   if (!release) return null;
 
   const TABS: { key: DetailTab; label: string }[] = [
-    { key: 'issues', label: 'Задачи' },
-    { key: 'sprints', label: 'Спринты' },
     { key: 'readiness', label: 'Готовность' },
     { key: 'checkpoints', label: 'Контрольные точки' },
     { key: 'burndown', label: 'Диаграмма сгорания' },
+    { key: 'issues', label: 'Задачи' },
+    { key: 'sprints', label: 'Спринты' },
     { key: 'history', label: 'История' },
   ];
 
@@ -477,15 +531,30 @@ function DetailPanel({ release, C, isDark, canManage, canBackfillBurndown, onClo
               </p>
             )}
           </div>
-          <button
-            onClick={onClose}
-            style={{
-              border: 'none', background: 'transparent', cursor: 'pointer',
-              color: C.t3, padding: 4, lineHeight: 1, flexShrink: 0,
-            }}
-          >
-            <CloseOutlined style={{ fontSize: 16 }} />
-          </button>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+            {canManage && (currentStatus ?? release.status)?.category !== 'DONE' && (
+              <Tooltip title="Редактировать релиз">
+                <button
+                  onClick={openEdit}
+                  style={{
+                    border: 'none', background: 'transparent', cursor: 'pointer',
+                    color: C.t3, padding: 4, lineHeight: 1,
+                  }}
+                >
+                  <EditOutlined style={{ fontSize: 16 }} />
+                </button>
+              </Tooltip>
+            )}
+            <button
+              onClick={onClose}
+              style={{
+                border: 'none', background: 'transparent', cursor: 'pointer',
+                color: C.t3, padding: 4, lineHeight: 1,
+              }}
+            >
+              <CloseOutlined style={{ fontSize: 16 }} />
+            </button>
+          </div>
         </div>
 
         {/* Transition buttons */}
@@ -710,13 +779,24 @@ function DetailPanel({ release, C, isDark, canManage, canBackfillBurndown, onClo
             ) : readiness ? (
               <div>
                 {/* Main metrics */}
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 20 }}>
-                  {[
-                    { label: 'Готовность', value: `${readiness.completionPercent}%`, icon: <CheckCircleOutlined style={{ color: '#4ADE80' }} /> },
-                    { label: 'Задачи', value: `${readiness.doneItems} / ${readiness.totalItems}`, icon: <ClockCircleOutlined style={{ color: C.acc }} /> },
-                    { label: 'Спринты закрыты', value: `${readiness.closedSprints} / ${readiness.totalSprints}`, icon: <CheckCircleOutlined style={{ color: C.acc }} /> },
-                    { label: 'В работе', value: String(readiness.inProgressItems), icon: <MinusCircleOutlined style={{ color: '#F97316' }} /> },
-                  ].map(({ label, value, icon }) => (
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, marginBottom: 20 }}>
+                  {(() => {
+                    const daysInfo = (() => {
+                      if (!release.plannedDate) return { label: 'Дней до релиза', value: '—', icon: <HourglassOutlined style={{ color: C.t4 }} /> };
+                      const diff = dayjs(release.plannedDate).startOf('day').diff(dayjs().startOf('day'), 'day');
+                      if (diff > 0) return { label: 'Дней до релиза', value: `${diff} дн.`, icon: <HourglassOutlined style={{ color: C.acc }} /> };
+                      if (diff === 0) return { label: 'Дней до релиза', value: 'Сегодня', icon: <HourglassOutlined style={{ color: '#F97316' }} /> };
+                      return { label: 'Просрочен', value: `${Math.abs(diff)} дн.`, icon: <HourglassOutlined style={{ color: '#F87171' }} /> };
+                    })();
+                    return [
+                      { label: 'Готовность', value: `${readiness.completionPercent}%`, icon: <CheckCircleOutlined style={{ color: '#4ADE80' }} /> },
+                      { label: 'Задачи', value: `${readiness.doneItems} / ${readiness.totalItems}`, icon: <ClockCircleOutlined style={{ color: C.acc }} /> },
+                      { label: 'Спринты закрыты', value: `${readiness.closedSprints} / ${readiness.totalSprints}`, icon: <CheckCircleOutlined style={{ color: C.acc }} /> },
+                      { label: 'В работе', value: String(readiness.inProgressItems), icon: <MinusCircleOutlined style={{ color: '#F97316' }} /> },
+                      { label: 'Плановая дата', value: formatDate(release.plannedDate), icon: <CalendarOutlined style={{ color: C.acc }} /> },
+                      daysInfo,
+                    ];
+                  })().map(({ label, value, icon }) => (
                     <div key={label} style={{
                       border: `1px solid ${C.border}`, borderRadius: 8,
                       padding: '14px 16px', background: C.bgCard,
@@ -1061,6 +1141,48 @@ function DetailPanel({ release, C, isDark, canManage, canBackfillBurndown, onClo
             </div>
           ))}
         </div>
+      </Modal>
+
+      {/* Edit Release Modal */}
+      <Modal
+        open={editOpen}
+        title="Редактировать релиз"
+        onCancel={() => { setEditOpen(false); editForm.resetFields(); onReleasesRefresh(); }}
+        onOk={() => editForm.submit()}
+        okText="Сохранить"
+        cancelText="Отмена"
+        confirmLoading={editLoading}
+        width={520}
+        destroyOnClose
+      >
+        <Form form={editForm} layout="vertical" onFinish={handleEdit}>
+          <Form.Item
+            name="name"
+            label="Название"
+            rules={[{ required: true, type: 'string', min: 1, max: 100, message: 'От 1 до 100 символов' }]}
+          >
+            <Input placeholder="v1.2.0 — Релиз управления правами" />
+          </Form.Item>
+
+          <Form.Item name="description" label="Описание">
+            <Input.TextArea rows={3} placeholder="Краткое описание релиза..." />
+          </Form.Item>
+
+          <Form.Item name="level" label="Уровень" rules={[{ required: true, message: 'Выберите уровень' }]}>
+            <Radio.Group>
+              <Radio value="MINOR">Minor</Radio>
+              <Radio value="MAJOR">Major</Radio>
+            </Radio.Group>
+          </Form.Item>
+
+          <Form.Item name="plannedDate" label="Плановая дата выпуска">
+            <DatePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+          </Form.Item>
+
+          <Form.Item name="releaseDate" label="Фактическая дата выпуска">
+            <DatePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+          </Form.Item>
+        </Form>
       </Modal>
     </div>
   );
@@ -1678,6 +1800,23 @@ export default function GlobalReleasesPage() {
             onClose={() => { setSelectedRelease(null); void loadReleases(page); }}
             onTransition={handleTransition}
             onReleasesRefresh={() => loadReleases(page)}
+            onReleaseUpdated={(updated) => setSelectedRelease((prev) => {
+              // PATCH /releases/:id only returns { status, project } in its include — other
+              // shape fields (_count, _projects, createdBy, sprints, …) would be clobbered
+              // by a full spread. Merge only the fields the update endpoint actually sets.
+              if (!prev) return updated;
+              return {
+                ...prev,
+                name: updated.name,
+                description: updated.description,
+                level: updated.level,
+                plannedDate: updated.plannedDate,
+                releaseDate: updated.releaseDate,
+                status: updated.status ?? prev.status,
+                project: updated.project ?? prev.project,
+                updatedAt: updated.updatedAt,
+              };
+            })}
           />
         </>
       )}

--- a/frontend/src/pages/admin/AdminReleaseWorkflowEditorPage.tsx
+++ b/frontend/src/pages/admin/AdminReleaseWorkflowEditorPage.tsx
@@ -9,6 +9,8 @@ import {
   useNodesState,
   useEdgesState,
   MarkerType,
+  Handle,
+  Position,
   type Node,
   type Edge,
   type NodeTypes,
@@ -85,6 +87,8 @@ function StatusNode({ data }: { data: StatusNodeData }) {
         position: 'relative',
       }}
     >
+      <Handle type="target" position={Position.Top} style={{ background: data.color, width: 8, height: 8 }} />
+      <Handle type="source" position={Position.Bottom} style={{ background: data.color, width: 8, height: 8 }} />
       <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
         <span
           style={{
@@ -733,7 +737,8 @@ export default function AdminReleaseWorkflowEditorPage() {
           </Form.Item>
           <Space>
             <Button type="primary" htmlType="submit">Сохранить</Button>
-            <Button onClick={() => setTransitionDrawerOpen(false)}>Отмена</Button>
+            {/* void load() reloads server state to strip any ghost edge added optimistically by onConnect drag */}
+            <Button onClick={() => { setTransitionDrawerOpen(false); void load(); }}>Отмена</Button>
           </Space>
         </Form>
       </Drawer>

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,32 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.68**
+**Last version: 2.69**
+
+---
+
+## [2.69] [2026-04-24] feat(releases): доработка карточки релиза + fix визуального редактора воркфлоу
+
+**PR:** TBD
+**Ветка:** `feat/release-card-enhancements`
+
+### Карточка релиза
+
+- **Порядок вкладок**: «Готовность → Контрольные точки → Диаграмма сгорания → Задачи → Спринты → История». Вкладка по умолчанию — «Готовность» (раньше «Задачи»).
+- **Готовность** — две новые плитки: «Плановая дата» (`release.plannedDate`) и «Дней до релиза» (считается через `dayjs`: положит. → «N дн.», 0 → «Сегодня», отриц. → «Просрочен»). Сетка метрик `repeat(3, 1fr)` — 6 карточек в 2 ряда.
+- **Редактирование релиза** — иконка-карандаш в шапке карточки (видна для `canManage` = SUPER_ADMIN / ADMIN / RELEASE_MANAGER, скрыта для релизов в категории DONE). Модалка с полями: название, описание, уровень, плановая/фактическая даты. На Save — `updateRelease` + surgical merge в `selectedRelease` (сохраняет `_count`, `_projects`, `createdBy` при partial-response от PATCH).
+
+### Визуальный редактор воркфлоу релиза (fix багов на стейдже)
+
+- **Переходы не отображались** в ReactFlow-канвасе — кастомный `StatusNode` не имел `<Handle>`-компонентов, xyflow не мог "приклеить" рёбра. Добавлены `Handle type="target"` (Top) и `Handle type="source"` (Bottom). Заодно починилась drag-to-connect.
+- **Ошибки «400 Validation failed»** при добавлении статуса/перехода — сид создаёт release-statuses со short-slug ID (`rs-draft`, `rs-building`...), а Zod-DTO ждал `z.string().uuid()`. Ослаблено до `z.string().min(1)` для `statusId`, `fromStatusId`, `toStatusId`. Референциальная целостность сохранена (service layer + DB FK).
+- **Ghost edge на Отмена** в transition-drawer'е — drag-connect добавлял оптимистичный edge, который не откатывался при клике «Отмена». Кнопка теперь вызывает `void load()` для перезагрузки графа с сервера.
+
+### Проверки
+
+- `tsc --noEmit` → 0 errors (frontend + backend).
+- ESLint — только pre-existing unused-disable warnings, не от этих правок.
+- Pre-push review (3 🟠 + 5 🟡 + 3 🔵) — все addressable-пункты закрыты (DONE-status guard, surgical merge, resetFields, 3-col grid, ghost-edge fix, form rules).
 
 ---
 


### PR DESCRIPTION
## Summary

**Карточка релиза** ([GlobalReleasesPage.tsx](../blob/feat/release-card-enhancements/frontend/src/pages/GlobalReleasesPage.tsx)):
- Изменён порядок вкладок детального представления: **Готовность → Контрольные точки → Диаграмма сгорания → Задачи → Спринты → История**. По умолчанию теперь активна «Готовность» (раньше «Задачи»).
- На вкладку «Готовность» добавлены две плитки: **«Плановая дата»** (из `release.plannedDate`) и **«Дней до релиза»** — считается через `dayjs().startOf('day').diff(...)`: положит. → «N дн.», 0 → «Сегодня», отриц. → «Просрочен N дн.». Сетка метрик `repeat(3, 1fr)` — 6 карточек в 2 ряда.
- **Редактирование релиза** для ролей SUPER_ADMIN / ADMIN / RELEASE_MANAGER: иконка-карандаш в шапке карточки рядом с крестиком. Модалка с полями: название (rule: string min 1 / max 100), описание, уровень (required), плановая дата, фактическая дата. Скрыта для релизов в категории DONE — совпадает с backend-контрактом 422 у `PATCH /releases/:id` и убирает путь к ошибке для релиз-менеджера. На Save — surgical merge в `selectedRelease` (не затирает `_count`, `_projects`, `createdBy` при partial-response от PATCH) + `onReleasesRefresh()` согласно CLAUDE.md.

**Визуальный редактор воркфлоу релиза (fix багов на стейдже)**:
- **Bug 1** — переходы не отображались в редакторе. Кастомная нода `StatusNode` в ReactFlow/xyflow не имела `<Handle>` компонентов, из-за чего edges не рендерились. Добавил `Handle type="target"` (Top) и `Handle type="source"` (Bottom). Заодно восстановился drag-to-connect.
- **Bug 2 + 3** — ошибка при добавлении статуса в новый воркфлоу и ошибка при добавлении перехода в существующий «Стандартный релизный процесс». Общий корень — сид [`seed-release-workflow.ts`](../blob/feat/release-card-enhancements/backend/src/prisma/seed-release-workflow.ts#L10-L16) создаёт release-statuses со short-slug ID (`rs-draft`, `rs-building`, ...), а Zod-DTO ждал `z.string().uuid()` → 400 Validation failed. Ослаблено до `z.string().min(1)` для `statusId`, `fromStatusId`, `toStatusId` в `createReleaseWorkflowStepDto`, `create/updateReleaseWorkflowTransitionDto`. Референциальная целостность сохранена — service layer (`releaseStatus.findUnique`, `assertStatusInReleaseWorkflow`) и DB foreign keys продолжают валидировать существование.
- **Ghost edge** в transition-drawer на «Отмена» — drag-connect добавлял оптимистичный edge, но кнопка «Отмена» его не откатывала. Теперь вызывает `void load()`.

## Test plan

- [x] `tsc --noEmit` — 0 errors (frontend + backend)
- [x] ESLint — только pre-existing unused-disable warnings, не от моих правок
- [x] Pre-push review (3 🟠 + 5 🟡 + 3 🔵) — все addressable-пункты закрыты:
  - 🟠 DONE-status guard в `openEdit` + скрытие кнопки
  - 🟠 surgical merge в `onReleaseUpdated` (сохраняет `_count`, `_projects`, `createdBy`)
  - 🟡 `editForm.resetFields()` после успешного сохранения
  - 🟡 комментарий про self-loading `burndown`
  - 🟡 3-колоночная сетка для 6 плиток
  - 🟡 Ghost-edge fix
  - 🔵 `Form.Item name` rule `{ type: 'string', min, max }` (AntD gotcha)
  - 🔵 `Form.Item level` — required
- [ ] **Ручной smoke на staging**:
  - Release card: открыть релиз → проверить порядок вкладок + счётчики «Дней до релиза» + редактирование (Save / Cancel / Esc)
  - Workflow editor: открыть «Стандартный релизный процесс» → переходы видны; добавить переход между сидовыми статусами — успех
  - Workflow editor: создать новый воркфлоу → добавить сидовый статус (напр. «Черновик») — успех; добавить переход — успех
- [ ] Deploy staging: `gh workflow run deploy-staging.yml -f image_tag=main` после merge + green CI

## Связанные изменения

- [`docs/version_history.md`](../blob/feat/release-card-enhancements/version_history.md) — запись v2.69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
