### PR TITLE
fix(e2e): 16-bulk-operations — inline /auth/register

### DIFF
--- a/frontend/e2e/specs/16-bulk-operations.spec.ts
+++ b/frontend/e2e/specs/16-bulk-operations.spec.ts
@@ -47,12 +47,19 @@ test.describe('TTBULK-1: bulk operations', () => {
   });
 
   test('POST /bulk-operations без BULK_OPERATOR роли → 401/403', async ({ request }) => {
-    // Создаём plain USER без системных ролей.
+    // Создаём plain USER без системных ролей через /auth/register.
     const email = `plain-${Date.now()}@e2e.test`;
-    const plain = await api.registerUser(request, email, 'Test Pass 123!');
+    const password = 'Test Pass 123!';
+    const regRes = await request.post(`${API_BASE}/auth/register`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: { email, password, name: `plain-${Date.now()}` },
+    });
+    // Register может вернуть 201 (created) или 409 (уже существует — повтор в serial). Обе ok — идём login.
+    expect([201, 409]).toContain(regRes.status());
+
     const loginRes = await request.post(`${API_BASE}/auth/login`, {
       headers: { 'Content-Type': 'application/json' },
-      data: { email: plain.email, password: 'Test Pass 123!' },
+      data: { email, password },
     });
     const token = loginRes.ok() ? (await loginRes.json()).accessToken : '';
 


### PR DESCRIPTION
## Summary

E2E run 24891240106 выявил `TypeError: api.registerUser is not a function`. Хелпер действительно не существует в `api.fixture.ts` (только `login`, `getAdminSession`, `getCleanupSession`).

Замена: прямой `request.post('/auth/register')` inline в тесте. Register endpoint не gated ролью, возвращает 201 (new) или 409 (уже есть) — обе валидные ситуации для serial teardown.

## Test plan

- [ ] E2E staging — `POST /bulk-operations без BULK_OPERATOR роли → 401/403` зелёный.

## Плановая дельта

- 1 файл (e2e spec), +10/-3 LoC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
