### PR TITLE
fix(auth): rotate-password — clean exit + opt-in mustChangePassword clear

### DIFF
--- a/backend/src/modules/users/password-rotation.service.ts
+++ b/backend/src/modules/users/password-rotation.service.ts
@@ -2,13 +2,27 @@ import { prisma } from '../../prisma/client.js';
 import { deleteUserSession } from '../../shared/redis.js';
 import { hashPassword } from '../../shared/utils/password.js';
 import { AppError } from '../../shared/middleware/error-handler.js';
+import { captureError } from '../../shared/utils/logger.js';
 
 type RotateUserPasswordInput = {
   email: string;
   newPassword: string;
+  /**
+   * Очистить `mustChangePassword` флаг. По умолчанию `false` — backward-compat
+   * с существующим `POST /admin/users/reset-password` (ADMIN set temp password,
+   * force user change on next login).
+   *
+   * CLI-скрипт `rotate-password.ts` передаёт `true` — это постоянный пароль,
+   * выбранный самим пользователем / автоматизацией (E2E setup).
+   */
+  clearMustChangePassword?: boolean;
 };
 
-export async function rotateUserPassword({ email, newPassword }: RotateUserPasswordInput) {
+export async function rotateUserPassword({
+  email,
+  newPassword,
+  clearMustChangePassword = false,
+}: RotateUserPasswordInput) {
   const normalizedEmail = email.trim().toLowerCase();
   const trimmedPassword = newPassword.trim();
 
@@ -34,14 +48,23 @@ export async function rotateUserPassword({ email, newPassword }: RotateUserPassw
   await prisma.$transaction([
     prisma.user.update({
       where: { id: user.id },
-      data: { passwordHash },
+      data: clearMustChangePassword
+        ? { passwordHash, mustChangePassword: false }
+        : { passwordHash },
     }),
     prisma.refreshToken.deleteMany({
       where: { userId: user.id },
     }),
   ]);
 
-  await deleteUserSession(user.id);
+  // Redis-failure не-fatal: DB уже committed, stale session отработает до
+  // idle-timeout. Альтернатива — throw после committed write — оставляет систему
+  // в несогласованном состоянии.
+  try {
+    await deleteUserSession(user.id);
+  } catch (err) {
+    captureError(err, { fn: 'rotateUserPassword.deleteUserSession', userId: user.id });
+  }
 
   return user;
 }

--- a/backend/src/scripts/rotate-password.ts
+++ b/backend/src/scripts/rotate-password.ts
@@ -13,12 +13,22 @@ async function main() {
   const user = await rotateUserPassword({
     email: ROTATE_PASSWORD_EMAIL,
     newPassword: ROTATE_PASSWORD_NEW_PASSWORD,
+    // CLI-скрипт — ротация постоянного пароля (E2E setup / автоматизация).
+    // Admin /reset-password endpoint передаёт default false (temp + force-change).
+    clearMustChangePassword: true,
   });
 
   console.log(`Password rotated for ${user.email}`);
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+main()
+  .then(() => {
+    // Explicit exit: Prisma pool + Redis (deleteUserSession) клиенты
+    // держат TCP-соединения живыми → иначе процесс висит до SIGPIPE
+    // (docker exec / ssh keeps alive ~5 мин). Форсируем termination.
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/backend/tests/password-rotation.test.ts
+++ b/backend/tests/password-rotation.test.ts
@@ -40,4 +40,47 @@ describe('rotateUserPassword', () => {
     });
     expect(newLogin.status).toBe(200);
   });
+
+  // clearMustChangePassword: true — CLI-скрипт path (ротация постоянного пароля).
+  // Контраст: default false preserves флаг (admin /reset-password endpoint).
+  it('clears mustChangePassword when clearMustChangePassword=true', async () => {
+    await createTestUser('temp@test.com', 'Temp1234', 'TempUser');
+    await prisma.user.update({
+      where: { email: 'temp@test.com' },
+      data: { mustChangePassword: true },
+    });
+
+    await rotateUserPassword({
+      email: 'temp@test.com',
+      newPassword: 'new-strong-password-456',
+      clearMustChangePassword: true,
+    });
+
+    const user = await prisma.user.findUnique({ where: { email: 'temp@test.com' } });
+    expect(user?.mustChangePassword).toBe(false);
+
+    // Full proof: пароль реально сменился (auth check — не только flag).
+    const login = await request.post('/api/auth/login').send({
+      email: 'temp@test.com',
+      password: 'new-strong-password-456',
+    });
+    expect(login.status).toBe(200);
+  });
+
+  // Default path (admin /reset-password endpoint) — mustChangePassword preserved.
+  it('preserves mustChangePassword when clearMustChangePassword is not set', async () => {
+    await createTestUser('admin-reset@test.com', 'Init1234', 'AdminUser');
+    await prisma.user.update({
+      where: { email: 'admin-reset@test.com' },
+      data: { mustChangePassword: true },
+    });
+
+    await rotateUserPassword({
+      email: 'admin-reset@test.com',
+      newPassword: 'admin-new-temp-789',
+    });
+
+    const user = await prisma.user.findUnique({ where: { email: 'admin-reset@test.com' } });
+    expect(user?.mustChangePassword).toBe(true);
+  });
 });

--- a/version_history.md
+++ b/version_history.md
@@ -2,7 +2,37 @@
 
 Все значимые изменения в проекте. Для каждого изменения указана ссылка на задачу (если есть).
 
-**Last version: 2.69**
+**Last version: 2.70**
+
+---
+
+## [2.70] [2026-04-24] fix(auth): rotate-password — clean exit + mustChangePassword=false
+
+**PR:** _(будет заполнено после push'а)_
+**Ветка:** `fix/rotate-password-cleanup`
+
+### Что было
+
+После первого запуска `reset-password-staging.yml` workflow дважды упал:
+
+1. **SSH висел 5 мин + exit 255 (Broken pipe)**. Причина: `rotate-password.ts` не вызывал `process.exit(0)` — Prisma pool + Redis client (через `deleteUserSession`) держали TCP-соединения. Node-процесс внутри docker exec не завершался → SSH keep-alive таймаутился.
+
+2. **E2E test `16-bulk-operations` упал** с `expect(getByText(/Массовые операции/i))` → not visible. Снапшот показал: admin-cleanup после логина редиректится на `/change-password` («Вам назначен временный пароль»). Причина: `rotateUserPassword` обновлял `passwordHash`, но НЕ сбрасывал `mustChangePassword`. Если флаг был true (e.g. после предыдущего `admin /reset-password`), rotation оставлял его в true → фронтенд (App.tsx:85) форсил change-password flow.
+
+### Что теперь
+
+- **`rotate-password.ts`** — явно `process.exit(0)` после main() + `process.exit(1)` в catch. Форсирует termination pool connections. CLI передаёт `clearMustChangePassword: true`.
+- **`password-rotation.service.ts`** — новый опциональный параметр `clearMustChangePassword?: boolean` (default `false`). При `true` очищает `mustChangePassword` флаг. Default `false` preserves backward-compat для `POST /admin/users/reset-password` (admin set temp password, force user change). Плюс `deleteUserSession` теперь в try/catch через `captureError` — не throw'ит если Redis down после DB commit.
+- **`password-rotation.test.ts`** — два новых теста: (1) `clearMustChangePassword: true` сбрасывает флаг + реальный login check; (2) default behavior preserves флаг (регрессия-guard для admin endpoint).
+
+### Проверки
+
+- `npx tsc --noEmit` (backend) → 0 errors.
+- Integration-тесты (Postgres) — запускает CI.
+
+### Связано
+
+- TTBULK-1 epic follow-up — разблокирует автоматизированные E2E-прогоны.
 
 ---
 


### PR DESCRIPTION
## Summary

После [первого запуска](https://github.com/NovakPAai/tasktime-mvp/actions/runs/24887672301) `reset-password-staging.yml` workflow выявил два бага:

1. **SSH висел 5 мин + exit 255**. `rotate-password.ts` не вызывал `process.exit(0)` — Prisma pool + Redis client держали TCP-соединения. Docker exec не завершался → GitHub SSH keep-alive таймаутил.

2. **E2E `16-bulk-operations` падал**: admin-cleanup редиректится на `/change-password` после login. `rotateUserPassword` не сбрасывал `mustChangePassword` флаг — если он был true (от предыдущего admin `/reset-password`), rotation его сохранял.

## Changes

- **`rotate-password.ts`** — `process.exit(0)` в then, передаёт `clearMustChangePassword: true`.
- **`password-rotation.service.ts`** — новый опциональный параметр `clearMustChangePassword?: boolean` (default `false`). Backward-compat для `POST /admin/users/reset-password` endpoint'а (там флаг должен сохраняться). Плюс `deleteUserSession` в try/catch через `captureError` — DB commit не откатывается если Redis flaky.
- **`password-rotation.test.ts`** — 2 новых теста: `clearMustChangePassword:true` (с login-check) + default (флаг preserved).

## Pre-push review — counts

- 🟠 1 applied: backward-compat через opt-in параметр (не breaking change для admin endpoint).
- 🟡 2 applied: login assert в test + Redis try/catch.
- 🔵 1: PR link (заполнится после push).
- ⚪ 1 noted: process.exit skips exit hooks.

## Test plan

- [ ] Запустить `reset-password-staging.yml` — workflow завершается < 30с (вместо 5 мин + fail)
- [ ] E2E staging после rotation — `admin-cleanup` не редиректится на `/change-password`
- [ ] `password-rotation.test.ts` — 3 test case'а зелёные (CI)

## Плановая дельта

- Backend: 4 files changed (+114 / -8)
- Tests: 2 новых case
- Security: backward-compat preserved — admin endpoint не задет

🤖 Generated with [Claude Code](https://claude.com/claude-code)
