### PR TITLE
docs: add MVP2JIRA planning docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,3 +112,43 @@ Before writing any code that uses a library API:
 
 Key versions to double-check: Prisma client API, Express 4 vs 5 routing, Zod v3 schema methods.
 <!-- END:framework-versions -->
+
+<!-- BEGIN:codex-adapted-from-claude -->
+# Codex workflow notes
+
+These notes adapt the local `CLAUDE.md` guidance for Codex.
+
+## Tooling
+
+- Prefer `rg` / `rg --files` for search and file discovery.
+- Prefer `sed`, `nl`, and other focused shell reads for file inspection.
+- Use `multi_tool_use.parallel` when independent reads or searches can run at the same time.
+- Use `apply_patch` for manual file edits.
+- Do not rely on Claude-only `lean-ctx` tools unless they are explicitly available in the current session.
+
+## UI — Modal/Drawer close must refresh parent page
+
+Whenever you add or modify a modal/drawer (Ant Design `Modal`, `Drawer`, or any custom
+overlay), both `onCancel` and `onClose` handlers MUST trigger a refresh of the data on
+the page from which the modal/drawer was opened. Closing via the × button, Esc key,
+backdrop click, or a "Cancel" footer button must all call the parent's data-loading
+function (`load()`, `fetchX()`, `loadX(page)`, etc.).
+
+Rationale: the modal may have side effects (nested actions, auto-save, cascading
+updates) that change server state even when the user "cancels". Forcing a refresh
+keeps the page consistent with the server without requiring manual F5.
+
+Pattern:
+
+```tsx
+// BAD
+<Modal onCancel={() => setOpen(false)} ... />
+
+// GOOD
+<Modal onCancel={() => { setOpen(false); void load(); }} ... />
+```
+
+Applies equally to custom footer "Отмена" buttons inside a Modal/Drawer form.
+If the load function is defined inside a `useEffect` closure, extract it as a
+top-level `useCallback` so it can be invoked from close handlers.
+<!-- END:codex-adapted-from-claude -->

--- a/backend/src/prisma/migrations/20260426000000_ttbus0_event_outbox/migration.sql
+++ b/backend/src/prisma/migrations/20260426000000_ttbus0_event_outbox/migration.sql
@@ -1,0 +1,28 @@
+-- TTBUS-0.1: transactional outbox and consumer deduplication tables.
+
+CREATE TABLE "event_outbox" (
+  "id" TEXT NOT NULL,
+  "topic" TEXT NOT NULL,
+  "message_id" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "envelope" JSONB NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "sent_at" TIMESTAMP(3),
+  "attempts" INTEGER NOT NULL DEFAULT 0,
+  "last_error" TEXT,
+
+  CONSTRAINT "event_outbox_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "processed_messages" (
+  "consumer_group" TEXT NOT NULL,
+  "message_id" TEXT NOT NULL,
+  "processed_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "processed_messages_pkey" PRIMARY KEY ("consumer_group", "message_id")
+);
+
+CREATE UNIQUE INDEX "event_outbox_message_id_key" ON "event_outbox"("message_id");
+CREATE INDEX "event_outbox_sent_at_created_at_idx" ON "event_outbox"("sent_at", "created_at");
+CREATE INDEX "event_outbox_message_id_idx" ON "event_outbox"("message_id");
+CREATE INDEX "processed_messages_processed_at_idx" ON "processed_messages"("processed_at");

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -1467,3 +1467,31 @@ model UserGroupSystemRole {
   @@index([groupId])
   @@map("user_group_system_roles")
 }
+
+// ===== EVENT BUS / TRANSACTIONAL OUTBOX =====
+
+model EventOutbox {
+  id        String    @id @default(uuid())
+  topic     String
+  messageId String    @unique @default(uuid()) @map("message_id")
+  type      String
+  envelope  Json
+  createdAt DateTime  @default(now()) @map("created_at")
+  sentAt    DateTime? @map("sent_at")
+  attempts  Int       @default(0)
+  lastError String?   @map("last_error")
+
+  @@index([sentAt, createdAt])
+  @@index([messageId])
+  @@map("event_outbox")
+}
+
+model ProcessedMessage {
+  consumerGroup String   @map("consumer_group")
+  messageId     String   @map("message_id")
+  processedAt   DateTime @default(now()) @map("processed_at")
+
+  @@id([consumerGroup, messageId])
+  @@index([processedAt])
+  @@map("processed_messages")
+}

--- a/backend/src/shared/eventbus/envelope.ts
+++ b/backend/src/shared/eventbus/envelope.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const EVENT_TOPICS = {
+  issues: 'tt.issues',
+  comments: 'tt.comments',
+  releases: 'tt.releases',
+  workflow: 'tt.workflow',
+  notificationsDlq: 'tt.notifications.dlq',
+} as const;
+
+export type EventTopic = (typeof EVENT_TOPICS)[keyof typeof EVENT_TOPICS];
+
+export const eventActorSchema = z.object({
+  userId: z.string().uuid().nullable(),
+  ip: z.string().optional(),
+  userAgent: z.string().optional(),
+});
+
+export type EventActor = z.infer<typeof eventActorSchema>;
+
+export const eventEnvelopeSchema = z.object({
+  v: z.literal(1),
+  messageId: z.string().uuid(),
+  type: z.string().min(1),
+  occurredAt: z.string().datetime(),
+  actor: eventActorSchema,
+  payload: z.record(z.unknown()),
+  meta: z.object({
+    tenantId: z.string().nullable(),
+    correlationId: z.string().optional(),
+  }),
+});
+
+export type EventEnvelope = z.infer<typeof eventEnvelopeSchema>;

--- a/backend/src/shared/outbox/outbox.service.ts
+++ b/backend/src/shared/outbox/outbox.service.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from 'node:crypto';
+import type { Prisma } from '@prisma/client';
+
+import { type EventActor, type EventEnvelope, eventEnvelopeSchema } from '../eventbus/envelope.js';
+
+export type PublishInTxOptions = {
+  correlationId?: string;
+  occurredAt?: Date;
+};
+
+const FORBIDDEN_PAYLOAD_KEYS = new Set([
+  'password',
+  'passwordHash',
+  'password_hash',
+  'token',
+  'accessToken',
+  'access_token',
+  'refreshToken',
+  'refresh_token',
+  'apiKey',
+  'api_key',
+  'secret',
+]);
+
+const FORBIDDEN_PAYLOAD_KEYS_NORMALIZED = new Set(
+  [...FORBIDDEN_PAYLOAD_KEYS].map((key) => key.replace(/[_-]/g, '').toLowerCase()),
+);
+
+function toJsonPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  const serialized = JSON.stringify(payload);
+  if (serialized === undefined) {
+    throw new Error('Event payload must be JSON-serializable');
+  }
+  return JSON.parse(serialized) as Record<string, unknown>;
+}
+
+function assertNoSecretKeys(value: unknown, path = 'payload') {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoSecretKeys(item, `${path}[${index}]`));
+    return;
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return;
+  }
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const normalizedKey = key.replace(/[_-]/g, '').toLowerCase();
+    if (FORBIDDEN_PAYLOAD_KEYS_NORMALIZED.has(normalizedKey)) {
+      throw new Error(`Event payload must not contain secret field "${path}.${key}"`);
+    }
+    assertNoSecretKeys(nestedValue, `${path}.${key}`);
+  }
+}
+
+export async function publishInTx(
+  tx: Prisma.TransactionClient,
+  topic: string,
+  type: string,
+  payload: Record<string, unknown>,
+  actor: EventActor,
+  options: PublishInTxOptions = {},
+): Promise<string> {
+  assertNoSecretKeys(payload);
+  const jsonPayload = toJsonPayload(payload);
+
+  const messageId = randomUUID();
+  const envelope: EventEnvelope = eventEnvelopeSchema.parse({
+    v: 1,
+    messageId,
+    type,
+    occurredAt: (options.occurredAt ?? new Date()).toISOString(),
+    actor,
+    payload: jsonPayload,
+    meta: {
+      tenantId: null,
+      ...(options.correlationId && { correlationId: options.correlationId }),
+    },
+  });
+
+  await tx.eventOutbox.create({
+    data: {
+      topic,
+      messageId,
+      type,
+      envelope: envelope as unknown as Prisma.InputJsonObject,
+    },
+  });
+
+  return messageId;
+}

--- a/backend/src/shared/outbox/processed-messages.service.ts
+++ b/backend/src/shared/outbox/processed-messages.service.ts
@@ -1,0 +1,28 @@
+import type { Prisma } from '@prisma/client';
+
+import { prisma } from '../../prisma/client.js';
+
+type PrismaLike = Pick<typeof prisma, 'processedMessage'> | Prisma.TransactionClient;
+
+export async function markProcessedOnce(
+  consumerGroup: string,
+  messageId: string,
+  client: PrismaLike = prisma,
+): Promise<boolean> {
+  try {
+    await client.processedMessage.create({
+      data: { consumerGroup, messageId },
+    });
+    return true;
+  } catch (err) {
+    if (
+      typeof err === 'object' &&
+      err !== null &&
+      'code' in err &&
+      (err as { code?: string }).code === 'P2002'
+    ) {
+      return false;
+    }
+    throw err;
+  }
+}

--- a/backend/tests/outbox.service.test.ts
+++ b/backend/tests/outbox.service.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { prisma } from '../src/prisma/client.js';
+import { EVENT_TOPICS, eventEnvelopeSchema } from '../src/shared/eventbus/envelope.js';
+import { publishInTx } from '../src/shared/outbox/outbox.service.js';
+import { markProcessedOnce } from '../src/shared/outbox/processed-messages.service.js';
+
+describe('transactional outbox', () => {
+  it('writes a valid envelope inside the caller transaction', async () => {
+    const messageId = await prisma.$transaction((tx) =>
+      publishInTx(
+        tx,
+        EVENT_TOPICS.issues,
+        'ISSUE_CREATED',
+        { issueId: 'issue-1', projectId: 'project-1' },
+        { userId: null },
+        { occurredAt: new Date('2026-04-26T00:00:00.000Z'), correlationId: 'corr-1' },
+      ),
+    );
+
+    const row = await prisma.eventOutbox.findUniqueOrThrow({ where: { messageId } });
+    expect(row.topic).toBe(EVENT_TOPICS.issues);
+    expect(row.type).toBe('ISSUE_CREATED');
+    expect(row.sentAt).toBeNull();
+    expect(row.attempts).toBe(0);
+
+    const envelope = eventEnvelopeSchema.parse(row.envelope);
+    expect(envelope).toMatchObject({
+      v: 1,
+      messageId,
+      type: 'ISSUE_CREATED',
+      occurredAt: '2026-04-26T00:00:00.000Z',
+      actor: { userId: null },
+      payload: { issueId: 'issue-1', projectId: 'project-1' },
+      meta: { tenantId: null, correlationId: 'corr-1' },
+    });
+  });
+
+  it('rolls back the outbox row when the caller transaction fails', async () => {
+    await expect(
+      prisma.$transaction(async (tx) => {
+        await publishInTx(
+          tx,
+          EVENT_TOPICS.issues,
+          'ISSUE_UPDATED',
+          { issueId: 'rollback-issue' },
+          { userId: null },
+        );
+        throw new Error('force rollback');
+      }),
+    ).rejects.toThrow('force rollback');
+
+    await expect(
+      prisma.eventOutbox.findFirstOrThrow({
+        where: {
+          type: 'ISSUE_UPDATED',
+          envelope: { path: ['payload', 'issueId'], equals: 'rollback-issue' },
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects payloads with secret-like fields before writing', async () => {
+    await expect(
+      prisma.$transaction((tx) =>
+        publishInTx(
+          tx,
+          EVENT_TOPICS.issues,
+          'ISSUE_UPDATED',
+          { issueId: 'issue-1', actorSnapshot: { password_hash: 'secret' } },
+          { userId: null },
+        ),
+      ),
+    ).rejects.toThrow('payload.actorSnapshot.password_hash');
+  });
+});
+
+describe('processed message deduplication', () => {
+  it('marks the first message and skips duplicates for the same consumer group', async () => {
+    const messageId = '8d6763ae-ded0-4cb7-9cc5-8bb6cbbd5f87';
+
+    await expect(markProcessedOnce('notifications-service', messageId)).resolves.toBe(true);
+    await expect(markProcessedOnce('notifications-service', messageId)).resolves.toBe(false);
+    await expect(markProcessedOnce('webhooks-service', messageId)).resolves.toBe(true);
+  });
+});

--- a/backend/tests/setup.ts
+++ b/backend/tests/setup.ts
@@ -60,6 +60,8 @@ beforeAll(async () => {
   });
 
   // Clean test database (respect foreign keys)
+  await prisma.processedMessage.deleteMany();
+  await prisma.eventOutbox.deleteMany();
   await prisma.auditLog.deleteMany();
   await prisma.timeLog.deleteMany();
   await prisma.comment.deleteMany();

--- a/docs/admin-vs-jira-comparison.html
+++ b/docs/admin-vs-jira-comparison.html
@@ -1,0 +1,1487 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<title>Сравнение TaskTime и коробочной JIRA — админка и функциональность</title>
+<style>
+  :root {
+    --bg: #f7f8fa;
+    --card: #ffffff;
+    --text: #1a1a1a;
+    --muted: #6b7280;
+    --border: #e5e7eb;
+    --p0: #dc2626;
+    --p0-bg: #fee2e2;
+    --p1: #ea580c;
+    --p1-bg: #ffedd5;
+    --p2: #ca8a04;
+    --p2-bg: #fef3c7;
+    --p3: #64748b;
+    --p3-bg: #e2e8f0;
+    --ok: #059669;
+    --ok-bg: #d1fae5;
+    --partial: #d97706;
+    --partial-bg: #fef3c7;
+    --missing: #991b1b;
+    --missing-bg: #fee2e2;
+    --win: #0369a1;
+    --win-bg: #dbeafe;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.55;
+  }
+  .wrap { max-width: 1320px; margin: 0 auto; padding: 32px 24px 80px; }
+  header.page {
+    background: linear-gradient(135deg, #0c4a6e 0%, #075985 100%);
+    color: #fff;
+    padding: 40px 32px;
+    border-radius: 16px;
+    margin-bottom: 24px;
+    box-shadow: 0 10px 30px -10px rgba(12, 74, 110, 0.4);
+  }
+  header.page h1 { margin: 0 0 8px; font-size: 28px; font-weight: 600; letter-spacing: -0.3px; }
+  header.page p { margin: 0; color: #cbd5e1; font-size: 15px; }
+  .meta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid rgba(255,255,255,0.15);
+  }
+  .meta { display: flex; flex-direction: column; }
+  .meta .k { font-size: 11px; text-transform: uppercase; color: #94a3b8; letter-spacing: 0.6px; }
+  .meta .v { font-size: 15px; font-weight: 500; color: #f1f5f9; margin-top: 2px; }
+
+  /* Tabs */
+  nav.tabs {
+    display: flex;
+    gap: 4px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 6px;
+    margin-bottom: 24px;
+    position: sticky;
+    top: 12px;
+    z-index: 10;
+    box-shadow: 0 4px 12px -6px rgba(0,0,0,0.08);
+  }
+  nav.tabs button {
+    flex: 1;
+    background: transparent;
+    border: none;
+    padding: 12px 16px;
+    font: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--muted);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+  nav.tabs button:hover { background: #f1f5f9; color: #0f172a; }
+  nav.tabs button.active { background: #0c4a6e; color: #fff; box-shadow: 0 2px 6px -2px rgba(12,74,110,0.5); }
+  nav.tabs .tab-icon { font-size: 15px; }
+  nav.tabs .tab-sub { font-size: 11px; opacity: 0.7; font-weight: 400; margin-left: 4px; }
+  nav.tabs button.active .tab-sub { opacity: 0.9; }
+
+  .tab-panel { display: none; animation: fadeIn 0.2s ease-out; }
+  .tab-panel.active { display: block; }
+  @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+
+  .summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 14px;
+    margin-bottom: 20px;
+  }
+  .kpi {
+    background: var(--card); border: 1px solid var(--border); border-radius: 12px;
+    padding: 16px 18px;
+  }
+  .kpi .label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+  .kpi .val { font-size: 26px; font-weight: 600; margin-top: 6px; }
+  .kpi.p0 .val { color: var(--p0); }
+  .kpi.p1 .val { color: var(--p1); }
+  .kpi.p2 .val { color: var(--p2); }
+  .kpi.p3 .val { color: var(--p3); }
+  .kpi.ok .val { color: var(--ok); }
+  .kpi.win .val { color: var(--win); }
+
+  .kpi-group-title {
+    font-size: 12px; text-transform: uppercase; letter-spacing: 0.6px;
+    color: #334155; font-weight: 600; margin: 8px 0 10px;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .kpi-group-title::before {
+    content: ""; display: inline-block; width: 4px; height: 14px;
+    background: #0369a1; border-radius: 2px;
+  }
+  .kpi-group-title.fn::before { background: #059669; }
+
+  section.section {
+    background: var(--card); border: 1px solid var(--border); border-radius: 12px;
+    padding: 24px 28px; margin-bottom: 24px;
+  }
+  section.section > h2 {
+    margin: 0 0 6px; font-size: 20px; font-weight: 600; color: #0f172a;
+  }
+  section.section > .sub { color: var(--muted); margin: 0 0 18px; font-size: 14px; }
+
+  table.cmp {
+    width: 100%; border-collapse: collapse; font-size: 13.5px;
+  }
+  table.cmp th, table.cmp td {
+    text-align: left; vertical-align: top;
+    padding: 10px 12px; border-bottom: 1px solid var(--border);
+  }
+  table.cmp th {
+    background: #f1f5f9; font-size: 11px; text-transform: uppercase;
+    letter-spacing: 0.5px; color: #334155; font-weight: 600;
+  }
+  table.cmp td.note { color: var(--muted); font-size: 12.5px; line-height: 1.5; }
+  table.cmp tr:last-child td { border-bottom: none; }
+
+  .badge {
+    display: inline-block; padding: 2px 8px; border-radius: 999px;
+    font-size: 11px; font-weight: 600; letter-spacing: 0.3px;
+    white-space: nowrap;
+  }
+  .badge.ok { background: var(--ok-bg); color: var(--ok); }
+  .badge.partial { background: var(--partial-bg); color: var(--partial); }
+  .badge.missing { background: var(--missing-bg); color: var(--missing); }
+  .badge.p0 { background: var(--p0-bg); color: var(--p0); }
+  .badge.p1 { background: var(--p1-bg); color: var(--p1); }
+  .badge.p2 { background: var(--p2-bg); color: var(--p2); }
+  .badge.p3 { background: var(--p3-bg); color: var(--p3); }
+  .badge.win { background: var(--win-bg); color: var(--win); }
+  .badge.na { background: #e5e7eb; color: #475569; }
+
+  .legend {
+    display: flex; flex-wrap: wrap; gap: 10px 18px; margin-bottom: 18px;
+    font-size: 12.5px; color: var(--muted);
+  }
+  .legend .item { display: flex; align-items: center; gap: 6px; }
+
+  .crit-block {
+    border-left: 4px solid;
+    padding: 14px 18px 14px 20px;
+    border-radius: 8px;
+    margin-bottom: 14px;
+    background: #fafafa;
+  }
+  .crit-block.p0 { border-color: var(--p0); background: #fff1f1; }
+  .crit-block.p1 { border-color: var(--p1); background: #fff7ed; }
+  .crit-block.p2 { border-color: var(--p2); background: #fffbeb; }
+  .crit-block.p3 { border-color: var(--p3); background: #f1f5f9; }
+  .crit-block.win { border-color: var(--win); background: #eff6ff; }
+  .crit-block h3 { margin: 0 0 4px; font-size: 15px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  .crit-block p.scope { margin: 0 0 10px; color: var(--muted); font-size: 13px; }
+  .crit-block ul { margin: 0; padding-left: 20px; font-size: 13.5px; }
+  .crit-block li { margin-bottom: 4px; }
+
+  .cols-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  @media (max-width: 1000px) {
+    .cols-2 { grid-template-columns: 1fr; }
+  }
+
+  .col-title {
+    font-size: 13px; text-transform: uppercase; letter-spacing: 0.6px;
+    color: #334155; font-weight: 600; margin: 0 0 10px;
+    padding: 6px 12px; background: #f1f5f9; border-radius: 6px;
+    display: inline-block;
+  }
+
+  .callout {
+    background: #ecfeff; border: 1px solid #67e8f9; border-radius: 8px;
+    padding: 14px 18px; margin-bottom: 18px; font-size: 14px;
+  }
+  .callout.warn { background: #fef3c7; border-color: #fbbf24; }
+  .callout.ok { background: #d1fae5; border-color: #34d399; }
+
+  footer {
+    text-align: center; color: var(--muted); font-size: 12px; margin-top: 40px;
+  }
+  code { background: #f1f5f9; padding: 1px 5px; border-radius: 4px; font-size: 12.5px; }
+
+  .toc-inline {
+    background: #f8fafc; border: 1px solid var(--border); border-radius: 10px;
+    padding: 12px 16px; margin-bottom: 20px; font-size: 13px;
+  }
+  .toc-inline strong { color: #0f172a; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; margin-right: 12px; }
+  .toc-inline a { color: #0369a1; text-decoration: none; margin-right: 14px; }
+  .toc-inline a:hover { text-decoration: underline; }
+
+  @media print {
+    body { background: #fff; }
+    .wrap { max-width: 100%; padding: 0; }
+    nav.tabs { display: none; }
+    .tab-panel { display: block !important; page-break-before: always; }
+    .tab-panel:first-of-type { page-break-before: auto; }
+    section.section, header.page { box-shadow: none; break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="page">
+  <h1>TaskTime MVP vs коробочная Jira — сравнительный анализ</h1>
+  <p>Чего уже хватает для запуска, а чего нет. Два пласта: администрирование и бизнес-функциональность. Jira рассматривается без Marketplace-плагинов.</p>
+  <div class="meta-row">
+    <div class="meta"><span class="k">Дата отчёта</span><span class="v">24 апреля 2026 (v2 — добавлен пласт функциональности)</span></div>
+    <div class="meta"><span class="k">Ветка источника</span><span class="v">feat/release-card-enhancements</span></div>
+    <div class="meta"><span class="k">База Jira для сравнения</span><span class="v">Jira Software DC 9.x (vanilla)</span></div>
+    <div class="meta"><span class="k">Автор анализа</span><span class="v">auto-scan модулей backend + frontend</span></div>
+    <div class="meta"><span class="k">Скоуп</span><span class="v">админка + функциональность end-user</span></div>
+    <div class="meta"><span class="k">План реализации</span><span class="v"><a href="tz/MVP2JIRA/INDEX.md" style="color:#7dd3fc;">docs/tz/MVP2JIRA/</a></span></div>
+  </div>
+</header>
+
+<div class="callout warn">
+  <strong>Версия 4 (2026-04-24):</strong> v2 добавила <b>функциональную часть</b>, v3 — анализ <b>Стэка &amp; Enterprise</b> на 5 000 users, v4 — отдельную вкладку <b>«Yandex Tracker»</b> с референсным сравнением (SaaS + Enterprise on-prem, РФ-альтернатива Jira).
+</div>
+
+<nav class="tabs" role="tablist">
+  <button type="button" data-tab="summary" class="active" role="tab"><span class="tab-icon">📊</span> Саммари <span class="tab-sub">гэпы и оценка</span></button>
+  <button type="button" data-tab="admin" role="tab"><span class="tab-icon">⚙️</span> Админка <span class="tab-sub">детали</span></button>
+  <button type="button" data-tab="functional" role="tab"><span class="tab-icon">🧩</span> Функциональность <span class="tab-sub">детали</span></button>
+  <button type="button" data-tab="enterprise" role="tab"><span class="tab-icon">🏢</span> Стэк &amp; Enterprise <span class="tab-sub">5000 users</span></button>
+  <button type="button" data-tab="ytracker" role="tab"><span class="tab-icon">🟡</span> Yandex Tracker <span class="tab-sub">референс</span></button>
+</nav>
+
+<!-- =========================================================================
+     ВКЛАДКА 1 — САММАРИ
+     ========================================================================= -->
+<div id="summary" class="tab-panel active" role="tabpanel">
+
+<section class="section">
+  <h2>Ключевое саммари — административная и функциональная части</h2>
+  <p class="sub">Сколько закрыто от коробочной Jira, где дыры, где TaskTime уже впереди. Цифры получены обходом <code>backend/src/modules</code>, <code>frontend/src/pages</code>, <code>prisma/schema.prisma</code> и <code>docs/user-manual/features/</code>.</p>
+
+  <div class="legend">
+    <div class="item"><span class="badge ok">Есть</span></div>
+    <div class="item"><span class="badge partial">Частично</span></div>
+    <div class="item"><span class="badge missing">Нет</span></div>
+    <div class="item"><span class="badge win">Лучше, чем в Jira</span></div>
+    <div class="item"><span class="badge p0">P0</span> блокер запуска</div>
+    <div class="item"><span class="badge p1">P1</span> критично</div>
+    <div class="item"><span class="badge p2">P2</span> важно</div>
+    <div class="item"><span class="badge p3">P3</span> nice-to-have</div>
+  </div>
+
+  <div class="kpi-group-title">Администрирование</div>
+  <div class="summary">
+    <div class="kpi ok"><div class="label">Покрыто от Jira</div><div class="val">~55%</div></div>
+    <div class="kpi p0"><div class="label">P0 гэпов</div><div class="val">4</div></div>
+    <div class="kpi p1"><div class="label">P1 гэпов</div><div class="val">6</div></div>
+    <div class="kpi p2"><div class="label">P2 гэпов</div><div class="val">4</div></div>
+    <div class="kpi win"><div class="label">Сильнее Jira</div><div class="val">5</div></div>
+  </div>
+
+  <div class="kpi-group-title fn">Бизнес-функциональность</div>
+  <div class="summary">
+    <div class="kpi ok"><div class="label">Покрыто от Jira</div><div class="val">~60%</div></div>
+    <div class="kpi p0"><div class="label">P0 гэпов</div><div class="val">1</div></div>
+    <div class="kpi p1"><div class="label">P1 гэпов</div><div class="val">7</div></div>
+    <div class="kpi p2"><div class="label">P2 гэпов</div><div class="val">6</div></div>
+    <div class="kpi win"><div class="label">Сильнее Jira</div><div class="val">7</div></div>
+  </div>
+
+  <p style="margin: 8px 0 0; font-size: 14px; color: var(--muted);">
+    <b>Короткий вердикт:</b> TaskTime ближе к Jira по <b>сквозным абстракциям</b> (Workflow / Screens / Field Schemas) и <b>опережает</b> её по <b>релизному контуру</b> (Release Workflows + Checkpoints + Burndown), <b>AI/MCP</b>, <b>гибкому Role Scheme</b>, <b>бесшовной интеграции с GitLab</b> и <b>TTQL-поиску</b>. Но на уровне <b>end-user фич</b> не хватает двух столпов: <b>вложений</b> и <b>уведомлений/коммуникаций</b> (watchers, @mentions, email, in-app bell). Плюс <b>agile-отчётности</b> (Velocity, CFD, Sprint Report).
+  </p>
+</section>
+
+<section class="section">
+  <h2>Где TaskTime уже сильнее коробочной Jira</h2>
+  <p class="sub">Уникальные конкурентные преимущества — их нельзя терять при реализации гэпов.</p>
+  <div class="cols-2">
+    <div>
+      <div class="col-title">Админка</div>
+      <div class="crit-block win">
+        <ul>
+          <li><b>Role Scheme с 33 permission-флагами</b> — плотнее, чем стандартная Permission Scheme Jira.</li>
+          <li><b>Field Schemas с 4-уровневым scope</b> — GLOBAL / PROJECT / ISSUE_TYPE / PROJECT+ISSUE_TYPE из коробки.</li>
+          <li><b>Release Workflows + Statuses + Checkpoint Templates</b> — отдельный lifecycle релиза с конструктором.</li>
+          <li><b>Custom Field type REFERENCE</b> — собственный справочник (в Jira — только Marketplace).</li>
+          <li><b>UAT-тесты в админке</b> — встроенный онбординг-чеклист для ролей, нет у Jira.</li>
+          <li><b>Monitoring Page</b> — системные / endpoint / page метрики, auto-refresh 30s.</li>
+          <li><b>MCP-сервер как first-class</b> — в Jira DC вообще не существует.</li>
+        </ul>
+      </div>
+    </div>
+    <div>
+      <div class="col-title">Функциональность</div>
+      <div class="crit-block win">
+        <ul>
+          <li><b>Release Checkpoints</b> — детерминированные release-gates с preview, risk scoring (LOW / MEDIUM / HIGH / CRITICAL), матрицей issue × checkpoint, аудитом. В Jira DC такого нет.</li>
+          <li><b>Release Burndown</b> — actual + ideal, daily snapshots, retention. Jira DC — только sprint burndown.</li>
+          <li><b>TTQL с release-/checkpoint-функциями</b> — <code>violatedCheckpoints()</code>, <code>releasePlannedDate()</code>, <code>currentUser()</code>. Семантически богаче, чем JQL.</li>
+          <li><b>AI-декомпозиция Epic → Subtasks</b> + оценка часов через Claude, сессии логируются с токенами и стоимостью.</li>
+          <li><b>GitLab webhooks из коробки</b> — auto-transition по <code>MR open/merge</code>, без Marketplace-плагина.</li>
+          <li><b>Bulk-operations с friendly-пикерами и CSV/XLSX-экспортом</b> — в Jira DC экспорт через отдельный шаг.</li>
+          <li><b>Teams (Business + Flow)</b> + Operations + UAT Tests — орг-абстракции, которых в Jira нет.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <h2>Блокеры и критичные гэпы</h2>
+  <p class="sub">Сгруппировано по уровню, раздельно для админки и функциональности. Ссылки на ТЗ (<code>TTxxx-N</code>) ведут в <code>docs/tz/MVP2JIRA/</code>.</p>
+
+  <div class="cols-2">
+
+    <!-- АДМИНКА -->
+    <div>
+      <div class="col-title">Админка — 4 P0 / 6 P1 / 4 P2</div>
+
+      <div class="crit-block p0">
+        <h3><span class="badge p0">P0</span> Блокеры продакшна — 4 ТЗ</h3>
+        <ul>
+          <li><b>Event Bus</b> — <a href="tz/MVP2JIRA/TTBUS-0.md">TTBUS-0</a> (54ч). Kafka (KRaft) + transactional outbox. Prerequisite для Notifications и Webhooks.</li>
+          <li><b>Notifications (Email + in-app bell)</b> — <a href="tz/MVP2JIRA/TTNOTIF-1.md">TTNOTIF-1</a> (110ч). SMTP, Notification Scheme per-project, watchers, mention-parser.</li>
+          <li><b>Resolutions</b> — <a href="tz/MVP2JIRA/TTRES-1.md">TTRES-1</a> (33ч). 5 системных + TTQL.</li>
+          <li><b>Issue Security</b> — <a href="tz/MVP2JIRA/TTSEC-3.md">TTSEC-3</a> (52ч). PUBLIC / TEAM / PRIVATE + extras + permission.</li>
+          <li><s>Backup/Restore в приложении</s> — закрывается DevOps (<code>pg_dump</code>, snapshots, Git).</li>
+        </ul>
+      </div>
+
+      <div class="crit-block p1">
+        <h3><span class="badge p1">P1</span> Критично для прома — 6 ТЗ</h3>
+        <ul>
+          <li><b>SSO / OIDC</b> — <a href="tz/MVP2JIRA/TTSSO-1.md">TTSSO-1</a> (102ч).</li>
+          <li><b>Password Policy + Audit Log UI + Banner</b> — <a href="tz/MVP2JIRA/TTSEC-4.md">TTSEC-4</a> (63ч).</li>
+          <li><b>Priorities CRUD + Status reconciliation</b> — <a href="tz/MVP2JIRA/TTCORE-1.md">TTCORE-1</a> (63ч).</li>
+          <li><b>Components + fix/affectsVersion</b> — <a href="tz/MVP2JIRA/TTPROJ-1.md">TTPROJ-1</a> (48ч).</li>
+          <li><b>Screens (контекст полей)</b> — <a href="tz/MVP2JIRA/TTSCR-1.md">TTSCR-1</a> (24ч).</li>
+          <li><b>Attachments (full feature)</b> — <a href="tz/MVP2JIRA/TTATTACH-1.md">TTATTACH-1</a> (84ч).</li>
+        </ul>
+      </div>
+
+      <div class="crit-block p2">
+        <h3><span class="badge p2">P2</span> Важно, но не блокирует — 4 ТЗ</h3>
+        <ul>
+          <li><b>2FA / TOTP</b> — <a href="tz/MVP2JIRA/TTMFA-1.md">TTMFA-1</a> (68ч).</li>
+          <li><b>Webhooks (system + project)</b> — <a href="tz/MVP2JIRA/TTINTEG-1.md">TTINTEG-1</a> (70ч).</li>
+          <li><b>Time Tracking parser + auto-stop</b> — <a href="tz/MVP2JIRA/TTCFG-1.md">TTCFG-1</a> (23ч).</li>
+          <li><b>Look &amp; Feel (брендинг)</b> — <a href="tz/MVP2JIRA/TTBRAND-1.md">TTBRAND-1</a> (32ч).</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- ФУНКЦИОНАЛЬНОСТЬ -->
+    <div>
+      <div class="col-title">Функциональность — 1 P0 / 7 P1 / 6 P2</div>
+
+      <div class="crit-block p0">
+        <h3><span class="badge p0">P0</span> Блокеры прод-использования</h3>
+        <p class="scope">На самом уровне задач, без чего нельзя эксплуатировать трекер.</p>
+        <ul>
+          <li><b>Attachments на задачах и комментариях</b> — в модели нет <code>Attachment</code>, нет <code>multer</code>, нет upload-endpoint'а. Закрывается тем же ТЗ <a href="tz/MVP2JIRA/TTATTACH-1.md">TTATTACH-1</a>. Без вложений в реальном bug tracking невозможны скриншоты, логи, артефакты.</li>
+        </ul>
+      </div>
+
+      <div class="crit-block p1">
+        <h3><span class="badge p1">P1</span> Критично для полноценной работы команды</h3>
+        <ul>
+          <li><b>Watchers + @mentions в комментариях</b> — требует <a href="tz/MVP2JIRA/TTNOTIF-1.md">TTNOTIF-1</a>. Без этого пользователи не узнают об изменениях.</li>
+          <li><b>In-app bell (история уведомлений)</b> — через ту же TTNOTIF-1.</li>
+          <li><b>Velocity chart</b> (средняя скорость команды за N спринтов). Требует Story Points или опоры на <code>estimatedHours</code>. <span class="badge p1">Новое ТЗ</span></li>
+          <li><b>Sprint Report</b> (commitment vs completed, added / removed scope) — базовая agile-отчётность. <span class="badge p1">Новое ТЗ</span></li>
+          <li><b>Cumulative Flow Diagram</b> — wip-поток по статусам во времени. <span class="badge p1">Новое ТЗ</span></li>
+          <li><b>Persistent Activity stream per issue</b> — сейчас <code>audit_logs</code> есть, но нет UI «история задачи на вкладке». <span class="badge p1">Новое ТЗ</span></li>
+          <li><b>CSV/XLSX import задач</b> — критично для миграции из Jira / Excel. <span class="badge p1">Новое ТЗ</span></li>
+        </ul>
+      </div>
+
+      <div class="crit-block p2">
+        <h3><span class="badge p2">P2</span> Важно, но обходится</h3>
+        <ul>
+          <li><b>Kanban swimlanes</b> (по assignee / epic / priority).</li>
+          <li><b>WIP-лимиты на колонках доски</b> с жёстким enforcement.</li>
+          <li><b>Roadmap / Timeline view</b> (аналог Advanced Roadmaps в base Jira DC тоже нет, но ожидается).</li>
+          <li><b>Personal Dashboards с виджетами</b> — сейчас единый read-only дашборд проекта.</li>
+          <li><b>Story Points как first-class</b> — сейчас только <code>estimatedHours</code>.</li>
+          <li><b>Reactions / pinned / edit-history на комментариях</b>.</li>
+        </ul>
+      </div>
+
+      <div class="crit-block p3">
+        <h3><span class="badge p3">P3</span> Nice-to-have / отложено</h3>
+        <ul>
+          <li>Gantt chart / dependency graph.</li>
+          <li>Mobile app / offline mode.</li>
+          <li>Visual query builder (JQL builder) — у нас есть help-страница <code>/search/help</code>.</li>
+          <li>Shared Dashboards admin-управление.</li>
+          <li>Comment reactions.</li>
+          <li>Time in Status / Control Chart / Cycle Time report.</li>
+        </ul>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<section class="section">
+  <h2>Итоговая оценка реализации гэпов</h2>
+  <p class="sub">Сводная матрица по всем областям. Колонка «Эффект на MVP-ready» показывает, насколько закрытие гэпа приближает к production для корпоративного заказчика.</p>
+
+  <table class="cmp">
+    <thead><tr>
+      <th style="width: 6%">Слой</th>
+      <th style="width: 22%">Область</th>
+      <th style="width: 10%">Покрытие</th>
+      <th style="width: 10%">Крит-ть</th>
+      <th style="width: 14%">Трудозатраты</th>
+      <th>Эффект на MVP-ready</th>
+    </tr></thead>
+    <tbody>
+      <tr><td>Админ</td><td>SMTP + Notification Scheme + in-app bell</td><td><span class="badge missing">0%</span></td><td><span class="badge p0">P0</span></td><td>110ч + 54ч infra</td><td class="note">Разблокирует коммуникационный pillar: watchers, mentions, подписки, рассылки. Без него команда работает вслепую.</td></tr>
+      <tr><td>Админ</td><td>Resolutions</td><td><span class="badge missing">0%</span></td><td><span class="badge p0">P0</span></td><td>33ч</td><td class="note">Закрывает сценарий «Won't Do / Duplicate / Can't Reproduce». Нужен для корректных DONE-переходов и отчётности.</td></tr>
+      <tr><td>Админ</td><td>Issue Security</td><td><span class="badge missing">0%</span></td><td><span class="badge p0">P0</span></td><td>52ч</td><td class="note">Compliance + корп-контур. Без Issue Security невозможно скрыть HR/Security-задачи от остальной команды проекта.</td></tr>
+      <tr><td>Функц.</td><td>Attachments (full feature)</td><td><span class="badge missing">0%</span></td><td><span class="badge p0">P0</span></td><td>84ч</td><td class="note">Базовая функция трекера. Пока её нет — любая операционная работа (bug reports со скриншотами, логи) невозможна.</td></tr>
+      <tr><td>Админ</td><td>SSO / OIDC</td><td><span class="badge missing">0%</span></td><td><span class="badge p1">P1</span></td><td>102ч</td><td class="note">Требование корп-контура. Без SSO невозможно автопровижн и массовый онбординг.</td></tr>
+      <tr><td>Админ</td><td>Priorities CRUD + Status reconciliation</td><td><span class="badge partial">~40%</span></td><td><span class="badge p1">P1</span></td><td>63ч</td><td class="note">Убирает хард-энум и двойное моделирование Issue.status / workflowStatusId.</td></tr>
+      <tr><td>Админ</td><td>Password Policy + Audit UI + Banner</td><td><span class="badge partial">~30%</span></td><td><span class="badge p1">P1</span></td><td>63ч</td><td class="note">Audit таблица уже есть, но нет UI; policy захардкожен — нужна админ-страница.</td></tr>
+      <tr><td>Админ</td><td>Components + fix/affectsVersion</td><td><span class="badge missing">0%</span></td><td><span class="badge p1">P1</span></td><td>48ч</td><td class="note">Для крупных проектов без компонент организовать работу практически нельзя.</td></tr>
+      <tr><td>Админ</td><td>Screens (контекст полей)</td><td><span class="badge partial">~40%</span></td><td><span class="badge p1">P1</span></td><td>24ч</td><td class="note">Field Schema есть, но нет showOnCreate/Edit/View — добавляется 3 флагами.</td></tr>
+      <tr><td>Функц.</td><td>Watchers + @mentions</td><td><span class="badge missing">0%</span></td><td><span class="badge p1">P1</span></td><td>входит в TTNOTIF-1</td><td class="note">Разблокируется вместе с Notifications pillar.</td></tr>
+      <tr><td>Функц.</td><td>Velocity / CFD / Sprint Report</td><td><span class="badge missing">0%</span></td><td><span class="badge p1">P1</span></td><td>~80–120ч суммарно</td><td class="note">Трио классической agile-отчётности. Без них Scrum-команда лишена ретроспективных метрик.</td></tr>
+      <tr><td>Функц.</td><td>CSV/XLSX import issues</td><td><span class="badge missing">0%</span></td><td><span class="badge p1">P1</span></td><td>~30–40ч</td><td class="note">Обязательно для миграции с Jira / Excel. Bulk export уже есть — import несимметричен.</td></tr>
+      <tr><td>Функц.</td><td>Activity stream per issue (UI)</td><td><span class="badge partial">~50%</span></td><td><span class="badge p1">P1</span></td><td>~20–30ч</td><td class="note">Данные в <code>audit_logs</code> есть, нужна только агрегированная вкладка на странице задачи.</td></tr>
+      <tr><td>Админ</td><td>2FA / TOTP</td><td><span class="badge missing">0%</span></td><td><span class="badge p2">P2</span></td><td>68ч</td><td class="note">Ожидается в корп-контуре, но паритет с Jira (там тоже нет из коробки).</td></tr>
+      <tr><td>Админ</td><td>Webhooks admin UI</td><td><span class="badge partial">~30%</span></td><td><span class="badge p2">P2</span></td><td>70ч</td><td class="note">Есть notifier для checkpoints; нужен универсальный UI.</td></tr>
+      <tr><td>Функц.</td><td>Kanban swimlanes + WIP</td><td><span class="badge missing">0%</span></td><td><span class="badge p2">P2</span></td><td>~40–60ч</td><td class="note">Увеличивает потолок сложности команд 20+ человек.</td></tr>
+      <tr><td>Функц.</td><td>Story Points (first-class)</td><td><span class="badge partial">(через hours)</span></td><td><span class="badge p2">P2</span></td><td>~20ч</td><td class="note">Есть estimatedHours; Points — отдельная культурная единица, добавляется полем / CF.</td></tr>
+      <tr><td>Функц.</td><td>Personal Dashboards с виджетами</td><td><span class="badge missing">0%</span></td><td><span class="badge p2">P2</span></td><td>~80ч</td><td class="note">Сейчас дашборд один на проект, read-only.</td></tr>
+      <tr><td>Функц.</td><td>Roadmap / Timeline</td><td><span class="badge missing">0%</span></td><td><span class="badge p2">P2</span></td><td>~100ч</td><td class="note">В vanilla Jira DC тоже нет — покрывается по запросу PM-команд.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="callout ok">
+    <strong>Оценка сверху:</strong> закрытие всех P0 (≈ 333ч — админка + attachments) + всех критических P1 (≈ 430ч) = <b>~760 часов</b> (≈ 4–5 команд-месяцев).
+    Это приведёт трекер к уровню, в котором его можно заменять Jira для любой <b>среднего размера ИТ-организации</b> (50–300 пользователей) без ощутимых потерь и с явным выигрышем по релизному контуру, AI, интеграциям и кастомизации полей.
+  </div>
+</section>
+
+<section id="recommend" class="section">
+  <h2>Рекомендованный план дозакрытия до MVP-ready</h2>
+  <p class="sub">Минимально необходимый набор для закрытия P0 и наиболее болезненных P1. Объём — ориентировочные спринты (2 недели). Полный план: <a href="tz/MVP2JIRA/mvp2jira_plan.md"><code>mvp2jira_plan.md</code></a>.</p>
+
+  <div class="callout">
+    <strong>14 отдельных ТЗ в <a href="tz/MVP2JIRA/INDEX.md"><code>docs/tz/MVP2JIRA/</code></a>.</strong>
+    Scenarios: single-team ~14 спринтов / two-teams ~9 спринтов.
+  </div>
+
+  <table class="cmp">
+    <thead><tr><th style="width: 3%">#</th><th style="width: 28%">Инициатива</th><th style="width: 10%">Крит-ть</th><th style="width: 12%">Объём</th><th>Что входит</th></tr></thead>
+    <tbody>
+      <tr><td>1</td><td>Event Bus + Email + in-app notifications (pillar)</td><td><span class="badge p0">P0</span></td><td>3 спринта</td><td class="note">Kafka outbox (TTBUS-0) + SMTP / Notification Scheme (TTNOTIF-1). Разблокирует watchers, mentions, webhook-notifier.</td></tr>
+      <tr><td>2</td><td>Resolutions</td><td><span class="badge p0">P0</span></td><td>0.5 спринта</td><td class="note">TTRES-1: модель + 5 системных + TTQL-фильтр.</td></tr>
+      <tr><td>3</td><td>Issue Security</td><td><span class="badge p0">P0</span></td><td>1 спринт</td><td class="note">TTSEC-3: PUBLIC / TEAM / PRIVATE + permission ISSUES_CHANGE_VISIBILITY.</td></tr>
+      <tr><td>4</td><td>Attachments (full feature)</td><td><span class="badge p0">P0</span></td><td>1.5 спринта</td><td class="note">TTATTACH-1: модель + pluggable storage + thumbnails + inherit permissions + undo-delete.</td></tr>
+      <tr><td>5</td><td>SSO / OIDC</td><td><span class="badge p1">P1</span></td><td>2 спринта</td><td class="note">TTSSO-1: несколько IdP, JIT provisioning, маппинг групп.</td></tr>
+      <tr><td>6</td><td>Password Policy + Audit Log UI + Banner</td><td><span class="badge p1">P1</span></td><td>1 спринт</td><td class="note">TTSEC-4: админ-UI + deep-diff drawer + баннер.</td></tr>
+      <tr><td>7</td><td>Priorities CRUD + Status reconciliation</td><td><span class="badge p1">P1</span></td><td>1 спринт</td><td class="note">TTCORE-1: enum → таблица + dual-field API на переход.</td></tr>
+      <tr><td>8</td><td>Components + Versions</td><td><span class="badge p1">P1</span></td><td>1 спринт</td><td class="note">TTPROJ-1: M:M Components + fix / affectsVersion.</td></tr>
+      <tr><td>9</td><td>Screens (контекст полей)</td><td><span class="badge p1">P1</span></td><td>0.5 спринта</td><td class="note">TTSCR-1: 3 флага на FieldSchemaItem + 7 virtual system fields.</td></tr>
+      <tr><td>10</td><td>Velocity + Sprint Report + CFD</td><td><span class="badge p1">P1</span></td><td>2 спринта</td><td class="note">Agile-отчётность: три графика на основе sprint-scope snapshots и status-transition log.</td></tr>
+      <tr><td>11</td><td>CSV/XLSX import задач</td><td><span class="badge p1">P1</span></td><td>0.5 спринта</td><td class="note">Симметрия к существующему bulk-export. Mapping: summary, type, status (по имени), assignee (email), custom fields.</td></tr>
+      <tr><td>12</td><td>Activity stream per issue (UI)</td><td><span class="badge p1">P1</span></td><td>0.5 спринта</td><td class="note">Новая вкладка на странице задачи, агрегация из audit_logs. Данные уже индексированы.</td></tr>
+    </tbody>
+  </table>
+
+  <p style="margin-top: 16px; font-size: 13.5px; color: var(--muted);">
+    Итог: <b>≈ 14 спринтов</b> full-time на команду, чтобы закрыть все P0 + критические P1 обоих пластов. Если срезать до <b>только P0</b>, получается ≈ 6 спринтов (3 месяца).
+  </p>
+</section>
+
+</div>
+<!-- /ВКЛАДКА 1 -->
+
+<!-- =========================================================================
+     ВКЛАДКА 2 — АДМИНКА, ДЕТАЛИ
+     ========================================================================= -->
+<div id="admin" class="tab-panel" role="tabpanel">
+
+<div class="toc-inline">
+  <strong>Содержание</strong>
+  <a href="#system">1. Система</a>
+  <a href="#users">2. Пользователи и доступы</a>
+  <a href="#projects">3. Проекты</a>
+  <a href="#issues-taxonomy">4. Таксономия задач</a>
+  <a href="#workflow">5. Workflow и Screens</a>
+  <a href="#fields">6. Поля и схемы</a>
+  <a href="#notifications">7. Уведомления</a>
+  <a href="#integrations">8. Интеграции</a>
+  <a href="#observability">9. Аудит и обслуживание</a>
+</div>
+
+<section id="system" class="section">
+  <h2>1. Система — общие настройки, безопасность, почта</h2>
+  <p class="sub">Соответствует блокам «System», «Security» и «Mail» в Jira Administration.</p>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Раздел Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>General Configuration (base URL, app title)</td><td>частично <code>AdminSystemPage</code></td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td class="note">Из настроек — только сессия (TTL) и JWT exp (read-only). Нет base URL, заголовка, tz, контактов админа.</td></tr>
+      <tr><td>Outgoing Mail (SMTP)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td class="note">Нет <code>nodemailer</code>, SMTP-клиента и модуля почты. Любые уведомления невозможны.</td></tr>
+      <tr><td>Incoming Mail Handlers</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Создание задачи из письма — отсутствует.</td></tr>
+      <tr><td>Session &amp; JWT</td><td><code>AdminSystemPage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Скользящая сессия 5–10080 мин. JWT_EXPIRES_IN — ENV, только чтение.</td></tr>
+      <tr><td>Password Policy</td><td>валидация в коде (CVE-11)</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td class="note">Правила хард-кодом, без админ-UI. Нет policy: срок, история, сложность, блокировка.</td></tr>
+      <tr><td>Captcha on login</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Есть rate-limit, но CAPTCHA после N fails — нет.</td></tr>
+      <tr><td>2FA / MFA</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">В коробочной Jira тоже нет — паритет, но корпоративно ожидается.</td></tr>
+      <tr><td>SSO / LDAP / SAML / OIDC</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Проверено: в backend нет упоминаний <code>ldap / saml / oauth / oidc / sso</code>.</td></tr>
+      <tr><td>Регистрация пользователей (toggle)</td><td><code>AdminUsersPage</code> → Registration switch</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Переключатель на странице пользователей.</td></tr>
+      <tr><td>Announcement Banner</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Нужен для maintenance-окна и релиз-анонсов.</td></tr>
+      <tr><td>Look and Feel (лого, цвета)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Только Ant Design дефолт.</td></tr>
+      <tr><td>Internationalization</td><td>RU hard-coded</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Исключено из списка ТЗ — UI остаётся RU-only.</td></tr>
+      <tr><td>Attachments (функционал вложений)</td><td>— <b>(нет функционала)</b></td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">В модели нет Attachment. Полноценная фича: TTATTACH-1 (доп. детали на вкладке «Функциональность»).</td></tr>
+      <tr><td>Backup / Restore</td><td>—</td><td><span class="badge na">Out-of-scope</span></td><td><span class="badge p3">P3</span></td><td class="note">Закрывается через DevOps: <code>pg_dump</code> cron на хосте, снэпшоты дисков.</td></tr>
+      <tr><td>Services (scheduled jobs)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Кроны работают, но управлять ими из UI нельзя.</td></tr>
+      <tr><td>License</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Актуально только для коммерческой self-hosted модели.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="users" class="section">
+  <h2>2. Пользователи, группы и доступы</h2>
+  <p class="sub">Соответствует «User Management» в Jira.</p>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Раздел Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Users</td><td><code>AdminUsersPage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">CRUD, выдача temp-пароля, deactivate с проверкой зависимостей, <code>mustChangePassword</code>.</td></tr>
+      <tr><td>Groups</td><td><code>AdminGroupsPage</code> + <code>AdminGroupDetailPage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Группы + вложенность ролей проекта (<code>ProjectGroupRole</code>) через TTSEC-2.</td></tr>
+      <tr><td>Global Permissions</td><td><code>SystemRoleType</code> (5 ролей)</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td class="note">Роли <i>SUPER_ADMIN / ADMIN / RELEASE_MANAGER / USER / AUDITOR</i>, но нет отдельной матрицы глобальных разрешений.</td></tr>
+      <tr><td>Project Roles (глобально)</td><td><code>AdminRolesPage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">CRUD глобальных ролей.</td></tr>
+      <tr><td>Role Schemes (per project)</td><td><code>AdminRoleSchemesPage</code> + <code>PermissionMatrixDrawer</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Матрица 33 permission-флагов на роль — <b>плотнее</b> чем стандартная Permission Scheme Jira.</td></tr>
+      <tr><td>Permission Scheme (независимая)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Jira отделяет Permission Scheme от Role Scheme. TaskTime объединил — осознанное упрощение, но может мешать при требованиях «разные проекты — разные права для одной и той же роли».</td></tr>
+      <tr><td>User directories (LDAP / Crowd)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Пользователи только внутренние.</td></tr>
+      <tr><td>Issue Security Scheme</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td class="note">Нельзя скрыть отдельные задачи от части участников проекта.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="projects" class="section">
+  <h2>3. Проекты</h2>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Раздел Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Projects (CRUD, lead, key)</td><td><code>AdminProjectsPage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Управление проектами и настройками.</td></tr>
+      <tr><td>Project Categories</td><td><code>AdminCategoriesPage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Категоризация проектов.</td></tr>
+      <tr><td>Components (подсистемы внутри проекта)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Нет моделей <code>Component</code>. Для крупных проектов — ограничение.</td></tr>
+      <tr><td>Versions / Fix Version</td><td><code>Release</code> + <code>ReleaseItem</code></td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td class="note">Есть концепция Releases с checkpoints, но нет полей <code>fixVersion / affectsVersion</code> на задаче в чистом виде.</td></tr>
+      <tr><td>Project Templates</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Нельзя клонировать проект с настройками как шаблон.</td></tr>
+      <tr><td>Default Assignee</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">В Jira — project lead / component lead / unassigned.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="issues-taxonomy" class="section">
+  <h2>4. Таксономия задач — типы, приоритеты, статусы, резолюции</h2>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Раздел Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Issue Types (CRUD, иконки)</td><td><code>IssueTypeConfig</code> + <code>AdminIssueTypeConfigsPage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Настраиваемый тип с иконкой / цветом.</td></tr>
+      <tr><td>Issue Type Schemes</td><td><code>AdminIssueTypeSchemesPage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Привязка набора типов к проекту (<code>IssueTypeSchemeProject</code>).</td></tr>
+      <tr><td>Priorities (CRUD)</td><td>enum <code>IssuePriority</code></td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Жёсткий enum <i>CRITICAL / HIGH / MEDIUM / LOW</i>. Нет админ-UI, нельзя добавить «Blocker / Trivial» или сменить иконки.</td></tr>
+      <tr><td>Statuses (глобальные)</td><td><code>WorkflowStatus</code> + <code>AdminWorkflowStatusesPage</code></td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td class="note">Есть таблица, но одновременно используется enum <code>IssueStatus</code> в <code>Issue.status</code> — двойное моделирование.</td></tr>
+      <tr><td>Resolutions</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td class="note">Нет ни модели, ни поля на задаче. Сценарий «закрыто как Won't Do / Duplicate» невозможен.</td></tr>
+      <tr><td>Labels</td><td><code>CustomFieldType.LABEL</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Через кастом-поле типа LABEL.</td></tr>
+      <tr><td>Issue Link Types</td><td><code>AdminLinkTypesPage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">CRUD, inbound / outbound имена, флаг system.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="workflow" class="section">
+  <h2>5. Workflow и Screens</h2>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Раздел Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Workflows (steps + transitions)</td><td><code>AdminWorkflowEditorPage</code> + <code>workflow-engine</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Полный конструктор с condition / validator / post-function. Системные workflow защищены.</td></tr>
+      <tr><td>Workflow Schemes</td><td><code>AdminWorkflowSchemesPage</code> + editor</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Привязка workflow → issue type → проект.</td></tr>
+      <tr><td>Transition Screens</td><td><code>AdminTransitionScreensPage</code> + editor</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Экраны, показываемые при выполнении перехода.</td></tr>
+      <tr><td>View / Edit / Create Screens</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Поля на просмотр / редактирование / создание управляются Field Schema. TTSCR-1 закроет.</td></tr>
+      <tr><td>Screen Schemes / Issue Type Screen Schemes</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">В Jira — связка создание / просмотр / правка → экран.</td></tr>
+      <tr><td>Release Workflows (уникальная фича)</td><td><code>AdminReleaseWorkflowsPage</code> + editor, <code>AdminReleaseStatusesPage</code>, checkpoints</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Доп. ценность vs Jira — отдельный workflow для lifecycle релиза с checkpoint-типами и шаблонами.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="fields" class="section">
+  <h2>6. Поля и схемы полей</h2>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Раздел Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Custom Fields (CRUD, типы)</td><td><code>AdminCustomFieldsPage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">13 типов: TEXT / TEXTAREA / NUMBER / DECIMAL / DATE / DATETIME / URL / CHECKBOX / SELECT / MULTI_SELECT / USER / LABEL / REFERENCE.</td></tr>
+      <tr><td>Field Configurations</td><td><code>FieldSchema</code> + <code>AdminFieldSchemasPage</code> + detail</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Items = поля, <code>isRequired</code>, <code>showOnKanban</code>. Draft / Active статус.</td></tr>
+      <tr><td>Field Configuration Schemes</td><td><code>FieldSchemaBinding</code> (GLOBAL / PROJECT / ISSUE_TYPE / PROJECT_ISSUE_TYPE)</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Богаче Jira: 4-уровневая область применения.</td></tr>
+      <tr><td>Default / System fields в UI</td><td>встроены в Issue</td><td><span class="badge partial">Частично</span></td><td><span class="badge p3">P3</span></td><td class="note">Системные поля (summary, description, assignee, priority) не редактируются через Field Schema.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="notifications" class="section">
+  <h2>7. Уведомления, события, почта</h2>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Раздел Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Events (системный реестр)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Нет реестра событий «issue created / assigned / commented».</td></tr>
+      <tr><td>Event Listeners</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">—</td></tr>
+      <tr><td>Notification Schemes</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td class="note">Нельзя определить «на событие X шлём email роли Y / пользователю Z».</td></tr>
+      <tr><td>In-app notifications</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Нет колокольчика и истории уведомлений пользователя.</td></tr>
+      <tr><td>Outgoing Mail (SMTP)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td class="note">Корневая блокировка всего pillar'а уведомлений.</td></tr>
+      <tr><td>Mail Templates</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">—</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="integrations" class="section">
+  <h2>8. Интеграции</h2>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Раздел Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>DVCS (GitLab / GitHub / Bitbucket)</td><td><code>integrations/gitlab</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">GitLab webhooks + pipeline-service из коробки. В Jira DC — через Marketplace.</td></tr>
+      <tr><td>Webhooks (админ-реестр)</td><td>частично (есть <code>webhook-notifier</code> для checkpoints)</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td class="note">Нет универсального UI «добавить свой webhook на событие».</td></tr>
+      <tr><td>Application Links / OAuth between apps</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">—</td></tr>
+      <tr><td>AI / MCP</td><td><code>mcp/http-transport.ts</code> + <code>ai</code> / <code>ai-sessions</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">MCP-сервер — уникальная фича vs Jira.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="observability" class="section">
+  <h2>9. Аудит, мониторинг, обслуживание</h2>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Раздел Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Audit Log (UI)</td><td><code>audit_logs</code> в БД; <code>AdminCheckpointAuditPage</code></td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td class="note">Таблица и индексы есть. Нет общего админ-UI просмотра / фильтра (TTSEC-4).</td></tr>
+      <tr><td>Monitoring / Performance</td><td><code>AdminMonitoringPage</code> + <code>AdminMonitoringTab</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">System / endpoint / page метрики, auto-refresh 30s, clear.</td></tr>
+      <tr><td>Logging &amp; Profiling</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Только через docker-логи.</td></tr>
+      <tr><td>Reindex (Lucene)</td><td>—</td><td><span class="badge na">—</span></td><td><span class="badge p3">P3</span></td><td class="note">Не требуется — поиск на PostgreSQL + TTQL compiler.</td></tr>
+      <tr><td>Integrity Checker</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">—</td></tr>
+      <tr><td>Backup / Restore</td><td>—</td><td><span class="badge na">Out-of-scope</span></td><td><span class="badge p3">P3</span></td><td class="note">DevOps (pg_dump + snapshots).</td></tr>
+      <tr><td>UAT-тесты</td><td><code>uat-tests.data.ts</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Своя админ-фича, нет у Jira.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+</div>
+<!-- /ВКЛАДКА 2 -->
+
+<!-- =========================================================================
+     ВКЛАДКА 3 — ФУНКЦИОНАЛЬНОСТЬ, ДЕТАЛИ
+     ========================================================================= -->
+<div id="functional" class="tab-panel" role="tabpanel">
+
+<div class="toc-inline">
+  <strong>Содержание</strong>
+  <a href="#f-issues">F1. Задачи и иерархия</a>
+  <a href="#f-boards">F2. Доски (Kanban)</a>
+  <a href="#f-sprints">F3. Scrum: спринты и бэклог</a>
+  <a href="#f-releases">F4. Релизы и чекпоинты</a>
+  <a href="#f-search">F5. Поиск (TTQL) и фильтры</a>
+  <a href="#f-reports">F6. Отчёты и дашборды</a>
+  <a href="#f-time">F7. Учёт времени</a>
+  <a href="#f-collab">F8. Коллаборация</a>
+  <a href="#f-integrations">F9. Интеграции и уникальные фичи</a>
+</div>
+
+<div class="callout">
+  <strong>Про эту вкладку:</strong> здесь сравнивается то, что видит <b>рядовой пользователь</b> — задачи, доски, спринты, релизы, отчёты, поиск, комментарии. Админская конфигурация — на соседней вкладке.
+  База сравнения — <b>Jira Software DC 9.x без Marketplace-плагинов</b>. Это важно: многие «привычные» по Jira фичи (Advanced Roadmaps, Tempo, Structure, Portfolio) — это плагины, в коробочной Jira их нет.
+</div>
+
+<section id="f-issues" class="section">
+  <h2>F1. Задачи и иерархия</h2>
+  <p class="sub">Модель <code>Issue</code>, иерархия parent / child, типы, приоритеты, статусы, пользовательские поля.</p>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Фича Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Создание / редактирование задачи</td><td><code>IssueDetailPage</code> + <code>CreateIssueModal</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">CRUD, inline-edit полей, permission checks через Role Scheme.</td></tr>
+      <tr><td>Типы задач (Epic / Story / Task / Bug / Subtask)</td><td><code>IssueTypeConfig</code> + <code>IssueTypeScheme</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Полностью настраиваемо. Эпики — просто тип в конфиге.</td></tr>
+      <tr><td>Parent / Subtasks (иерархия)</td><td><code>Issue.parentId</code> self-relation</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Многоуровневая иерархия (Epic → Story → Subtask). Без лимита глубины.</td></tr>
+      <tr><td>Issue Links (depends, blocks, relates)</td><td><code>IssueLink</code> + <code>AdminLinkTypesPage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">CRUD типов линков, inbound / outbound тексты. Паритет с Jira.</td></tr>
+      <tr><td>Priorities</td><td>enum CRITICAL / HIGH / MEDIUM / LOW</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td class="note">Enum хардкоднут. Иконок / цветов не настроить (см. TTCORE-1).</td></tr>
+      <tr><td>Statuses на задаче</td><td><code>Issue.status</code> (enum) + <code>workflowStatusId</code></td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td class="note">Двойное моделирование — надо свести к одному источнику (TTCORE-1).</td></tr>
+      <tr><td>Resolution на задаче</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td class="note">Нет поля / модели. Сценарий «закрыто как Duplicate» невозможен. TTRES-1.</td></tr>
+      <tr><td>Custom Fields per-issue</td><td>13 типов, включая REFERENCE</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">REFERENCE (справочник) — в Jira DC нет, только через Marketplace.</td></tr>
+      <tr><td>Story Points</td><td>есть <code>estimatedHours</code></td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td class="note">Оценка в часах, не в story points. Для Scrum-команд, работающих в points, — ограничение.</td></tr>
+      <tr><td>Acceptance Criteria</td><td><code>Issue.acceptanceCriteria</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Отдельное поле — удобнее Jira (там через description).</td></tr>
+      <tr><td>Due date / Start date</td><td><code>Issue.dueDate</code></td><td><span class="badge partial">Частично</span></td><td><span class="badge p3">P3</span></td><td class="note">Есть dueDate, нет startDate.</td></tr>
+      <tr><td>Attachments на задаче</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td class="note"><b>Ключевая дыра.</b> Нет модели Attachment, нет upload. Нельзя приложить скриншот / лог. TTATTACH-1.</td></tr>
+      <tr><td>Bulk operations (change status / assignee / sprint)</td><td><code>BulkStatusWizardModal</code>, bulk-ops API</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Friendly-пикеры (см. TTBULK-1), CSV / XLSX экспорт из коробки.</td></tr>
+      <tr><td>Issue history (field changes)</td><td><code>audit_logs</code> в БД</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td class="note">Данные пишутся, но нет вкладки «История» на странице задачи. Нужен UI.</td></tr>
+      <tr><td>Flagged / impediments</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Можно эмулировать через custom field.</td></tr>
+      <tr><td>Voting</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Мало используется, не критично.</td></tr>
+      <tr><td>Cloning issue</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">В Jira клонирование с переносом полей / субтасков.</td></tr>
+      <tr><td>Move Issue (между проектами)</td><td><code>MoveIssueModal</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Готово, с валидацией совместимости схем.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="f-boards" class="section">
+  <h2>F2. Доски — Kanban</h2>
+  <p class="sub">Доска проекта для визуализации потока задач. <code>BoardPage</code> + <code>KanbanBoard</code>.</p>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Фича Jira Agile Board</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Kanban-доска</td><td><code>BoardPage</code> + <code>KanbanBoard</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">DnD между колонками, фильтры по assignee / epic / type, real-time обновления.</td></tr>
+      <tr><td>Колонки = статусы workflow</td><td>WorkflowStatus → columns</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Конфигурируется через workflow editor.</td></tr>
+      <tr><td>Swimlanes (по assignee / epic / priority)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Упрощает навигацию для 20+ участников. Сейчас только фильтры.</td></tr>
+      <tr><td>WIP-лимиты с enforcement</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Можно показывать, можно блокировать дроп. В Jira — soft warning.</td></tr>
+      <tr><td>Card cover images / attachments preview</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Blocked by Attachments (TTATTACH-1).</td></tr>
+      <tr><td>Quick-create с клавиши</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Сейчас через модалку.</td></tr>
+      <tr><td>Card customization (показ Story Points, due date, labels)</td><td>частично (через <code>showOnKanban</code> в FieldSchema)</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td class="note">Есть флаг, но настройка через админку, не самим пользователем.</td></tr>
+      <tr><td>Epic-панель / epic-link фильтр</td><td>фильтр по epic-родителю</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Через обычный фильтр по parent.</td></tr>
+      <tr><td>Scrum-доска (sprint view)</td><td><code>SprintIssuesDrawer</code> + sprint-scoped filter</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td class="note">Нет отдельной strict sprint-board как в Jira; показываем через drawer и фильтр.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="f-sprints" class="section">
+  <h2>F3. Scrum — спринты и бэклог</h2>
+  <p class="sub">Модели <code>Sprint</code>, <code>SprintIssue</code>. Страницы <code>SprintsPage</code>, <code>GlobalSprintsPage</code>, <code>SprintPlanningDrawer</code>.</p>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Фича Jira Scrum</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>CRUD спринта (plan / start / close)</td><td><code>SprintsPage</code> + <code>SprintPlanningDrawer</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Create / start / close, drag задач в sprint.</td></tr>
+      <tr><td>Cross-project Global Sprints</td><td><code>GlobalSprintsPage</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">В Jira DC cross-project boards — отдельная фича «Board by filter». У нас нативно.</td></tr>
+      <tr><td>Backlog view (ранжирование)</td><td>drag-and-drop, <code>orderIndex</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Порядок сохраняется через orderIndex.</td></tr>
+      <tr><td>Sprint Goal</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Отдельное поле для цели спринта.</td></tr>
+      <tr><td>Burndown chart</td><td>частично (release-level есть)</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td class="note">Release-burndown есть, sprint-burndown на базовом уровне.</td></tr>
+      <tr><td>Velocity chart</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Ключевая agile-метрика (avg delivered за N спринтов).</td></tr>
+      <tr><td>Sprint Report (commit vs completed)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">added / removed scope, что не сделано, что перенесено.</td></tr>
+      <tr><td>Sprint capacity / team commitment</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Капасити команды на спринт по часам / поинтам.</td></tr>
+      <tr><td>Retrospective / Sprint Review артефакты</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">В Jira тоже слабо — делается плагинами.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="f-releases" class="section">
+  <h2>F4. Релизы и чекпоинты — уникальная зона</h2>
+  <p class="sub">Самая сильная часть TaskTime. Модели <code>Release</code>, <code>ReleaseItem</code>, <code>Checkpoint</code>, <code>CheckpointRun</code>. Страницы <code>ReleasesPage</code>, <code>GlobalReleasesPage</code>.</p>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Фича Jira Release</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Версии (CRUD)</td><td><code>Release</code> + <code>ReleaseItem</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Плюс статусы, даты, ответственные.</td></tr>
+      <tr><td>fixVersion / affectsVersion на задаче</td><td>частично через <code>releaseId</code> (single)</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td class="note">fixVersion ≡ releaseId (single), affectsVersion — M:M в TTPROJ-1.</td></tr>
+      <tr><td>Release Hub (обзор версии)</td><td><code>GlobalReleasesPage</code> + Release Card</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Сводная карточка с метриками, чекпоинтами, задачами.</td></tr>
+      <tr><td>Release Notes generation</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Автосборка заметок по задачам в версии.</td></tr>
+      <tr><td>Release Workflow (lifecycle релиза)</td><td><code>AdminReleaseWorkflowsPage</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note"><b>Нет в Jira.</b> Конструктор с статусами, переходами.</td></tr>
+      <tr><td>Release Checkpoints (quality gates)</td><td>Checkpoint / <code>CheckpointRun</code> / <code>CheckpointCriterion</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note"><b>Нет в Jira.</b> 5 типов критериев + TTQL + combined; preview; risk scoring LOW / MEDIUM / HIGH / CRITICAL; матрица issue × checkpoint.</td></tr>
+      <tr><td>Release Burndown</td><td><code>ReleaseBurndown</code> + daily snapshots</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note"><b>В Jira DC только sprint burndown.</b> Actual + ideal + retention + manual backfill.</td></tr>
+      <tr><td>Risk scoring релиза</td><td>rules-engine по чекпоинтам + violations</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Детерминированный расчёт risk-level по violated checkpoints.</td></tr>
+      <tr><td>Checkpoint Audit</td><td><code>AdminCheckpointAuditPage</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Лог всех запусков / переполнений, exportable.</td></tr>
+      <tr><td>Webhook-notifier на release-events</td><td><code>release-webhook-notifier.service</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Точечный notifier (не общий webhooks-реестр).</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="f-search" class="section">
+  <h2>F5. Поиск — TTQL и фильтры</h2>
+  <p class="sub">Собственный язык запросов TTQL (аналог JQL), compiler, help-страница, сохранённые фильтры.</p>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Фича Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Basic filters (assignee / status / …)</td><td><code>SearchPage</code> + filter-panel</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">UI-фильтры + превращение в TTQL под капотом.</td></tr>
+      <tr><td>JQL ⟷ TTQL</td><td>TTQL compiler в backend</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Функции <code>currentUser()</code>, <code>releasePlannedDate()</code>, <code>violatedCheckpoints()</code> — release-aware.</td></tr>
+      <tr><td>Help / syntax reference</td><td><code>SearchHelpPage</code> (<code>/search/help</code>)</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Отдельная справочная страница.</td></tr>
+      <tr><td>Visual query builder</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">В Jira JQL builder — покрывается filter-panel + help.</td></tr>
+      <tr><td>Saved Filters (private / shared)</td><td><code>SavedFilter</code> с visibility PRIVATE / SHARED / PUBLIC</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Per-user permissions, starred, use-count.</td></tr>
+      <tr><td>Filter subscription (email-рассылка)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Требует SMTP (TTNOTIF-1) — как следствие блокируется одним pillar'ом.</td></tr>
+      <tr><td>Full-text search (description / comments)</td><td>частично (Phase 2)</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td class="note">Сейчас — по полям. Full-text (pg_trgm / tsvector) в плане.</td></tr>
+      <tr><td>Export search results</td><td>через Bulk ops (CSV / XLSX)</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Работает для любого набора задач.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="f-reports" class="section">
+  <h2>F6. Отчёты и дашборды</h2>
+  <p class="sub">Слабое место относительно Jira. Сейчас только 2 отчёта + единый read-only Dashboard.</p>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Фича Jira Reports</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Задачи по статусам</td><td>Admin → Отчёты → Задачи по статусам</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Фильтр по проекту / спринту / периоду.</td></tr>
+      <tr><td>Задачи по исполнителям</td><td>Admin → Отчёты → Задачи по исполнителям</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Выявление перекоса нагрузки.</td></tr>
+      <tr><td>Velocity Chart</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Ключевой agile-отчёт.</td></tr>
+      <tr><td>Sprint Report (commit vs done)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Scope-changes, что перенесено / отменено.</td></tr>
+      <tr><td>Cumulative Flow Diagram</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Накопительный поток задач по статусам.</td></tr>
+      <tr><td>Burndown / Burnup (sprint)</td><td>частично</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td class="note">Release-burndown — да; sprint-level — базово.</td></tr>
+      <tr><td>Burndown (release)</td><td><code>ReleaseBurndown</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note"><b>В Jira DC отсутствует.</b></td></tr>
+      <tr><td>Time Tracking report</td><td>частично (My Time / TimePage)</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td class="note">Сводки по пользователю / дню есть, нет кросс-команды / кросс-проекта.</td></tr>
+      <tr><td>Control Chart / Cycle Time / Time in Status</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Метрики lean / kanban-команд.</td></tr>
+      <tr><td>Personal Dashboards с виджетами (drag-n-drop)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Сейчас один общий <code>DashboardPage</code> read-only.</td></tr>
+      <tr><td>Shared Dashboards</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">В Jira — публикация дашборда ролям / группам.</td></tr>
+      <tr><td>Gadgets / widgets marketplace</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Концепция плагинных гаджетов.</td></tr>
+      <tr><td>Release-level risk / violations matrix</td><td><code>AdminCheckpointAuditPage</code> + violations</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note"><b>Новый тип отчётности</b>, в Jira нет.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="f-time" class="section">
+  <h2>F7. Учёт времени</h2>
+  <p class="sub">Интегрированный таймер и ручной лог часов. Модель <code>TimeLog</code>, страница <code>TimePage</code>.</p>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Фича Jira Time Tracking</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Original / Remaining estimate</td><td><code>Issue.estimatedHours</code></td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td class="note">Один оценочный слот. В Jira — original + remaining.</td></tr>
+      <tr><td>Work logs (manual entries)</td><td><code>TimeLog</code> CRUD</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Работает через TimePage.</td></tr>
+      <tr><td>Live timer (start / stop)</td><td>таймер, 1 active per user</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">В Jira DC — нет, плагин Tempo.</td></tr>
+      <tr><td>Auto-stop таймера</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">TTCFG-1: auto-stop через N часов.</td></tr>
+      <tr><td>Парсер формата (1w 2d 3h)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">TTCFG-1: Jira-style парсер.</td></tr>
+      <tr><td>My Time / daily aggregation</td><td><code>TimePage</code></td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Персональная сводка дня.</td></tr>
+      <tr><td>Timesheet (team-wide таблица)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Кросс-команда недельная / месячная.</td></tr>
+      <tr><td>Billing rates / costs</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Из коробки в Jira тоже нет.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="f-collab" class="section">
+  <h2>F8. Коллаборация — комментарии, watchers, mentions, вложения</h2>
+  <p class="sub">Крупная дыра. Без уведомлений и вложений трекер остаётся CRM-style, а не Jira-style.</p>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Фича Jira</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>Комментарии (CRUD)</td><td><code>Comment</code> CRUD + permissions</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td class="note">Add / edit own / delete, role-based permissions.</td></tr>
+      <tr><td>@mentions в комментариях</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Парсер-лексер + нотификация упомянутому. Закрывается TTNOTIF-1.</td></tr>
+      <tr><td>Watchers на задаче</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Нет модели Watcher. Закрывается TTNOTIF-1.</td></tr>
+      <tr><td>Notifications (in-app bell)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Нет колокольчика и истории. Закрывается TTNOTIF-1.</td></tr>
+      <tr><td>Email notifications</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td class="note">Нет SMTP. Закрывается TTNOTIF-1.</td></tr>
+      <tr><td>Attachments (upload)</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td class="note">Нет модели, нет storage, нет multer. TTATTACH-1.</td></tr>
+      <tr><td>Thumbnails / preview вложений</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td class="note">Зависит от TTATTACH-1.</td></tr>
+      <tr><td>Comment reactions</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">В Jira есть эмоджи-реакции (Cloud).</td></tr>
+      <tr><td>Edit-history / pinned comments</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Улучшение UX.</td></tr>
+      <tr><td>Rich-text editor (Markdown / WYSIWYG)</td><td>базовый</td><td><span class="badge partial">Частично</span></td><td><span class="badge p3">P3</span></td><td class="note">Базовый редактор без таблиц / code blocks на уровне Jira.</td></tr>
+      <tr><td>Activity stream per issue (UI-вкладка)</td><td>audit_logs (данные) / нет UI</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td class="note">Данные пишутся, нужна отдельная вкладка на странице задачи.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="f-integrations" class="section">
+  <h2>F9. Интеграции, AI, уникальные фичи</h2>
+  <p class="sub">Зона преимущества TaskTime. MCP, AI-декомпозиция, GitLab из коробки, Teams / Operations / UAT.</p>
+  <table class="cmp">
+    <thead><tr><th style="width: 22%">Фича</th><th style="width: 26%">Аналог в TaskTime</th><th style="width: 10%">Статус</th><th style="width: 10%">Критичность</th><th>Примечание</th></tr></thead>
+    <tbody>
+      <tr><td>GitLab (webhook → auto-transition)</td><td><code>integrations/gitlab</code> + <code>webhooks</code> + <code>pipeline-service</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">MR open / merge → статус задачи. В Jira DC — только через Marketplace.</td></tr>
+      <tr><td>GitHub / Bitbucket DVCS</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Можно добавить по запросу.</td></tr>
+      <tr><td>CI Pipeline Dashboard</td><td><code>PipelineDashboardPage</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Визуализация пайплайнов — нет у Jira нативно.</td></tr>
+      <tr><td>AI — декомпозиция Epic → Subtasks</td><td><code>ai/ai.service</code> + Anthropic provider</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note"><b>Нет у Jira DC.</b> Claude-based.</td></tr>
+      <tr><td>AI — оценка часов задачи</td><td><code>ai</code> module</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">С логированием sessions / tokens / стоимости.</td></tr>
+      <tr><td>MCP-сервер (Model Context Protocol)</td><td><code>mcp/http-transport</code> + tools</td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note"><b>Уникально.</b> Позволяет подключить задачи к Claude / агентам.</td></tr>
+      <tr><td>Teams abstraction</td><td><code>BusinessTeamsPage</code>, <code>FlowTeamsPage</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Бизнес-команды и flow-команды отдельно от User Groups. В Jira нет.</td></tr>
+      <tr><td>Operations (meta-проект)</td><td><code>OperationsPage</code> + <code>OperationDetailPage</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Ops-задачи отдельно от продуктовых.</td></tr>
+      <tr><td>UAT Tests (роль-specific чеклисты)</td><td><code>UatTestsPage</code></td><td><span class="badge win">Лучше</span></td><td><span class="badge na">—</span></td><td class="note">Встроенный онбординг-чеклист.</td></tr>
+      <tr><td>Slack / Teams notifications</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td class="note">Требует SMTP → webhook → channel. В Jira — плагины.</td></tr>
+      <tr><td>Email → create issue</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Incoming Mail Handlers.</td></tr>
+      <tr><td>Mobile app</td><td>—</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td class="note">Jira имеет — у нас пока нет PWA.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+</div>
+<!-- /ВКЛАДКА 3 -->
+
+<!-- =========================================================================
+     ВКЛАДКА 4 — СТЭК & ENTERPRISE-ГОТОВНОСТЬ (5000 users)
+     ========================================================================= -->
+<div id="enterprise" class="tab-panel" role="tabpanel">
+
+<div class="toc-inline">
+  <strong>Содержание</strong>
+  <a href="#e-snapshot">E1. Стэк — как есть</a>
+  <a href="#e-posture">E2. Prod-постура (текущий деплой)</a>
+  <a href="#e-capacity">E3. Оценка нагрузки для 5000 users</a>
+  <a href="#e-matrix">E4. Матрица Enterprise-готовности</a>
+  <a href="#e-target">E5. Целевая архитектура</a>
+  <a href="#e-plan">E6. План дозакрытия</a>
+</div>
+
+<div class="callout warn">
+  <strong>Целевой сценарий:</strong> on-premise Astra Linux SE 1.7+ / Red OS 7.3+, корпоративный контур РФ,
+  <b>5 000 зарегистрированных пользователей</b>, из них ~1 500 DAU (30%) и ~500–800 concurrent в пиках.
+  Для такой нагрузки single-node compose из <code>deploy/docker-compose.production.yml</code> — <b>не годится</b>.
+  Текущие целевые NFR в <code>docs/architecture/overview.md</code> заявляют 2 500+ concurrent sessions; для 5 000
+  users этого мало, нужна горизонтальная стратегия.
+</div>
+
+<section id="e-snapshot" class="section">
+  <h2>E1. Стэк — как есть</h2>
+  <p class="sub">Выжимка из <code>backend/package.json</code>, <code>frontend/package.json</code>, <code>docker-compose.yml</code>, <code>deploy/docker-compose.production.yml</code>, <code>docs/architecture/overview.md</code>.</p>
+  <table class="cmp">
+    <thead><tr>
+      <th style="width: 18%">Слой</th>
+      <th style="width: 30%">Технология</th>
+      <th style="width: 14%">Версия</th>
+      <th style="width: 12%">Enterprise-profile</th>
+      <th>Комментарий</th>
+    </tr></thead>
+    <tbody>
+      <tr><td>Runtime</td><td>Node.js</td><td>20 LTS</td><td><span class="badge ok">Подходит</span></td><td class="note">LTS до 2026-04. Поддержка clustering через <code>node:cluster</code> / PM2 / K8s.</td></tr>
+      <tr><td>Язык</td><td>TypeScript</td><td>5.7</td><td><span class="badge ok">Подходит</span></td><td class="note">Строгая типизация — плюс для enterprise аудита.</td></tr>
+      <tr><td>HTTP-фреймворк</td><td>Express</td><td>4.21</td><td><span class="badge partial">Приемлемо</span></td><td class="note">Зрелый, но не самый быстрый. Для 5k users ок, в hot-path при тестировании проверить.</td></tr>
+      <tr><td>ORM</td><td>Prisma</td><td>6.5</td><td><span class="badge partial">Приемлемо</span></td><td class="note">Без connection pool из коробки — нужен <b>PgBouncer</b>. Query planner иногда генерит неэффективный SQL — мониторить.</td></tr>
+      <tr><td>Валидация</td><td>Zod</td><td>3.24</td><td><span class="badge ok">Подходит</span></td><td class="note">Используется как на backend, так и на frontend — паритет схем.</td></tr>
+      <tr><td>БД (основная)</td><td>PostgreSQL</td><td>16 (alpine)</td><td><span class="badge partial">Single-node</span></td><td class="note">Нет streaming replication, нет read-replicas, нет pooler. Для 5k users — критический гэп.</td></tr>
+      <tr><td>Кэш / сессии</td><td>Redis</td><td>7 (alpine)</td><td><span class="badge partial">Single-node</span></td><td class="note">AOF включён, но нет Sentinel/Cluster. Используется для rate-limiting и кэша.</td></tr>
+      <tr><td>Event Bus</td><td>—</td><td>—</td><td><span class="badge missing">Нет</span></td><td class="note">Kafka в плане TTBUS-0 (54ч). Критически важен для notifications/webhooks pillar'а.</td></tr>
+      <tr><td>Auth</td><td>JWT (access + refresh) + bcryptjs</td><td>—</td><td><span class="badge partial">Приемлемо</span></td><td class="note">Refresh-tokens в БД — OK. Нет SSO (TTSSO-1, 102ч), нет MFA (TTMFA-1, 68ч).</td></tr>
+      <tr><td>Метрики</td><td>prom-client + Prometheus + Grafana</td><td>15.1</td><td><span class="badge ok">Готово</span></td><td class="note"><code>deploy/prometheus</code>, <code>deploy/grafana</code> уже в репо. Дашборды готовы.</td></tr>
+      <tr><td>Логирование</td><td>stdout → docker logs</td><td>—</td><td><span class="badge missing">Нет агрегации</span></td><td class="note">Нет централизованного логирования (Loki / ELK / Graylog). Для 5k users обязательно.</td></tr>
+      <tr><td>Трейсинг</td><td>—</td><td>—</td><td><span class="badge missing">Нет</span></td><td class="note">Нет OpenTelemetry / Jaeger / Tempo. Для SLO-debugging обязательно.</td></tr>
+      <tr><td>Cron / scheduler</td><td>node-cron</td><td>4.2</td><td><span class="badge partial">In-process</span></td><td class="note">Работает внутри backend-инстанса. При horizontal scaling — race: нужен leader election или внешний scheduler.</td></tr>
+      <tr><td>Webhooks out</td><td>native fetch</td><td>—</td><td><span class="badge partial">Custom</span></td><td class="note">Checkpoint-notifier есть, общий реестр — TTINTEG-1 (70ч).</td></tr>
+      <tr><td>Reverse proxy / TLS</td><td>Nginx</td><td>—</td><td><span class="badge partial">Single</span></td><td class="note">Rate limiting 5–30 r/s, security headers. Single instance — SPOF.</td></tr>
+      <tr><td>Frontend runtime</td><td>React + Vite</td><td>18.3 / 6.x</td><td><span class="badge ok">Подходит</span></td><td class="note">SPA, Ant Design 5, Zustand 5, Recharts 3.</td></tr>
+      <tr><td>UI-состояние</td><td>Zustand</td><td>5.0</td><td><span class="badge ok">Подходит</span></td><td class="note">Лёгкий, без излишней оркестрации.</td></tr>
+      <tr><td>Drag &amp; drop</td><td>@hello-pangea/dnd</td><td>18.x</td><td><span class="badge ok">Подходит</span></td><td class="note">Fork react-beautiful-dnd, поддержан.</td></tr>
+      <tr><td>CI / CD</td><td>GitHub Actions</td><td>—</td><td><span class="badge partial">Приемлемо</span></td><td class="note">5 workflows (ci, build, deploy-staging, deploy-production, update-docs). Нет canary / blue-green.</td></tr>
+      <tr><td>Контейнеризация</td><td>Docker Compose</td><td>—</td><td><span class="badge partial">Single-host</span></td><td class="note">Нет K8s / Swarm. Horizontal scaling через compose не делается — нужен orchestrator.</td></tr>
+      <tr><td>AI</td><td>Anthropic SDK 0.39</td><td>—</td><td><span class="badge ok">Подходит</span></td><td class="note">Сессии логируются (tokens/стоимость), feature-flag <code>FEATURES_AI</code>.</td></tr>
+      <tr><td>MCP</td><td>@modelcontextprotocol/sdk 1.29</td><td>—</td><td><span class="badge ok">Подходит</span></td><td class="note">Отдельный сервис в compose, HTTP transport на 3002.</td></tr>
+      <tr><td>Pipeline-service</td><td>Отдельный Node/Express + свой Postgres</td><td>—</td><td><span class="badge partial">Standalone</span></td><td class="note">Правильная изоляция CI-данных. Тоже single-node.</td></tr>
+      <tr><td>Secrets</td><td>.env / docker env</td><td>—</td><td><span class="badge missing">Нет vault</span></td><td class="note">Для корпоративного контура нужен Vault / Conjur / Kube Secrets + sealed.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="e-posture" class="section">
+  <h2>E2. Текущая prod-постура (как деплоится сейчас)</h2>
+  <p class="sub">Что реально видно в <code>deploy/docker-compose.production.yml</code> + <code>deploy/nginx/nginx.conf.template</code>.</p>
+
+  <div class="cols-2">
+    <div>
+      <div class="col-title">Что есть</div>
+      <ul style="font-size: 13.5px; padding-left: 20px;">
+        <li>Единый Docker Compose на один хост: <code>web</code> (nginx+static), <code>backend</code>, <code>postgres</code>, <code>redis</code>, <code>mcp</code>, <code>pipeline-service</code>, <code>pipeline-postgres</code>.</li>
+        <li>Healthcheck'и на все сервисы, <code>restart: unless-stopped</code>.</li>
+        <li>Rate-limit в nginx (5 r/s auth, 30 r/s api), client_max_body_size 10m.</li>
+        <li>Скрипты <code>backup-postgres.sh</code>, <code>restore-postgres.sh</code>, <code>rollback.sh</code> в <code>deploy/scripts/</code>.</li>
+        <li>Prometheus + Grafana (есть конфиги в <code>deploy/</code>).</li>
+        <li>Feature-flags через ENV (<code>FEATURES_*</code>).</li>
+      </ul>
+    </div>
+    <div>
+      <div class="col-title">Что отсутствует на уровне инфры</div>
+      <ul style="font-size: 13.5px; padding-left: 20px;">
+        <li><b>Нет репликации Postgres</b> (одна instance → SPOF + только вертикальное масштабирование).</li>
+        <li><b>Нет PgBouncer</b> — Prisma-пул упрётся в <code>max_connections</code> постгри при &gt;5 backend replica.</li>
+        <li><b>Нет Redis HA</b> (ни Sentinel, ни Cluster).</li>
+        <li><b>Нет K8s / orchestrator</b> — масштабировать backend можно только добавив реплик в compose и балансировщик перед ним.</li>
+        <li><b>Нет centralized logging</b> (нет Loki / ELK / Vector).</li>
+        <li><b>Нет tracing</b> (нет OpenTelemetry).</li>
+        <li><b>Нет WAF / IPS</b> перед nginx.</li>
+        <li><b>Нет CDN</b> для фронтенд-статики (для 5k — не критично, но снижает latency региональным пользователям).</li>
+        <li><b>Нет blue-green / canary deploy</b>; deploy-скрипт останавливает контейнеры.</li>
+        <li><b>Нет secrets vault</b>; всё через <code>.env</code>-файлы на хосте.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section id="e-capacity" class="section">
+  <h2>E3. Оценка нагрузки для 5 000 пользователей</h2>
+  <p class="sub">Грубый расчёт — для sizing'а. Реальные цифры нужно валидировать load-тестом с Playwright + k6 на staging.</p>
+
+  <div class="summary">
+    <div class="kpi"><div class="label">Зарегистрировано</div><div class="val">5 000</div></div>
+    <div class="kpi"><div class="label">DAU (≈30%)</div><div class="val">~1 500</div></div>
+    <div class="kpi"><div class="label">Concurrent (peak)</div><div class="val">500–800</div></div>
+    <div class="kpi"><div class="label">RPS sustained</div><div class="val">50–100</div></div>
+    <div class="kpi"><div class="label">RPS peak</div><div class="val">200–400</div></div>
+    <div class="kpi"><div class="label">Issues в БД (2–3 года)</div><div class="val">500k–1.5M</div></div>
+  </div>
+
+  <table class="cmp" style="margin-top: 16px;">
+    <thead><tr>
+      <th style="width: 22%">Ресурс</th>
+      <th style="width: 28%">Оценка для 5k users</th>
+      <th style="width: 22%">Сейчас</th>
+      <th>Действие</th>
+    </tr></thead>
+    <tbody>
+      <tr><td>Backend инстансы</td><td>3–5 реплик × 1–2 vCPU / 1 GB</td><td>1 реплика</td><td class="note">Добавить replicas, поставить nginx upstream или K8s Service. Удостовериться в <b>stateless</b> (сейчас node-cron in-process — требует leader election).</td></tr>
+      <tr><td>Postgres</td><td>4–8 vCPU / 16–32 GB RAM / NVMe; shared_buffers 25%, effective_cache_size 75%; streaming replication + 1 read-replica</td><td>single alpine без тюнинга</td><td class="note">Тюнинг + primary-standby + PgBouncer (transaction pooling) между backend и postgres.</td></tr>
+      <tr><td>Connection pool</td><td>~60–100 соединений PgBouncer; Prisma 10–20 на backend × 5 = 50–100</td><td>Prisma прямо в Postgres</td><td class="note"><b>P0.</b> Без PgBouncer любая replica-атака упрётся в <code>max_connections</code> (default 100).</td></tr>
+      <tr><td>Redis</td><td>Sentinel (1 primary + 2 replicas + 3 sentinels) или Cluster (3 shard × 2 nodes)</td><td>single node</td><td class="note">Для rate-limiting и кэша. Для session-store (если будет) — обязательно HA.</td></tr>
+      <tr><td>Kafka (будущее)</td><td>3 broker × KRaft, 3 × 4 vCPU / 16 GB / SSD</td><td>отсутствует</td><td class="note">TTBUS-0 (54ч). Для notifications + webhooks. 3 ноды — минимум для quorum.</td></tr>
+      <tr><td>Frontend (статика)</td><td>nginx + gzip + brotli + long-cache; опционально CDN</td><td>есть nginx</td><td class="note">Vite-бандл ~1.5–2 MB gzipped. Для РФ-контура CDN не обязателен.</td></tr>
+      <tr><td>Attachments storage</td><td>S3-совместимый (MinIO для on-prem) или NFS; ~100 GB / год при средних 5 MB/задача</td><td>не реализовано</td><td class="note">TTATTACH-1 предусматривает pluggable storage (local / s3).</td></tr>
+      <tr><td>Logs</td><td>~30–100 GB / месяц при 100 RPS; retention 30–90 дней</td><td>docker-logs</td><td class="note">Vector / Loki или ELK + S3 archive.</td></tr>
+      <tr><td>Бэкапы Postgres</td><td>pg_dump / pg_basebackup ежедневно + WAL-archive; S3 / NFS; RPO ≤ 15 мин, RTO ≤ 1ч</td><td>есть cron-скрипт</td><td class="note">Нужна регулярная drill-проверка restore.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="e-matrix" class="section">
+  <h2>E4. Матрица Enterprise-готовности</h2>
+  <p class="sub">Что критично для 5 000 users и корпоративного контура. Сгруппировано по слоям.</p>
+
+  <table class="cmp">
+    <thead><tr>
+      <th style="width: 18%">Категория</th>
+      <th style="width: 26%">Требование</th>
+      <th style="width: 10%">Статус</th>
+      <th style="width: 10%">Крит-ть</th>
+      <th style="width: 14%">Трудозатраты</th>
+      <th>Комментарий</th>
+    </tr></thead>
+    <tbody>
+
+      <!-- Приложение / runtime -->
+      <tr><td>Runtime</td><td>Horizontal scaling backend (stateless, 3–5 replicas)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td>~40–60ч</td><td class="note">Убрать in-process state (node-cron), вывести jobs в отдельный worker с leader-election (Redis Redlock или Postgres advisory lock).</td></tr>
+      <tr><td>Runtime</td><td>Orchestrator (K8s / Swarm / Nomad)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td>~80–120ч</td><td class="note">Для 5k users compose на одном хосте — SPOF. Минимально — K3s / managed K8s.</td></tr>
+      <tr><td>Runtime</td><td>Graceful shutdown + connection draining</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td>~16ч</td><td class="note">Для zero-downtime deploy обязательно.</td></tr>
+
+      <!-- DB -->
+      <tr><td>БД</td><td>PgBouncer (transaction pooling)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td>~16ч</td><td class="note">Без этого больше 3–4 backend replicas не запустить.</td></tr>
+      <tr><td>БД</td><td>Postgres HA (Patroni / streaming replication + automated failover)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td>~80ч</td><td class="note">Минимум primary + 1 sync standby + automatic failover (Patroni + etcd / consul).</td></tr>
+      <tr><td>БД</td><td>Read-replica для reporting / отчётов</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td>~24ч</td><td class="note">Развязать тяжёлые TTQL-запросы и dashboard-агрегации от транзакционного primary.</td></tr>
+      <tr><td>БД</td><td>DB tuning (shared_buffers, WAL, autovacuum)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td>~16ч</td><td class="note">Сейчас только <code>postgres:16-alpine</code> без конфига.</td></tr>
+      <tr><td>БД</td><td>Partitioning больших таблиц (audit_logs, time_logs)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td>~40ч</td><td class="note">При 5k users audit_logs быстро превысит 10M записей. Partitioning по дате обязателен.</td></tr>
+
+      <!-- Cache -->
+      <tr><td>Cache</td><td>Redis HA (Sentinel / Cluster)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td>~40ч</td><td class="note">Redis — сейчас в critical path для rate-limit. Его падение = DoS.</td></tr>
+      <tr><td>Cache</td><td>Redis-based distributed locks (для cron и idempotency)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td>~16ч</td><td class="note">Нужен для работы node-cron в кластере backend.</td></tr>
+
+      <!-- Event bus -->
+      <tr><td>Messaging</td><td>Kafka (KRaft) для событий + outbox pattern</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td>54ч (TTBUS-0)</td><td class="note">Разблокирует Notifications (TTNOTIF-1) и Webhooks (TTINTEG-1). Уже в плане MVP2JIRA.</td></tr>
+
+      <!-- Observability -->
+      <tr><td>Observability</td><td>Prometheus + Grafana</td><td><span class="badge ok">Есть</span></td><td><span class="badge na">—</span></td><td>—</td><td class="note">Конфиги в <code>deploy/prometheus</code> и <code>deploy/grafana</code>. prom-client уже встроен.</td></tr>
+      <tr><td>Observability</td><td>Centralized logging (Loki + Promtail или ELK / Vector)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td>~40ч</td><td class="note">Для 5k users docker-logs не поисковый. Loki + Grafana — дешевле всего.</td></tr>
+      <tr><td>Observability</td><td>Distributed tracing (OpenTelemetry + Jaeger / Tempo)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td>~40ч</td><td class="note">Для debugging cross-service latency (backend ↔ pipeline-service ↔ postgres).</td></tr>
+      <tr><td>Observability</td><td>SLO / error-budget / alerting</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td>~24ч</td><td class="note">Дашборды в Grafana — да; алерты (Alertmanager / Slack / email) — не настроены продакшн-grade.</td></tr>
+      <tr><td>Observability</td><td>Audit Log UI + экспорт</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td>~63ч (TTSEC-4)</td><td class="note">Данные есть, UI — нет. Обязательно для ФЗ-152 compliance и корп-безопасности.</td></tr>
+
+      <!-- Security -->
+      <tr><td>Security</td><td>SSO / OIDC</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td>102ч (TTSSO-1)</td><td class="note">Корп-контур без SSO невозможен. Keycloak / Blitz Identity / Azure AD.</td></tr>
+      <tr><td>Security</td><td>MFA / TOTP (минимум для SUPER_ADMIN)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td>68ч (TTMFA-1)</td><td class="note">Для админов — обязательно.</td></tr>
+      <tr><td>Security</td><td>Secrets vault (HashiCorp Vault / Conjur / Kube Secrets + sealed)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td>~40ч</td><td class="note">Сейчас <code>.env</code>-файлы на хосте — не соответствует корп-стандартам.</td></tr>
+      <tr><td>Security</td><td>WAF / IPS перед nginx</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td>~16ч</td><td class="note">ModSecurity / CrowdSec / облачный WAF.</td></tr>
+      <tr><td>Security</td><td>Image scanning (Trivy / Grype в CI)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td>~8ч</td><td class="note">В pipeline сейчас нет vulnerability scan Docker-образов.</td></tr>
+      <tr><td>Security</td><td>TLS 1.2+ / mTLS между сервисами</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td>~16ч</td><td class="note">TLS снаружи — да (nginx); между backend↔postgres / backend↔redis внутри сети — обычно plaintext.</td></tr>
+      <tr><td>Security</td><td>Issue Security (visibility levels)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p0">P0</span></td><td>52ч (TTSEC-3)</td><td class="note">Корп-контур: HR / инфобез задачи не должны быть видны всем.</td></tr>
+      <tr><td>Security</td><td>Password policy + lockout</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td>входит в TTSEC-4</td><td class="note">Правила хардкодом, без admin-UI.</td></tr>
+
+      <!-- DR -->
+      <tr><td>DR</td><td>Automated Postgres backups + off-site</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td>~16ч</td><td class="note">Скрипт есть; нужна cron-регулярность + off-site copy + restore drill.</td></tr>
+      <tr><td>DR</td><td>RPO / RTO документация + drills</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td>~8ч</td><td class="note">Регламент + квартальные учения восстановления.</td></tr>
+      <tr><td>DR</td><td>Geo-redundancy (multi-DC / multi-region)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p3">P3</span></td><td>по отдельному плану</td><td class="note">Есть <code>docs/architecture/geo-redundancy-plan.md</code> — план для второго DC.</td></tr>
+
+      <!-- CI/CD -->
+      <tr><td>CI/CD</td><td>Blue-green / canary / rolling deploy</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td>~40ч</td><td class="note">Сейчас deploy-скрипт гасит контейнеры — downtime пара минут. Для 5k users непозволительно.</td></tr>
+      <tr><td>CI/CD</td><td>DB migration safety (expand/contract, review-gate)</td><td><span class="badge partial">Частично</span></td><td><span class="badge p1">P1</span></td><td>~16ч</td><td class="note">Prisma migrate deploy — OK. Но нет проверок обратной совместимости и auto-lock.</td></tr>
+      <tr><td>CI/CD</td><td>Load-testing в CI (k6 / Artillery)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p2">P2</span></td><td>~40ч</td><td class="note">Нужен baseline-тест перед релизами.</td></tr>
+
+      <!-- App -->
+      <tr><td>App</td><td>Full-text search через <code>pg_trgm</code> / <code>tsvector</code> или Elasticsearch</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td>~60ч</td><td class="note">Сейчас TTQL без FTS по description/comments. При 1M+ задач — обязательно.</td></tr>
+      <tr><td>App</td><td>Pagination всех API-листингов с cursor</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td>~30ч</td><td class="note">Проверить, что все <code>/api/*/list</code> используют keyset-пагинацию.</td></tr>
+      <tr><td>App</td><td>Idempotency-keys для bulk и webhooks</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td>~24ч</td><td class="note">Bulk-ops уже есть частично; webhooks in/out — обязательно.</td></tr>
+      <tr><td>App</td><td>Rate limiting per-user (не только per-IP в nginx)</td><td><span class="badge partial">Частично</span></td><td><span class="badge p2">P2</span></td><td>~16ч</td><td class="note">Redis-based token bucket per userId.</td></tr>
+      <tr><td>App</td><td>File upload pipeline (virus scan, size limits, rate-limit)</td><td><span class="badge missing">Нет</span></td><td><span class="badge p1">P1</span></td><td>входит в TTATTACH-1</td><td class="note">После закрытия attachments.</td></tr>
+
+    </tbody>
+  </table>
+</section>
+
+<section id="e-target" class="section">
+  <h2>E5. Целевая архитектура для 5 000 users (HA)</h2>
+  <p class="sub">Минимальная HA-постура. Все слои без SPOF, каждый компонент — 3 ноды или primary+replica(+арбитр).</p>
+
+<pre style="background:#0f172a;color:#e2e8f0;padding:18px 20px;border-radius:10px;font-size:12.5px;overflow-x:auto;line-height:1.45;">
+                          ┌────────────────────────┐
+                          │  Corporate IdP (OIDC)   │
+                          │  Keycloak / Blitz / AD  │
+                          └───────────┬────────────┘
+                                      │ OIDC
+                                      ▼
+┌─────────────┐    ┌──────────────────────────────────────────────────┐
+│  Пользова-   │    │      LB / ingress (keepalived + nginx × 2)       │
+│  тели (5k)   │───▶│      TLS term + WAF (ModSecurity / CrowdSec)     │
+└─────────────┘    └────┬──────────────────────────┬──────────────────┘
+                        │                          │
+         ┌──────────────┴────┐            ┌────────┴──────────┐
+         ▼                   ▼            ▼                   ▼
+   ┌──────────┐     ┌──────────┐    ┌──────────┐     ┌──────────────┐
+   │ backend  │ ... │ backend  │    │  MCP     │     │ notifications│
+   │ (3–5)    │     │ (3–5)    │    │ (2)      │     │ service (2)  │
+   └────┬─────┘     └────┬─────┘    └────┬─────┘     └──────┬───────┘
+        │                │                │                 │
+        └────────┬───────┴───────┬────────┘                 │
+                 ▼               ▼                          ▼
+          ┌──────────────┐  ┌──────────────┐       ┌────────────────┐
+          │  PgBouncer    │  │  Redis        │       │  Kafka (KRaft)  │
+          │  (2, ha)      │  │  Sentinel     │       │  3 broker       │
+          └──────┬───────┘  │  3 primary    │       │  (TTBUS-0)      │
+                 ▼           │  + 3 replicas │       └────────────────┘
+     ┌──────────────────┐   └──────────────┘
+     │ PostgreSQL HA    │
+     │ Patroni + etcd   │
+     │ primary + 2 repl │◀── WAL archive → S3 / MinIO ─▶ off-site
+     └──────────────────┘                                       │
+                                                                ▼
+                                         Backups / Point-in-time recovery
+                                         RPO ≤ 15 мин, RTO ≤ 1ч
+
+ Observability:   Prometheus × 2  ─┐
+                  Grafana          │  Alertmanager → Slack / email / PagerDuty
+                  Loki + Promtail  │  (всем backend/mcp/pipeline — side-car логи)
+                  Tempo + OTel    ─┘
+
+ Attachments:     MinIO (S3-совместимое) — 3 ноды, erasure coding
+ Secrets:         HashiCorp Vault — 3 ноды с Raft storage
+ CI/CD:           GitHub Actions → registry → ArgoCD / deploy.sh → K8s (K3s)
+</pre>
+
+  <p style="margin-top: 14px; font-size: 13.5px; color: var(--muted);">
+    Диаграмма отражает <b>минимум</b> для 5 000 users. Для 10 000+ — добавляется read-replica Postgres под отчёты, Kafka-кластер увеличивается до 5 broker'ов, backend вырастает до 6–8 реплик.
+  </p>
+</section>
+
+<section id="e-plan" class="section">
+  <h2>E6. План дозакрытия до Enterprise-ready (5 000 users)</h2>
+  <p class="sub">Только инфраструктурный трек. Продуктовые гэпы (TTNOTIF-1, TTSEC-3 и т.д.) — см. вкладки «Саммари» / «Админка». Часть инициатив пересекается.</p>
+
+  <table class="cmp">
+    <thead><tr><th style="width: 3%">#</th><th style="width: 28%">Инициатива</th><th style="width: 10%">Крит-ть</th><th style="width: 12%">Объём</th><th>Что входит</th></tr></thead>
+    <tbody>
+      <tr><td>1</td><td>PgBouncer + Postgres tuning</td><td><span class="badge p0">P0</span></td><td>0.5 спринта</td><td class="note">Transaction pooling, настройка shared_buffers / WAL / autovacuum, установка max_connections ≈ 200.</td></tr>
+      <tr><td>2</td><td>Postgres HA (Patroni / streaming replication + failover)</td><td><span class="badge p0">P0</span></td><td>2 спринта</td><td class="note">Primary + sync standby + automatic failover через Patroni + etcd. WAL-archive на S3 / MinIO.</td></tr>
+      <tr><td>3</td><td>Redis Sentinel (3+3)</td><td><span class="badge p0">P0</span></td><td>1 спринт</td><td class="note">Для rate-limiting, locks и будущего session-store.</td></tr>
+      <tr><td>4</td><td>Stateless backend + leader-election для jobs</td><td><span class="badge p0">P0</span></td><td>1 спринт</td><td class="note">Вынести node-cron в отдельный worker. Redis Redlock / Postgres advisory lock.</td></tr>
+      <tr><td>5</td><td>Orchestrator (K3s / managed K8s)</td><td><span class="badge p1">P1</span></td><td>2 спринта</td><td class="note">Деплой через Helm charts. nginx ingress + Horizontal Pod Autoscaler.</td></tr>
+      <tr><td>6</td><td>Event Bus (Kafka KRaft)</td><td><span class="badge p0">P0</span></td><td>54ч (TTBUS-0)</td><td class="note">Prereq для notifications (TTNOTIF-1) и webhooks (TTINTEG-1). 3-node кластер.</td></tr>
+      <tr><td>7</td><td>Centralized logging (Loki + Promtail)</td><td><span class="badge p1">P1</span></td><td>1 спринт</td><td class="note">Side-car агенты на каждый сервис, хранение 30–90 дней, архив в S3.</td></tr>
+      <tr><td>8</td><td>Distributed tracing (OpenTelemetry + Tempo)</td><td><span class="badge p1">P1</span></td><td>1 спринт</td><td class="note">Инструментирование Express-middleware + Prisma.</td></tr>
+      <tr><td>9</td><td>SSO / OIDC</td><td><span class="badge p0">P0</span></td><td>102ч (TTSSO-1)</td><td class="note">Интеграция с корп-IdP (Keycloak / Blitz / AD).</td></tr>
+      <tr><td>10</td><td>Secrets vault (HashiCorp Vault)</td><td><span class="badge p1">P1</span></td><td>1 спринт</td><td class="note">Убрать <code>.env</code> с хостов. Vault Agent для инжекта.</td></tr>
+      <tr><td>11</td><td>Blue-green / rolling deploy</td><td><span class="badge p1">P1</span></td><td>0.5 спринта</td><td class="note">Graceful shutdown + connection draining + K8s rolling update.</td></tr>
+      <tr><td>12</td><td>Automated backup + restore drill</td><td><span class="badge p1">P1</span></td><td>0.5 спринта</td><td class="note">Квартальный drill с документированием RPO/RTO.</td></tr>
+      <tr><td>13</td><td>Alertmanager + runbooks</td><td><span class="badge p1">P1</span></td><td>0.5 спринта</td><td class="note">Правила для SLI (p95 latency, 5xx rate, DB pool saturation) + playbook'и на on-call.</td></tr>
+      <tr><td>14</td><td>Load-testing baseline (k6)</td><td><span class="badge p2">P2</span></td><td>1 спринт</td><td class="note">Сценарии: 500 concurrent + 5k ramp-up, регресс-тест на main.</td></tr>
+      <tr><td>15</td><td>Partitioning audit_logs / time_logs</td><td><span class="badge p2">P2</span></td><td>0.5 спринта</td><td class="note">По месяцам, retention 2–3 года hot, остальное — archive.</td></tr>
+      <tr><td>16</td><td>Read-replica Postgres под отчёты</td><td><span class="badge p2">P2</span></td><td>0.5 спринта</td><td class="note">Разгрузить primary от тяжёлых TTQL-агрегаций.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="callout ok" style="margin-top: 16px;">
+    <strong>Итог по infrastructure-треку:</strong> <b>≈ 10–12 спринтов</b> (5–6 месяцев infra-команды) для полной HA + observability + security-постуры на 5 000 users.
+    Из них <b>P0-минимум (pgbouncer + pg ha + redis ha + stateless + kafka + sso + issue security) ≈ 6 спринтов</b> — без этого трекер на 5k users падает на первом же инциденте.
+    Стэк сам по себе (Node 20 / TS / Postgres 16 / Redis 7 / React 18) — зрелый и enterprise-grade; основная работа — <b>эксплуатационная обвязка</b>, а не замена технологий.
+  </div>
+
+  <div class="callout" style="margin-top: 12px;">
+    <strong>Отличие этого плана от плана «MVP-ready»:</strong> там 760ч закрывают <i>функциональные</i> дыры (attachments, notifications, resolutions, security, velocity и т.д.).
+    Здесь — <i>операционные</i>. Оба трека можно вести параллельно; шесть пунктов (Event Bus TTBUS-0, SSO TTSSO-1, Issue Security TTSEC-3, Audit UI TTSEC-4, MFA TTMFA-1, Attachments TTATTACH-1) пересекаются и зачтутся в обоих.
+  </div>
+</section>
+
+</div>
+<!-- /ВКЛАДКА 4 -->
+
+<!-- =========================================================================
+     ВКЛАДКА 5 — YANDEX TRACKER (РЕФЕРЕНСНОЕ СРАВНЕНИЕ)
+     ========================================================================= -->
+<div id="ytracker" class="tab-panel" role="tabpanel">
+
+<div class="toc-inline">
+  <strong>Содержание</strong>
+  <a href="#y-context">Y1. Контекст и позиционирование</a>
+  <a href="#y-admin">Y2. Админка — сравнение</a>
+  <a href="#y-func">Y3. Функциональность — сравнение</a>
+  <a href="#y-enterprise">Y4. Enterprise-постура</a>
+  <a href="#y-verdict">Y5. Итоговый вердикт</a>
+</div>
+
+<div class="callout">
+  <strong>Почему это сравнение важно:</strong> Yandex Tracker — <b>прямой конкурент</b> TaskTime в российском корп-сегменте.
+  С 2022 года доступен в двух вариантах: <b>Yandex 360 SaaS</b> (yandex.cloud) и <b>Yandex Tracker Enterprise</b> (on-premise),
+  имеет сертификацию ФСТЭК и аттестации для КИИ. Для fintech-заказчика, выбирающего замену Jira, это реалистичная альтернатива TaskTime.
+  Данные о Yandex Tracker — по публичной документации <code>yandex.cloud/docs/tracker</code> на 2026-04.
+</div>
+
+<section id="y-context" class="section">
+  <h2>Y1. Контекст и позиционирование</h2>
+  <p class="sub">Что такое Yandex Tracker в 2026 году, в каких конфигурациях поставляется, где пересекается с TaskTime и Jira.</p>
+
+  <div class="cols-2">
+    <div>
+      <div class="col-title">Yandex Tracker — ключевые факты</div>
+      <ul style="font-size: 13.5px; padding-left: 20px;">
+        <li><b>Модель:</b> Yandex 360 SaaS (облако) + Enterprise on-prem (K8s-based).</li>
+        <li><b>Парадигма:</b> «очереди» (queues) вместо проектов — немного иная ментальная модель, но похоже на Jira Project.</li>
+        <li><b>Типы задач, workflow, статусы, резолюции, приоритеты</b> — всё есть, настраивается.</li>
+        <li><b>Language-first:</b> UI и документация изначально на русском. RU-техподдержка.</li>
+        <li><b>Макросы + автодействия</b> (триггеры) — аналог Jira Automation Rules.</li>
+        <li><b>Мобильные приложения</b> iOS/Android.</li>
+        <li><b>Интеграции:</b> GitLab, Bitbucket, Telegram-бот, Yandex 360 (Почта, Диск, Мессенджер), Yandex Forms (Service Desk).</li>
+        <li><b>Сертификация:</b> ФСТЭК на Enterprise-поставку, поддержка КИИ-контура, ФЗ-152.</li>
+        <li><b>AI:</b> интеграция с YandexGPT (генерация резюме, подсказки).</li>
+      </ul>
+    </div>
+    <div>
+      <div class="col-title">TaskTime — как позиционируется против</div>
+      <ul style="font-size: 13.5px; padding-left: 20px;">
+        <li><b>Тот же рынок:</b> РФ-fintech, on-prem Astra / Red OS, ФЗ-152.</li>
+        <li><b>Сильнее:</b> Release Checkpoints + Release Burndown + Release Workflows (у Yandex Tracker нет структурированных релиз-gate).</li>
+        <li><b>Сильнее:</b> AI-декомпозиция через Claude + MCP-сервер (Yandex Tracker имеет YandexGPT-подсказки, но не MCP / не decomposition-loop).</li>
+        <li><b>Сильнее:</b> TTQL с release-/checkpoint-функциями, REFERENCE custom field, 33-permission Role Scheme.</li>
+        <li><b>Слабее:</b> нет attachments, notifications pillar, мобильного приложения, Service Desk / SLA, автодействий-UI, дашбордов с виджетами.</li>
+        <li><b>Паритет:</b> workflow, issue types, custom fields, issue links, bulk ops, TTQL vs Yandex Query Language.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section id="y-admin" class="section">
+  <h2>Y2. Админка — сравнение</h2>
+  <p class="sub">Сопоставление административных возможностей Yandex Tracker, TaskTime и Jira DC 9.x.</p>
+  <table class="cmp">
+    <thead><tr>
+      <th style="width: 22%">Функция</th>
+      <th style="width: 14%">Yandex Tracker</th>
+      <th style="width: 14%">TaskTime</th>
+      <th style="width: 14%">Jira DC 9.x</th>
+      <th>Комментарий</th>
+    </tr></thead>
+    <tbody>
+      <tr><td>Users / Groups</td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td class="note">Паритет по базовому user management.</td></tr>
+      <tr><td>Queues / Projects</td><td><span class="badge ok">Queues</span></td><td><span class="badge ok">Projects</span></td><td><span class="badge ok">Projects</span></td><td class="note">Разная терминология, одинаковая семантика.</td></tr>
+      <tr><td>Permissions per queue / project</td><td><span class="badge ok">Есть</span></td><td><span class="badge win">33 флага</span></td><td><span class="badge ok">Permission Scheme</span></td><td class="note">TaskTime имеет более гранулярную матрицу; у Yandex Tracker — наборы ролей + доступы по типу.</td></tr>
+      <tr><td>SSO / SAML / OIDC</td><td><span class="badge ok">Есть</span></td><td><span class="badge missing">Нет (TTSSO-1)</span></td><td><span class="badge missing">Нет</span></td><td class="note">Yandex Tracker поддерживает SAML и Yandex ID; в TaskTime запланировано (102ч).</td></tr>
+      <tr><td>LDAP / AD sync</td><td><span class="badge ok">Есть (Enterprise)</span></td><td><span class="badge missing">Нет</span></td><td><span class="badge missing">Нет</span></td><td class="note">В Yandex Tracker Enterprise — штатно.</td></tr>
+      <tr><td>Issue Types (CRUD)</td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td class="note">Все три.</td></tr>
+      <tr><td>Statuses / Workflows</td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td class="note">Конструктор статусов и переходов — у всех.</td></tr>
+      <tr><td>Автодействия / triggers</td><td><span class="badge ok">Есть (макросы + автодействия)</span></td><td><span class="badge partial">Частично (post-functions)</span></td><td><span class="badge partial">Workflow post-functions</span></td><td class="note">Yandex Tracker ближе всего к Jira Cloud Automation — UI-конструктор триггеров. В TaskTime только backend post-functions.</td></tr>
+      <tr><td>Priorities (CRUD)</td><td><span class="badge ok">Есть</span></td><td><span class="badge missing">Enum</span></td><td><span class="badge ok">Есть</span></td><td class="note">TaskTime — хардкод enum, см. TTCORE-1.</td></tr>
+      <tr><td>Resolutions</td><td><span class="badge ok">Есть</span></td><td><span class="badge missing">Нет (TTRES-1)</span></td><td><span class="badge ok">Есть</span></td><td class="note">Критический гэп TaskTime.</td></tr>
+      <tr><td>Components / Версии</td><td><span class="badge ok">Есть</span></td><td><span class="badge partial">Release-вместо-version</span></td><td><span class="badge ok">Есть</span></td><td class="note">TTPROJ-1 закроет.</td></tr>
+      <tr><td>Custom Fields</td><td><span class="badge ok">Есть (~12 типов)</span></td><td><span class="badge win">13 типов + REFERENCE</span></td><td><span class="badge ok">Есть</span></td><td class="note">REFERENCE — собственный справочник — есть только у TaskTime.</td></tr>
+      <tr><td>Field Schemas / Configurations</td><td><span class="badge partial">Есть (per queue)</span></td><td><span class="badge win">4-level scope</span></td><td><span class="badge ok">Есть</span></td><td class="note">TaskTime — GLOBAL / PROJECT / ISSUE_TYPE / PROJECT_ISSUE_TYPE, богаче.</td></tr>
+      <tr><td>Issue Security / visibility</td><td><span class="badge ok">Есть (access per queue / per issue)</span></td><td><span class="badge missing">Нет (TTSEC-3)</span></td><td><span class="badge ok">Есть</span></td><td class="note">Yandex Tracker умеет скрывать отдельные задачи — TaskTime пока нет.</td></tr>
+      <tr><td>Notification Schemes</td><td><span class="badge ok">Есть</span></td><td><span class="badge missing">Нет (TTNOTIF-1)</span></td><td><span class="badge ok">Есть</span></td><td class="note">Крупнейший админ-гэп TaskTime.</td></tr>
+      <tr><td>SMTP</td><td><span class="badge ok">Есть</span></td><td><span class="badge missing">Нет</span></td><td><span class="badge ok">Есть</span></td><td class="note">В SaaS — готово, в Enterprise — в админке.</td></tr>
+      <tr><td>Audit Log UI</td><td><span class="badge ok">Есть</span></td><td><span class="badge partial">Есть данные, нет UI</span></td><td><span class="badge ok">Есть</span></td><td class="note">TTSEC-4 закроет.</td></tr>
+      <tr><td>Announcement Banner</td><td><span class="badge ok">Есть</span></td><td><span class="badge missing">Нет</span></td><td><span class="badge missing">Нет</span></td><td class="note">У Yandex Tracker — «системные сообщения».</td></tr>
+      <tr><td>Look &amp; Feel (брендинг)</td><td><span class="badge ok">Есть (Enterprise)</span></td><td><span class="badge missing">Нет (TTBRAND-1)</span></td><td><span class="badge missing">Нет</span></td><td class="note">Yandex Tracker Enterprise — логотип, цвета, email-подпись.</td></tr>
+      <tr><td>Release Workflows (lifecycle релиза)</td><td><span class="badge missing">Нет</span></td><td><span class="badge win">Есть</span></td><td><span class="badge missing">Нет</span></td><td class="note"><b>Только у TaskTime.</b></td></tr>
+      <tr><td>Release Checkpoints (quality gates)</td><td><span class="badge missing">Нет</span></td><td><span class="badge win">Есть</span></td><td><span class="badge missing">Нет</span></td><td class="note"><b>Только у TaskTime.</b></td></tr>
+      <tr><td>UAT-тесты в админке</td><td><span class="badge missing">Нет</span></td><td><span class="badge win">Есть</span></td><td><span class="badge missing">Нет</span></td><td class="note"><b>Только у TaskTime.</b></td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="y-func" class="section">
+  <h2>Y3. Функциональность — сравнение</h2>
+  <p class="sub">Сопоставление бизнес-возможностей, которые видит рядовой пользователь.</p>
+  <table class="cmp">
+    <thead><tr>
+      <th style="width: 22%">Функция</th>
+      <th style="width: 14%">Yandex Tracker</th>
+      <th style="width: 14%">TaskTime</th>
+      <th style="width: 14%">Jira DC 9.x</th>
+      <th>Комментарий</th>
+    </tr></thead>
+    <tbody>
+      <tr><td>Создание / редактирование задачи</td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td class="note">Паритет.</td></tr>
+      <tr><td>Иерархия задач (Epic / Story / Subtask)</td><td><span class="badge ok">Есть (эпики, подзадачи)</span></td><td><span class="badge ok">parentId self-relation</span></td><td><span class="badge ok">Есть</span></td><td class="note">Паритет.</td></tr>
+      <tr><td>Attachments на задачах / комментариях</td><td><span class="badge ok">Есть (лимит 50 МБ/файл)</span></td><td><span class="badge missing">Нет (TTATTACH-1)</span></td><td><span class="badge ok">Есть</span></td><td class="note"><b>P0-гэп TaskTime.</b> Интеграция с Yandex Disk у YT.</td></tr>
+      <tr><td>Комментарии + @mentions</td><td><span class="badge ok">Есть + notifications</span></td><td><span class="badge partial">Есть CRUD, нет mentions</span></td><td><span class="badge ok">Есть</span></td><td class="note">Закрывается TTNOTIF-1.</td></tr>
+      <tr><td>Watchers / подписки</td><td><span class="badge ok">Есть (follow/unfollow)</span></td><td><span class="badge missing">Нет</span></td><td><span class="badge ok">Есть</span></td><td class="note">Закрывается TTNOTIF-1.</td></tr>
+      <tr><td>In-app bell / email notifications</td><td><span class="badge ok">Есть</span></td><td><span class="badge missing">Нет</span></td><td><span class="badge ok">Есть</span></td><td class="note">Закрывается TTNOTIF-1 (110ч).</td></tr>
+      <tr><td>Issue Links (blocks, relates, duplicates)</td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td class="note">Паритет.</td></tr>
+      <tr><td>Bulk operations</td><td><span class="badge ok">Есть</span></td><td><span class="badge win">CSV/XLSX export</span></td><td><span class="badge partial">Limited</span></td><td class="note">TaskTime bulk-ops с friendly-пикерами (TTBULK-1) лучше, но нет import.</td></tr>
+      <tr><td>CSV / XLSX import</td><td><span class="badge ok">Есть</span></td><td><span class="badge missing">Нет (план P1)</span></td><td><span class="badge partial">CSV only</span></td><td class="note">Yandex Tracker поддерживает миграцию из Jira и Excel.</td></tr>
+      <tr><td>Kanban-доска</td><td><span class="badge ok">Есть + swimlanes + WIP</span></td><td><span class="badge partial">Есть, без swimlanes / WIP</span></td><td><span class="badge ok">Есть</span></td><td class="note">YT полнее.</td></tr>
+      <tr><td>Scrum-sprints</td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">Есть</span></td><td class="note">Паритет по базе.</td></tr>
+      <tr><td>Velocity / Sprint Report / CFD</td><td><span class="badge ok">Есть</span></td><td><span class="badge missing">Нет (план P1)</span></td><td><span class="badge ok">Есть</span></td><td class="note">Крупный гэп agile-отчётности.</td></tr>
+      <tr><td>Roadmap / Timeline / Gantt</td><td><span class="badge ok">Есть (гантограммы)</span></td><td><span class="badge missing">Нет</span></td><td><span class="badge missing">Нет в vanilla</span></td><td class="note">Yandex Tracker имеет штатный timeline. Для PM-команд — важно.</td></tr>
+      <tr><td>Personal Dashboards с виджетами</td><td><span class="badge ok">Есть</span></td><td><span class="badge missing">Read-only</span></td><td><span class="badge ok">Есть</span></td><td class="note">YT — drag-drop конструктор.</td></tr>
+      <tr><td>Поиск / язык запросов</td><td><span class="badge ok">YQL (Yandex Query Language)</span></td><td><span class="badge ok">TTQL</span></td><td><span class="badge ok">JQL</span></td><td class="note">Функционально близко; TTQL имеет <b>release-/checkpoint-функции</b>, которых нет в YQL.</td></tr>
+      <tr><td>Saved Filters</td><td><span class="badge ok">Есть (private/public)</span></td><td><span class="badge ok">PRIVATE/SHARED/PUBLIC</span></td><td><span class="badge ok">Есть</span></td><td class="note">Паритет.</td></tr>
+      <tr><td>Full-text search (description, comments)</td><td><span class="badge ok">Есть (ClickHouse под капотом)</span></td><td><span class="badge partial">Phase 2</span></td><td><span class="badge ok">Lucene</span></td><td class="note">Пока TaskTime слабее.</td></tr>
+      <tr><td>Time Tracking (manual + live timer)</td><td><span class="badge ok">Есть</span></td><td><span class="badge win">Timer встроенный</span></td><td><span class="badge partial">Manual only</span></td><td class="note">TaskTime с live-таймером — сильнее vanilla Jira; YT тоже имеет timer.</td></tr>
+      <tr><td>Macros / автодействия (UI)</td><td><span class="badge win">Есть (мощно)</span></td><td><span class="badge missing">Нет</span></td><td><span class="badge missing">Нет в DC (есть в Cloud)</span></td><td class="note">YT-макросы — их сильная сторона.</td></tr>
+      <tr><td>Service Desk / SLA mode</td><td><span class="badge ok">Есть (через Yandex Forms)</span></td><td><span class="badge missing">Нет</span></td><td><span class="badge missing">Jira SM — отдельный продукт</span></td><td class="note">Для customer-facing очередей важно.</td></tr>
+      <tr><td>Mobile app</td><td><span class="badge ok">iOS + Android</span></td><td><span class="badge missing">Нет (даже PWA)</span></td><td><span class="badge ok">Есть</span></td><td class="note">Для мобильных ролей (менеджмент, ops) — существенный фактор.</td></tr>
+      <tr><td>GitLab / Bitbucket / GitHub</td><td><span class="badge ok">Есть</span></td><td><span class="badge ok">GitLab webhooks</span></td><td><span class="badge partial">Plugin</span></td><td class="note">Паритет по GitLab.</td></tr>
+      <tr><td>AI / GPT</td><td><span class="badge ok">YandexGPT-подсказки</span></td><td><span class="badge win">Claude + MCP + decomposition</span></td><td><span class="badge missing">Нет</span></td><td class="note"><b>TaskTime глубже</b>: декомпозиция Epic → Subtasks, оценка часов, MCP для агентов.</td></tr>
+      <tr><td>Release Management (планы, burndown)</td><td><span class="badge partial">Есть базовый</span></td><td><span class="badge win">Releases + Checkpoints + Burndown</span></td><td><span class="badge partial">Release Hub</span></td><td class="note"><b>TaskTime — сильнее всех.</b></td></tr>
+      <tr><td>Release Workflows</td><td><span class="badge missing">Нет</span></td><td><span class="badge win">Есть</span></td><td><span class="badge missing">Нет</span></td><td class="note"><b>Уникальная фича TaskTime.</b></td></tr>
+      <tr><td>Release Checkpoints с TTQL</td><td><span class="badge missing">Нет</span></td><td><span class="badge win">Есть</span></td><td><span class="badge missing">Нет</span></td><td class="note"><b>Уникальная фича TaskTime.</b></td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="y-enterprise" class="section">
+  <h2>Y4. Enterprise-постура (on-prem, 5000 users, РФ)</h2>
+  <p class="sub">Сравнение зрелости инфраструктуры и эксплуатации для on-prem enterprise-сценария.</p>
+  <table class="cmp">
+    <thead><tr>
+      <th style="width: 22%">Аспект</th>
+      <th style="width: 18%">Yandex Tracker Enterprise</th>
+      <th style="width: 18%">TaskTime (сейчас)</th>
+      <th style="width: 18%">TaskTime (после infra-плана)</th>
+      <th>Комментарий</th>
+    </tr></thead>
+    <tbody>
+      <tr><td>Поставка on-prem</td><td><span class="badge ok">K8s + Helm charts</span></td><td><span class="badge partial">Docker Compose single-host</span></td><td><span class="badge ok">K3s + Helm</span></td><td class="note">Yandex Tracker из коробки в K8s; TaskTime нужен orchestrator — см. E6 п.5.</td></tr>
+      <tr><td>Horizontal scaling</td><td><span class="badge ok">Auto-scaling pods</span></td><td><span class="badge missing">Single replica</span></td><td><span class="badge ok">3–5 replicas + HPA</span></td><td class="note">Целевая архитектура E5.</td></tr>
+      <tr><td>Postgres HA</td><td><span class="badge ok">Managed по умолчанию</span></td><td><span class="badge missing">Single node</span></td><td><span class="badge ok">Patroni + standby</span></td><td class="note">E4: 80ч на внедрение.</td></tr>
+      <tr><td>Redis HA</td><td><span class="badge ok">Sentinel / Cluster</span></td><td><span class="badge missing">Single node</span></td><td><span class="badge ok">Sentinel 3+3</span></td><td class="note">E4: 40ч.</td></tr>
+      <tr><td>Event bus</td><td><span class="badge ok">Kafka / внутренние очереди</span></td><td><span class="badge missing">Нет</span></td><td><span class="badge ok">Kafka KRaft 3-node (TTBUS-0)</span></td><td class="note">54ч.</td></tr>
+      <tr><td>Logging / tracing</td><td><span class="badge ok">Централизованное из коробки</span></td><td><span class="badge missing">docker-logs</span></td><td><span class="badge ok">Loki + Tempo + OTel</span></td><td class="note">E4: 80ч суммарно.</td></tr>
+      <tr><td>Metrics / алерты</td><td><span class="badge ok">Встроенные дашборды</span></td><td><span class="badge ok">Prometheus + Grafana</span></td><td><span class="badge ok">Есть + Alertmanager</span></td><td class="note">Паритет по метрикам.</td></tr>
+      <tr><td>SSO / SAML / OIDC</td><td><span class="badge ok">Есть + LDAP sync</span></td><td><span class="badge missing">Нет</span></td><td><span class="badge ok">TTSSO-1 (OIDC)</span></td><td class="note">102ч.</td></tr>
+      <tr><td>Secrets management</td><td><span class="badge ok">Sealed secrets / Vault</span></td><td><span class="badge missing">.env files</span></td><td><span class="badge ok">HashiCorp Vault</span></td><td class="note">E4: 40ч.</td></tr>
+      <tr><td>Backup / PITR</td><td><span class="badge ok">Managed</span></td><td><span class="badge partial">Скрипты pg_dump</span></td><td><span class="badge ok">WAL-archive + drills</span></td><td class="note">E4: 16ч.</td></tr>
+      <tr><td>Blue-green / zero-downtime deploy</td><td><span class="badge ok">Rolling update</span></td><td><span class="badge missing">Downtime deploy</span></td><td><span class="badge ok">K8s rolling</span></td><td class="note">E4: 40ч.</td></tr>
+      <tr><td>Сертификация ФСТЭК / КИИ</td><td><span class="badge ok">Есть</span></td><td><span class="badge missing">Нет</span></td><td><span class="badge partial">Требует процесса</span></td><td class="note"><b>Ключевое преимущество YT</b> для гос-fin сектора. TaskTime-сертификация — отдельный проект за рамками ТЗ.</td></tr>
+      <tr><td>ФЗ-152 compliance</td><td><span class="badge ok">Есть</span></td><td><span class="badge partial">Audit + RBAC есть</span></td><td><span class="badge ok">+ Issue Security + Audit UI</span></td><td class="note">Нужно закрыть TTSEC-3 + TTSEC-4.</td></tr>
+      <tr><td>SLA поддержки от вендора</td><td><span class="badge ok">24/7 Yandex Support</span></td><td><span class="badge partial">Зависит от команды</span></td><td><span class="badge partial">Зависит от команды</span></td><td class="note">Поставка в виде on-prem обычно сопровождается SLA-контрактом; для TaskTime — нужно формировать.</td></tr>
+      <tr><td>Гибкость доработки</td><td><span class="badge partial">Только через API / макросы</span></td><td><span class="badge win">Полный open-source контроль</span></td><td><span class="badge win">Полный контроль</span></td><td class="note"><b>Ключевое преимущество TaskTime</b>: исходники, TS-типизация, возможность глубоких кастомизаций.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="y-verdict" class="section">
+  <h2>Y5. Итоговый вердикт</h2>
+  <p class="sub">Где TaskTime впереди, где догоняет, и что это значит для позиционирования.</p>
+
+  <div class="cols-2">
+    <div>
+      <div class="col-title">Где TaskTime впереди Yandex Tracker</div>
+      <div class="crit-block win">
+        <ul>
+          <li><b>Release Workflows + Checkpoints + Burndown</b> — детерминированные релиз-gate с risk scoring. У Yandex Tracker релиз-контур минимальный.</li>
+          <li><b>AI-integration уровня decomposition</b> — Claude-based декомпозиция Epic → Subtasks, оценка часов, логирование токенов. YT имеет YandexGPT-подсказки, но не decomposition-loop.</li>
+          <li><b>MCP-сервер</b> — первоклассный протокол для подключения AI-агентов. У YT нет аналога.</li>
+          <li><b>Role Scheme с 33 permission-флагами</b> — гранулярнее, чем YT role-based модель.</li>
+          <li><b>Custom Field type REFERENCE</b> — собственный справочник на уровне админки.</li>
+          <li><b>Field Schema 4-level scope</b> (GLOBAL / PROJECT / ISSUE_TYPE / PROJECT_ISSUE_TYPE).</li>
+          <li><b>Open-source контроль</b> — исходники под контролем заказчика, возможность любых доработок без зависимости от вендора.</li>
+          <li><b>GitLab + Pipeline-service из коробки</b> — визуализация CI-пайплайнов, которой у YT нет.</li>
+        </ul>
+      </div>
+    </div>
+    <div>
+      <div class="col-title">Где TaskTime догоняет</div>
+      <div class="crit-block p1">
+        <ul>
+          <li><b>Attachments</b> — критически; у YT штатно + интеграция с Yandex Disk (TTATTACH-1, 84ч).</li>
+          <li><b>Notifications pillar</b> — email, in-app bell, watchers, @mentions (TTNOTIF-1 + TTBUS-0, 164ч).</li>
+          <li><b>Mobile app</b> — iOS/Android у YT; в TaskTime даже PWA нет.</li>
+          <li><b>Agile-отчётность</b> — Velocity, CFD, Sprint Report (план P1).</li>
+          <li><b>Roadmap / Gantt</b> — timeline-диаграмма у YT штатно.</li>
+          <li><b>Personal Dashboards с виджетами</b> — drag-drop конструктор у YT.</li>
+          <li><b>SSO / SAML / LDAP sync</b> (TTSSO-1, 102ч).</li>
+          <li><b>Automation / автодействия UI</b> — макросы у YT, у нас только backend post-functions.</li>
+          <li><b>Service Desk / SLA-режим</b> — не приоритет MVP, но отсутствует.</li>
+          <li><b>ФСТЭК / КИИ сертификация</b> — у YT есть, у TaskTime — требует отдельной процедуры.</li>
+          <li><b>On-prem K8s-поставка</b> — у YT штатно, у нас — в плане E6.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="callout ok" style="margin-top: 18px;">
+    <strong>Стратегический вывод:</strong> Yandex Tracker — <b>более зрелый на момент 2026-04</b> в части коммодити-фич (notifications, attachments, mobile, Gantt, macros, SSO, SLA-поддержка, сертификация).
+    TaskTime — <b>стратегически уникален</b> в 4 зонах: релизный контур с checkpoints, AI/MCP, гибкая кастомизация полей/ролей, open-source контроль.
+    <br><br>
+    <b>Реалистичное позиционирование:</b> TaskTime выигрывает у Yandex Tracker там, где заказчику важен <b>релизный контроль с gate'ами</b>, <b>глубокая AI-интеграция</b> и <b>полный контроль кода</b> (например, для внутренних команд банка, где готовы содержать devops-ресурс).
+    Yandex Tracker выигрывает там, где нужен <b>«взял и работает»</b> — готовые мобильные приложения, notifications, dashboards и <b>формальная сертификация</b> для закупки в гос- и крупном корп-секторе.
+  </div>
+
+  <div class="callout" style="margin-top: 12px;">
+    <strong>Что закрытие плана MVP2JIRA даст в терминах YT-паритета:</strong>
+    после выполнения 14 ТЗ из <code>docs/tz/MVP2JIRA/</code> (~760ч) TaskTime закрывает ~70% гэпов относительно Yandex Tracker (notifications, attachments, SSO, security, resolutions, priorities, components, audit UI, screens, bulk-import).
+    Остаются: <b>mobile app</b>, <b>Gantt/Timeline</b>, <b>Personal Dashboards с виджетами</b>, <b>automation UI</b>, <b>Service Desk</b>, <b>ФСТЭК-сертификация</b> — это следующая фаза после MVP-ready.
+  </div>
+</section>
+
+</div>
+<!-- /ВКЛАДКА 5 -->
+
+<footer>
+  Сгенерировано 2026-04-24 · <code>docs/admin-vs-jira-comparison.html</code> · v2 (добавлен пласт функциональности)<br>
+  Источники: <code>backend/src/modules</code>, <code>frontend/src/pages</code>, <code>backend/src/prisma/schema.prisma</code>, <code>docs/user-manual/features/</code>, <code>docs/tz/MVP2JIRA/</code>
+</footer>
+
+</div>
+
+<script>
+(function() {
+  const tabs = document.querySelectorAll('nav.tabs button[data-tab]');
+  const panels = document.querySelectorAll('.tab-panel');
+
+  function activate(name, updateHash) {
+    tabs.forEach(t => t.classList.toggle('active', t.dataset.tab === name));
+    panels.forEach(p => p.classList.toggle('active', p.id === name));
+    if (updateHash) {
+      history.replaceState(null, '', '#tab=' + name);
+    }
+  }
+
+  tabs.forEach(t => {
+    t.addEventListener('click', () => activate(t.dataset.tab, true));
+  });
+
+  // Support #tab=admin, #tab=functional, #tab=summary, and anchor-links
+  function applyHash() {
+    const hash = window.location.hash || '';
+    const m = hash.match(/tab=(summary|admin|functional|enterprise|ytracker)/);
+    if (m) {
+      activate(m[1], false);
+      return;
+    }
+    // If hash points to a section, open its tab
+    if (hash.length > 1) {
+      const target = document.querySelector(hash);
+      if (target) {
+        const panel = target.closest('.tab-panel');
+        if (panel) {
+          activate(panel.id, false);
+          setTimeout(() => target.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
+        }
+      }
+    }
+  }
+
+  window.addEventListener('hashchange', applyHash);
+  applyHash();
+
+  // TOC links: if user clicks an inline TOC anchor that belongs to other tab, switch tab first
+  document.querySelectorAll('.toc-inline a[href^="#"]').forEach(a => {
+    a.addEventListener('click', () => {
+      const id = a.getAttribute('href').slice(1);
+      const target = document.getElementById(id);
+      if (target) {
+        const panel = target.closest('.tab-panel');
+        if (panel && !panel.classList.contains('active')) {
+          activate(panel.id, true);
+        }
+      }
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/docs/tz/MVP2JIRA/INDEX.md
+++ b/docs/tz/MVP2JIRA/INDEX.md
@@ -1,0 +1,108 @@
+# MVP2JIRA — Индекс ТЗ
+
+**Дата:** 2026-04-23
+**План реализации:** [mvp2jira_plan.md](./mvp2jira_plan.md)
+**Источник:** [admin-vs-jira-comparison.html](../../admin-vs-jira-comparison.html)
+
+---
+
+## Все ТЗ (14 штук)
+
+| Ключ | Название | Фаза | Оценка | Статус |
+|------|----------|------|--------|--------|
+| [TTBUS-0](./TTBUS-0.md) | Event Bus (Kafka + Transactional Outbox) | **P0-prereq** | 54ч (1.5сп) | OPEN |
+| [TTNOTIF-1](./TTNOTIF-1.md) | Notifications Service (Email + In-app Bell) | **P0** | 110ч (2сп) | OPEN |
+| [TTRES-1](./TTRES-1.md) | Resolutions (результат закрытия задачи) | **P0** | 33ч (0.5сп) | OPEN |
+| [TTSEC-3](./TTSEC-3.md) | Issue Security (уровни видимости задач) | **P0** | 52ч (1сп) | OPEN |
+| [TTSSO-1](./TTSSO-1.md) | SSO / OIDC | **P1** | 102ч (2сп) | OPEN |
+| [TTSEC-4](./TTSEC-4.md) | Password Policy + Audit Log UI + Banner | **P1** | 63ч (1сп) | OPEN |
+| [TTCORE-1](./TTCORE-1.md) | Priorities CRUD + IssueStatus reconciliation | **P1** | 63ч (1сп) | OPEN |
+| [TTPROJ-1](./TTPROJ-1.md) | Components + fix/affects Versions | **P1** | 48ч (1сп) | OPEN |
+| [TTSCR-1](./TTSCR-1.md) | Screens (контекст видимости полей) | **P1** | 24ч (0.5сп) | OPEN |
+| [TTATTACH-1](./TTATTACH-1.md) | Функционал вложений (Issue + Comment) | **P1** | 84ч (1.5сп) | OPEN |
+| [TTMFA-1](./TTMFA-1.md) | 2FA / TOTP | **P2** | 68ч (1сп) | OPEN |
+| [TTINTEG-1](./TTINTEG-1.md) | Webhooks (system + project) | **P2** | 70ч (1сп) | OPEN |
+| [TTCFG-1](./TTCFG-1.md) | Time Tracking (parser + auto-stop) | **P2** | 23ч (0.5сп) | OPEN |
+| [TTBRAND-1](./TTBRAND-1.md) | Look & Feel (брендинг) | **P2** | 32ч (0.5сп) | OPEN |
+
+**Итого:** ~826 часов ≈ **14.5 спринтов** (одна команда full-time).
+
+---
+
+## По фазам
+
+### P0 — Блокеры запуска (~249ч / 5сп)
+1. **TTBUS-0** — фундамент event-bus. Блокирует TTNOTIF-1 и TTINTEG-1.
+2. **TTNOTIF-1** — уведомления. Критично, без них трекер не полноценен.
+3. **TTRES-1** — resolutions. Закрытие задач с причиной.
+4. **TTSEC-3** — issue security. Скрытие отдельных задач.
+
+### P1 — Критично для корп-использования (~384ч / 7сп)
+5. **TTSSO-1** — SSO/OIDC.
+6. **TTSEC-4** — password policy, audit UI, banner.
+7. **TTCORE-1** — приоритеты + согласование статусов.
+8. **TTPROJ-1** — components + versions.
+9. **TTSCR-1** — screens (контекст полей).
+10. **TTATTACH-1** — функционал вложений (в JIRA-отчёте было в P2, поднято до P1).
+
+### P2 — Важно, но не блокирует (~193ч / 3сп)
+11. **TTMFA-1** — 2FA.
+12. **TTINTEG-1** — webhooks.
+13. **TTCFG-1** — time tracking parser.
+14. **TTBRAND-1** — брендинг.
+
+---
+
+## Осознанно НЕ реализовано (P3 / out-of-scope)
+
+- **Backup/Restore на уровне приложения** — закрывается через DevOps (pg_dump cron, снэпшоты, git).
+- **Интернационализация (i18n)** — UI остаётся RU-only.
+- **Independent Permission Scheme** — текущая Role Scheme с 33 флагами достаточна.
+- **Incoming mail handlers** — сценарий нечастотный, нет запроса от клиентов.
+- **Services cron UI** — BullMQ dashboard покрывает need.
+- **DB Integrity Checker** — применимо только после backup/restore, который тоже вынесен.
+- **Application Links** — не нужно для self-hosted MVP.
+- **License management** — специфично для коммерческой self-hosted модели.
+
+Эти пункты могут появиться как отдельные roadmap-инициативы, если потребуется (см. `mvp2jira_plan.md` секция 10).
+
+---
+
+## Roadmap после MVP2JIRA
+
+Инфраструктура, подготовленная в этом плане, открывает дешёвые доработки:
+
+- **TTAUTO-1** — Automations (асинхронный аналог ScriptRunner). Уже готова event-bus (TTBUS-0), добавить consumer + DSL для правил.
+- **TTINTEG-2** — Public Events API (pull + WebSocket stream).
+- **TTI18N-1** — i18n при появлении international клиентов.
+- **TTMAIL-2** — Incoming Mail Handlers.
+- **TTAV-1** — Virus scanning для attachments (ClamAV через Kafka).
+- **TTMFA-2** — WebAuthn/passkey в дополнение к TOTP.
+- **TTSSO-2** — SAML2 и LDAP если пойдут запросы.
+
+---
+
+## Дерево зависимостей (сокращённо)
+
+```
+TTBUS-0 ─┬─► TTNOTIF-1 ─► TTINTEG-1
+         │        ▲
+         │        │ (уведомления TTSEC-3 violations)
+         │        │
+TTSEC-3 ─┼────────┘
+         │
+TTRES-1  (independent, желает TTCORE-1)
+TTCORE-1 (independent)
+TTSSO-1  (independent)
+TTSEC-4 ─► TTMFA-1
+TTPROJ-1 (independent)
+TTSCR-1  (independent, желает TTPROJ-1)
+TTATTACH-1 ─► TTBRAND-1
+TTCFG-1  (independent)
+```
+
+---
+
+## История изменений этого индекса
+
+- **2026-04-23** — Создан. 14 ТЗ, ~826ч, все решения утверждены.

--- a/docs/tz/MVP2JIRA/TTATTACH-1.md
+++ b/docs/tz/MVP2JIRA/TTATTACH-1.md
@@ -1,0 +1,428 @@
+# ТЗ: TTATTACH-1 — Функционал вложений (Issue + Comment)
+
+**Дата:** 2026-04-23
+**Тип:** EPIC | **Приоритет:** P1 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+В текущей системе **нет функционала вложений**. Невозможно прикрепить скриншот к задаче, спецификацию к комментарию, мокап к release-note. Это критический пробел для любого серьёзного tracker'а.
+
+Задача реализует:
+- Полиморфные attachments к **Issue** и **Comment**.
+- **Pluggable storage** — local FS и S3 (выбор через ENV).
+- **MIME whitelist** (images/docs/text/archives) + admin-настройка.
+- **Max file size** 25 MB default, в админ-настройке.
+- **Thumbnails** для images (server-side через `sharp`) + lightbox preview.
+- **Inherit permissions** — доступ к attachment = доступ к parent entity (через TTSEC-3).
+- **Hard-delete** + 10-сек undo-banner на фронте.
+- **Multipart upload** (без TUS — файлы до 25MB).
+- **Virus scan — нет в MVP** (только MIME whitelist).
+
+### Пользовательские сценарии
+
+**Dev прикладывает скриншот:**
+1. На карточке issue жмёт «Прикрепить файл» → drag-n-drop.
+2. Upload показывает прогресс-бар, после завершения — thumbnail.
+3. Клик по thumbnail → lightbox с zoom.
+
+**QA прикладывает PDF-спецификацию:**
+1. На комментарии кнопка «+Файл».
+2. PDF загружается, в комментарии появляется иконка-файл + имя + размер + кнопка «Скачать».
+
+**Админ настраивает storage:**
+1. `/admin/attachments/settings` → max size 50 MB, добавляет MIME `video/mp4`.
+2. ENV `ATTACHMENT_STORAGE=s3`, `S3_BUCKET=tt-uploads`.
+
+**PRIVATE задача:**
+1. На PRIVATE issue (TTSEC-3) attachment виден только тем, у кого есть доступ к issue.
+
+---
+
+## 2. Текущее состояние
+
+- **Модель Attachment отсутствует.**
+- **Multer / upload endpoint отсутствует** для задач (есть только CSV-экспорт).
+- **Storage abstraction отсутствует.**
+- **Thumbnail pipeline отсутствует.**
+- Comments — есть, markdown-рендеринг в BEM-стиле (react-markdown).
+
+---
+
+## 3. Зависимости
+
+### Модули backend (новые)
+- [ ] `modules/attachments/attachments.service.ts` — upload, download, delete, list.
+- [ ] `modules/attachments/attachments.router.ts` — endpoints.
+- [ ] `shared/storage/` — абстракция `StorageProvider`, реализации `LocalStorage` и `S3Storage`.
+- [ ] `shared/thumbnails/` — sharp-wrapper для image resize.
+
+### Модули backend (изменённые)
+- [ ] `modules/issues/issues.service.ts` — добавить relation `attachments`.
+- [ ] `modules/comments/comments.service.ts` — аналогично.
+- [ ] `shared/middleware/visibility.ts` (TTSEC-3) — extend для attachments.
+
+### Frontend
+- [ ] `components/attachments/AttachmentUploader.tsx` — drag-n-drop + progress.
+- [ ] `components/attachments/AttachmentList.tsx` — превью + download.
+- [ ] `components/attachments/ImageLightbox.tsx` — overlay для images.
+- [ ] `pages/admin/AdminAttachmentsSettingsPage.tsx` — MIME whitelist + max size.
+
+### Модели данных (Prisma)
+- [ ] `Attachment` — полиморфная.
+- [ ] `SystemSetting` ключи: `attachments.max_size_bytes`, `attachments.mime_whitelist`, `attachments.enabled`.
+
+### Внешние зависимости
+- [ ] `multer` — multipart parsing.
+- [ ] `sharp` — thumbnails (image resize).
+- [ ] `@aws-sdk/client-s3` — S3 (опционально, lazy-loaded если storage=s3).
+- [ ] `mime-types` — validation.
+
+### Блокеры
+- Нет. TTSEC-3 желателен (иначе attachments не наследуют visibility), но не строго блокер.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Upload без virus-scan → вредонос попадает в storage | Средняя | Infection | MIME whitelist + Content-Disposition:attachment при download + отсутствие inline-рендеринга неdoc/image файлов; в roadmap — ClamAV через Kafka (следующее ТЗ) |
+| 2 | Пользователь скачивает PRIVATE attachment через direct URL без сессии | Высокая | Leak | Signed URLs с JWT-токеном (TTL 60 сек), генерятся при каждом запросе; S3 — presigned URL |
+| 3 | Thumbnail-генерация блокирует upload (sharp slow на больших images) | Средняя | Slow uploads | Async thumbnail: запись attachment в БД сразу, генерация в BullMQ background-job |
+| 4 | S3-bucket misconfigured (public read) → leak | Высокая | Leak | Bucket-policy требование «private», health-check при старте сервиса |
+| 5 | Big file blocks HTTP keep-alive | Средняя | Performance | Nginx/proxy-level `client_max_body_size=30M` (25 MB + overhead); backend `express.json()` не применяется к `/attachments/upload` |
+| 6 | Hard-delete — undo-окно не успевает, юзер случайно удалил важное | Средняя | Data loss | Undo-banner 10 сек + подтверждение для файлов > 10MB; audit-log восстановления (хотя файл уже unlink) |
+| 7 | Local storage переполняется | Средняя | Crash | Cleanup cron для soft-deleted attachments (но у нас hard-delete); метрика дискового пространства + alert |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Модели
+
+```prisma
+enum AttachmentEntityType {
+  ISSUE
+  COMMENT
+}
+
+model Attachment {
+  id              String                @id @default(uuid())
+  entityType      AttachmentEntityType  @map("entity_type")
+  entityId        String                @map("entity_id")
+  filename        String                // original filename
+  storageKey      String                @map("storage_key")  // path в storage
+  mimeType        String                @map("mime_type")
+  sizeBytes       Int                   @map("size_bytes")
+  checksumSha256  String                @map("checksum_sha256")
+  uploadedById    String                @map("uploaded_by_id")
+  thumbnailKey    String?               @map("thumbnail_key")  // для images, null для остальных
+  createdAt       DateTime              @default(now())
+
+  uploadedBy      User                  @relation(fields: [uploadedById], references: [id])
+
+  @@index([entityType, entityId])
+  @@index([uploadedById])
+  @@map("attachments")
+}
+```
+
+### 5.2 Storage abstraction
+
+```typescript
+// shared/storage/storage.interface.ts
+export interface StorageProvider {
+  put(key: string, data: Buffer | Readable, mime: string): Promise<void>;
+  get(key: string): Promise<Readable>;
+  delete(key: string): Promise<void>;
+  getSignedUrl(key: string, ttlSeconds: number): Promise<string>;
+  exists(key: string): Promise<boolean>;
+}
+
+// shared/storage/local.ts
+export class LocalStorage implements StorageProvider {
+  constructor(private basePath: string) {}
+  // использует fs/promises + crypto.createHmac для signed URLs
+}
+
+// shared/storage/s3.ts
+export class S3Storage implements StorageProvider {
+  constructor(private bucket: string, private client: S3Client) {}
+  // использует @aws-sdk/s3-request-presigner
+}
+
+// shared/storage/index.ts
+export function createStorage(): StorageProvider {
+  const type = process.env.ATTACHMENT_STORAGE ?? 'local';
+  if (type === 's3') {
+    return new S3Storage(
+      process.env.S3_BUCKET!,
+      new S3Client({ region: process.env.AWS_REGION, ... }),
+    );
+  }
+  return new LocalStorage(process.env.ATTACHMENT_LOCAL_PATH ?? '/var/attachments');
+}
+```
+
+### 5.3 Upload endpoint
+
+```typescript
+// POST /api/:entityType/:entityId/attachments  (entityType: issues|comments)
+// Content-Type: multipart/form-data, field "file"
+router.post(
+  '/:entityType/:entityId/attachments',
+  requireAuth,
+  multer({ limits: { fileSize: 25 * 1024 * 1024 } }).single('file'),
+  async (req, res) => {
+    const { entityType, entityId } = req.params;
+    const file = req.file;
+
+    // 1. Validate MIME
+    const settings = await getAttachmentSettings();
+    if (!settings.mimeWhitelist.includes(file.mimetype)) {
+      return res.status(400).json({ error: 'MIME_NOT_ALLOWED' });
+    }
+
+    // 2. Check parent entity exists + user has access
+    await assertCanAccessEntity(req.userId, entityType, entityId);
+
+    // 3. Compute checksum
+    const checksum = crypto.createHash('sha256').update(file.buffer).digest('hex');
+
+    // 4. Store
+    const storageKey = `${entityType}/${entityId}/${Date.now()}-${randomSuffix()}-${sanitize(file.originalname)}`;
+    await storage.put(storageKey, file.buffer, file.mimetype);
+
+    // 5. Create DB record
+    const att = await prisma.attachment.create({
+      data: {
+        entityType: entityType.toUpperCase(),
+        entityId,
+        filename: file.originalname,
+        storageKey,
+        mimeType: file.mimetype,
+        sizeBytes: file.size,
+        checksumSha256: checksum,
+        uploadedById: req.userId,
+      },
+    });
+
+    // 6. Async: generate thumbnail для images
+    if (file.mimetype.startsWith('image/')) {
+      await queue.add('generate-thumbnail', { attachmentId: att.id });
+    }
+
+    return res.status(201).json(att);
+  }
+);
+```
+
+### 5.4 Download с signed URLs
+
+```typescript
+// GET /api/attachments/:id/download
+// 1. Find attachment
+// 2. Check access (parent entity visibility)
+// 3. Если local — stream из файла
+// 4. Если S3 — redirect на presigned URL (TTL 60 сек)
+// 5. Set Content-Disposition: attachment; filename=...
+// 6. Audit-log скачивания (для sensitive MIME)
+```
+
+### 5.5 Thumbnail generator (BullMQ)
+
+```typescript
+// shared/thumbnails/generator.ts
+export async function generateThumbnail(attachmentId: string): Promise<void> {
+  const att = await prisma.attachment.findUnique({ where: { id: attachmentId } });
+  if (!att) return;
+
+  const original = await storage.get(att.storageKey);
+  const resized = await sharp(await streamToBuffer(original))
+    .resize(320, 320, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: 80 })
+    .toBuffer();
+
+  const thumbKey = `thumbs/${att.id}.jpg`;
+  await storage.put(thumbKey, resized, 'image/jpeg');
+
+  await prisma.attachment.update({
+    where: { id: att.id },
+    data: { thumbnailKey: thumbKey },
+  });
+}
+```
+
+### 5.6 Default MIME whitelist
+
+```json
+{
+  "mimeWhitelist": [
+    "image/jpeg", "image/png", "image/gif", "image/webp", "image/svg+xml",
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "text/plain",
+    "text/csv",
+    "text/markdown",
+    "application/zip",
+    "application/x-tar",
+    "application/gzip",
+    "application/json"
+  ],
+  "maxSizeBytes": 26214400,
+  "enabled": true
+}
+```
+
+### 5.7 Delete + undo
+
+- `DELETE /api/attachments/:id` — hard-delete (удаляет файл со storage + запись из БД).
+- Audit-log событие `attachment_deleted` с `{ filename, sizeBytes }` — для расследований.
+- Фронт после delete показывает toast «Файл удалён» + «Отменить» на 10 сек.
+- Если «Отменить» нажата **в течение окна** — из локального state удаляется `attachment`, но запрос **не уходит** (на фронте debounce-реализация отложенного запроса).
+
+```typescript
+// Frontend:
+const handleDelete = () => {
+  setOptimisticallyDeleted(attachmentId);
+  const timer = setTimeout(() => {
+    api.delete(`/attachments/${attachmentId}`);  // только через 10 сек
+  }, 10_000);
+  showToast({ message: 'Файл удалён', action: { label: 'Отменить', onClick: () => {
+    clearTimeout(timer);
+    setOptimisticallyDeleted(null);
+  } } });
+};
+```
+
+### 5.8 Frontend — AttachmentUploader
+
+- Drag-n-drop zone + button «Выбрать файлы».
+- Многофайловый upload параллельно.
+- Прогресс-бар per-file + общий.
+- Ошибки (413, 400 MIME_NOT_ALLOWED) — показываем на тосте.
+
+### 5.9 AttachmentList
+
+Для каждого attachment:
+- **Images:** thumbnail 120×120 + click → lightbox с original.
+- **Non-images:** иконка (PDF/doc/generic) + filename + size + кнопки Download/Delete.
+- Group by upload date (today / yesterday / earlier).
+
+### 5.10 Admin settings UI
+
+`/admin/attachments/settings`:
+- Toggle «Enabled».
+- InputNumber max size (MB).
+- TagsInput для MIME whitelist.
+- Info-блок: текущий storage (local/s3), disk usage (если local).
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: Модель Attachment + API upload/download/delete/list.
+- [ ] FR-2: Storage pluggable (local/s3) через ENV.
+- [ ] FR-3: MIME whitelist + max size настраивается в админке.
+- [ ] FR-4: Thumbnails для images генерятся async.
+- [ ] FR-5: Permissions наследуются от parent entity (через TTSEC-3 JOIN).
+- [ ] FR-6: Signed URL TTL 60 сек для local; presigned для S3.
+- [ ] FR-7: Hard-delete + 10-сек undo-banner на фронте.
+- [ ] FR-8: Multipart up to 25 MB.
+- [ ] FR-9: Attachment прикрепляется к Issue и Comment.
+- [ ] FR-10: Drag-n-drop + progress в UI.
+- [ ] FR-11: Lightbox для images.
+
+### Нефункциональные
+- [ ] NFR-1: Upload 10 MB файла < 5 сек на localhost.
+- [ ] NFR-2: Thumbnail generation async — не блокирует upload.
+- [ ] NFR-3: Download для S3 → presigned URL, backend не стримит сам.
+- [ ] NFR-4: Disk-usage для local: alert при > 80% заполнения volume.
+
+### Безопасность
+- [ ] SEC-1: MIME whitelist — single source of truth, не обходится через extension.
+- [ ] SEC-2: Content-Disposition: attachment (не inline) для всех, кроме images/pdf (где разрешаем inline).
+- [ ] SEC-3: Signed URLs с JWT-подписью и expiry.
+- [ ] SEC-4: S3-bucket проверяется на приватность при старте.
+- [ ] SEC-5: Audit-log для upload, delete, download (sensitive).
+- [ ] SEC-6: Filename sanitization (убираем `..`, control chars).
+
+### Тестирование
+- [ ] Unit: storage abstraction (обе реализации).
+- [ ] Unit: MIME-validation, size limits, filename-sanitization.
+- [ ] Integration: upload PDF to issue → download works → visibility через TTSEC-3.
+- [ ] Integration: PRIVATE issue — не-admin не скачивает attachment (403).
+- [ ] E2E: drag-n-drop → thumbnail → lightbox.
+- [ ] Покрытие ≥ 70%.
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: Upload PNG к issue → появляется thumbnail через ~2 сек.
+- [ ] AC-2: Upload PDF к comment → иконка файла + download.
+- [ ] AC-3: Upload MP4 (не в whitelist) → 400 MIME_NOT_ALLOWED.
+- [ ] AC-4: Upload 30MB → 413.
+- [ ] AC-5: S3-storage работает через ENV-switch (integration-тест на MinIO).
+- [ ] AC-6: Delete + undo в течение 10 сек сохраняет файл.
+- [ ] AC-7: Delete после 10 сек реально удаляет (storage + DB).
+- [ ] AC-8: PRIVATE issue — 3й пользователь получает 403 на /attachments/:id/download.
+- [ ] AC-9: Admin settings настраиваются, применяются без перезапуска.
+- [ ] AC-10: Tests + security-review зелёные.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Storage abstraction (local + s3) | 12 |
+| Prisma model + migration | 2 |
+| Upload endpoint (multer + validation + sanitization) | 6 |
+| Download endpoint + signed URLs | 5 |
+| Delete + audit-logging | 3 |
+| Thumbnail pipeline (sharp + BullMQ) | 6 |
+| Visibility integration (TTSEC-3) | 3 |
+| Admin settings UI | 4 |
+| Frontend: AttachmentUploader (drag-n-drop + progress) | 8 |
+| Frontend: AttachmentList + Lightbox | 8 |
+| Integration с IssueDetailPage + Comment | 4 |
+| Tests (unit + integration + security + MinIO) | 14 |
+| Docs | 3 |
+| Code review + AI review | 6 |
+| **Итого** | **84** (~1.5 спринта) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** нет (TTSEC-3 желателен для полноценной visibility-фильтрации).
+- **Блокирует:** **TTBRAND-1** (reuse storage-абстракции для логотипа).
+- **Связано:** TTNOTIF-1 (attachments в email — опциональная фаза).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTATTACH-1 (EPIC) — Функционал вложений
+  ├─ TTATTACH-1.1 — Storage abstraction (local + s3)
+  ├─ TTATTACH-1.2 — Prisma model + migration
+  ├─ TTATTACH-1.3 — Upload/download/delete endpoints + security
+  ├─ TTATTACH-1.4 — Thumbnail BullMQ pipeline
+  ├─ TTATTACH-1.5 — Visibility integration
+  ├─ TTATTACH-1.6 — Admin settings UI
+  ├─ TTATTACH-1.7 — Frontend uploader + list + lightbox
+  └─ TTATTACH-1.8 — Tests + docs
+```

--- a/docs/tz/MVP2JIRA/TTBRAND-1.md
+++ b/docs/tz/MVP2JIRA/TTBRAND-1.md
@@ -1,0 +1,268 @@
+# ТЗ: TTBRAND-1 — Look & Feel (брендинг)
+
+**Дата:** 2026-04-23
+**Тип:** TASK | **Приоритет:** P2 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+Возможность кастомизации брендинга для корпоративного заказчика: логотип, favicon, заголовок приложения, primary-color, текст на логин-странице, текст футера, логотип в email-шаблонах.
+
+**Storage переиспользует TTATTACH-1** — логотип/favicon/email-logo хранятся через `StorageProvider` (local/s3).
+
+**Темы (light/dark)** уже реализованы — в этом ТЗ **не трогаем**.
+
+### Пользовательские сценарии
+
+**Админ кастомизирует продукт:**
+1. `/admin/branding` → upload логотипа (PNG 400×80).
+2. Primary color → `#0066cc`.
+3. App title → «CorpTasks».
+4. Footer text → «© 2026 ОАО Ромашка. Только для внутреннего использования».
+5. Save → весь UI обновляется, email-шаблоны тоже.
+
+---
+
+## 2. Текущее состояние
+
+- Логотип и favicon — встроены в frontend bundle, кастомизация невозможна без rebuild'а.
+- Primary color — hard-coded через AntDesign default theme.
+- App title — `<title>TaskTime MVP</title>` в index.html.
+- Email-шаблоны (после TTNOTIF-1) — без логотипа.
+
+---
+
+## 3. Зависимости
+
+### Модули backend
+- [ ] `modules/admin/branding.router.ts` — GET/PATCH настроек.
+- [ ] `modules/admin/branding.service.ts` — lookup + upload delegation.
+
+### Frontend
+- [ ] `pages/admin/AdminBrandingPage.tsx` — форма настроек + upload.
+- [ ] `components/layout/Logo.tsx` — читает из settings.
+- [ ] `App.tsx` — в useEffect обновить `document.title` + favicon + CSS-vars для primary color.
+- [ ] `pages/LoginPage.tsx` — блок с loginPageText.
+
+### Модели данных (Prisma)
+- [ ] `SystemSetting` ключи: `branding.*`.
+
+### Внешние зависимости
+- Нет новых. Переиспользует storage из TTATTACH-1.
+
+### Блокеры
+- **TTATTACH-1 обязателен** (storage abstraction + upload API).
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Огромный логотип (5MB PNG) замедляет загрузку страницы | Средняя | UX | Validation на upload: max 500KB для brand-assets; server-side resize через sharp (аналог thumbnail) |
+| 2 | Primary color = ярко-жёлтый → нечитабельно | Низкая | Brand-fail | Preview в настройках + contrast-checker (WCAG AA) с warning |
+| 3 | Старый логотип закэширован у пользователей | Средняя | UX | Storage-key в URL меняется на каждый upload (timestamp в filename); cache-busting автоматический |
+| 4 | SVG логотип содержит XSS (embedded script) | Средняя | Compromise | SVG-sanitizer при upload (удаляет `<script>`, `on*` handlers); или просто отказ от SVG — только PNG/JPG |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Settings keys
+
+```
+branding.logoStorageKey        String    — ссылка на attachment storage key
+branding.logoThumbUrl          String    — cached signed URL (TTL 24h)
+branding.faviconStorageKey     String
+branding.emailLogoStorageKey   String    — отдельный логотип для email (может быть light-версия)
+branding.appTitle              String    — "TaskTime", "CorpTasks"
+branding.primaryColor          String    — hex #0066cc
+branding.loginPageText         String?   — markdown (минимум), ~500 chars
+branding.footerText            String?   — ~200 chars
+```
+
+### 5.2 Upload через TTATTACH-1
+
+Специальный endpoint:
+
+```
+POST /admin/branding/:assetType/upload   (assetType: logo | favicon | emailLogo)
+  multipart file
+  → reuse TTATTACH-1 upload logic with:
+    - fixed storage path `/branding/:assetType/...`
+    - stricter MIME whitelist: image/png, image/jpeg, image/x-icon (только favicon)
+    - max size 500KB
+    - server-side resize для logo (max 600×120), emailLogo (400×80)
+  → возвращает { storageKey }
+  → backend обновляет SystemSetting[branding.{assetType}StorageKey]
+```
+
+### 5.3 Public API
+
+```
+GET /api/branding   (unauthenticated — нужно до login'а для кастомного login-page)
+  → {
+    appTitle: "CorpTasks",
+    primaryColor: "#0066cc",
+    logoUrl: "/api/branding/assets/logo?v=1714...",
+    faviconUrl: "/api/branding/assets/favicon?v=1714...",
+    loginPageText: "...",
+    footerText: "..."
+  }
+```
+
+`logoUrl` — динамический endpoint, проксирует из storage с правильным cache-control:
+
+```
+GET /api/branding/assets/:assetType  (public, unauthenticated)
+  → reads branding.{assetType}StorageKey
+  → stream from storage with Cache-Control: public, max-age=3600
+```
+
+Secret-check не нужен — логотип публичный по определению.
+
+### 5.4 Frontend runtime injection
+
+```typescript
+// App.tsx
+useEffect(() => {
+  const loadBranding = async () => {
+    const b = await fetch('/api/branding').then(r => r.json());
+    document.title = b.appTitle;
+    // primary color через CSS custom property
+    document.documentElement.style.setProperty('--primary-color', b.primaryColor);
+    // favicon
+    const link = document.querySelector("link[rel='icon']") as HTMLLinkElement;
+    if (link) link.href = b.faviconUrl;
+    // AntDesign theme override
+    ConfigProvider.config({ theme: { token: { colorPrimary: b.primaryColor } } });
+  };
+  void loadBranding();
+}, []);
+```
+
+Первоначальная загрузка — показывает defaults (TT-brand), через ~100ms подменяется на кастом. Это допустимый trade-off (альтернатива — SSR, overkill).
+
+### 5.5 Email templates (TTNOTIF-1)
+
+Handlebars-шаблоны получают доступ к `brandingLogoUrl`:
+
+```handlebars
+<table>
+  <tr><td align="center">
+    <img src="{{brandingLogoUrl}}" alt="{{brandingAppTitle}}" style="max-height: 60px" />
+  </td></tr>
+</table>
+```
+
+Notifications-service при render email делает `GET /api/branding` (с internal auth) и прокидывает в context.
+
+### 5.6 Admin UI — AdminBrandingPage
+
+Секции:
+1. **Логотип** — preview (current) + drop-zone upload + «Удалить».
+2. **Favicon** — preview + upload.
+3. **Email-логотип** — preview + upload.
+4. **Заголовок** — Input.
+5. **Primary color** — ColorPicker (AntDesign) + contrast-checker.
+6. **Текст на логин-экране** — textarea (markdown).
+7. **Футер** — textarea.
+8. **Preview** — iframe с рендером кастомного login-page (для проверки).
+
+Save-кнопка → 1 PATCH на все поля сразу (оптимистичный apply + rollback при error).
+
+### 5.7 Default fallback
+
+Если `branding.*` keys не заданы — используются defaults:
+- appTitle = `TaskTime MVP`.
+- primaryColor = `#1677ff` (AntDesign default blue).
+- logoUrl = `/static/tt-logo.svg` (в bundle).
+- faviconUrl = `/favicon.ico`.
+- loginPageText = null (не показывается).
+- footerText = null.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: Admin загружает логотип/favicon/emailLogo через UI.
+- [ ] FR-2: Server-side resize для размеров 600×120 / 64×64 / 400×80.
+- [ ] FR-3: SVG запрещён (только PNG/JPG/ICO для favicon).
+- [ ] FR-4: Settings сохраняются в `SystemSetting`.
+- [ ] FR-5: `/api/branding` public endpoint.
+- [ ] FR-6: Frontend на старте подгружает branding и применяет.
+- [ ] FR-7: Primary color доступен через `var(--primary-color)` и AntDesign theme.
+- [ ] FR-8: Email-шаблоны используют `brandingLogoUrl`.
+- [ ] FR-9: Contrast-checker в UI warning.
+- [ ] FR-10: Cache-busting при смене (query-параметр ver).
+
+### Нефункциональные
+- [ ] NFR-1: `/api/branding` cache на CDN-layer (если появится) — cacheable 1 hour с revalidation.
+- [ ] NFR-2: Branding apply < 200ms после fetch.
+
+### Безопасность
+- [ ] SEC-1: Upload — только SUPER_ADMIN.
+- [ ] SEC-2: MIME/size validation на server-side.
+- [ ] SEC-3: Primary color валидируется как валидный hex (regex).
+- [ ] SEC-4: loginPageText markdown — sanitize (escape HTML, whitelist Markdown).
+
+### Тестирование
+- [ ] Unit: hex validation, sanitize logic.
+- [ ] Integration: upload → settings updated → `/api/branding` returns correctly.
+- [ ] E2E: сменить primary color → UI обновился без перезагрузки.
+- [ ] Покрытие ≥ 60%.
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: Upload 300KB PNG → логотип виден в шапке.
+- [ ] AC-2: Upload 2MB → 413.
+- [ ] AC-3: Upload SVG → 400 MIME_NOT_ALLOWED.
+- [ ] AC-4: Изменение primary-color → вся UI с новым цветом без refresh.
+- [ ] AC-5: Email после TTNOTIF-1 содержит custom-logo.
+- [ ] AC-6: Login-page показывает кастомный текст.
+- [ ] AC-7: Footer в подвале виден.
+- [ ] AC-8: Tests зелёные.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Backend: branding.service (integrate storage) + resize | 4 |
+| Backend: /api/branding public + /branding/assets/:type | 3 |
+| Admin upload router (delegate to TTATTACH-1) | 3 |
+| Frontend: AdminBrandingPage + ColorPicker + preview | 8 |
+| Frontend: App.tsx runtime injection | 3 |
+| Frontend: LoginPage customization + footer | 3 |
+| Email template integration | 2 |
+| Tests | 4 |
+| Code review | 2 |
+| **Итого** | **32** (~0.5 спринта) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** TTATTACH-1.
+- **Связано:** TTNOTIF-1 (email templates).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTBRAND-1 (TASK) — Look & Feel
+  ├─ TTBRAND-1.1 — Backend branding service + public API
+  ├─ TTBRAND-1.2 — Admin UI + ColorPicker + preview
+  ├─ TTBRAND-1.3 — Runtime frontend injection
+  ├─ TTBRAND-1.4 — Email template integration
+  └─ TTBRAND-1.5 — Tests
+```

--- a/docs/tz/MVP2JIRA/TTBUS-0.md
+++ b/docs/tz/MVP2JIRA/TTBUS-0.md
@@ -1,0 +1,339 @@
+# ТЗ: TTBUS-0 — Event Bus (Kafka + Transactional Outbox)
+
+**Дата:** 2026-04-23
+**Тип:** EPIC | **Приоритет:** P0-prerequisite | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+В системе нужна **шина событий** как фундамент для асинхронных consumer'ов: notifications-service, будущего automation-runner'а (асинхронный аналог ScriptRunner), webhooks-service, возможных аналитических стрим-пайплайнов.
+
+Ключевые требования:
+- Producer (бизнес-модули) не должен знать о consumer'ах.
+- Гарантия доставки at-least-once даже при падении Kafka (transactional outbox).
+- Consumer'ы умеют дедупликацию идемпотентно (по `message_id`).
+- Domain-oriented топики, не один общий `tt.events`.
+
+### Пользовательский сценарий
+
+**Разработчик TTNOTIF-1:**
+1. Подписывает notifications-service на топики `tt.issues`, `tt.releases`, `tt.comments`.
+2. Получает envelope: `{ v, messageId, type, occurredAt, payload, meta }`.
+3. Проверяет `messageId` в `processed_messages` — если уже обработано, skip (идемпотентность).
+
+**Разработчик TTAUTO-1 (будущее):**
+1. Подписывается на тот же топик с другим `consumerGroup` — получает свои offset.
+2. Automation-правило триггерится без модификации issues-модуля.
+
+---
+
+## 2. Текущее состояние
+
+- В стеке уже есть **Redis** (BullMQ/session) и **PostgreSQL** (основная БД).
+- Отдельный процесс **`pipeline-service`** создаёт прецедент микросервис-split — команда с этим знакома.
+- **Webhook-notifier** для release-checkpoints (`backend/src/modules/releases/checkpoints/webhook-notifier.service.ts`) сейчас посылает HTTP прямо из бизнес-логики — после TTBUS-0 должен быть переведён на consume из Kafka.
+- **Kafka в инфре отсутствует.**
+- **Схема `event_outbox` отсутствует.**
+
+---
+
+## 3. Зависимости
+
+### Модули backend
+- [ ] `shared/eventbus/` (новый) — обёртка над kafkajs: `EventBusProducer`, `EventBusConsumer`, envelope schema.
+- [ ] `shared/outbox/` (новый) — service для записи в `event_outbox`, `RelayWorker` (отдельный процесс или in-process cron).
+- [ ] `modules/issues/issues.service.ts` — интеграция outbox-паттерна как reference implementation (create/update/delete/status change → запись в outbox в одной транзакции с БД-операцией).
+
+### Новый процесс
+- [ ] `backend-relay/` — worker-процесс, читает `event_outbox` pollingом, публикует в Kafka, помечает строки как `sent`. Можно в docker-compose как отдельный service.
+
+### Инфра
+- [ ] **Kafka** в `docker-compose.yml` (KRaft mode, single-broker для dev).
+- [ ] **Kafka** в staging/prod docker-compose (single-broker MVP, multi-broker — отдельное ТЗ).
+- [ ] Переменные окружения: `KAFKA_BROKERS`, `KAFKA_CLIENT_ID`.
+
+### Frontend
+- Нет изменений.
+
+### Модели данных (Prisma)
+- [ ] `event_outbox` — новая таблица.
+- [ ] `processed_messages` — новая таблица (для consumer-side dedup).
+
+### Внешние зависимости
+- [ ] `kafkajs` — клиент.
+- [ ] `@apache/kafka` docker-image `bitnami/kafka:3.7` (KRaft mode).
+
+### Блокеры
+- Нет.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Kafka down при публикации из outbox-relay → события не доставляются | Средняя | Задержка доставки | Relay-worker ретраит с backoff; outbox не очищается до успешной публикации; DLQ-топик для permanent failures |
+| 2 | Dev-окружение поднимается медленно из-за Kafka | Высокая | Замедление DX | ENV-флаг `NOTIFICATIONS_ENABLED=false` — producer пишет в outbox, но relay не запускается; никаких consumer'ов не стартует |
+| 3 | Двойная публикация события при retry — consumer получает дубль | Средняя | Двойные уведомления | Envelope содержит `messageId` UUID; consumer-side dedup через `processed_messages` с TTL 7 дней |
+| 4 | Outbox-таблица разрастается (не чистится) | Высокая | Разрастание БД | Relay-worker помечает `sent_at`; cleanup-cron удаляет строки старше 7 дней с `sent_at != null` |
+| 5 | Transaction-граница Prisma: `prisma.$transaction` vs запись в outbox в том же callback'е | Низкая | Non-atomic write | Обязательное использование `prisma.$transaction` во всех producer-методах с чётким API `publishInTx(tx, event)` |
+| 6 | Schema envelope меняется — несовместимость с существующими событиями в очереди | Низкая | Broken consume | `v` (version) в envelope; consumer разбирает по версии; legacy-events поддерживаются в read-only режиме до их вычитки |
+| 7 | `pipeline-service` и будущие consumer'ы конкурируют за одну Kafka — ресурсы | Низкая | Ограничение пропускной способности | Мониторинг topic lag; при необходимости scale broker'ов (отдельное ТЗ) |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Envelope schema
+
+```typescript
+export const eventEnvelopeSchema = z.object({
+  v: z.literal(1),                        // schema version
+  messageId: z.string().uuid(),           // server-generated UUID
+  type: z.string(),                       // 'ISSUE_CREATED', 'ISSUE_ASSIGNED', etc.
+  occurredAt: z.string().datetime(),      // ISO-8601 UTC
+  actor: z.object({
+    userId: z.string().uuid().nullable(), // null для system-триггеров
+    ip: z.string().optional(),
+    userAgent: z.string().optional(),
+  }),
+  payload: z.record(z.unknown()),         // event-specific
+  meta: z.object({
+    tenantId: z.string().nullable(),      // для будущей мульти-тенантности
+    correlationId: z.string().optional(), // для цепочек событий
+  }),
+});
+export type EventEnvelope = z.infer<typeof eventEnvelopeSchema>;
+```
+
+### 5.2 Топики (domain-oriented)
+
+- `tt.issues` — `ISSUE_CREATED`, `ISSUE_UPDATED`, `ISSUE_DELETED`, `ISSUE_ASSIGNED`, `ISSUE_STATUS_CHANGED`, `ISSUE_MENTIONED`.
+- `tt.comments` — `COMMENT_CREATED`, `COMMENT_UPDATED`, `COMMENT_DELETED` *(producer будет добавлен в TTNOTIF-1)*.
+- `tt.releases` — `RELEASE_CREATED`, `RELEASE_PUBLISHED`, `RELEASE_STATUS_CHANGED`, `CHECKPOINT_VIOLATED` *(producer в release-модуле после TTBUS-0)*.
+- `tt.workflow` — `WORKFLOW_TRANSITION_EXECUTED` *(TTCORE-1)*.
+- `tt.notifications.dlq` — dead-letter для событий, которые consumer не смог обработать.
+- Partitioning: 3 partitions на prod, 1 на dev (достаточно для consumer-scaling).
+- Retention: 7 дней для бизнес-топиков, 30 дней для DLQ.
+
+### 5.3 Модели Prisma
+
+```prisma
+model EventOutbox {
+  id          String    @id @default(uuid())
+  topic       String    // 'tt.issues' и т.д.
+  messageId   String    @unique @default(uuid()) @map("message_id")
+  type        String    // 'ISSUE_CREATED'
+  envelope    Json      // весь envelope целиком
+  createdAt   DateTime  @default(now()) @map("created_at")
+  sentAt      DateTime? @map("sent_at")
+  attempts    Int       @default(0)
+  lastError   String?   @map("last_error")
+
+  @@index([sentAt, createdAt])  // для relay-worker: WHERE sent_at IS NULL
+  @@index([messageId])
+  @@map("event_outbox")
+}
+
+model ProcessedMessage {
+  consumerGroup String   @map("consumer_group")
+  messageId     String   @map("message_id")
+  processedAt   DateTime @default(now()) @map("processed_at")
+
+  @@id([consumerGroup, messageId])
+  @@index([processedAt])  // для cleanup-cron
+  @@map("processed_messages")
+}
+```
+
+### 5.4 Producer API
+
+```typescript
+// shared/outbox/outbox.service.ts
+export async function publishInTx(
+  tx: Prisma.TransactionClient,
+  topic: string,
+  type: string,
+  payload: Record<string, unknown>,
+  actor: { userId: string | null; ip?: string; userAgent?: string }
+): Promise<string /* messageId */> {
+  const messageId = crypto.randomUUID();
+  const envelope: EventEnvelope = {
+    v: 1,
+    messageId,
+    type,
+    occurredAt: new Date().toISOString(),
+    actor,
+    payload,
+    meta: { tenantId: null },
+  };
+
+  await tx.eventOutbox.create({
+    data: { topic, messageId, type, envelope: envelope as unknown as Prisma.JsonObject },
+  });
+
+  return messageId;
+}
+```
+
+Использование в issues.service:
+```typescript
+await prisma.$transaction(async (tx) => {
+  const issue = await tx.issue.create({ data });
+  await publishInTx(tx, 'tt.issues', 'ISSUE_CREATED', { issueId: issue.id, ... }, actor);
+  return issue;
+});
+```
+
+### 5.5 Relay Worker
+
+Отдельный процесс (или in-process cron при `NOTIFICATIONS_ENABLED=true`):
+
+1. Цикл каждые 500ms:
+   - `SELECT * FROM event_outbox WHERE sent_at IS NULL ORDER BY created_at LIMIT 100 FOR UPDATE SKIP LOCKED`
+   - Для каждой строки: `producer.send({ topic, messages: [{ key: messageId, value: JSON.stringify(envelope) }] })`
+   - При успехе: `UPDATE event_outbox SET sent_at = NOW() WHERE id = $1`
+   - При ошибке: `UPDATE event_outbox SET attempts = attempts + 1, last_error = $1 WHERE id = $2`
+2. После `attempts > 10` — событие не удаляется, но логируется как `permanent_failure` (метрика). Админ вручную решает.
+3. Cleanup-cron: раз в час удаляет строки с `sent_at IS NOT NULL AND sent_at < now() - interval '7 days'`.
+
+### 5.6 Consumer API
+
+```typescript
+// shared/eventbus/consumer.ts
+export function subscribe<T>(
+  consumerGroup: string,
+  topics: string[],
+  handler: (env: EventEnvelope, payload: T) => Promise<void>
+) {
+  const consumer = kafka.consumer({ groupId: consumerGroup });
+  // ... run:
+  //   1. parse + validate envelope
+  //   2. check ProcessedMessage — skip if exists
+  //   3. await handler()
+  //   4. insert into ProcessedMessage
+  //   5. commit offset
+}
+```
+
+### 5.7 Docker-compose для dev
+
+```yaml
+services:
+  kafka:
+    image: bitnami/kafka:3.7
+    environment:
+      KAFKA_CFG_NODE_ID: 0
+      KAFKA_CFG_PROCESS_ROLES: controller,broker
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@kafka:9093
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "true"  # только для dev
+    ports:
+      - "9092:9092"
+
+  backend-relay:
+    build: ./backend
+    command: node dist/relay.js
+    environment:
+      NOTIFICATIONS_ENABLED: "true"
+      KAFKA_BROKERS: kafka:9092
+    depends_on: [kafka, postgres]
+```
+
+### 5.8 Топики auto-create
+
+- Dev: `KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true` для удобства.
+- Prod: отдельная one-time init-job создаёт топики с нужными partitions/retention.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: `publishInTx(tx, topic, type, payload, actor)` доступен из любого service-модуля.
+- [ ] FR-2: Событие, записанное в outbox, гарантированно попадает в Kafka или остаётся в outbox с `sent_at IS NULL`.
+- [ ] FR-3: Consumer получает события в порядке публикации в рамках одной partition.
+- [ ] FR-4: Consumer-side dedup через `ProcessedMessage` — повторная обработка одного `messageId` тем же `consumerGroup` невозможна.
+- [ ] FR-5: Reference implementation — issues-модуль публикует 6 событий: `ISSUE_CREATED`, `ISSUE_UPDATED`, `ISSUE_DELETED`, `ISSUE_ASSIGNED`, `ISSUE_STATUS_CHANGED`, `ISSUE_MENTIONED`.
+- [ ] FR-6: `NOTIFICATIONS_ENABLED=false` → publisher продолжает писать в outbox, но relay не стартует, consumer'ы тоже — система работает без Kafka локально.
+
+### Нефункциональные
+- [ ] NFR-1: Publish latency (insert в outbox в рамках tx) — добавляет не более 5ms к бизнес-операции.
+- [ ] NFR-2: Relay-worker batch-size 100, interval 500ms — выдерживает 200 events/sec устойчиво.
+- [ ] NFR-3: Consumer-side dedup-lookup — по индексу `(consumer_group, message_id)` p99 < 5ms.
+- [ ] NFR-4: При падении relay-worker outbox не теряется — relay перезапускается, все несемпленные события доставляются.
+
+### Безопасность
+- [ ] SEC-1: Payload не должен содержать секретов (passwords, API-keys) — sanitize в producer.
+- [ ] SEC-2: Kafka-порт не проксируется наружу — только из internal docker-network.
+- [ ] SEC-3: Будущая интеграция (когда будет Broker-over-TLS) — не в MVP.
+
+### Тестирование
+- [ ] Unit: `publishInTx` — rollback транзакции откатывает и issue, и outbox-row.
+- [ ] Unit: Relay-worker — retry на Kafka-error, increment attempts, ограничение повторов.
+- [ ] Unit: Consumer-dedup — второй вызов с тем же messageId скипается.
+- [ ] Integration: 100 параллельных `ISSUE_CREATED` → все 100 events в топике, без дубликатов.
+- [ ] Integration: kill relay-worker, reboot → pending outbox-rows подхватываются.
+- [ ] Покрытие ≥ 70%.
+
+---
+
+## 7. Критерии приёмки (Definition of Done)
+
+- [ ] AC-1: Kafka поднимается в docker-compose одной командой `make up`.
+- [ ] AC-2: В миграциях Prisma есть `event_outbox` и `processed_messages`.
+- [ ] AC-3: Issues-модуль публикует все 6 событий через `publishInTx`.
+- [ ] AC-4: relay-worker процесс работает в отдельном docker-service, устойчив к падению Kafka.
+- [ ] AC-5: Админ-consumer-чек: вспомогательный скрипт `npm run events:tail -- tt.issues` печатает envelope'ы в stdout.
+- [ ] AC-6: Флаг `NOTIFICATIONS_ENABLED=false` полностью отключает Kafka-producer и relay, тесты бизнес-логики проходят без Kafka.
+- [ ] AC-7: Документация `docs/architecture/event-bus.md` с описанием envelope, топиков, consumer-gotchas.
+- [ ] Тесты зелёные (`make test`).
+- [ ] Lint проходит.
+- [ ] Code review + AI-review пройдены.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Анализ + дизайн envelope/outbox/relay | 4 |
+| Prisma-миграции | 2 |
+| `shared/eventbus/` wrapper + producer/consumer | 8 |
+| `shared/outbox/` + relay-worker процесс | 10 |
+| Integration в issues-модуле (6 событий) | 6 |
+| Docker-compose updates (dev + staging + prod) | 3 |
+| Init-job для топиков в prod | 2 |
+| Tests (unit + integration) | 12 |
+| Документация | 3 |
+| Code-review fixes | 4 |
+| **Итого** | **54** (~1.5 спринта) |
+
+---
+
+## 9. Связанные задачи
+
+- **Блокирует:** TTNOTIF-1 (consumer notifications-service), TTINTEG-1 (consumer webhooks-service), будущий TTAUTO-1.
+- **Зависит от:** нет.
+- **Переводит на новые рельсы:** `checkpoints/webhook-notifier.service.ts` — в рамках этого ТЗ или следующего (TTNOTIF-1 — решим по приоритетам после).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTBUS-0 (EPIC) — Event Bus
+  ├─ TTBUS-0.1 — Prisma models (outbox, processed_messages)
+  ├─ TTBUS-0.2 — shared/eventbus (kafkajs wrapper)
+  ├─ TTBUS-0.3 — shared/outbox (publishInTx + relay)
+  ├─ TTBUS-0.4 — docker-compose infra (dev/staging/prod)
+  ├─ TTBUS-0.5 — issues-producer integration (reference impl)
+  └─ TTBUS-0.6 — tests + docs
+```

--- a/docs/tz/MVP2JIRA/TTCFG-1.md
+++ b/docs/tz/MVP2JIRA/TTCFG-1.md
@@ -1,0 +1,312 @@
+# ТЗ: TTCFG-1 — Time Tracking (parser + settings + auto-stop)
+
+**Дата:** 2026-04-23
+**Тип:** TASK | **Приоритет:** P2 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+Три небольших улучшения системы учёта времени:
+
+1. **Парсер Jira-style строк** `1w 2d 3h 30m` для ввода/отображения `estimatedHours` и `timeLog.hours`. В БД остаётся `Decimal` часов.
+2. **Системные настройки:** `workingHoursPerDay`, `workingDaysPerWeek`, `workingWeekStart`, `defaultEstimateUnit`, `showTimeTrackingInKanban`. Глобальные в `SystemSetting`.
+3. **Auto-stop таймера:** если `TimeLog.startedAt` активен более N часов (default 24ч) — авто-stop с установкой `stoppedAt = startedAt + Nhours`, запись «автозакрыто».
+
+### Пользовательские сценарии
+
+**Dev логирует время:**
+1. В поле estimatedHours вводит `2d 4h` → парсер (на 8-часовой день) → `20h`.
+2. В UI показывается `2d 4h`, а не `20`.
+
+**Пользователь забыл таймер:**
+1. Запустил в пятницу 18:00, ушёл в отпуск.
+2. В понедельник 18:00 таймер не работает уже 3+ суток, но при auto-stop останавливается ровно на 24 часа работы.
+3. Запись в TimeLog `hours=24, note: "[auto-stopped] Timer exceeded 24h"`.
+
+**Админ настраивает:**
+1. `/admin/time-tracking` → ставит `workingHoursPerDay=6` (для сокращённой недели).
+2. Парсер теперь: `1d = 6h`, `1w = 5×6 = 30h`.
+
+---
+
+## 2. Текущее состояние
+
+- `Issue.estimatedHours: Decimal` — просто число часов.
+- `TimeLog.hours: Decimal`, `startedAt/stoppedAt: DateTime?`.
+- Парсера времени нет — пользователь вводит только числа.
+- Настроек часов/дня нет.
+- Auto-stop нет — таймеры висят вечно.
+
+---
+
+## 3. Зависимости
+
+### Модули backend
+- [ ] `shared/time-parser/` — новый: parse/format для Jira-style строк.
+- [ ] `modules/time/time.service.ts` — интеграция auto-stop cron.
+- [ ] `modules/admin/time-tracking-settings.router.ts` — settings.
+- [ ] `shared/scheduler/auto-stop.cron.ts` — cron (раз в 5 мин).
+
+### Frontend
+- [ ] `components/time/TimeInput.tsx` — input с auto-parse на blur.
+- [ ] `pages/admin/AdminTimeTrackingPage.tsx` — settings.
+- [ ] Все места ввода/отображения времени (IssueForm, TimeLog, Kanban) — используют парсер.
+
+### Модели данных (Prisma)
+- [ ] `SystemSetting` ключи: `time_tracking.*` (JSON).
+- [ ] Никаких новых таблиц.
+
+### Внешние зависимости
+- Нет (парсер — свой маленький код).
+
+### Блокеры
+- Нет.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Пользователь вводит `1.5h 30m` (неоднозначно) | Средняя | UX confusion | Парсер игнорирует дробные части внутри компонента (только `1h 30m` или `1.5h`, не оба) |
+| 2 | Auto-stop срабатывает на обычно-длинный таск (кодер реально работал 24 часа) | Низкая | Fake data | Notification пользователю за 2 часа до auto-stop + возможность продлить через UI |
+| 3 | Изменение workingHoursPerDay задним числом ломает отображение прошлых estimates | Средняя | Разный рендер | Парсер работает только при НОВОМ вводе; прошлые значения в БД — просто числа, отображаются текущим setting'ом |
+| 4 | Auto-stop cron пропускает timer из-за downtime | Низкая | Огромный неправильный log | При старте сервиса — проверка «таймеров, которые должны были остановиться», исправление |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Парсер (shared/time-parser/)
+
+```typescript
+// shared/time-parser/parse.ts
+export interface TimeTrackingSettings {
+  workingHoursPerDay: number;    // 8
+  workingDaysPerWeek: number;    // 5
+}
+
+const RX = /(\d+(?:\.\d+)?)\s*([wdhm])/gi;
+
+export function parseTimeString(
+  s: string,
+  settings: TimeTrackingSettings,
+): number {
+  // Если пришло просто число — трактуем как часы
+  const maybeNum = parseFloat(s);
+  if (!isNaN(maybeNum) && !/[a-z]/i.test(s)) return maybeNum;
+
+  let hours = 0;
+  for (const match of s.matchAll(RX)) {
+    const value = parseFloat(match[1]);
+    const unit = match[2].toLowerCase();
+    switch (unit) {
+      case 'w': hours += value * settings.workingDaysPerWeek * settings.workingHoursPerDay; break;
+      case 'd': hours += value * settings.workingHoursPerDay; break;
+      case 'h': hours += value; break;
+      case 'm': hours += value / 60; break;
+    }
+  }
+  return Math.round(hours * 100) / 100;  // 2 decimals
+}
+
+export function formatHours(
+  hours: number,
+  settings: TimeTrackingSettings,
+): string {
+  // 20 → "2d 4h" при 8-hour-day
+  if (hours === 0) return '0h';
+  const perDay = settings.workingHoursPerDay;
+  const perWeek = perDay * settings.workingDaysPerWeek;
+
+  let remaining = hours;
+  const weeks = Math.floor(remaining / perWeek); remaining -= weeks * perWeek;
+  const days = Math.floor(remaining / perDay); remaining -= days * perDay;
+  const wholeH = Math.floor(remaining); remaining -= wholeH;
+  const minutes = Math.round(remaining * 60);
+
+  const parts = [];
+  if (weeks) parts.push(`${weeks}w`);
+  if (days) parts.push(`${days}d`);
+  if (wholeH) parts.push(`${wholeH}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  return parts.join(' ') || '0h';
+}
+```
+
+### 5.2 Settings
+
+```
+Key: time_tracking
+Value: JSON
+{
+  "workingHoursPerDay": 8,
+  "workingDaysPerWeek": 5,
+  "workingWeekStart": "MONDAY",          // "MONDAY" | "SUNDAY"
+  "defaultEstimateUnit": "h",            // для UI-hint
+  "showTimeTrackingInKanban": false,
+  "autoStopAfterHours": 24
+}
+```
+
+API:
+- `GET /admin/time-tracking` — все.
+- `PATCH /admin/time-tracking` — обновить.
+
+Валидация:
+- `workingHoursPerDay`: 1–24.
+- `workingDaysPerWeek`: 1–7.
+- `autoStopAfterHours`: 1–168 (неделя).
+
+### 5.3 Auto-stop cron
+
+```typescript
+// shared/scheduler/auto-stop.cron.ts — запускается раз в 5 мин
+async function autoStopLongRunningTimers() {
+  const settings = await getTimeTrackingSettings();
+  const cutoff = new Date(Date.now() - settings.autoStopAfterHours * 3600 * 1000);
+
+  const longRunning = await prisma.timeLog.findMany({
+    where: {
+      startedAt: { lt: cutoff },
+      stoppedAt: null,
+    },
+  });
+
+  for (const tl of longRunning) {
+    const newStoppedAt = new Date(tl.startedAt!.getTime() + settings.autoStopAfterHours * 3600 * 1000);
+    const hours = settings.autoStopAfterHours;
+    await prisma.timeLog.update({
+      where: { id: tl.id },
+      data: {
+        stoppedAt: newStoppedAt,
+        hours,
+        note: (tl.note ?? '') + ` [auto-stopped: таймер превысил ${hours}ч]`,
+      },
+    });
+    // audit
+    await writeAuditLog(null, 'TimeLog', tl.id, 'auto_stopped', { originalStartedAt: tl.startedAt });
+    // notification (TTNOTIF-1) — через publishInTx
+    await publishInTx(prisma, 'tt.notifications', 'TIMER_AUTO_STOPPED', {
+      userId: tl.userId,
+      timeLogId: tl.id,
+      hours,
+    }, { userId: null });
+  }
+}
+```
+
+### 5.4 2-часовое предупреждение
+
+Опциональный warning cron (каждые 30 мин):
+- Найти running-timers с `startedAt < now - (autoStopAfterHours - 2) * 3600`.
+- Для каждого — publish `TIMER_WARNING_2H_BEFORE_STOP` (если ранее не отправлено для того же timer'а — через Redis-dedup `warn:timerId` TTL 2 часа).
+
+TTNOTIF-1 → user получает bell-уведомление «Таймер будет остановлен через ~2 часа».
+
+### 5.5 Frontend TimeInput
+
+```tsx
+// components/time/TimeInput.tsx
+function TimeInput({ value, onChange }: { value: number; onChange: (h: number) => void }) {
+  const settings = useTimeTrackingSettings();
+  const [text, setText] = useState(formatHours(value, settings));
+
+  const handleBlur = () => {
+    try {
+      const h = parseTimeString(text, settings);
+      onChange(h);
+      setText(formatHours(h, settings));  // normalize display
+    } catch {
+      // keep raw, pass-through для validation error
+    }
+  };
+
+  return <Input value={text} onChange={(e) => setText(e.target.value)} onBlur={handleBlur} />;
+}
+```
+
+### 5.6 Admin UI
+
+Страница `/admin/time-tracking`:
+- Форма со всеми 6 полями.
+- Preview-блок: «Для пользователя ввод `1w 2d 3h` будет означать = X часов».
+- Кнопка «Сохранить».
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: Parser `parseTimeString('1w 2d 3h')` работает согласно settings.
+- [ ] FR-2: Formatter `formatHours(20)` → `"2d 4h"` при 8h/day.
+- [ ] FR-3: `SystemSetting` ключ `time_tracking` с 6 полями.
+- [ ] FR-4: API `/admin/time-tracking` get/patch.
+- [ ] FR-5: Admin-UI страница.
+- [ ] FR-6: TimeInput component заменяет InputNumber везде.
+- [ ] FR-7: Auto-stop cron работает, TimeLog закрывается со стабильным `stoppedAt`.
+- [ ] FR-8: 2h-before warning публикуется в TTNOTIF-1 pipeline.
+
+### Нефункциональные
+- [ ] NFR-1: Parser < 1ms.
+- [ ] NFR-2: Cron на 10k running-timers < 5 сек.
+
+### Безопасность
+- [ ] SEC-1: Settings — SUPER_ADMIN only.
+
+### Тестирование
+- [ ] Unit: parser для edge-cases (`0`, `1w 2w` — последний wins или сумма? — sum).
+- [ ] Unit: formatter symmetric: `format(parse(x)) === normalize(x)`.
+- [ ] Integration: auto-stop cron на фикстуре.
+- [ ] E2E: input `2d 4h` → submit → display `2d 4h`.
+- [ ] Покрытие ≥ 70%.
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: Parser корректно разбирает `1w 2d 3h 30m`.
+- [ ] AC-2: Formatter `20h` → `2d 4h` при 8/day.
+- [ ] AC-3: Settings сохраняются, применяются глобально.
+- [ ] AC-4: Auto-stop работает.
+- [ ] AC-5: 2h-warning bell приходит.
+- [ ] AC-6: TimeInput используется во всех issue/timelog формах.
+- [ ] AC-7: Tests зелёные.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Parser/formatter + unit-tests | 4 |
+| Settings API + UI | 4 |
+| Auto-stop cron + warning cron | 4 |
+| TimeInput component + замена в 4 местах | 5 |
+| Tests (unit + integration) | 4 |
+| Code review | 2 |
+| **Итого** | **23** (~0.5 спринта) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** нет (TTNOTIF-1 желателен для warning-уведомлений, иначе skip).
+- **Связано:** TTUI-75 (общие UI настройки).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTCFG-1 (TASK) — Time Tracking
+  ├─ TTCFG-1.1 — Parser + formatter
+  ├─ TTCFG-1.2 — Settings API + UI
+  ├─ TTCFG-1.3 — Auto-stop + warning crons
+  ├─ TTCFG-1.4 — TimeInput + integration
+  └─ TTCFG-1.5 — Tests
+```

--- a/docs/tz/MVP2JIRA/TTCORE-1.md
+++ b/docs/tz/MVP2JIRA/TTCORE-1.md
@@ -1,0 +1,333 @@
+# ТЗ: TTCORE-1 — Priorities CRUD + IssueStatus → WorkflowStatus reconciliation
+
+**Дата:** 2026-04-23
+**Тип:** EPIC | **Приоритет:** P1 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+Две связанные миграции моделирования:
+
+### 1.1 Priorities (enum → table)
+`enum IssuePriority` (`CRITICAL/HIGH/MEDIUM/LOW`) хардкодится. Невозможно добавить «Blocker», изменить цвет/иконку, отключить уровень. Переводим в таблицу `Priority` с CRUD в админке.
+
+### 1.2 IssueStatus reconciliation
+На `Issue` сейчас сосуществуют `status: IssueStatus` (enum) и `workflowStatusId` (FK, nullable). Двойное моделирование — источник багов и ограничение для кастомных статусов. Убираем enum, оставляем только `workflowStatusId` (NOT NULL). Группировка «To Do / In Progress / Done» доступна через `workflowStatus.category` (enum `StatusCategory`, уже существует).
+
+### Пользовательские сценарии
+
+**Админ добавляет приоритет «Blocker»:**
+1. `/admin/priorities` → «Добавить».
+2. name=`Blocker`, color=#dc2626, iconName=`FireOutlined`, orderIndex=0 (выше Critical).
+3. В UI Issue-формы в dropdown'е приоритетов появляется «Blocker».
+
+**Проект ставит дефолтный приоритет:**
+1. Project settings → «Приоритет по умолчанию» → выбрать `HIGH`.
+2. Новые задачи в этом проекте создаются с priorityId = HIGH.
+
+**Миграция статусов:**
+- Все задачи с `status=DONE` имеют `workflowStatusId` указывающий на системный статус c `systemKey='DONE'` и `category='DONE'`.
+- Фронт рендерит `category` для группировок (kanban-колонки).
+
+---
+
+## 2. Текущее состояние
+
+- `IssuePriority` enum (4 значения), `Issue.priority` required.
+- `IssueStatus` enum (5 значений: OPEN/IN_PROGRESS/REVIEW/DONE/CANCELLED), `Issue.status` required.
+- `WorkflowStatus` таблица существует, имеет `category: StatusCategory`, `systemKey` unique, `color`, `iconName`, `isSystem`.
+- `Issue.workflowStatusId` — FK nullable.
+- TTQL-compiler поддерживает `priority` и `status` фильтры (по enum-значениям).
+
+---
+
+## 3. Зависимости
+
+### Модули backend
+- [ ] `modules/priorities/` — новый модуль: CRUD, default-per-project.
+- [ ] `modules/issues/` — заменить `priority` enum на `priorityId` FK; `status` enum убрать, оставить только `workflowStatusId` NOT NULL.
+- [ ] `modules/workflow-statuses/` — создать 5 системных статусов при миграции (если ещё нет).
+- [ ] `modules/projects/` — добавить `defaultPriorityId`.
+- [ ] `modules/search/search-compiler/` — переписать `priority` и `status` на join'ы по FK.
+
+### Frontend
+- [ ] `pages/admin/AdminPrioritiesPage.tsx` — новая.
+- [ ] `pages/admin/AdminProjectSettingsPage.tsx` (existing) — добавить default priority.
+- [ ] Все компоненты с приоритетом/статусом — обновить на FK-based rendering.
+
+### Модели данных (Prisma)
+- [ ] `Priority` — новая таблица (по образцу `WorkflowStatus`).
+- [ ] `Issue.priority: IssuePriority` → `Issue.priorityId: String` (FK, NOT NULL).
+- [ ] `Issue.status: IssueStatus` → удалить (после миграции).
+- [ ] `Issue.workflowStatusId: String?` → NOT NULL.
+- [ ] `Project.defaultPriorityId: String?` — новая колонка.
+
+### Внешние зависимости
+- Нет.
+
+### Блокеры
+- **TTRES-1 желателен** (resolution использует `workflowStatus.category === 'DONE'` вместо enum), но не блокирует — TTRES-1 написан с fallback'ом на legacy.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Влияние | Митигация |
+|---|------|-------------|---------|---------|-----------|
+| 1 | Миграция на prod с 100k+ issues упадёт по timeout | Средняя | Downtime релиза | Разбить миграцию на батчи (10k за раз), прогон на копии prod заранее |
+| 2 | Legacy-code в frontend/TTQL использует строки `"DONE"` — ломается после удаления enum | **Высокая** | Невидимые регрессии | Dual-field API на 1 спринт: backend шлёт `status` (computed из statusCategory + workflowStatus.systemKey) рядом с `workflowStatus` объектом |
+| 3 | Seed 5 системных статусов пересекается с существующими записями `WorkflowStatus` | Средняя | Дубли | Idempotent seed: `ON CONFLICT (systemKey) DO NOTHING` |
+| 4 | TTQL `status = DONE` пользователей ломается после миграции | Высокая | UX-поломка | Compiler мапит `status` → category (если matches enum-like values) + `workflowStatus.systemKey` |
+| 5 | Внешние интеграции (webhooks TTINTEG-1, events TTBUS-0) полагаются на enum | Средняя | Ломка | В payload событий отправляем оба: `statusId`, `statusCategory`, `statusName` |
+| 6 | Priority удалён, а задачи используют его → FK violation | Средняя | 500-error | Soft-delete (`isActive=false`) или принудительная перепривязка на default перед удалением |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Модель Priority
+
+```prisma
+model Priority {
+  id          String   @id @default(uuid())
+  key         String   @unique           // 'CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'BLOCKER'
+  name        String   @unique
+  description String?
+  color       String   @default("#9E9E9E")
+  iconName    String?  @map("icon_name")  // имя из @ant-design/icons
+  orderIndex  Int      @default(0) @map("order_index")
+  isSystem    Boolean  @default(false) @map("is_system")
+  isActive    Boolean  @default(true) @map("is_active")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  issues         Issue[]
+  defaultProjects Project[]  @relation("projectDefaultPriority")
+
+  @@map("priorities")
+}
+```
+
+**Seed (в migration):**
+
+```sql
+INSERT INTO priorities (id, key, name, color, icon_name, order_index, is_system, is_active) VALUES
+  (uuid(), 'CRITICAL', 'Критический', '#dc2626', 'ExclamationCircleOutlined', 1, true, true),
+  (uuid(), 'HIGH',     'Высокий',     '#ea580c', 'ArrowUpOutlined',          2, true, true),
+  (uuid(), 'MEDIUM',   'Средний',     '#ca8a04', 'MinusOutlined',            3, true, true),
+  (uuid(), 'LOW',      'Низкий',      '#16a34a', 'ArrowDownOutlined',        4, true, true);
+```
+
+### 5.2 Миграция Priorities
+
+```sql
+-- 1. Добавить priority_id nullable
+ALTER TABLE issues ADD COLUMN priority_id UUID REFERENCES priorities(id);
+
+-- 2. Заполнить
+UPDATE issues SET priority_id = (SELECT id FROM priorities WHERE key = priority::text);
+-- priority::text превращает enum 'CRITICAL' → 'CRITICAL'
+
+-- 3. Сделать NOT NULL
+ALTER TABLE issues ALTER COLUMN priority_id SET NOT NULL;
+
+-- 4. Удалить старую колонку
+ALTER TABLE issues DROP COLUMN priority;
+
+-- 5. Drop enum type
+DROP TYPE "IssuePriority";
+```
+
+### 5.3 Миграция Status reconciliation
+
+```sql
+-- 1. Seed 5 system WorkflowStatus (idempotent)
+INSERT INTO workflow_statuses (id, name, category, color, system_key, is_system) VALUES
+  (uuid(), 'Открыто',     'TODO',        '#3b82f6', 'OPEN',         true),
+  (uuid(), 'В работе',    'IN_PROGRESS', '#f59e0b', 'IN_PROGRESS',  true),
+  (uuid(), 'Ревью',       'IN_PROGRESS', '#8b5cf6', 'REVIEW',       true),
+  (uuid(), 'Готово',      'DONE',        '#10b981', 'DONE',         true),
+  (uuid(), 'Отменено',    'DONE',        '#6b7280', 'CANCELLED',    true)
+ON CONFLICT (system_key) DO NOTHING;
+
+-- 2. Заполнить workflow_status_id для issues с null
+UPDATE issues SET workflow_status_id = (
+  SELECT id FROM workflow_statuses WHERE system_key = issues.status::text
+) WHERE workflow_status_id IS NULL;
+
+-- 3. Сделать NOT NULL
+ALTER TABLE issues ALTER COLUMN workflow_status_id SET NOT NULL;
+
+-- 4. Удалить status (ПОСЛЕ merge dual-field API — через 1 спринт, отдельная миграция)
+-- ALTER TABLE issues DROP COLUMN status;
+-- DROP TYPE "IssueStatus";
+```
+
+**Миграция разбивается на 2 PR'а:**
+- **PR1 (TTCORE-1.a):** добавить Priority таблицу + priorityId, заполнить, переключить API на FK, оставить enum temporarily.
+- **PR2 (TTCORE-1.b):** через 1 спринт после деплоя PR1 — убрать enum колонку.
+
+### 5.4 API мигрирует
+
+**До:**
+```json
+{ "id": "...", "priority": "HIGH", "status": "IN_PROGRESS" }
+```
+
+**Dual-field (промежуточная 1 спринт):**
+```json
+{
+  "id": "...",
+  "priority": "HIGH",                          // legacy string
+  "priorityId": "uuid",
+  "priorityObj": { "key": "HIGH", "name": "Высокий", "color": "#ea580c", "iconName": "..." },
+  "status": "IN_PROGRESS",                     // legacy string
+  "workflowStatusId": "uuid",
+  "statusCategory": "IN_PROGRESS",             // computed
+  "workflowStatus": { "name": "В работе", "systemKey": "IN_PROGRESS", "category": "IN_PROGRESS", "color": "..." }
+}
+```
+
+**После (через 1 спринт):**
+```json
+{
+  "id": "...",
+  "priorityId": "uuid",
+  "priority": { "key": "HIGH", "name": "Высокий", "color": "#ea580c", ... },
+  "workflowStatusId": "uuid",
+  "status": { "name": "В работе", "systemKey": "IN_PROGRESS", "category": "IN_PROGRESS", "color": "..." }
+}
+```
+
+### 5.5 TTQL-compiler изменения
+
+- `priority = high` → `WHERE p.key = 'HIGH'` (case-insensitive match по `key` или `name`).
+- `priority in (Blocker, Critical)` → `WHERE p.key IN ('BLOCKER', 'CRITICAL')`.
+- `priority = "Высокий"` — литерал совпадает с `name` — работает.
+- `status = done` → `WHERE ws.system_key = 'DONE' OR ws.category = 'DONE'` (до удаления enum — fallback на старое поле).
+- `statusCategory = Done` — новая возможность фильтровать по категории.
+
+### 5.6 Default priority per project
+
+- `Project.defaultPriorityId: String?` — nullable, FK на `Priority`.
+- При создании Issue без явного `priorityId`:
+  - Использовать `project.defaultPriorityId` если задан.
+  - Иначе — системный `MEDIUM` (lookup по `key='MEDIUM'` один раз, кэш).
+
+### 5.7 Admin UI — AdminPrioritiesPage
+
+- Таблица: name, color-swatch, iconName (preview), orderIndex, isSystem, isActive, _count.issues.
+- Создание/редакция — form с ColorPicker и IconPicker (dropdown из предустановленного набора `@ant-design/icons`: `ArrowUpOutlined`, `ExclamationCircleOutlined`, `FireOutlined`, и т.д., ~20 штук).
+- Drag-and-drop для orderIndex.
+- Delete: если `isSystem=true` — отклоняется, если `_count.issues > 0` — prompt «Перепривязать на другой приоритет сначала» + dropdown.
+
+### 5.8 IssueStatus — handling enum removal plan
+
+**Спринт 1 (TTCORE-1.a):**
+- Seed 5 system statuses.
+- Миграция `workflow_status_id` NOT NULL.
+- Backend API возвращает оба поля (dual-field).
+- Frontend читает `workflowStatus.systemKey` и `statusCategory`, но может fallback на `status` enum.
+
+**Спринт 2 (TTCORE-1.b — через 1 спринт после релиза спринта 1):**
+- Удаление колонки `status` и enum type.
+- Frontend — убрать legacy-ветку.
+- TTQL — убрать fallback на enum-поле.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: Модель `Priority` создана, 4 системных приоритета сидятся.
+- [ ] FR-2: `/admin/priorities` CRUD (ADMIN/SUPER_ADMIN).
+- [ ] FR-3: `Issue.priorityId` NOT NULL; endpoint принимает.
+- [ ] FR-4: `Project.defaultPriorityId` настраивается в project settings.
+- [ ] FR-5: При create issue без priority — используется project default, иначе `MEDIUM`.
+- [ ] FR-6: TTQL: `priority = High`, `priority in (...)` работают.
+- [ ] FR-7: 5 системных WorkflowStatus сидятся (если ещё нет).
+- [ ] FR-8: Все Issue имеют `workflow_status_id NOT NULL`.
+- [ ] FR-9: API возвращает dual-field (status + workflowStatus) на 1 спринт переходного периода.
+- [ ] FR-10: TTQL: `status = DONE`, `statusCategory = Done` работают.
+
+### Нефункциональные
+- [ ] NFR-1: Миграция Issue-priority на prod-snapshot (1M задач) < 5 мин.
+- [ ] NFR-2: Миграция workflow_status_id — тот же SLA.
+- [ ] NFR-3: Issue list API не замедляется более чем на 30ms (доп. JOIN'ы на Priority + WorkflowStatus).
+
+### Безопасность
+- [ ] SEC-1: Priority CRUD — ADMIN+.
+- [ ] SEC-2: Удаление системных priorities — 403.
+
+### Тестирование
+- [ ] Unit: TTQL priority/status match, Priority-service CRUD.
+- [ ] Integration: миграция на фикстуре (100 issues) — все получают corrent FK.
+- [ ] Integration: TTQL `priority = high` находит задачи.
+- [ ] Integration: dual-field API — legacy field совместим.
+- [ ] Migration rollback: проверить, что миграция обратима (add columns, drop new, restore old).
+- [ ] Покрытие ≥ 70%.
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: `/admin/priorities` работает: создание/редактирование/архивация.
+- [ ] AC-2: 4 системных priorities сидятся, нельзя удалить.
+- [ ] AC-3: Issue создаётся с project default priority, если не указан явно.
+- [ ] AC-4: TTQL `priority = High` находит задачи с `HIGH`.
+- [ ] AC-5: Все existing issues имеют `workflow_status_id`.
+- [ ] AC-6: `status = DONE` возвращает все issues с workflowStatus.category=DONE.
+- [ ] AC-7: Frontend показывает цветные priority-бейджи с иконками.
+- [ ] AC-8: Tests зелёные, миграция dry-run на prod-snapshot успешна.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Prisma model `Priority` + seed + миграция | 5 |
+| Seed system WorkflowStatus + миграция `workflow_status_id` NOT NULL | 3 |
+| Backend: modules/priorities CRUD + router | 4 |
+| Backend: Issue-service рефактор (priority FK, dual-field) | 6 |
+| Backend: project default priority | 2 |
+| Backend: TTQL-compiler updates | 5 |
+| Backend: webhooks/events payload dual-field | 2 |
+| Frontend: AdminPrioritiesPage | 6 |
+| Frontend: все формы/фильтры/бейджи на новый API | 10 |
+| Tests + migration verification | 8 |
+| Code review + AI review | 4 |
+| **Итого PR1 (TTCORE-1.a)** | **55** |
+| Спринт 2 — удаление enum колонки `status` | 4 |
+| Frontend — убрать legacy | 2 |
+| Tests cleanup | 2 |
+| **Итого PR2 (TTCORE-1.b)** | **8** |
+| **Общий итог** | **63** (~1 спринт) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** нет.
+- **Связано:** TTRES-1 (использует category='DONE'), TTSRH-1 (TTQL).
+- **Частично блокирует (fallback OK):** TTRES-1 (может работать без TTCORE-1 через fallback).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTCORE-1 (EPIC) — Priorities + Status reconciliation
+  ├─ TTCORE-1.1 — Priority model + seed
+  ├─ TTCORE-1.2 — Issue.priorityId + миграция
+  ├─ TTCORE-1.3 — Project defaultPriorityId
+  ├─ TTCORE-1.4 — AdminPrioritiesPage
+  ├─ TTCORE-1.5 — WorkflowStatus seed + Issue.workflow_status_id NOT NULL
+  ├─ TTCORE-1.6 — Dual-field API (status + workflowStatus)
+  ├─ TTCORE-1.7 — TTQL compiler updates
+  └─ TTCORE-1.8 — (через 1 спринт) — drop Issue.status enum
+```

--- a/docs/tz/MVP2JIRA/TTINTEG-1.md
+++ b/docs/tz/MVP2JIRA/TTINTEG-1.md
@@ -1,0 +1,424 @@
+# ТЗ: TTINTEG-1 — Webhooks (system + project-level)
+
+**Дата:** 2026-04-23
+**Тип:** EPIC | **Приоритет:** P2 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+Реализовать универсальный реестр webhook'ов — **ещё один consumer** Kafka-шины (после TTBUS-0), принципиально аналогичный `notifications-service`.
+
+Возможности:
+- **Two-level scope:** system-wide (админ регистрирует) + project-level (project ADMIN/MANAGER).
+- **Native envelope format** — одинаковый с Kafka-событиями, без Jira-compat.
+- **HMAC-SHA256 signing** + **timestamp header** (anti-replay, window ±5 мин).
+- **Retry:** 5 попыток с backoff (1s/10s/60s/600s/3600s), **настраивается per-webhook** (override в advanced settings).
+- **DLQ:** после 10 fails → `isEnabled=false` автоматически + admin-нотификация.
+- **Delivery log:** опционально хранит full payload через `storeFullPayload` флаг (default off).
+
+### Пользовательские сценарии
+
+**Админ подключает SIEM:**
+1. `/admin/webhooks` → Add.
+2. URL `https://siem.corp.ru/events`, scope=SYSTEM, secret generated, eventTypes=`[ISSUE_CREATED, ISSUE_UPDATED, visibility_changed]`.
+3. После save — все system-events идут в SIEM с HMAC-подписью.
+
+**Project admin подключает Slack webhook:**
+1. Project settings → Webhooks.
+2. URL Slack incoming, scope=PROJECT, eventTypes=`[ISSUE_COMMENTED]`, storeFullPayload=true (для debugging).
+
+**Auto-disable:**
+1. Slack URL упал. 10 fails подряд → webhook `isEnabled=false`.
+2. Admin получает email «Webhook `slack-main` отключён после 10 ошибок».
+
+---
+
+## 2. Текущее состояние
+
+- `webhook-notifier.service.ts` (checkpoints) — ad-hoc, single purpose. После TTBUS-0 мигрирует на event-bus.
+- Kafka + outbox готовы (TTBUS-0).
+- Reference consumer pattern в `notifications-service` (TTNOTIF-1).
+
+---
+
+## 3. Зависимости
+
+### Модули backend (новый сервис)
+- [ ] `webhooks-service/` — отдельный процесс, consumer `tt.*` топиков.
+
+### Модули backend (в monolith)
+- [ ] `modules/webhooks/webhooks.router.ts` — CRUD + delivery-log API.
+- [ ] `modules/webhooks/webhooks.service.ts`.
+
+### Frontend
+- [ ] `pages/admin/AdminWebhooksPage.tsx` — system-level.
+- [ ] `pages/project/ProjectWebhooksPage.tsx` — project-level.
+- [ ] `components/webhooks/WebhookForm.tsx` + `DeliveryLogTable.tsx`.
+
+### Модели данных (Prisma, main schema)
+- [ ] `Webhook` — новая.
+- [ ] `WebhookDelivery` — новая.
+
+### Внешние зависимости
+- [ ] `got` — HTTP клиент с retry built-in (альтернатива `fetch`).
+- [ ] Уже есть `kafkajs` (от TTBUS-0).
+
+### Блокеры
+- **TTBUS-0 + TTNOTIF-1 обязательны** (consumer pattern + event definitions).
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | SSRF: злоумышленник регистрирует webhook на `http://localhost:metadata` или внутреннюю сеть | Высокая | Leak внутренних метаданных | Блок-лист приватных ranges (RFC 1918, 127.0.0.0/8, 169.254.0.0/16), localhost; DNS-резолвинг до запроса; проверка final IP |
+| 2 | Retry-storm после длительного сбоя receiver | Средняя | Overload receiver при восстановлении | Auto-disable после 10 fails; exponential backoff; random jitter ±20% |
+| 3 | Payload с PII в delivery-log exposed через API | Средняя | Leak | `storeFullPayload=false` default; audit log кто смотрел payload |
+| 4 | Webhook owner покинул проект / компания ушла | Низкая | Orphaned webhooks | cleanup-job раз в сутки: отключает webhooks с неактивным `createdById` > 90 дней |
+| 5 | Timing-attack на HMAC signature verify | Низкая | Theoretical | Constant-time comparison (`crypto.timingSafeEqual`) на receiver-side (документировать в payload-spec для внешних интеграторов) |
+| 6 | Large payload (attachments в issue.updated) > 1MB | Средняя | HTTP-timeout | Max payload 256KB; если больше — отправлять meta-only + URL для pull |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Модели
+
+```prisma
+enum WebhookScope {
+  SYSTEM
+  PROJECT
+}
+
+model Webhook {
+  id              String         @id @default(uuid())
+  name            String
+  scope           WebhookScope
+  projectId       String?        @map("project_id")  // if PROJECT-scope
+  url             String
+  secretEnc       String         @map("secret_enc")  // AES-GCM encrypted
+  eventTypes      String[]       @map("event_types")  // ['ISSUE_CREATED', ...]
+  isEnabled       Boolean        @default(true) @map("is_enabled")
+  storeFullPayload Boolean       @default(false) @map("store_full_payload")
+
+  // Retry config (override defaults)
+  maxAttempts     Int            @default(5) @map("max_attempts")
+  backoffMsJson   String         @default("[1000,10000,60000,600000,3600000]") @map("backoff_ms_json")
+  // массив миллисекунд; длина должна быть = maxAttempts
+
+  autoDisabledAt  DateTime?      @map("auto_disabled_at")
+  lastDeliveryAt  DateTime?      @map("last_delivery_at")
+  createdById     String         @map("created_by_id")
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @updatedAt
+
+  project         Project?       @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  deliveries      WebhookDelivery[]
+
+  @@index([scope, isEnabled])
+  @@index([projectId])
+  @@map("webhooks")
+}
+
+enum DeliveryStatus {
+  PENDING
+  DELIVERED
+  RETRYING
+  FAILED_PERMANENTLY
+}
+
+model WebhookDelivery {
+  id            String         @id @default(uuid())
+  webhookId     String         @map("webhook_id")
+  eventId       String         @map("event_id")  // = envelope.messageId
+  eventType     String         @map("event_type")
+  status        DeliveryStatus @default(PENDING)
+  attempts      Int            @default(0)
+  requestUrl    String         @map("request_url")
+  payloadStored Boolean        @default(false) @map("payload_stored")  // true если копия сохранена для debug
+  payloadJson   String?        @map("payload_json")  // только если storeFullPayload + payload < 256KB
+  lastError     String?        @map("last_error")
+  lastAttemptAt DateTime?      @map("last_attempt_at")
+  responseCode  Int?           @map("response_code")
+  deliveredAt   DateTime?      @map("delivered_at")
+  createdAt     DateTime       @default(now())
+
+  webhook       Webhook        @relation(fields: [webhookId], references: [id], onDelete: Cascade)
+
+  @@unique([webhookId, eventId])
+  @@index([webhookId, status])
+  @@index([status, createdAt])
+  @@map("webhook_deliveries")
+}
+```
+
+### 5.2 Consumer в webhooks-service
+
+```typescript
+// webhooks-service/src/consumer.ts
+subscribe('webhooks-service', ['tt.issues', 'tt.comments', 'tt.releases', 'tt.workflow'],
+  async (envelope) => {
+    const { type, messageId } = envelope;
+    const projectId = envelope.payload.projectId as string | undefined;
+
+    // Найти все webhook'и, слушающие это событие
+    const webhooks = await prisma.webhook.findMany({
+      where: {
+        isEnabled: true,
+        eventTypes: { has: type },
+        OR: [
+          { scope: 'SYSTEM' },
+          { scope: 'PROJECT', projectId: projectId ?? '___none___' },
+        ],
+      },
+    });
+
+    // Для каждого — создать delivery, добавить job в очередь
+    await Promise.all(webhooks.map((wh) => enqueueDelivery(wh.id, envelope)));
+  });
+```
+
+### 5.3 Delivery worker (BullMQ)
+
+```typescript
+// webhooks-service/src/delivery.worker.ts
+async function processDelivery(job: Job<{ deliveryId: string }>) {
+  const delivery = await prisma.webhookDelivery.findUnique({
+    where: { id: job.data.deliveryId },
+    include: { webhook: true },
+  });
+  if (!delivery || !delivery.webhook.isEnabled) return;
+
+  const wh = delivery.webhook;
+  const envelope = JSON.parse(delivery.payloadJson ?? ''); // или ре-fetch из outbox
+
+  // Build signature
+  const ts = Math.floor(Date.now() / 1000);
+  const body = JSON.stringify(envelope);
+  const payloadToSign = `${ts}.${body}`;
+  const secret = decrypt(wh.secretEnc);
+  const signature = crypto.createHmac('sha256', secret).update(payloadToSign).digest('hex');
+
+  try {
+    const res = await got.post(wh.url, {
+      body,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-TT-Signature': `sha256=${signature}`,
+        'X-TT-Timestamp': String(ts),
+        'X-TT-Event-Type': envelope.type,
+        'X-TT-Delivery-Id': delivery.id,
+        'X-TT-Webhook-Id': wh.id,
+      },
+      timeout: { request: 30_000 },
+      retry: { limit: 0 },  // retry вручную ниже
+    });
+
+    await prisma.webhookDelivery.update({
+      where: { id: delivery.id },
+      data: {
+        status: 'DELIVERED',
+        attempts: delivery.attempts + 1,
+        deliveredAt: new Date(),
+        responseCode: res.statusCode,
+        lastAttemptAt: new Date(),
+      },
+    });
+    await prisma.webhook.update({
+      where: { id: wh.id },
+      data: { lastDeliveryAt: new Date() },
+    });
+  } catch (err) {
+    const backoffs = JSON.parse(wh.backoffMsJson) as number[];
+    const nextAttempts = delivery.attempts + 1;
+    const canRetry = nextAttempts < wh.maxAttempts;
+
+    if (canRetry) {
+      const delayMs = backoffs[nextAttempts - 1] + jitter(delayMs, 0.2);
+      await job.queue.add('deliver', { deliveryId: delivery.id }, { delay: delayMs });
+      await prisma.webhookDelivery.update({
+        where: { id: delivery.id },
+        data: { status: 'RETRYING', attempts: nextAttempts, lastError: String(err), lastAttemptAt: new Date() },
+      });
+    } else {
+      await prisma.webhookDelivery.update({
+        where: { id: delivery.id },
+        data: { status: 'FAILED_PERMANENTLY', attempts: nextAttempts, lastError: String(err), lastAttemptAt: new Date() },
+      });
+      await maybeAutoDisableWebhook(wh.id);
+    }
+  }
+}
+
+async function maybeAutoDisableWebhook(webhookId: string): Promise<void> {
+  const recent = await prisma.webhookDelivery.count({
+    where: {
+      webhookId,
+      status: 'FAILED_PERMANENTLY',
+      createdAt: { gte: new Date(Date.now() - 24 * 3600 * 1000) },
+    },
+  });
+  if (recent >= 10) {
+    await prisma.webhook.update({
+      where: { id: webhookId },
+      data: { isEnabled: false, autoDisabledAt: new Date() },
+    });
+    // публикуем событие для notifications
+    await publishInTx(prisma, 'tt.webhooks', 'WEBHOOK_AUTO_DISABLED', { webhookId }, { userId: null });
+  }
+}
+```
+
+### 5.4 SSRF защита
+
+```typescript
+function isDisallowedUrl(url: string): boolean {
+  const u = new URL(url);
+  if (!['http:', 'https:'].includes(u.protocol)) return true;
+  // блокировка служебных host'ов
+  const blocklist = ['localhost', '127.0.0.1', '0.0.0.0', '169.254.169.254', 'metadata.google.internal'];
+  if (blocklist.some((b) => u.hostname.toLowerCase().includes(b))) return true;
+  // приватные IP-диапазоны — проверяем через DNS-резолв и ip-range-check
+  // ... (отдельная функция)
+  return false;
+}
+```
+
+При create/update webhook — валидация + пре-резолв DNS, отказ если приватный IP.
+
+### 5.5 API
+
+**System-level (SUPER_ADMIN):**
+- `GET /admin/webhooks` — list.
+- `POST /admin/webhooks` — create.
+- `PUT /admin/webhooks/:id` — update.
+- `DELETE /admin/webhooks/:id`.
+- `POST /admin/webhooks/:id/test` — отправляет тестовый event `WEBHOOK_TEST`.
+- `GET /admin/webhooks/:id/deliveries` — delivery log (payload только если storeFullPayload).
+- `POST /admin/webhooks/:id/deliveries/:deliveryId/retry` — manual retry.
+- `POST /admin/webhooks/:id/enable` — re-enable after auto-disable.
+
+**Project-level (requires `PROJECT_SETTINGS_EDIT`):**
+- `/api/projects/:projectId/webhooks` — те же операции в scope проекта.
+
+**Новый permission:** `WEBHOOKS_MANAGE` в `ProjectPermission` — для project-level webhooks.
+
+### 5.6 Admin UI
+
+`/admin/webhooks`:
+- Таблица: name, url, eventTypes count, status (enabled/auto-disabled), last delivery, success rate.
+- Actions: edit, test, view log, re-enable.
+
+Form:
+- name, URL (с SSRF-валидацией при blur).
+- Scope (system/project selection).
+- Event types — мультиселект с группировкой по домену.
+- Secret — generated, shown once на create.
+- Advanced settings (collapsed):
+  - Max attempts: 1–10 (default 5).
+  - Backoff array — JSON-input с валидацией длины.
+  - Store full payload: toggle.
+
+### 5.7 Миграция webhook-notifier (checkpoints)
+
+`checkpoints/webhook-notifier.service.ts` — упраздняется. Вместо него:
+- При violation — publishInTx `CHECKPOINT_VIOLATED` в `tt.releases` (TTNOTIF-1 уже делает).
+- Webhook-consumer принимает эту событие наравне со всеми.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: CRUD webhooks в admin UI (system) и project-settings.
+- [ ] FR-2: HMAC-SHA256 + timestamp подпись.
+- [ ] FR-3: SSRF-блокировка приватных адресов.
+- [ ] FR-4: Retry с exp backoff + jitter.
+- [ ] FR-5: Auto-disable после 10 fails за 24 часа.
+- [ ] FR-6: Delivery log с опциональным storeFullPayload.
+- [ ] FR-7: Test-button отправляет `WEBHOOK_TEST` event.
+- [ ] FR-8: Manual retry из UI.
+- [ ] FR-9: Re-enable button после auto-disable.
+- [ ] FR-10: Миграция checkpoints-notifier на универсальный pipeline.
+- [ ] FR-11: Permission `WEBHOOKS_MANAGE` в ProjectPermission.
+
+### Нефункциональные
+- [ ] NFR-1: Delivery latency < 30 сек p95 при живом receiver.
+- [ ] NFR-2: Consumer работает на 100 webhooks × 1000 events/hour без drop'ов.
+- [ ] NFR-3: Delivery log хранит последние 1000 записей per webhook (cleanup cron старше).
+
+### Безопасность
+- [ ] SEC-1: Secret encrypted at rest.
+- [ ] SEC-2: SSRF-validation на create/update.
+- [ ] SEC-3: storeFullPayload + view delivery-log — audit-logged.
+- [ ] SEC-4: timing-safe HMAC verify в документации для integrators.
+
+### Тестирование
+- [ ] Unit: HMAC generation + verification.
+- [ ] Unit: SSRF validator (edge-cases).
+- [ ] Unit: retry + auto-disable logic.
+- [ ] Integration: event → webhook → receiver (mock HTTP server).
+- [ ] E2E: создать webhook в UI → событие → проверка в delivery log.
+- [ ] Security: попытка регистрации SSRF-URL отклоняется.
+- [ ] Покрытие ≥ 75%.
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: System + project webhooks работают.
+- [ ] AC-2: Подпись валидируется на тестовом receiver.
+- [ ] AC-3: Receiver упал → retry согласно backoff → auto-disable после 10 fails.
+- [ ] AC-4: SSRF: `http://169.254.169.254/` — 400 DISALLOWED_URL.
+- [ ] AC-5: Test-button рабочий.
+- [ ] AC-6: Delivery log показывает last 100 попыток.
+- [ ] AC-7: Checkpoints-notifier заменён на универсальный pipeline.
+- [ ] AC-8: Tests + security review пройдены.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Prisma models | 3 |
+| Webhooks CRUD router (admin + project) | 6 |
+| SSRF-validator | 3 |
+| webhooks-service skeleton (Kafka consumer) | 6 |
+| Delivery worker (BullMQ + retry + auto-disable) | 10 |
+| Frontend admin page + form | 10 |
+| Frontend project-settings webhooks | 4 |
+| Delivery log UI | 4 |
+| Migration checkpoints-notifier | 3 |
+| Permission `WEBHOOKS_MANAGE` + seed | 2 |
+| Tests (unit + integration + security) | 10 |
+| Docs (integration guide + HMAC spec) | 4 |
+| Code review | 5 |
+| **Итого** | **70** (~1 спринт) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** TTBUS-0, TTNOTIF-1.
+- **Связано:** TTSEC-2 (permissions), TTMP-160 (checkpoints — мигрирует).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTINTEG-1 (EPIC) — Webhooks
+  ├─ TTINTEG-1.1 — Prisma models
+  ├─ TTINTEG-1.2 — CRUD + SSRF-validation
+  ├─ TTINTEG-1.3 — webhooks-service + consumer
+  ├─ TTINTEG-1.4 — Delivery worker + retry + auto-disable
+  ├─ TTINTEG-1.5 — Admin & project UI
+  ├─ TTINTEG-1.6 — Migrate checkpoints-notifier
+  └─ TTINTEG-1.7 — Tests + docs
+```

--- a/docs/tz/MVP2JIRA/TTMFA-1.md
+++ b/docs/tz/MVP2JIRA/TTMFA-1.md
@@ -1,0 +1,370 @@
+# ТЗ: TTMFA-1 — Two-Factor Authentication (TOTP)
+
+**Дата:** 2026-04-23
+**Тип:** TASK | **Приоритет:** P2 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+Двухфакторная аутентификация через **TOTP** (Google Authenticator, Authy, 1Password) для пользователей с локальным паролем. SSO-юзеры MFA делают на стороне IdP, поэтому TTMFA-1 дополняет TTSSO-1, а не конкурирует.
+
+Ключевые особенности:
+- **TOTP only** (RFC 6238, 30-сек окно, 6 цифр).
+- **Обязательность настраивается** per-role через SystemSetting (default: обязательно для `SUPER_ADMIN`).
+- **10 recovery codes** при enrollment + admin-reset как fallback.
+- **Re-auth** для чувствительных операций (смена пароля/email, отключение MFA).
+- **Trust device** опционально, включается через Password Policy.
+
+### Пользовательские сценарии
+
+**SUPER_ADMIN enrollment:**
+1. После login'а — редирект на `/mfa/enroll` (forced).
+2. Показывается QR + secret (copy).
+3. Сканирует Google Authenticator → вводит первый код.
+4. Получает 10 recovery codes → «Сохраните, не показываются повторно».
+5. Подтверждает копирование → MFA включён.
+
+**Обычный логин:**
+1. Email + пароль.
+2. Если MFA включён → экран «Введите код».
+3. Вводит 6 цифр → успех.
+
+**Потерял телефон:**
+1. На логин-экране «Не можете войти?» → форма с recovery code.
+2. Ввёл код → доступ + disable существующего TOTP.
+3. Или: обращается к SUPER_ADMIN, который делает `POST /admin/users/:id/mfa/reset`.
+
+---
+
+## 2. Текущее состояние
+
+- MFA отсутствует полностью.
+- `User.passwordHash` уже есть.
+- Password Policy (TTSEC-4) содержит флаг `mfaTrustDevice` — интегрируемся.
+
+---
+
+## 3. Зависимости
+
+### Модули backend
+- [ ] `modules/mfa/mfa.service.ts` — enroll, verify, recovery-codes, reset.
+- [ ] `modules/mfa/mfa.router.ts` — endpoints.
+- [ ] `modules/auth/auth.service.ts` — интегрировать MFA-check в login-flow.
+- [ ] `modules/auth/reauth.service.ts` (новый) — для sensitive-ops (re-auth flow).
+
+### Frontend
+- [ ] `pages/MfaEnrollPage.tsx`.
+- [ ] `pages/MfaVerifyPage.tsx`.
+- [ ] `pages/MfaRecoveryPage.tsx`.
+- [ ] `pages/SettingsPage.tsx` — добавить раздел «MFA» с disable-кнопкой.
+- [ ] `components/admin/MfaResetButton.tsx` — для admin user page.
+- [ ] `components/auth/ReauthDialog.tsx` — модалка для re-auth.
+
+### Модели данных (Prisma)
+- [ ] `UserMfa` — новая.
+- [ ] `UserMfaRecoveryCode` — новая.
+- [ ] `UserMfaTrustedDevice` (опционально, если trust-device включён).
+- [ ] `SystemSetting` ключ: `mfa.required_roles` — array of SystemRoleType.
+
+### Внешние зависимости
+- [ ] `otplib` — TOTP генерация/валидация.
+- [ ] `qrcode` — для QR-generation.
+- [ ] `argon2` — для recovery-code hashing (уже может быть в deps, либо bcrypt).
+
+### Блокеры
+- **TTSEC-4 желателен** (переиспользуем re-auth pattern). Без TTSEC-4 работает, но `mfaTrustDevice` настраивается отдельно.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Time-drift между server и authenticator → valid OTP отклоняется | Средняя | UX | Default window=1 (допускает ±30сек drift); в высоконагруженных случаях — window=2 |
+| 2 | Secret leak через логи | Средняя | Compromise | Secret encrypted at rest (AES-GCM с master-key из ENV); никогда не логируется |
+| 3 | Recovery codes показаны один раз, пользователь не сохранил | Высокая | Lockout | Admin-reset как second line; clear warning на enrollment |
+| 4 | SUPER_ADMIN все потеряли MFA — backdoor? | Низкая | Lockout всей системы | Emergency CLI: `npm run admin:mfa:reset -- --email=...` (подписано SUPER_ADMIN_EMERGENCY_KEY) |
+| 5 | Brute-force TOTP (1M попыток за 30 сек → шанс 0.01%) | Низкая | Compromise | Rate-limit 5 attempts per 5 min per-user (Redis); после 5 fails — auto-lockout + alert |
+| 6 | Trust-device cookie захвачен | Средняя | Compromise | HTTP-only, Secure, SameSite=Strict; TTL 30 дней max; fingerprint = hash(user-agent + ip /24) |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Модели
+
+```prisma
+enum MfaMethod {
+  TOTP
+  // WEBAUTHN — фазово
+}
+
+model UserMfa {
+  id          String    @id @default(uuid())
+  userId      String    @unique @map("user_id")
+  method      MfaMethod @default(TOTP)
+  secretEnc   String    @map("secret_enc")  // AES-GCM encrypted
+  isConfirmed Boolean   @default(false) @map("is_confirmed")
+  enrolledAt  DateTime? @map("enrolled_at")
+  lastUsedAt  DateTime? @map("last_used_at")
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  user             User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  recoveryCodes    UserMfaRecoveryCode[]
+  trustedDevices   UserMfaTrustedDevice[]
+
+  @@map("user_mfa")
+}
+
+model UserMfaRecoveryCode {
+  id         String    @id @default(uuid())
+  mfaId      String    @map("mfa_id")
+  codeHash   String    @map("code_hash")  // argon2 hash
+  usedAt     DateTime? @map("used_at")
+  createdAt  DateTime  @default(now())
+
+  mfa        UserMfa   @relation(fields: [mfaId], references: [id], onDelete: Cascade)
+
+  @@index([mfaId])
+  @@map("user_mfa_recovery_codes")
+}
+
+model UserMfaTrustedDevice {
+  id              String   @id @default(uuid())
+  mfaId           String   @map("mfa_id")
+  fingerprint     String   // hash(UA + IP /24)
+  deviceName      String?  @map("device_name")  // "Chrome on MacBook"
+  expiresAt       DateTime @map("expires_at")
+  createdAt       DateTime @default(now())
+
+  mfa             UserMfa  @relation(fields: [mfaId], references: [id], onDelete: Cascade)
+
+  @@unique([mfaId, fingerprint])
+  @@map("user_mfa_trusted_devices")
+}
+```
+
+### 5.2 Login-flow расширение
+
+```
+POST /auth/login { email, password }
+  → 200 { requiresMfa: true, mfaSessionToken: "jwt-short" }   // если user имеет UserMfa и isConfirmed=true
+  → 200 { accessToken, refreshToken, user }                   // если MFA не требуется
+
+POST /auth/mfa/verify { mfaSessionToken, code }
+  → 200 { accessToken, refreshToken, user }
+  → 401 { error: 'INVALID_CODE', attemptsLeft: 4 }
+
+POST /auth/mfa/recovery { mfaSessionToken, recoveryCode }
+  → 200 { accessToken, refreshToken, user, mfaDisabled: true }  // recovery сбрасывает MFA
+```
+
+`mfaSessionToken` — короткоживущий JWT (TTL 5 мин), содержит `{ userId, step: 'mfa' }`.
+
+### 5.3 Enrollment
+
+```
+GET /api/mfa/enroll
+  → { qrDataUrl: "data:image/png;base64,...", secret: "base32" }
+  // secret хранится в Redis по userId на 10 мин; в БД не пишется до confirm
+
+POST /api/mfa/confirm { code }
+  → валидирует code против Redis-secret
+  → сохраняет UserMfa(userId, secretEnc, isConfirmed=true)
+  → генерирует 10 recovery codes (hashed в UserMfaRecoveryCode)
+  → возвращает { recoveryCodes: ['aaaa-bbbb', ...] }
+  // ПОКАЗАНО ОДИН РАЗ, дальше админ-сброс
+
+DELETE /api/mfa  (require re-auth)
+  → удаляет UserMfa cascade (recovery + trusted devices)
+```
+
+### 5.4 Required roles — enforcement
+
+```typescript
+// modules/mfa/mfa-enforcement.ts
+export async function ensureMfaCompliance(user: UserWithRoles): Promise<void> {
+  const required = await getSystemSetting('mfa.required_roles') as SystemRoleType[];
+  const hasRequiredRole = user.systemRoles.some((r) => required.includes(r));
+  if (!hasRequiredRole) return;
+
+  const mfa = await prisma.userMfa.findUnique({ where: { userId: user.id } });
+  if (!mfa || !mfa.isConfirmed) {
+    // Forced enrollment на фронте
+    throw new MfaEnrollmentRequiredError();
+  }
+}
+```
+
+Default: `mfa.required_roles = ['SUPER_ADMIN']`.
+
+### 5.5 Re-auth для sensitive operations
+
+```typescript
+// shared/reauth.ts
+// Sensitive: change-password, change-email, disable-mfa, create-api-token
+
+// GET /auth/reauth/challenge  — возвращает тип challenge
+//   → { requiresPassword: true, requiresMfa: true }
+
+// POST /auth/reauth { password, mfaCode }
+//   → 200 { reauthToken: "jwt-ttl-5min" }
+
+// Все sensitive endpoints требуют header X-Reauth-Token: <token>
+// backend проверяет: JWT valid, userId matches, < 5 мин
+```
+
+Frontend показывает `ReauthDialog` при вызове sensitive операции.
+
+### 5.6 Recovery codes
+
+```typescript
+function generateRecoveryCodes(): string[] {
+  return Array.from({ length: 10 }, () => {
+    const part1 = crypto.randomBytes(2).toString('hex');
+    const part2 = crypto.randomBytes(2).toString('hex');
+    return `${part1}-${part2}`;
+  });
+}
+
+// При verify recovery code:
+// - find code by hash match among unused codes of user's MFA
+// - mark used_at
+// - если это recovery flow: disable MFA, отправить email «MFA disabled»
+```
+
+### 5.7 Trusted Device
+
+Если Password Policy.mfaTrustDevice = true:
+- При verify успехе — checkbox «Не спрашивать 30 дней».
+- Если отмечен: генерируется device fingerprint hash (UA + IP/24), создаётся `UserMfaTrustedDevice`.
+- Cookie `tt_mfa_trust` (HTTP-only, Secure, SameSite=Strict, TTL 30 дней) = JWT с `{ userId, fingerprint, exp }`.
+- При следующем логине — если cookie валиден и fingerprint совпадает → skip MFA step.
+
+### 5.8 Admin reset
+
+```
+POST /admin/users/:id/mfa/reset  (SUPER_ADMIN only, requires re-auth)
+  → удаляет UserMfa cascade
+  → audit-log
+  → уведомление юзера (email через TTNOTIF-1)
+```
+
+### 5.9 Rate limiting
+
+Redis ключи:
+- `mfa:attempts:{userId}` — счётчик failed attempts, TTL 5 мин.
+- После 5 fails → `mfa:lockout:{userId}` TTL 30 мин → все verify возвращают 429.
+
+### 5.10 Emergency CLI
+
+```bash
+# backend/scripts/admin-mfa-reset.ts
+# Usage: npm run admin:mfa:reset -- --email=foo@bar.com --emergencyKey=$SUPER_ADMIN_EMERGENCY_KEY
+
+# Проверяет ENV SUPER_ADMIN_EMERGENCY_KEY, находит user, удаляет UserMfa, логирует.
+```
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: `/api/mfa/enroll` → QR + secret в Redis.
+- [ ] FR-2: `/api/mfa/confirm` → сохраняет, генерирует 10 recovery codes.
+- [ ] FR-3: Login-flow с MFA: requiresMfa → verify.
+- [ ] FR-4: Recovery-flow работает, сбрасывает MFA.
+- [ ] FR-5: Admin-reset + audit + email-notify.
+- [ ] FR-6: Forced enrollment для required roles (default SUPER_ADMIN).
+- [ ] FR-7: Re-auth для sensitive operations.
+- [ ] FR-8: Trust-device через Password Policy.
+- [ ] FR-9: Rate-limit 5 per 5 min.
+- [ ] FR-10: Emergency CLI.
+
+### Нефункциональные
+- [ ] NFR-1: TOTP-validate < 10ms.
+- [ ] NFR-2: Enrollment-QR < 200ms.
+
+### Безопасность
+- [ ] SEC-1: Secret encrypted at rest.
+- [ ] SEC-2: Recovery codes hashed (argon2id).
+- [ ] SEC-3: mfaSessionToken — JWT с short TTL и `step=mfa` claim.
+- [ ] SEC-4: Re-auth token — short TTL, одноразовый nonce.
+- [ ] SEC-5: Trust-device cookie — HTTP-only, Secure, SameSite=Strict.
+- [ ] SEC-6: Audit для: enroll, disable, reset, trust-device add/remove.
+
+### Тестирование
+- [ ] Unit: otp validation (window ±1), rate-limit, recovery-code hash.
+- [ ] Integration: full login with MFA.
+- [ ] Integration: recovery flow sets MFA disabled.
+- [ ] Integration: required role → forced enrollment.
+- [ ] Integration: re-auth gate на sensitive ops.
+- [ ] Security: brute-force отсекается.
+- [ ] Покрытие ≥ 75% (security-critical).
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: Enrollment → Google Authenticator принимает TOTP.
+- [ ] AC-2: Login с правильным кодом — success.
+- [ ] AC-3: 5 неправильных → 429 lockout 30 мин.
+- [ ] AC-4: Recovery code сбрасывает MFA.
+- [ ] AC-5: Admin-reset работает.
+- [ ] AC-6: SUPER_ADMIN не может логиниться без MFA, пока не enrolled.
+- [ ] AC-7: Re-auth требуется для change-password / disable-mfa.
+- [ ] AC-8: Trust-device cookie skip'ает verify.
+- [ ] AC-9: Emergency CLI сбрасывает MFA.
+- [ ] AC-10: Tests + security review.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Prisma models + encryption | 4 |
+| otplib integration + enroll/verify endpoints | 6 |
+| Recovery codes + admin reset | 4 |
+| Login-flow integration | 4 |
+| Re-auth service + dialog | 6 |
+| Required-roles enforcement | 3 |
+| Trust-device (cookie + fingerprint) | 4 |
+| Rate-limit Redis | 2 |
+| Emergency CLI | 2 |
+| Frontend: Enroll/Verify/Recovery pages | 10 |
+| Frontend: Settings MFA section | 3 |
+| Admin MFA reset button | 2 |
+| Tests (unit + integration + security) | 12 |
+| Docs | 2 |
+| Code review | 4 |
+| **Итого** | **68** (~1 спринт) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** TTSEC-4 (re-auth integration желателен).
+- **Связано:** TTSSO-1 (MFA не применяется к SSO-юзерам).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTMFA-1 (TASK) — 2FA / TOTP
+  ├─ TTMFA-1.1 — Prisma models + encryption
+  ├─ TTMFA-1.2 — otplib integration + enroll/verify
+  ├─ TTMFA-1.3 — Recovery codes + admin reset
+  ├─ TTMFA-1.4 — Login-flow integration
+  ├─ TTMFA-1.5 — Re-auth service
+  ├─ TTMFA-1.6 — Trust-device (optional)
+  ├─ TTMFA-1.7 — Emergency CLI
+  ├─ TTMFA-1.8 — Frontend pages
+  └─ TTMFA-1.9 — Tests + review
+```

--- a/docs/tz/MVP2JIRA/TTNOTIF-1.md
+++ b/docs/tz/MVP2JIRA/TTNOTIF-1.md
@@ -1,0 +1,423 @@
+# ТЗ: TTNOTIF-1 — Notifications Service (Email + In-app Bell)
+
+**Дата:** 2026-04-23
+**Тип:** EPIC | **Приоритет:** P0 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+В системе **полностью отсутствует** исходящая почта и механизм оповещений. Это блокирует базовый пользовательский сценарий трекера — «команда получает уведомление, когда что-то меняется».
+
+Задача реализует:
+- **SMTP-настройки** в админке (+ шифрование пароля).
+- **Events → Notifications pipeline**: consumer из Kafka (после TTBUS-0).
+- **Notification Scheme** per-project — упрощённая матрица «проектная роль × тип события».
+- **Шаблоны писем** (RU-only в MVP, EN-заготовки под будущий i18n).
+- **Watchers** — модель `IssueWatcher` + кнопка «Наблюдать» в UI.
+- **In-app bell** — колокольчик в шапке + список.
+- **Per-user preferences** — «не слать мне уведомления о моих собственных изменениях» (default off).
+- **Coalescing** — при 10 быстрых изменениях одной задачи одним пользователем в адрес одного получателя → 1 письмо.
+
+### Пользовательские сценарии
+
+**Алиса создаёт задачу, Боб assignee:**
+1. Боб получает email «Вам назначена задача TT-123».
+2. Боб видит красную точку на колокольчике — «1 новое уведомление».
+3. Боб кликает → список с заголовком задачи, именем actor'а, временем, ссылкой.
+
+**Вики добавляет `@алиса` в комментарий:**
+1. Алиса получает email «Вас упомянули в TT-123» + запись в bell'е.
+2. Алиса автоматически становится watcher задачи.
+
+**Админ:**
+1. Идёт в `/admin/notifications/smtp` → настраивает SMTP-сервер.
+2. Идёт в `/admin/notifications/schemes` → для роли `DEVELOPER` в проекте X включает получение на `ISSUE_COMMENTED`.
+3. Кликает «Отправить тест» → получает тестовое письмо.
+
+---
+
+## 2. Текущее состояние
+
+- **SMTP-клиента нет вообще.**
+- **Notification-модуля нет.**
+- **`IssueWatcher` модель отсутствует.**
+- **Колокольчика в UI нет.**
+- `webhook-notifier` для checkpoints — шлёт HTTP без схемы получателей. После TTNOTIF-1 — переводим на универсальную pipeline.
+- В `User.preferences: Json?` уже есть поле для пользовательских предпочтений (используется для «тем», можно расширить).
+
+---
+
+## 3. Зависимости
+
+### Модули backend (существующие)
+- [ ] `issues` — добавить auto-subscribe assignee в watchers.
+- [ ] `comments` — producer события `COMMENT_CREATED` в outbox (TTBUS-0 инфра).
+- [ ] `releases` — producer `RELEASE_PUBLISHED`.
+- [ ] `releases/checkpoints/webhook-notifier` — переключить на publishing в outbox (унификация).
+- [ ] `admin` — добавить smtp-settings endpoints.
+- [ ] `auth` — после `createUser` — публикация `USER_CREATED_FOR_YOU` вместо копипасты пароля в модалке.
+
+### Новый процесс
+- [ ] `notifications-service/` — отдельный Node.js процесс. Consumer Kafka, свой Prisma-client (shared PG, schema `notifications`). Запускается в docker-compose.
+
+### Новые модули backend
+- [ ] `shared/mentions/` — парсер `@username` в markdown → список userId.
+- [ ] `modules/watchers/` — CRUD API для watchers (публичный: GET/POST/DELETE `/api/issues/:id/watchers`).
+- [ ] `modules/bell/` — API для in-app уведомлений (GET list, PATCH mark-as-read).
+
+### Frontend
+- [ ] `components/bell/BellDropdown.tsx` — колокольчик + список.
+- [ ] `pages/admin/AdminSmtpPage.tsx` — настройки SMTP.
+- [ ] `pages/admin/AdminNotificationSchemePage.tsx` — матрица «роль × событие» per-project.
+- [ ] `components/issues/WatchButton.tsx` — кнопка «Наблюдать».
+- [ ] `pages/SettingsPage.tsx` — добавить чекбокс «Не уведомлять меня о моих действиях».
+
+### Модели данных (Prisma)
+- [ ] `IssueWatcher` — main schema.
+- [ ] `NotificationScheme` — schema `notifications`.
+- [ ] `NotificationSchemeRule` — schema `notifications`.
+- [ ] `InAppNotification` — schema `notifications`.
+- [ ] `SentEmail` — schema `notifications` (лог отправок для дедупа/аудита).
+- [ ] Новые ключи в `SystemSetting`: `smtp_config` (encrypted JSON), `notifications.coalesce_window_sec`.
+
+### Внешние зависимости
+- [ ] `nodemailer` — SMTP-клиент.
+- [ ] `handlebars` (или `mjml`) — шаблоны писем.
+- [ ] `ioredis` — для coalescing-окна (уже есть).
+
+### Блокеры
+- [x] **TTBUS-0 должен быть смержён.**
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | SMTP-пароль утекает в логах/аудите | Средняя | Компрометация | Шифрование AES-256-GCM с `SMTP_ENCRYPTION_KEY` из ENV; никогда не отдавать пароль в API-ответах; в логах — `***` |
+| 2 | Coalescing теряет события при падении Redis | Низкая | Задержка/пропуск 1 уведомления | Redis-fallback: если недоступен — шлём immediate без coalescing (logged warning) |
+| 3 | Пользователь отписывается от всех уведомлений — пропускает важные админ-события | Средняя | Операционный риск | Админ-события (temp-password, role-granted) — **не управляются user preferences**, всегда приходят |
+| 4 | Bell-consumer лагает → пользователь не видит «новое» в шапке | Низкая | UX-задержка | Bell работает через WebSocket/SSE для live; при отсутствии — polling каждые 30 сек |
+| 5 | Mention-парсер false-positive на email (`info@corp.ru` → `@corp`) | Средняя | Ложные уведомления | Парсер только на `@username` строго по паттерну + lookup в БД; email не матчится |
+| 6 | Watcher auto-add засоряет `IssueWatcher` — тысячи строк на популярную задачу | Низкая | Deoptim-список для UI | Индекс на `(issueId, userId)`; UI пагинирует watchers |
+| 7 | Email-quota SMTP-провайдера (SendGrid/Yandex 500/day free) | Высокая | Потеря уведомлений | Rate-limit на уровне `notifications-service` + метрики количества отправок; админ видит графики |
+| 8 | `notifications-service` падает — events копятся в Kafka | Средняя | Задержка | При перезапуске consumer подхватывает offset, events не теряются; alert на topic lag |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Модели (Prisma)
+
+**Main schema:**
+
+```prisma
+model IssueWatcher {
+  issueId   String   @map("issue_id")
+  userId    String   @map("user_id")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  issue     Issue    @relation(fields: [issueId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([issueId, userId])
+  @@index([userId])
+  @@map("issue_watchers")
+}
+```
+
+**Schema `notifications`:**
+
+```prisma
+model NotificationScheme {
+  id          String   @id @default(uuid())
+  projectId   String   @unique @map("project_id")  // one scheme per project
+  // Каждый проект имеет одну схему. Глобального fallback'а нет — default создаётся при создании проекта.
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  rules       NotificationSchemeRule[]
+
+  @@map("notification_schemes")
+  @@schema("notifications")
+}
+
+model NotificationSchemeRule {
+  id          String   @id @default(uuid())
+  schemeId    String   @map("scheme_id")
+  projectRoleId String @map("project_role_id")  // FK на ProjectRoleDefinition (main schema)
+  eventType   String   // 'ISSUE_CREATED', 'ISSUE_COMMENTED', ...
+  channel     NotificationChannel  // EMAIL | IN_APP
+  enabled     Boolean  @default(true)
+
+  scheme      NotificationScheme @relation(fields: [schemeId], references: [id], onDelete: Cascade)
+
+  @@unique([schemeId, projectRoleId, eventType, channel])
+  @@map("notification_scheme_rules")
+  @@schema("notifications")
+}
+
+enum NotificationChannel {
+  EMAIL
+  IN_APP
+  @@schema("notifications")
+}
+
+model InAppNotification {
+  id         String   @id @default(uuid())
+  recipientId String  @map("recipient_id")   // userId (main schema, логический FK, без REFERENCES для cross-schema)
+  eventType  String
+  title      String
+  body       String
+  link       String?  // URL на issue/comment/release
+  payload    Json?    // structured data для rendering
+  isRead     Boolean  @default(false) @map("is_read")
+  readAt     DateTime? @map("read_at")
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  @@index([recipientId, isRead, createdAt])
+  @@map("in_app_notifications")
+  @@schema("notifications")
+}
+
+model SentEmail {
+  id          String   @id @default(uuid())
+  messageId   String   @map("message_id")    // из envelope — для дедупа
+  recipientEmail String @map("recipient_email")
+  recipientUserId String? @map("recipient_user_id")
+  subject     String
+  templateName String  @map("template_name")
+  status      EmailStatus @default(PENDING)
+  attempts    Int      @default(0)
+  lastError   String?  @map("last_error")
+  sentAt      DateTime? @map("sent_at")
+  createdAt   DateTime @default(now())
+
+  @@unique([messageId, recipientEmail])  // защита от двойной отправки
+  @@index([status, createdAt])
+  @@map("sent_emails")
+  @@schema("notifications")
+}
+
+enum EmailStatus {
+  PENDING
+  SENT
+  FAILED
+  BOUNCED
+  @@schema("notifications")
+}
+```
+
+### 5.2 SMTP-настройки (combined ENV + DB)
+
+ENV-fallback values (используются при отсутствии записи в `SystemSetting`):
+```
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_FROM="TaskTime <noreply@tasktime.internal>"
+SMTP_SECURE=false
+SMTP_ENCRYPTION_KEY=   # 32-byte base64 — обязательно для шифрования БД-значений
+```
+
+БД (key в `SystemSetting`): `smtp_config` = JSON:
+```json
+{
+  "host": "smtp.yandex.ru",
+  "port": 465,
+  "user": "noreply@corp.ru",
+  "passwordEncrypted": "base64(aes-256-gcm(password))",
+  "from": "TaskTime <noreply@corp.ru>",
+  "secure": true
+}
+```
+
+API:
+- `GET /admin/settings/smtp` — возвращает конфиг **без пароля** (маскированный как `***`).
+- `PUT /admin/settings/smtp` — принимает пароль, шифрует и сохраняет.
+- `POST /admin/settings/smtp/test` — body `{ to: string }` — отправляет тестовое письмо, возвращает результат.
+- `DELETE /admin/settings/smtp` — сброс к ENV-fallback.
+
+### 5.3 Notification Scheme (B-вариант)
+
+Каждый проект имеет одну схему (создаётся при создании проекта). Матрица:
+
+| Роль в проекте \ Событие | ISSUE_CREATED | ISSUE_ASSIGNED | ISSUE_STATUS_CHANGED | ISSUE_UPDATED | ISSUE_MENTIONED | ISSUE_DELETED | ISSUE_COMMENTED | RELEASE_PUBLISHED | CHECKPOINT_VIOLATED |
+|---|---|---|---|---|---|---|---|---|---|
+| ADMIN | ☑ | ☑ | ☐ | ☐ | (auto) | ☐ | ☑ | ☑ | ☑ |
+| MANAGER | ☑ | ☑ | ☐ | ☐ | (auto) | ☐ | ☑ | ☑ | ☑ |
+| USER | ☐ | ☑ | ☐ | ☐ | (auto) | ☐ | ☐ | ☑ | ☐ |
+| VIEWER | ☐ | ☐ | ☐ | ☐ | (auto) | ☐ | ☐ | ☐ | ☐ |
+
+**Системные получатели (всегда, неконфигурируемо):**
+- `ISSUE_CREATED` → project creator (reporter)
+- `ISSUE_ASSIGNED` → new assignee
+- `ISSUE_COMMENTED` → watchers + assignee
+- `ISSUE_MENTIONED` → mentioned users
+- `ISSUE_STATUS_CHANGED` → watchers
+- `ISSUE_UPDATED` → watchers
+- `ISSUE_DELETED` → watchers
+
+**USER_CREATED_FOR_YOU** — получатель = новый юзер, не управляется схемой.
+
+Матрица — канал-специфична: можно включить email, но выключить bell, и наоборот.
+
+### 5.4 Watchers
+
+- Authomatic:
+  - При создании комментария → commenter добавляется в watchers issue.
+  - При назначении assignee → assignee добавляется.
+  - Поле `User.preferences.autoWatchOnComment: boolean` (default `true`).
+- Manual: кнопка «Наблюдать / Не наблюдать» в карточке issue.
+- Удаление: unwatch (cascade при удалении user/issue).
+
+### 5.5 Mentions parser
+
+```typescript
+// shared/mentions/parser.ts
+// regex: @([a-zA-Z0-9_-]+) — ник до первого не-идентификатор-символа
+const MENTION_RX = /@([a-zA-Z0-9_-]+)/g;
+
+export async function extractMentionedUserIds(
+  markdown: string,
+  projectId: string,
+): Promise<string[]> {
+  const candidates = Array.from(markdown.matchAll(MENTION_RX)).map((m) => m[1]);
+  if (candidates.length === 0) return [];
+  // lookup только среди участников проекта (minimize false-positives на внешние имена)
+  const users = await prisma.user.findMany({
+    where: {
+      name: { in: candidates, mode: 'insensitive' },
+      projectRoles: { some: { projectId } },
+    },
+    select: { id: true },
+  });
+  return users.map((u) => u.id);
+}
+```
+
+### 5.6 Coalescing
+
+Окно 60 сек, ключ Redis `coalesce:{recipientId}:{issueId}:{eventType}` → list событий. TTL = окно. Когда окно закрывается (через `setTimeout` воркера, не при приёме события) — собираем список в один email.
+
+### 5.7 Self-notification suppression
+
+`User.preferences.notifySelf: boolean` (default `false`). При подготовке получателей: если `event.actor.userId === recipientId` и `notifySelf=false` — skip.
+
+### 5.8 Шаблоны писем
+
+- Handlebars-шаблоны в `notifications-service/templates/ru/*.hbs`.
+- По одному шаблону на тип события.
+- Common layout с логотипом из TTBRAND-1 (после его реализации — пока текст).
+
+### 5.9 In-app bell delivery
+
+- Consumer при обработке события: если channel `IN_APP` в схеме для получателя — `INSERT INTO in_app_notifications`.
+- Frontend: polling `GET /api/bell/notifications?unread=true` каждые 30 сек + badge с количеством.
+- PATCH `/api/bell/notifications/:id/read` — помечает прочитанным.
+- Retention: запись жива 30 дней, потом cleanup.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: SMTP настраивается через UI; пароль шифруется; test-email работает.
+- [ ] FR-2: 10 типов событий доставляются по email согласно Notification Scheme.
+- [ ] FR-3: Те же 10 событий пишутся в `InAppNotification` при включённом канале `IN_APP`.
+- [ ] FR-4: Watchers: auto-add при assign/comment, manual watch-button в UI, список watchers на задаче.
+- [ ] FR-5: Mention-парсер находит `@username` только среди участников проекта.
+- [ ] FR-6: Coalescing 60 сек работает — при 10 быстрых изменениях один пользователь получает 1 email.
+- [ ] FR-7: `notifySelf=false` подавляет self-уведомления, кроме админских (`USER_CREATED_FOR_YOU`).
+- [ ] FR-8: Колокольчик в шапке показывает unread-count и раскрывается в дропдаун.
+- [ ] FR-9: `notifications-service` работает как отдельный процесс docker-compose.
+- [ ] FR-10: При создании нового проекта — автоматически создаётся NotificationScheme с разумным default (USER ←→ IN_APP для всех событий; EMAIL только для критических).
+
+### Нефункциональные
+- [ ] NFR-1: Latency от события → delivered email < 60 сек в 95-м перцентиле (coalescing-окно доминирует).
+- [ ] NFR-2: Bell-notifications доставляются в БД < 5 сек после события.
+- [ ] NFR-3: `notifications-service` выдерживает 1000 events/hour на single instance.
+
+### Безопасность
+- [ ] SEC-1: SMTP-пароль шифруется AES-256-GCM, ключ только в ENV.
+- [ ] SEC-2: API не возвращает пароль никогда.
+- [ ] SEC-3: Unsubscribe-link в каждом email → one-click без логина (signed JWT в URL, TTL 30 дней).
+- [ ] SEC-4: Bell показывает только уведомления текущего пользователя (RBAC).
+- [ ] SEC-5: Email-получатели — только пользователи с `isActive=true`.
+
+### Тестирование
+- [ ] Unit: SMTP-wrapper, mention-parser, coalescing, scheme-resolver.
+- [ ] Integration: event in Kafka → email sent + bell created + coalesced correctly.
+- [ ] E2E: User creates issue → assignee gets email + bell.
+- [ ] Покрытие ≥ 70% для notifications-service.
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: Админ настраивает SMTP через UI, получает test-email.
+- [ ] AC-2: При assign-операции Боб получает email и bell.
+- [ ] AC-3: Вики `@алиса` в комментарии → Алиса mentioned + watcher.
+- [ ] AC-4: Страница `/admin/notifications/schemes` редактирует матрицу per-project.
+- [ ] AC-5: Пользователь в Settings выключает `notifySelf` → не получает уведомления о своих изменениях.
+- [ ] AC-6: Bell-dropdown показывает 10 последних unread, mark-as-read работает.
+- [ ] AC-7: Watcher-страница на issue показывает список, add/remove работает.
+- [ ] AC-8: `notifications-service` перезапускается без потери событий (integration-тест).
+- [ ] AC-9: Тесты зелёные.
+- [ ] AC-10: Docs: `docs/architecture/notifications.md` с диаграммой pipeline.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Дизайн (schemes, shapes, matrix UI) | 6 |
+| Prisma-миграции (notifications.*, IssueWatcher) | 4 |
+| SMTP-wrapper + encryption | 6 |
+| notifications-service скелет + consumer | 10 |
+| Scheme-resolver (кому слать) | 8 |
+| Coalescing через Redis | 4 |
+| Mention-parser | 3 |
+| Watchers-модуль (API + UI) | 6 |
+| Шаблоны писем (10 шт) | 8 |
+| In-app bell (backend API + frontend component) | 10 |
+| Admin-UI: SMTP page + Scheme matrix + test-button | 14 |
+| Миграция `checkpoints/webhook-notifier` на новый pipeline | 4 |
+| Producer `USER_CREATED_FOR_YOU` + RELEASE_PUBLISHED + comments | 4 |
+| Tests | 14 |
+| Docs | 3 |
+| Code review | 6 |
+| **Итого** | **110** (~2 спринта) |
+
+---
+
+## 9. Связанные задачи
+
+- **Родитель:** нет
+- **Зависит от:** TTBUS-0.
+- **Блокирует:** TTINTEG-1 (он использует ту же pipeline).
+- **Связано:** TTATTACH-1 (attachments в email — фаза 2), TTBRAND-1 (email-logo).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTNOTIF-1 (EPIC) — Notifications Service
+  ├─ TTNOTIF-1.1 — Prisma models (notifications.*, IssueWatcher)
+  ├─ TTNOTIF-1.2 — SMTP config + encryption + admin UI
+  ├─ TTNOTIF-1.3 — notifications-service процесс
+  ├─ TTNOTIF-1.4 — Scheme-resolver + matrix UI
+  ├─ TTNOTIF-1.5 — Mentions parser + watchers модуль
+  ├─ TTNOTIF-1.6 — Coalescing
+  ├─ TTNOTIF-1.7 — Email templates (10)
+  ├─ TTNOTIF-1.8 — In-app bell (backend + frontend)
+  ├─ TTNOTIF-1.9 — Migrate existing producers (comments, releases, checkpoints, user-create)
+  └─ TTNOTIF-1.10 — Tests + docs
+```

--- a/docs/tz/MVP2JIRA/TTPROJ-1.md
+++ b/docs/tz/MVP2JIRA/TTPROJ-1.md
@@ -1,0 +1,328 @@
+# ТЗ: TTPROJ-1 — Components + fixVersion / affectsVersion
+
+**Дата:** 2026-04-23
+**Тип:** EPIC | **Приоритет:** P1 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+### 1.1 Components
+В крупных проектах задачи группируются по **подсистемам** — `auth`, `billing`, `frontend`. Сейчас в TaskTime такого понятия нет. Добавляем модель `Component` с lead'ом и правилом auto-assignment.
+
+### 1.2 fixVersion / affectsVersion
+Сейчас задача может быть в одном primary релизе (`Issue.releaseId`). В Jira есть два отдельных поля:
+- **fixVersion** — релиз(ы), в которых исправление выкатится.
+- **affectsVersion** — релиз(ы), которые задача затрагивает (для bug-tracking: «найден в v1.0, исправлено в v1.2»).
+
+**Решение:**
+- `Issue.releaseId` оставляем как primary **fixVersion** (singular, обратная совместимость).
+- Добавляем новую модель M:M — `IssueAffectsRelease` — для affectsVersion.
+
+### Пользовательские сценарии
+
+**QA репортит баг:**
+1. Создаёт задачу. В affectsVersion — `v1.0, v1.1` (мультиселект).
+2. После триажа в fixVersion ставит `v1.2`.
+3. TTQL: `affectsVersion = "v1.0" AND fixVersion = "v1.2"` — находит.
+
+**Развитие проекта:**
+1. Админ в настройках проекта создаёт компоненты: `Frontend`, `Backend`, `Mobile`.
+2. Назначает `Frontend`-lead на Alice, `Backend`-lead на Bob.
+3. При создании issue с `components = [Frontend]` — assignee автоматически Alice.
+
+---
+
+## 2. Текущее состояние
+
+- `Issue.releaseId: String?` — primary релиз (single).
+- `ReleaseItem` — M:M `Release ↔ Issue`, используется для scope релиза (параллельно с releaseId).
+- **Components** — модель отсутствует.
+- **affectsVersion** — отсутствует.
+- Releases — полноценные (workflow, checkpoints).
+
+---
+
+## 3. Зависимости
+
+### Модули backend
+- [ ] `modules/components/` — новый.
+- [ ] `modules/issues/issues.service.ts` — поддержка components (M:M), affectsReleases (M:M), auto-assign.
+- [ ] `modules/search/search-compiler/` — TTQL-поля `component`, `affectsVersion`, `fixVersion`.
+
+### Frontend
+- [ ] `pages/project/ProjectComponentsPage.tsx` — CRUD компонентов проекта.
+- [ ] `components/issues/ComponentsSelector.tsx`.
+- [ ] `components/issues/AffectsVersionSelector.tsx`.
+- [ ] `components/issues/IssueDetailPage.tsx` — показывать components + affectsVersion.
+
+### Модели данных (Prisma)
+- [ ] `Component` — новая.
+- [ ] `IssueComponent` — M:M.
+- [ ] `IssueAffectsRelease` — M:M.
+
+### Внешние зависимости
+- Нет.
+
+### Блокеры
+- Нет.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Components M:M на популярной задаче (10+ компонентов) замедляет list-issues | Низкая | Slow queries | Индекс `(issueId)` и `(componentId)`, выборка компонентов отдельным запросом (not N+1) |
+| 2 | Auto-assign через компонент перезаписывает явно выбранный assignee | Средняя | UX-регрессия | Auto-assign срабатывает **только если assignee=null в payload** |
+| 3 | Component lead удалён из системы → auto-assign падает | Низкая | 500-error | При deactivate user component-lead обнуляется; при hard-delete — cascade |
+| 4 | Ambiguity: `ReleaseItem` vs `IssueAffectsRelease` (какую модель для fixVersion использовать?) | Высокая | Путаница в коде | Чётко документировать: `Issue.releaseId` = fixVersion (single); `IssueAffectsRelease` = affectsVersions (M:M); `ReleaseItem` остаётся для release-scope planning как отдельная сущность |
+| 5 | TTQL `fixVersion = "v1.0"` vs `release = "v1.0"` — какое поле? | Средняя | Confusion | `fixVersion` — новый ссылается на `Issue.releaseId`; `release` — alias для backward compat в TTQL |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Модели
+
+```prisma
+enum ComponentAssigneeType {
+  PROJECT_DEFAULT    // project.leadId
+  COMPONENT_LEAD     // component.leadId
+  UNASSIGNED         // null
+}
+
+model Component {
+  id            String                 @id @default(uuid())
+  projectId     String                 @map("project_id")
+  name          String
+  description   String?
+  leadId        String?                @map("lead_id")
+  assigneeType  ComponentAssigneeType  @default(PROJECT_DEFAULT) @map("assignee_type")
+  isActive      Boolean                @default(true) @map("is_active")
+  orderIndex    Int                    @default(0) @map("order_index")
+  createdAt     DateTime               @default(now())
+  updatedAt     DateTime               @updatedAt
+
+  project  Project          @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  lead     User?            @relation("componentLead", fields: [leadId], references: [id], onDelete: SetNull)
+  issues   IssueComponent[]
+
+  @@unique([projectId, name])
+  @@index([projectId])
+  @@map("components")
+}
+
+model IssueComponent {
+  issueId      String   @map("issue_id")
+  componentId  String   @map("component_id")
+  addedAt      DateTime @default(now())
+
+  issue        Issue     @relation(fields: [issueId], references: [id], onDelete: Cascade)
+  component    Component @relation(fields: [componentId], references: [id], onDelete: Cascade)
+
+  @@id([issueId, componentId])
+  @@index([componentId])
+  @@map("issue_components")
+}
+
+model IssueAffectsRelease {
+  issueId    String   @map("issue_id")
+  releaseId  String   @map("release_id")
+  addedAt    DateTime @default(now())
+  addedById  String?  @map("added_by_id")
+
+  issue    Issue   @relation(fields: [issueId], references: [id], onDelete: Cascade)
+  release  Release @relation(fields: [releaseId], references: [id], onDelete: Cascade)
+
+  @@id([issueId, releaseId])
+  @@index([releaseId])
+  @@map("issue_affects_releases")
+}
+```
+
+### 5.2 Auto-assign logic
+
+```typescript
+async function resolveAutoAssignee(
+  projectId: string,
+  componentIds: string[],
+  explicitAssigneeId?: string | null,
+): Promise<string | null> {
+  if (explicitAssigneeId !== undefined) return explicitAssigneeId;  // явный — не трогаем, включая null
+
+  if (componentIds.length === 0) return null;
+
+  // Берём компоненты в порядке orderIndex, первый = primary
+  const primary = await prisma.component.findFirst({
+    where: { id: { in: componentIds }, isActive: true },
+    orderBy: { orderIndex: 'asc' },
+  });
+  if (!primary) return null;
+
+  switch (primary.assigneeType) {
+    case 'PROJECT_DEFAULT':
+      const project = await prisma.project.findUnique({ where: { id: projectId } });
+      return project?.leadId ?? null;
+    case 'COMPONENT_LEAD':
+      return primary.leadId;
+    case 'UNASSIGNED':
+    default:
+      return null;
+  }
+}
+```
+
+### 5.3 Soft-delete компонента
+
+```typescript
+// DELETE /admin/projects/:projectId/components/:id
+// → обязательно soft-delete (isActive=false)
+await prisma.component.update({
+  where: { id },
+  data: { isActive: false },
+});
+```
+
+Permanent delete через отдельный endpoint `DELETE /admin/projects/:projectId/components/:id/permanent` — **только если `_count.issues === 0`**, иначе 400 с сообщением «Сначала удалите привязки».
+
+### 5.4 TTQL расширение
+
+Новые поля:
+- `component` — matches by component.name (case-insensitive) on joined `IssueComponent`.
+- `affectsVersion` — matches by release.name through `IssueAffectsRelease`.
+- `fixVersion` — alias для существующего `release` поля (для Jira-паритета).
+
+Примеры:
+- `component = Frontend` → `EXISTS (SELECT 1 FROM issue_components ic JOIN components c ON c.id = ic.component_id WHERE ic.issue_id = issue.id AND c.name ILIKE 'Frontend')`
+- `component in (Frontend, Backend)` — аналог с `IN`.
+- `affectsVersion = "v1.0"` → `EXISTS (SELECT 1 FROM issue_affects_releases iar JOIN releases r ON r.id = iar.release_id WHERE iar.issue_id = issue.id AND r.name = 'v1.0')`
+- `fixVersion = "v1.2"` → `issue.release_id = (SELECT id FROM releases WHERE name='v1.2')`
+
+### 5.5 Модуль Components — API
+
+- `GET /api/projects/:projectId/components` — публичный (с `ISSUES_VIEW`).
+- `POST /api/projects/:projectId/components` — требует `PROJECT_SETTINGS_EDIT`.
+- `PATCH /api/projects/:projectId/components/:id` — тот же permission.
+- `DELETE /api/projects/:projectId/components/:id` — soft-delete.
+- `DELETE /api/projects/:projectId/components/:id/permanent` — hard-delete если 0 issues.
+
+### 5.6 Issue API изменения
+
+**Create/Update DTO:**
+```typescript
+{
+  ...existingFields,
+  componentIds?: string[];                // UUID компонентов
+  affectsReleaseIds?: string[];           // UUID релизов
+}
+```
+
+В response:
+```json
+{
+  ...,
+  "components": [{ "id", "name", "leadName" }],
+  "affectsReleases": [{ "id", "name" }]
+}
+```
+
+### 5.7 Archive Release — небольшое расширение из 3.5.KKK
+
+Добавляем в `Release`:
+```prisma
+isArchived   Boolean  @default(false) @map("is_archived")
+archivedAt   DateTime? @map("archived_at")
+```
+
+Архивированные релизы:
+- Не появляются в dropdown'ах `fixVersion`/`affectsVersion` (но остаются связь для уже существующих привязок).
+- `/admin/releases/archived` — отдельная админ-страница.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: Модель Component + M:M IssueComponent.
+- [ ] FR-2: Модель IssueAffectsRelease.
+- [ ] FR-3: CRUD компонентов в project settings.
+- [ ] FR-4: Auto-assign по primary (orderIndex=0) компоненту работает согласно assigneeType.
+- [ ] FR-5: Auto-assign НЕ срабатывает, если assignee явно указан в payload.
+- [ ] FR-6: Soft-delete компонента; hard-delete только с 0 issues.
+- [ ] FR-7: TTQL: `component`, `affectsVersion`, `fixVersion` (alias для `release`).
+- [ ] FR-8: Release.isArchived + UI.
+- [ ] FR-9: `Issue.release_id` не меняется семантически — остаётся primary fixVersion.
+
+### Нефункциональные
+- [ ] NFR-1: Issue list с component-JOIN не замедляется более чем на 30ms p95.
+- [ ] NFR-2: TTQL поиск по component на 10k issues < 400ms.
+
+### Безопасность
+- [ ] SEC-1: Component CRUD требует `PROJECT_SETTINGS_EDIT`.
+- [ ] SEC-2: Lead user может быть только с ролью в проекте.
+
+### Тестирование
+- [ ] Unit: auto-assign logic (все 3 варианта assigneeType, ambiguous orderIndex).
+- [ ] Integration: create issue с компонентом → assignee подставился.
+- [ ] Integration: create issue с assignee + компонентом → не перезаписан.
+- [ ] Integration: TTQL `component = X AND affectsVersion = Y`.
+- [ ] E2E: full flow через UI (admin → create component → user → create issue).
+- [ ] Покрытие ≥ 70%.
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: Project settings → components CRUD работает.
+- [ ] AC-2: Issue-create с `componentIds` → запись в `IssueComponent`.
+- [ ] AC-3: Issue-create с компонентом, assigneeType=COMPONENT_LEAD → assignee = lead.
+- [ ] AC-4: TTQL `component = Frontend` находит задачи.
+- [ ] AC-5: TTQL `affectsVersion = "v1.0"` — аналогично.
+- [ ] AC-6: Soft-delete компонента → `isActive=false`, задачи сохраняют privязку.
+- [ ] AC-7: Hard-delete с существующими привязками → 400.
+- [ ] AC-8: Archive release → не в dropdown'ах.
+- [ ] AC-9: Tests зелёные.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Prisma models (Component, IssueComponent, IssueAffectsRelease, archive-fields) | 4 |
+| Backend components module + CRUD | 5 |
+| Backend Issue-service: componentIds, affectsReleaseIds, auto-assign | 6 |
+| TTQL compiler: component, affectsVersion, fixVersion alias | 5 |
+| Frontend: ProjectComponentsPage | 5 |
+| Frontend: ComponentsSelector + AffectsVersionSelector | 6 |
+| Frontend: IssueDetailPage updates | 3 |
+| Archive Release — minor UI + endpoint | 3 |
+| Tests | 8 |
+| Code review | 3 |
+| **Итого** | **48** (~1 спринт) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** нет.
+- **Связано:** TTMP-140 (Releases), TTSRH-1 (TTQL compiler).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTPROJ-1 (EPIC) — Components + fix/affects Versions
+  ├─ TTPROJ-1.1 — Prisma models
+  ├─ TTPROJ-1.2 — Backend components CRUD + auto-assign
+  ├─ TTPROJ-1.3 — Backend Issue-service updates (M:M)
+  ├─ TTPROJ-1.4 — TTQL extensions
+  ├─ TTPROJ-1.5 — Frontend pages + selectors
+  ├─ TTPROJ-1.6 — Release.isArchived
+  └─ TTPROJ-1.7 — Tests + docs
+```

--- a/docs/tz/MVP2JIRA/TTRES-1.md
+++ b/docs/tz/MVP2JIRA/TTRES-1.md
@@ -1,0 +1,270 @@
+# ТЗ: TTRES-1 — Resolutions (Результат закрытия задачи)
+
+**Дата:** 2026-04-23
+**Тип:** TASK | **Приоритет:** P0 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+Сейчас задача закрывается переходом в статус `DONE` или `CANCELLED` — но **почему** закрыта, не фиксируется. Это ломает базовый Jira-сценарий «закрыли как дубликат / как не баг / как не будет сделано» и обесценивает отчётность.
+
+Задача вводит сущность `Resolution` (справочник) + поле `resolutionId` на `Issue` + validator на workflow-transition, требующий выбор resolution при переходе в терминальный статус.
+
+### Пользовательский сценарий
+
+**Разработчик:**
+1. Задача в `IN_PROGRESS`. Кликает «Перейти в Done».
+2. Появляется transition-screen с селектом «Результат: Решено / Дубликат / Не воспроизводится / …».
+3. Выбирает, комментирует (опционально) → submit.
+
+**Репортёр ищет старые закрытые задачи:**
+- `TTQL: resolution = Duplicate AND resolved >= -30d` → список.
+
+**Админ:**
+- Идёт в `/admin/resolutions` → CRUD справочника.
+
+---
+
+## 2. Текущее состояние
+
+- `Issue.status: IssueStatus` enum — проставляется при переходе, но нет «почему».
+- Workflow-engine поддерживает `validators` на переходах (`workflow-engine/transition-validators`) — готовый механизм для принудительного требования resolution.
+- Модели `Resolution` нет.
+- TTQL-compiler (`search.service.ts`, `search-compiler`) — модульный, поддерживает добавление полей.
+
+---
+
+## 3. Зависимости
+
+### Модули backend
+- [ ] `modules/resolutions/` — новый модуль: CRUD + router `/admin/resolutions`.
+- [ ] `modules/issues/issues.service.ts` — добавить `resolutionId`/`resolvedAt` в create/update API.
+- [ ] `modules/workflow-engine/transition-validators/` — новый validator `RequireResolutionOnTerminalStatus`.
+- [ ] `modules/search/search-compiler/` — добавить fields `resolution` + `resolved` в TTQL.
+- [ ] `modules/transition-screens/` — возможность включить поле `resolution` в transition screen.
+
+### Frontend
+- [ ] `pages/admin/AdminResolutionsPage.tsx` — новая админ-страница.
+- [ ] `components/issues/IssueDetailPage.tsx` — показывать `resolution` + `resolvedAt` если задача закрыта.
+- [ ] `components/workflow/TransitionDialog.tsx` — рендерить селект resolution в transition-screen.
+- [ ] `components/search/JqlEditor.tsx` — автодополнение для `resolution` / `resolved`.
+
+### Модели данных (Prisma)
+- [ ] `Resolution` — новая модель.
+- [ ] `Issue.resolutionId` — новая колонка (nullable FK).
+- [ ] `Issue.resolvedAt` — новая колонка (nullable DateTime).
+
+### Внешние зависимости
+- Нет.
+
+### Блокеры
+- [ ] TTCORE-1 **желательно** (но не обязательно) — согласование `IssueStatus` vs `WorkflowStatus`. Здесь `resolution` привязывается к `StatusCategory=DONE` (тот что уже есть на `WorkflowStatus`). Если TTCORE-1 мержится позже — логика validator'а резолвится через `workflowStatus.category === 'DONE'`.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Миграция существующих закрытых задач: неправильный auto-fill resolution | Низкая | UX-деградация | Auto-assign: `status=DONE` → `Решено`, `status=CANCELLED` → `Не будет сделано`. Флаг в audit-log `resolution_auto_assigned=true` для возможности массового отката |
+| 2 | Validator ломает существующие workflow (старые задачи не могут переходить без resolution) | Высокая | Поломка UX | Validator опциональный на workflow level — админ включает явно; существующие workflow получают миграцию: флаг активируется только на новых |
+| 3 | Удаление resolution из справочника, пока она используется 100+ задачами | Средняя | FK violation | Soft-delete (`isActive=false`), hard-delete — только если 0 задач используют |
+| 4 | TTQL `resolution is EMPTY` — семантика? | Низкая | Неоднозначность | Документировать: `EMPTY` = NULL (открытая задача или закрытая без явного resolution) |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Модель
+
+```prisma
+model Resolution {
+  id          String   @id @default(uuid())
+  key         String   @unique          // 'DONE', 'WONT_DO', etc. — стабильный ID для миграций
+  name        String                    // RU-строка, editable
+  description String?
+  color       String?  @default("#6B7280")
+  orderIndex  Int      @default(0)
+  isSystem    Boolean  @default(false)  // нельзя hard-delete
+  isActive    Boolean  @default(true)   // архивация
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  issues      Issue[]
+
+  @@map("resolutions")
+}
+
+// Изменения в модели Issue:
+// resolutionId String?   @map("resolution_id")
+// resolvedAt   DateTime? @map("resolved_at")
+// resolution   Resolution? @relation(fields: [resolutionId], references: [id])
+```
+
+### 5.2 Seed (при создании миграции)
+
+```sql
+INSERT INTO resolutions (id, key, name, order_index, is_system, is_active) VALUES
+  (uuid(), 'DONE',              'Решено',                  1, true, true),
+  (uuid(), 'WONT_DO',            'Не будет сделано',        2, true, true),
+  (uuid(), 'DUPLICATE',          'Дубликат',                3, true, true),
+  (uuid(), 'CANNOT_REPRODUCE',   'Не воспроизводится',      4, true, true),
+  (uuid(), 'INCOMPLETE',         'Недостаточно информации', 5, true, true);
+```
+
+### 5.3 Миграция данных (в той же Prisma-миграции)
+
+```sql
+-- Установить resolution для всех existing closed задач:
+UPDATE issues SET
+  resolution_id = (SELECT id FROM resolutions WHERE key = 'DONE'),
+  resolved_at = updated_at
+WHERE status = 'DONE' AND resolution_id IS NULL;
+
+UPDATE issues SET
+  resolution_id = (SELECT id FROM resolutions WHERE key = 'WONT_DO'),
+  resolved_at = updated_at
+WHERE status = 'CANCELLED' AND resolution_id IS NULL;
+
+-- audit-log:
+INSERT INTO audit_logs (entity_type, entity_id, action, details)
+SELECT 'Issue', id, 'resolution_auto_assigned', json_build_object('source', 'migration_TTRES-1')
+FROM issues WHERE resolution_id IS NOT NULL AND status IN ('DONE', 'CANCELLED');
+```
+
+### 5.4 Validator на workflow-transition
+
+Новый тип validator в `workflow-engine/transition-validators/`:
+
+```typescript
+// RequireResolutionOnTerminalStatus
+export const requireResolutionValidator: TransitionValidator = {
+  type: 'REQUIRE_RESOLUTION_ON_TERMINAL',
+  validate: async ({ issue, transition, toStatus, input }) => {
+    if (toStatus.category !== 'DONE') return { ok: true };
+    if (!input.resolutionId) {
+      return { ok: false, error: 'RESOLUTION_REQUIRED' };
+    }
+    const res = await prisma.resolution.findUnique({ where: { id: input.resolutionId } });
+    if (!res || !res.isActive) return { ok: false, error: 'RESOLUTION_INVALID' };
+    return { ok: true };
+  },
+};
+```
+
+В админке workflow-editor — добавить checkbox на transition: «Требовать resolution при переходе».
+
+### 5.5 UI на карточке задачи
+
+- Если `resolutionId != null`: показывать рядом со статусом бейдж с `resolution.name` + `resolution.color`.
+- Клик на бейдж — tooltip с `resolution.description` и `resolvedAt` (relative: «закрыто 3 дня назад»).
+- Поле **не редактируется напрямую** на карточке — только через transition (re-open issue → снова закрыть с другим resolution).
+
+### 5.6 Transition screen
+
+Расширить `TransitionScreen` — добавить системное поле `resolution` как опциональный элемент (в стиле существующих custom fields). При `validator=REQUIRE_RESOLUTION_ON_TERMINAL` — поле required.
+
+### 5.7 TTQL-расширение
+
+Новые поля в грамматике:
+- `resolution` — ожидает `key` или `name` resolution'а (case-insensitive).
+- `resolved` — date-field, аналог `created`/`updated`.
+
+Примеры:
+- `resolution = "Дубликат"` → `WHERE r.name ILIKE 'Дубликат'`
+- `resolution = Duplicate` → `WHERE r.key = 'DUPLICATE'`
+- `resolution is EMPTY` → `WHERE issue.resolution_id IS NULL`
+- `resolution in (Done, Duplicate)` → `WHERE r.key IN ('DONE', 'DUPLICATE')`
+- `resolved >= -7d` → `WHERE issue.resolved_at >= NOW() - INTERVAL '7 days'`
+
+### 5.8 API
+
+- `GET /api/resolutions` — публичный (для UI-дропдаунов), только `isActive=true`.
+- `GET /admin/resolutions` — админский, все, с `_count.issues`.
+- `POST /admin/resolutions` — create.
+- `PATCH /admin/resolutions/:id` — update (name, description, color, orderIndex, isActive).
+- `DELETE /admin/resolutions/:id` — hard-delete если `_count.issues === 0 && !isSystem`; иначе 400.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: Справочник `Resolution` — CRUD в `/admin/resolutions` (только ADMIN/SUPER_ADMIN).
+- [ ] FR-2: 5 системных resolution сидятся при миграции, `isSystem=true`.
+- [ ] FR-3: На `Issue` появляются поля `resolutionId` + `resolvedAt`.
+- [ ] FR-4: Validator `REQUIRE_RESOLUTION_ON_TERMINAL` — доступен в workflow-editor, опционален per-transition.
+- [ ] FR-5: Transition screen умеет показывать selector resolution.
+- [ ] FR-6: Существующие закрытые задачи автозаполняются (`DONE` → `Решено`, `CANCELLED` → `Не будет сделано`).
+- [ ] FR-7: TTQL поддерживает `resolution` и `resolved`.
+- [ ] FR-8: При `status → OPEN` (re-open) — `resolutionId` и `resolvedAt` очищаются.
+
+### Нефункциональные
+- [ ] NFR-1: Миграция данных на БД с 100k issues выполняется < 30 сек.
+- [ ] NFR-2: Индекс на `(project_id, resolution_id)` — фильтрация «все resolved задачи проекта» быстрая.
+
+### Безопасность
+- [ ] SEC-1: `Resolution` CRUD — только ADMIN/SUPER_ADMIN.
+- [ ] SEC-2: Изменение `resolution` на задаче — требует `ISSUES_EDIT` или разрешение на transition.
+
+### Тестирование
+- [ ] Unit: validator, TTQL-compiler для `resolution` и `resolved`.
+- [ ] Integration: переход в `DONE` без resolution (с активным validator) → 400.
+- [ ] Integration: soft-delete resolution при использовании её в issues → отклоняется.
+- [ ] Migration-тест: фикстура с 50 issues, миграция, проверка auto-fill.
+- [ ] Покрытие ≥ 70%.
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: `/admin/resolutions` — CRUD страница работает.
+- [ ] AC-2: 5 системных resolution созданы.
+- [ ] AC-3: Переход в `DONE` с активным validator без resolution → 400 `RESOLUTION_REQUIRED`.
+- [ ] AC-4: Карточка resolved-задачи показывает бейдж с цветом и именем.
+- [ ] AC-5: TTQL: `resolution = Duplicate` находит задачи.
+- [ ] AC-6: TTQL: `resolved >= -7d` находит.
+- [ ] AC-7: Миграция на dev-БД прошла, все старые closed задачи имеют `resolution_id`.
+- [ ] AC-8: Re-open задачи обнуляет `resolution_id` и `resolved_at`.
+- [ ] AC-9: Тесты зелёные. Lint проходит.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Prisma-миграция (модель + seed + data-migration) | 4 |
+| `modules/resolutions/` CRUD + router | 4 |
+| Validator `REQUIRE_RESOLUTION_ON_TERMINAL` | 3 |
+| Transition screen integration | 3 |
+| TTQL extension (fields: resolution, resolved) | 4 |
+| Frontend: AdminResolutionsPage | 4 |
+| Frontend: transition dialog + issue card badge | 4 |
+| Tests | 5 |
+| Code review | 2 |
+| **Итого** | **33** (~0.5 спринта) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** нет (TTCORE-1 желателен).
+- **Блокирует:** нет.
+- **Связано:** TTSRH-1 (TTQL-compiler — расширяем).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTRES-1 (TASK) — Resolutions
+  ├─ TTRES-1.1 — Prisma model + seed + data migration
+  ├─ TTRES-1.2 — Backend CRUD + validator + TTQL
+  ├─ TTRES-1.3 — Frontend AdminResolutionsPage + transition dialog
+  └─ TTRES-1.4 — Tests + docs
+```

--- a/docs/tz/MVP2JIRA/TTSCR-1.md
+++ b/docs/tz/MVP2JIRA/TTSCR-1.md
@@ -1,0 +1,237 @@
+# ТЗ: TTSCR-1 — Screens (контекст видимости полей)
+
+**Дата:** 2026-04-23
+**Тип:** TASK | **Приоритет:** P1 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+В Jira есть понятие **Screens** — разные наборы полей на create/edit/view задачи. Сейчас в TaskTime `FieldSchema` управляет, **какие** поля доступны, но не **где именно** они видны. Админ не может скрыть `priority` с create-экрана, но показать на edit, или наоборот.
+
+Задача **минимально расширяет существующую модель FieldSchema** флагами контекста без создания новых таблиц (Screen/ScreenScheme/IssueTypeScreenScheme), избегая дублирования.
+
+**Системные поля имеют разную политику:**
+- **Всегда видимы** (`summary`, `description`, текущий статус) — не управляются через FieldSchema.
+- **Управляемы** (`priority`, `assignee`, `dueDate`, `reporter`, etc.) — могут быть скрыты/показаны.
+
+### Пользовательские сценарии
+
+**Админ настраивает упрощённую форму создания:**
+1. `/admin/field-schemas/:id` → в списке полей у `priority` снимает флаг «Показывать при создании».
+2. При создании новой задачи — `priority` в форме отсутствует (устанавливается default).
+
+**Компактная карточка issue:**
+1. У поля `dueDate` админ снимает флаг «Показывать при просмотре» для `FieldSchema=Kanban-min`.
+2. В проектах с этой схемой dueDate не рендерится на issue-странице.
+
+---
+
+## 2. Текущее состояние
+
+- `FieldSchema` + `FieldSchemaItem` — существуют, `isRequired` и `showOnKanban` уже есть.
+- `FieldSchemaBinding` — 4 уровня (GLOBAL/PROJECT/ISSUE_TYPE/PROJECT_ISSUE_TYPE).
+- Transition Screens — отдельная сущность (не трогаем).
+- Системные поля рендерятся вручную в компонентах фронта (`IssueForm.tsx`, `IssueDetailPage.tsx`) — не через FieldSchema.
+
+---
+
+## 3. Зависимости
+
+### Модули backend
+- [ ] `modules/field-schemas/field-schemas.service.ts` — добавить 3 флага в DTO и persist.
+- [ ] `modules/issues/issues.service.ts` — валидировать обязательные поля с учётом контекста (create/edit отличаются).
+- [ ] `modules/custom-fields/` — для системных полей добавить «виртуальные» записи в FieldSchema.
+
+### Frontend
+- [ ] `pages/admin/AdminFieldSchemaDetailPage.tsx` — добавить 3 чекбокса в строке.
+- [ ] `components/issues/IssueForm.tsx` — фильтрация полей по context (`create`/`edit`).
+- [ ] `components/issues/IssueDetailPage.tsx` — фильтрация по `view`.
+
+### Модели данных (Prisma)
+- [ ] `FieldSchemaItem` — 3 новые boolean колонки: `showOnCreate`, `showOnEdit`, `showOnView` (default true).
+- [ ] Миграция: для существующих записей проставить все 3 флага в `true`.
+
+### Внешние зависимости
+- Нет.
+
+### Блокеры
+- Нет.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Админ скрывает `priority` с create, но поле обязательное → 400 на каждый create | Средняя | Блокировка создания issue | Если `isRequired=true`, нельзя сохранить `showOnCreate=false` — валидация в backend и UI |
+| 2 | Системные поля («priority» — встроенное в Issue, не FieldSchemaItem) — как управлять? | **Высокая** | Неконсистентность | Ввести «виртуальные» системные entries: при создании FieldSchema автоматически сидятся записи для priority/assignee/dueDate/reporter/components/fixVersion/affectsVersion (после TTPROJ-1). Админ управляет их видимостью через те же флаги |
+| 3 | View-контекст скрывает поле, но оно заполнено — данные «невидимы», непонятно | Низкая | UX-путаница | Tooltip «Некоторые поля скрыты администратором»; admin debug-view для troubleshooting |
+| 4 | При смене FieldSchema на проекте поведение форм меняется — пользователи в замешательстве | Низкая | UX | Changelog в audit-log; при смене — уведомление project-lead'ам |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Модель
+
+```prisma
+// Дополнение к существующей FieldSchemaItem:
+model FieldSchemaItem {
+  // ...existing fields...
+  showOnCreate  Boolean  @default(true) @map("show_on_create")
+  showOnEdit    Boolean  @default(true) @map("show_on_edit")
+  showOnView    Boolean  @default(true) @map("show_on_view")
+  // showOnKanban  Boolean  — уже есть
+}
+```
+
+### 5.2 Системные поля — виртуальные FieldSchemaItem
+
+Добавляем концепцию «системные поля» в `CustomField`:
+
+```prisma
+// CustomField.isSystem уже есть. Расширяем семантику:
+// isSystem=true + systemKey='priority' → specialized rendering + behavior
+```
+
+Системные поля-кандидаты:
+- `priority` — systemKey `priority`
+- `assignee` — systemKey `assignee`
+- `dueDate` — systemKey `dueDate`
+- `reporter` — systemKey `reporter`
+- `components` — systemKey `components` (появляется после TTPROJ-1)
+- `fixVersion` — systemKey `fixVersion`
+- `affectsVersion` — systemKey `affectsVersion`
+
+При создании FieldSchema — автоматически (seed) добавляется FieldSchemaItem для каждого системного поля с default `showOnCreate=true, showOnEdit=true, showOnView=true`.
+
+**NEVER-HIDDEN (захардкожены):**
+- `summary`, `description`, `status` — нельзя управлять через FieldSchema; всегда видимы во всех контекстах.
+
+### 5.3 Backend API обогащается контекстом
+
+```
+GET /api/issues/:id?context=view      → возвращает только showOnView=true
+GET /api/issues/:id?context=edit      → только showOnEdit=true
+POST /api/issues (create)             → принимает только showOnCreate=true
+```
+
+Контекст определяется endpoint'ом + полем в query. Поля, исключённые через FieldSchema, **не попадают** в API-ответ (исключение — системные: они всегда в response, но frontend решает показывать).
+
+### 5.4 Frontend logic
+
+```typescript
+// components/issues/useFieldSchema.ts
+export function useVisibleFields(
+  projectId: string,
+  issueTypeId: string,
+  context: 'create' | 'edit' | 'view',
+): FieldSchemaItem[] {
+  const schema = useFieldSchema(projectId, issueTypeId);
+  const contextKey =
+    context === 'create' ? 'showOnCreate' :
+    context === 'edit'   ? 'showOnEdit'   :
+                           'showOnView';
+  return schema.items.filter((i) => i[contextKey]);
+}
+```
+
+`IssueForm` и `IssueDetailPage` используют этот хук. Системные поля рендерятся conditionally:
+
+```tsx
+{visible.find(i => i.customField.systemKey === 'priority') && <PriorityField />}
+```
+
+### 5.5 Admin UI обновление
+
+В `AdminFieldSchemaDetailPage.tsx`, таблица FieldSchemaItem — добавить 3 чекбокса в колонке «Контекст»:
+
+| Поле | Обязательно | Create | Edit | View | Kanban |
+|------|------------|--------|------|------|--------|
+| priority | ☐ | ☑ | ☑ | ☑ | ☑ |
+| dueDate | ☐ | ☐ | ☑ | ☑ | ☐ |
+
+**Validation на save:** если `isRequired=true && showOnCreate=false` — запрет с сообщением «Обязательное поле должно быть видимо при создании».
+
+### 5.6 Transition screens — не трогаем
+
+Подчёркивается: `TransitionScreen` остаётся отдельной моделью. Она работает **в контексте transition**, и контексты `create/edit/view` её не касаются.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: FieldSchemaItem получает 3 новых флага с default true.
+- [ ] FR-2: При создании FieldSchema seed'ятся записи для 7 системных полей (priority/assignee/dueDate/reporter/components/fixVersion/affectsVersion).
+- [ ] FR-3: `summary`/`description`/`status` — NEVER hidden.
+- [ ] FR-4: API принимает/возвращает поля согласно контексту.
+- [ ] FR-5: Admin UI показывает 3 чекбокса в FieldSchema.
+- [ ] FR-6: Валидация: `isRequired=true && showOnCreate=false` блокирует save.
+- [ ] FR-7: Frontend форм: фильтрация полей через `useVisibleFields`.
+
+### Нефункциональные
+- [ ] NFR-1: `useVisibleFields` кеширует schema per-project-per-issueType в React-Query.
+- [ ] NFR-2: Render IssueForm с 20 полями < 100ms.
+
+### Безопасность
+- [ ] SEC-1: FieldSchema CRUD — ADMIN+.
+- [ ] SEC-2: Скрытое поле **не возвращается** в API (kannikkuse: fully not-in-response, чтобы не утекало существование значения).
+
+### Тестирование
+- [ ] Unit: validation `isRequired + !showOnCreate`.
+- [ ] Integration: API с `?context=view` исключает `showOnView=false` поля.
+- [ ] E2E: админ убирает `dueDate` с view → на issue-странице поле отсутствует.
+- [ ] Покрытие ≥ 70%.
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: 3 новых колонки в `field_schema_items`.
+- [ ] AC-2: 7 системных полей добавлены в существующие FieldSchemas при миграции (idempotent seed).
+- [ ] AC-3: `summary`/`description`/`status` всегда видимы.
+- [ ] AC-4: Validation блокирует `required && !showOnCreate`.
+- [ ] AC-5: IssueForm на create не рендерит поля с `showOnCreate=false`.
+- [ ] AC-6: IssueDetailPage на view не рендерит с `showOnView=false`.
+- [ ] AC-7: Admin UI работает, 3 чекбокса сохраняются.
+- [ ] AC-8: Tests зелёные.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Prisma migration + seed системных полей | 3 |
+| Backend: API context-filtering | 4 |
+| Backend: validation isRequired+showOnCreate | 1 |
+| Frontend: useVisibleFields hook | 3 |
+| Frontend: IssueForm/IssueDetailPage рефактор | 4 |
+| Frontend: AdminFieldSchemaDetailPage UI | 3 |
+| Tests | 4 |
+| Code review | 2 |
+| **Итого** | **24** (~0.5 спринта) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** нет (TTPROJ-1 желателен — добавляет `components`/`fixVersion`/`affectsVersion` системные поля).
+- **Связано:** TTADM-68 (Workflow Editor).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTSCR-1 (TASK) — Screens (context flags)
+  ├─ TTSCR-1.1 — Prisma migration + seed system fields
+  ├─ TTSCR-1.2 — Backend API filtering
+  ├─ TTSCR-1.3 — Frontend useVisibleFields + form refactor
+  └─ TTSCR-1.4 — Admin UI + tests
+```

--- a/docs/tz/MVP2JIRA/TTSEC-3.md
+++ b/docs/tz/MVP2JIRA/TTSEC-3.md
@@ -1,0 +1,332 @@
+# ТЗ: TTSEC-3 — Issue Security (Уровни видимости задач)
+
+**Дата:** 2026-04-23
+**Тип:** TASK | **Приоритет:** P0 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+Сейчас в проекте все участники с правом `ISSUES_VIEW` видят все задачи. Нет способа скрыть отдельную задачу (например, HR-инцидент, security-уязвимость, юридический спор) от части команды. Это блокер для enterprise-использования.
+
+Задача вводит **3 фиксированных уровня видимости** + возможность расширенного списка доступа для `PRIVATE`:
+- `PUBLIC` — как сейчас (все с `ISSUES_VIEW`).
+- `TEAM` — отсекаются роли `VIEWER` (только `USER+`).
+- `PRIVATE` — только creator + assignee + project `ADMIN`/`MANAGER` + extra users/groups.
+
+Видимость проставляется при создании/редактировании задачи пользователем с новым permission `ISSUES_CHANGE_VISIBILITY`.
+
+### Пользовательские сценарии
+
+**HR-менеджер:**
+1. Создаёт задачу «Выговор сотруднику X за нарушение». В момент создания выбирает visibility=`PRIVATE`.
+2. Кликает «Добавить к списку доступа» → добавляет юриста из `UserGroup 'Legal'`.
+3. Задача не видна остальным участникам проекта.
+
+**Security-инженер:**
+1. Репортит уязвимость. Ставит `PRIVATE`, в extras добавляет только группу `security-team`.
+2. В поиске, Kanban, sprint'ах задача не появляется у посторонних.
+
+**Админ:**
+1. Добавляет роли pattern «может менять видимость»: `PROJECT_ADMIN` и `PROJECT_MANAGER` по умолчанию. Роль `USER` — может только если permission включён.
+
+---
+
+## 2. Текущее состояние
+
+- На `Issue` нет поля visibility. Все видят всё, что не запрещено RBAC.
+- RBAC middleware (`shared/middleware/rbac.ts`) проверяет роль на проекте, но на уровне task-level ничего нет.
+- В `ProjectPermission` enum уже 33 флага, но нет `ISSUES_CHANGE_VISIBILITY`.
+- Фильтрация запросов (list issues, TTQL search) работает через `projectId → projectRole`, дополнительная проверка на visibility нужна.
+
+---
+
+## 3. Зависимости
+
+### Модули backend
+- [ ] `modules/issues/issues.service.ts` — все read/list/search методы добавляют visibility-фильтр.
+- [ ] `modules/issues/issues.router.ts` — create/update принимают `visibility` и `visibilityExtras`.
+- [ ] `modules/comments/comments.service.ts` — list через `JOIN issues` с visibility-фильтром.
+- [ ] `modules/time/time.service.ts` — то же для TimeLog.
+- [ ] `modules/search/search.service.ts` — TTQL-компилятор добавляет WHERE-условие.
+- [ ] `shared/middleware/rbac.ts` — новая функция `canSeeIssue(userId, issue)` для get-endpoint'ов.
+
+### Frontend
+- [ ] `components/issues/IssueVisibilityBadge.tsx` — иконка замка с цветом.
+- [ ] `components/issues/IssueVisibilitySelector.tsx` — dropdown с 3 уровнями + extras-dialog.
+- [ ] `components/issues/IssueDetailPage.tsx` — показывать visibility, открывать selector для уполномоченных.
+
+### Модели данных (Prisma)
+- [ ] `Issue.visibility: IssueVisibility` (enum).
+- [ ] `Issue.visibilityExtras: Json?` — `{ userIds: string[], groupIds: string[] }`.
+- [ ] `ProjectPermission` — новое значение `ISSUES_CHANGE_VISIBILITY`.
+
+### Внешние зависимости
+- Нет.
+
+### Блокеры
+- Нет. Работает независимо от TTCORE-1 и TTSSO-1.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Visibility-фильтр пропущен в одном из query-путей (`JOIN`-запросы, raw SQL) → утечка PRIVATE-задач | Высокая | Security-инцидент | Единая библиотека `visibilityWhereClause(userId, projectId)`, обязательная в list/search/get. Security-review на merge |
+| 2 | Производительность на больших БД: LEFT JOIN visibility_extras замедляет list | Средняя | Slow queries | Индексы: `(project_id, visibility)`, `(visibility, creator_id)`, JSONB GIN на `visibility_extras`; p99 < 200ms |
+| 3 | User убран из `visibilityExtras.userIds`, но задача закеширована на фронте | Низкая | Кратковременная утечка | Invalidate client cache при изменении visibility; опционально — broadcast через WebSocket/SSE |
+| 4 | Creator удалён (user.deleted=true) — задача «сиротеет» с доступом только admin/assignee | Низкая | UX-потеря | Подхват: если `creatorId` → inactive user, доступ у assignee + admin/manager остаётся; логика учитывает |
+| 5 | Comments-leak: пользователь не видит issue, но знает ID и делает GET /issues/:id/comments | Высокая | Leak | Все comment-ендпоинты делают pre-check `canSeeIssue` |
+| 6 | Notifications (TTNOTIF-1) шлют mention/assigned-email пользователю, у которого нет visibility на issue | Средняя | Leak в email | Notification-consumer фильтрует recipients через `canSeeIssue` перед отправкой |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Модель
+
+```prisma
+enum IssueVisibility {
+  PUBLIC
+  TEAM
+  PRIVATE
+}
+
+// В модели Issue:
+// visibility        IssueVisibility @default(PUBLIC)
+// visibilityExtras  Json?  // { userIds: string[], groupIds: string[] }
+
+// В ProjectPermission добавить:
+ISSUES_CHANGE_VISIBILITY
+```
+
+### 5.2 Семантика уровней
+
+| Уровень | Кто видит |
+|---------|-----------|
+| `PUBLIC` | Любой с `ISSUES_VIEW` на проекте |
+| `TEAM` | Любой с project role `USER` / `MANAGER` / `ADMIN` (отсекаются `VIEWER`-подобные) |
+| `PRIVATE` | creator ∪ assignee ∪ project `ADMIN`/`MANAGER` ∪ users in `extras.userIds` ∪ members of `extras.groupIds` |
+
+### 5.3 Where-clause generator
+
+```typescript
+// shared/middleware/visibility.ts
+export async function visibilityWhereClause(
+  userId: string,
+  projectId: string,
+): Promise<Prisma.IssueWhereInput> {
+  const userGroupIds = await getUserGroupIds(userId);
+  const userProjectRole = await getUserProjectRole(userId, projectId);
+
+  // Если юзер admin/manager проекта — видит всё
+  if (userProjectRole && ['ADMIN', 'MANAGER'].includes(userProjectRole)) {
+    return {};
+  }
+
+  const orConditions: Prisma.IssueWhereInput[] = [];
+
+  // PUBLIC: всегда видно (при наличии ISSUES_VIEW — проверяется выше)
+  orConditions.push({ visibility: 'PUBLIC' });
+
+  // TEAM: видно USER и выше
+  if (userProjectRole && userProjectRole !== 'VIEWER') {
+    orConditions.push({ visibility: 'TEAM' });
+  }
+
+  // PRIVATE: creator OR assignee OR в extras
+  orConditions.push({
+    visibility: 'PRIVATE',
+    OR: [
+      { creatorId: userId },
+      { assigneeId: userId },
+      // JSONB-предикат: extras.userIds содержит userId
+      { visibilityExtras: { path: ['userIds'], array_contains: userId } as Prisma.JsonFilter },
+      // extras.groupIds пересекается с userGroupIds
+      ...(userGroupIds.length > 0
+        ? userGroupIds.map((gId) => ({
+            visibilityExtras: { path: ['groupIds'], array_contains: gId } as Prisma.JsonFilter,
+          }))
+        : []),
+    ],
+  });
+
+  return { OR: orConditions };
+}
+```
+
+### 5.4 Интеграция в читающие пути
+
+Все методы `listIssues`, `searchIssues`, `getIssue` используют этот clause. Для get-по-ID:
+
+```typescript
+export async function getIssueById(userId: string, issueId: string): Promise<Issue> {
+  const issue = await prisma.issue.findUnique({ where: { id: issueId } });
+  if (!issue) throw new NotFound();
+
+  const canSee = await canSeeIssue(userId, issue);
+  if (!canSee) throw new NotFound();  // 404, не 403 — чтобы не утекать существование
+
+  return issue;
+}
+```
+
+### 5.5 Write-side: меняем visibility
+
+```typescript
+// PUT /api/issues/:id/visibility
+// body: { visibility: 'PRIVATE', extras: { userIds: [...], groupIds: [...] } }
+export async function changeVisibility(
+  actorId: string,
+  issueId: string,
+  payload: VisibilityChangeDto,
+): Promise<Issue> {
+  const issue = await prisma.issue.findUnique({ where: { id: issueId } });
+  if (!issue) throw new NotFound();
+
+  // проверяем permission
+  const hasPermission = await userHasProjectPermission(
+    actorId, issue.projectId, 'ISSUES_CHANGE_VISIBILITY'
+  );
+  if (!hasPermission) throw new Forbidden();
+
+  // audit
+  await writeAuditLog(actorId, 'Issue', issueId, 'visibility_changed', {
+    from: issue.visibility, to: payload.visibility, extras: payload.extras,
+  });
+
+  return prisma.issue.update({
+    where: { id: issueId },
+    data: {
+      visibility: payload.visibility,
+      visibilityExtras: payload.visibility === 'PRIVATE' ? payload.extras : null,
+    },
+  });
+}
+```
+
+### 5.6 UI компоненты
+
+**Badge:**
+- PUBLIC → нет иконки / глаз
+- TEAM → иконка группы (🤝) + tooltip «Видно команде»
+- PRIVATE → замок (🔒) + tooltip «Приватно. Доступ: …»
+
+**Selector:**
+- Dropdown с 3 уровнями.
+- При выборе `PRIVATE` — расширяется блок «Дополнительный доступ» с input'ами `Пользователи` и `Группы` (autocomplete).
+- Показывается только пользователям с permission.
+
+### 5.7 Миграция разрешения (permission enum)
+
+Для `ProjectPermission` enum добавление значения — отдельная миграция:
+
+```sql
+-- Prisma migration
+ALTER TYPE "ProjectPermission" ADD VALUE 'ISSUES_CHANGE_VISIBILITY';
+```
+
+По умолчанию permission выдаётся только ролям `ADMIN` и `MANAGER` (в seed для системных Role Schemes). Для `USER` — off по умолчанию.
+
+### 5.8 Notifications integration
+
+В `notifications-service` (TTNOTIF-1): перед включением user в recipient-список — проверка `canSeeIssue(recipientId, issue)`. Если нет — skip (с log'ом «suppressed due to visibility»).
+
+### 5.9 TTQL-фильтрация
+
+TTQL-compiler автоматически применяет visibility-фильтр к всем запросам (добавляется к финальному `WHERE`). Пользователь не может это обойти. Явно фильтровать по visibility — опционально, добавить field `visibility`:
+
+```
+visibility = PRIVATE
+visibility in (PUBLIC, TEAM)
+```
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: На `Issue` появляются поля `visibility` и `visibilityExtras`.
+- [ ] FR-2: В `ProjectPermission` добавлен `ISSUES_CHANGE_VISIBILITY`, проставлен в seed Role Schemes для ADMIN/MANAGER.
+- [ ] FR-3: `POST /api/issues/:id/visibility` меняет visibility с audit-logging.
+- [ ] FR-4: Все list/search endpoints (`/api/issues`, TTQL) фильтруют по visibility.
+- [ ] FR-5: `GET /api/issues/:id` возвращает 404 для пользователей без доступа.
+- [ ] FR-6: Comments, time-logs, custom fields — наследуют visibility parent-issue.
+- [ ] FR-7: UI показывает badge visibility, selector — пользователям с permission.
+- [ ] FR-8: Notifications подавляются для пользователей без visibility.
+- [ ] FR-9: TTQL field `visibility` работает.
+
+### Нефункциональные
+- [ ] NFR-1: visibilityWhereClause не замедляет list-issues более чем на 20ms p99.
+- [ ] NFR-2: JSONB GIN-индекс на `visibility_extras` — фильтрация по 10k task'ов < 100ms.
+- [ ] NFR-3: User-group resolution (для extras) кэшируется в Redis (уже используется).
+
+### Безопасность
+- [ ] SEC-1: RBAC-тесты: 404 для не-admin/manager/creator/assignee на PRIVATE issue.
+- [ ] SEC-2: API возвращает 404 (не 403) на inaccessible issue — чтобы не утекать существование.
+- [ ] SEC-3: Audit-log на каждое изменение visibility.
+- [ ] SEC-4: Fuzz-тест: попытки доступа через comment/time-log IDs в обход issue-фильтра.
+
+### Тестирование
+- [ ] Unit: `visibilityWhereClause` — все 12 комбинаций (4 уровня permissions × 3 visibility).
+- [ ] Unit: `canSeeIssue` — те же.
+- [ ] Integration: comment-endpoints с PRIVATE issue.
+- [ ] Integration: TTQL-search возвращает только visible issues.
+- [ ] Покрытие ≥ 80% (security-critical).
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: При создании issue можно выбрать visibility.
+- [ ] AC-2: PRIVATE issue с extras: `alice@corp.ru` в списке → Alice видит, другие нет.
+- [ ] AC-3: `GET /api/issues/:private-id` от не-admin'а без доступа → 404.
+- [ ] AC-4: TTQL-search не показывает PRIVATE без доступа.
+- [ ] AC-5: Notifications не идут пользователям без visibility.
+- [ ] AC-6: Audit-log содержит запись о смене visibility.
+- [ ] AC-7: Permission `ISSUES_CHANGE_VISIBILITY` работает: USER не может менять без неё.
+- [ ] AC-8: Тесты зелёные + security-review пройден.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Prisma-миграция (enum, колонки, индексы, permission) | 3 |
+| `shared/middleware/visibility.ts` — where-clause | 6 |
+| Интеграция в issues.service (list/get/search) | 6 |
+| Интеграция в comments / time / custom-fields | 4 |
+| Router + DTO + audit для change-visibility | 3 |
+| TTQL extension (field `visibility`) | 3 |
+| Frontend: badge + selector + dialog | 8 |
+| Integration в TTNOTIF-1 (recipient filter) | 3 |
+| Tests (unit + integration + security) | 12 |
+| Security-review + fixes | 4 |
+| **Итого** | **52** (~1 спринт) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** нет.
+- **Блокирует:** (затрагивается) TTNOTIF-1 (recipient filter).
+- **Связано:** TTSEC-2 (user-groups), TTSRH-1 (TTQL).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTSEC-3 (TASK) — Issue Security
+  ├─ TTSEC-3.1 — Prisma model + permission enum + indices
+  ├─ TTSEC-3.2 — visibility-middleware + integration в read-paths
+  ├─ TTSEC-3.3 — change-visibility API + audit
+  ├─ TTSEC-3.4 — Frontend badge + selector
+  ├─ TTSEC-3.5 — TTQL field
+  └─ TTSEC-3.6 — Security-tests + review
+```

--- a/docs/tz/MVP2JIRA/TTSEC-4.md
+++ b/docs/tz/MVP2JIRA/TTSEC-4.md
@@ -1,0 +1,334 @@
+# ТЗ: TTSEC-4 — Password Policy + Audit Log UI + Announcement Banner
+
+**Дата:** 2026-04-23
+**Тип:** TASK | **Приоритет:** P1 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+Три security/admin-UI фичи в одном ТЗ:
+
+### 1.1 Password Policy
+Сейчас правила пароля (CVE-11) захардкожены в коде. Нужна админ-настройка: минимальная длина, требования complexity, email-lockout при брутфорсе.
+
+### 1.2 Audit Log UI
+Таблица `audit_logs` растёт, индексы есть, но UI просмотра отсутствует. Нужна страница `/admin/audit-log` с фильтрами, детальным drawer с diff'ом, экспорт CSV/JSON, configurable retention.
+
+### 1.3 Announcement Banner
+Нет способа сообщить всем пользователям о запланированных работах. Нужна модель с расписанием (startsAt/endsAt), типами (info/warning/error) и dismissibility (только для info).
+
+### Пользовательские сценарии
+
+**Password Policy:** Админ в `/admin/security/password-policy` ужесточает minLength 8→12 + lockout 5 попыток/30 мин. Существующие юзеры при следующем логине получают `PASSWORD_POLICY_VIOLATION` и требование смены.
+
+**Audit Log:** Security engineer расследует инцидент: фильтрует `entityType=Issue, action=visibility_changed, date [-7d..now]`, кликает событие → drawer с before/after diff.
+
+**Banner:** DevOps за день до maintenance создаёт banner `[warning] Плановые работы 25.04 с 02:00 до 04:00 MSK, startsAt=2026-04-25T02:00Z, endsAt=2026-04-25T04:00Z`. Автоматически появляется и исчезает.
+
+---
+
+## 2. Текущее состояние
+
+- Password-валидация CVE-11 в `modules/auth/auth.service.ts` — `minLength=8`, символы — захардкожены.
+- `SystemSetting` модель есть (ключ/строковое значение).
+- `audit_logs` таблица с индексами `(entityType, entityId)`, `(userId)`, `(createdAt)`, `(action)`.
+- Колокольчик (после TTNOTIF-1) не путать с баннером — баннер глобальный, не per-user.
+
+---
+
+## 3. Зависимости
+
+### Модули backend
+- [ ] `modules/security/password-policy.service.ts` — новый, валидация + policy-get/set.
+- [ ] `modules/auth/auth.service.ts` — интегрировать policy в login/register/changePassword; добавить lockout через Redis.
+- [ ] `modules/admin/audit-log.router.ts` — новый endpoint с фильтрами + экспорт.
+- [ ] `modules/admin/announcements.router.ts` — CRUD.
+- [ ] `shared/scheduler/retention.cron.ts` — cron очистки старых audit-logs согласно retention.
+
+### Frontend
+- [ ] `pages/admin/AdminPasswordPolicyPage.tsx`.
+- [ ] `pages/admin/AdminAuditLogPage.tsx` + `components/admin/AuditLogDrawer.tsx` (detail + diff).
+- [ ] `pages/admin/AdminAnnouncementsPage.tsx`.
+- [ ] `components/layout/AnnouncementBanner.tsx` — рендер в шапке приложения.
+
+### Модели данных (Prisma)
+- [ ] `SystemSetting` — ключи: `password_policy`, `audit_retention_days`.
+- [ ] `Announcement` — новая таблица.
+- [ ] Redis-ключ для lockout-counter: `lockout:{email}` (TTL = lockoutDurationMinutes × 60).
+
+### Внешние зависимости
+- Нет новых.
+
+### Блокеры
+- Нет.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | Email-level lockout → DoS: злоумышленник блокирует юзера бесконечно | **Средняя** | Deadlock для пользователя | Компенсация: (a) короткий window = 30 мин default; (b) unlock через email-reset link; (c) SUPER_ADMIN whitelist не блокируется; (d) админ-кнопка «Разблокировать» |
+| 2 | Ужесточение policy → все юзеры заблокированы на старте (старые пароли не проходят) | Высокая | Downtime auth | Lazy enforcement: при логине валидируется против текущей политики. При провале — `mustChangePassword=true`, юзер вынужденно меняет |
+| 3 | Audit-log UI рендерит 100k записей → браузер фризит | Высокая | UX | Server-side pagination + limit 100 на страницу. Экспорт — async-job для > 10k |
+| 4 | Export CSV/JSON с sensitive data (IP, user-agent, payload с email адресами) | Высокая | Compliance | Только SUPER_ADMIN экспортирует; в audit логирование «кто когда экспортировал» |
+| 5 | Retention cron удаляет audit раньше, чем админ заметил инцидент | Средняя | Потеря evidence | Default retention = null (хранить вечно); включение — явное действие; alert за 30 дней до первого удаления |
+| 6 | Banner показывает устаревшее сообщение (time-drift между server/client) | Низкая | Cosmetic | Сравнение `startsAt/endsAt` на сервере; frontend получает резолвлённый список «активных сейчас» |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Password Policy
+
+**Модель (через `SystemSetting`):**
+
+Ключ `password_policy`, значение — JSON:
+```json
+{
+  "minLength": 8,
+  "requireUppercase": true,
+  "requireLowercase": true,
+  "requireDigit": true,
+  "requireSpecial": false,
+  "lockoutAfterFailedAttempts": 5,
+  "lockoutDurationMinutes": 30,
+  "mustChangeOnFirstLogin": true,
+  "mfaTrustDevice": false
+}
+```
+
+**Validation helper:**
+
+```typescript
+export function validatePassword(password: string, policy: PasswordPolicy): string[] {
+  const errors: string[] = [];
+  if (password.length < policy.minLength) errors.push(`MIN_LENGTH_${policy.minLength}`);
+  if (policy.requireUppercase && !/[A-Z]/.test(password)) errors.push('NEED_UPPER');
+  if (policy.requireLowercase && !/[a-z]/.test(password)) errors.push('NEED_LOWER');
+  if (policy.requireDigit && !/[0-9]/.test(password)) errors.push('NEED_DIGIT');
+  if (policy.requireSpecial && !/[!@#$%^&*(),.?":{}|<>]/.test(password)) errors.push('NEED_SPECIAL');
+  return errors;
+}
+```
+
+**Lockout (Redis):**
+
+```typescript
+// On failed login:
+const key = `lockout:${email}`;
+const attempts = await redis.incr(key);
+if (attempts === 1) {
+  await redis.expire(key, policy.lockoutDurationMinutes * 60);
+}
+if (attempts >= policy.lockoutAfterFailedAttempts) {
+  const isSuperAdmin = await checkSuperAdmin(email);
+  if (!isSuperAdmin) throw new Forbidden('ACCOUNT_LOCKED');
+}
+
+// On successful login:
+await redis.del(key);
+```
+
+**Admin-unlock:** `POST /admin/users/:id/unlock` → `redis.del(lockout:${email})`.
+
+**Lazy enforcement:** при логине — если `validatePassword(password, currentPolicy)` провалилась → `User.mustChangePassword = true`, продолжаем логин, на следующий запрос фронт показывает `/change-password`.
+
+### 5.2 Audit Log UI
+
+**Endpoint:**
+
+```
+GET /admin/audit-log
+  ?entityType=Issue
+  &userId=...
+  &entityId=...
+  &action=...
+  &fromDate=...
+  &toDate=...
+  &search=  (full-text по details JSON, через to_tsvector)
+  &page=1&pageSize=100
+```
+
+Response: `{ items: AuditLog[], total: number }`. `items[i]` содержит `{ id, action, entityType, entityId, userId, userName, ipAddress, userAgent, details, createdAt }`.
+
+**Full-text search по JSON:** добавить generated column + GIN:
+```sql
+ALTER TABLE audit_logs ADD COLUMN details_tsv tsvector
+  GENERATED ALWAYS AS (to_tsvector('simple', coalesce(details::text, ''))) STORED;
+CREATE INDEX audit_logs_details_tsv_idx ON audit_logs USING GIN (details_tsv);
+```
+
+**Drawer с diff:**
+
+Для actions c явной before/after семантикой (update, visibility_changed, role_changed, etc.) — `details.before` и `details.after` + рендер с библиотекой `deep-object-diff` (показ removed/added/changed).
+
+Для create/delete — просто full payload.
+
+**Retention:**
+
+Ключ `audit_retention_days` в `SystemSetting` (default null = бесконечно).
+
+Cron раз в сутки:
+```sql
+DELETE FROM audit_logs WHERE created_at < NOW() - (INTERVAL '1 day' * $1)
+  AND action NOT IN ('user_deleted', 'role_granted', 'visibility_changed')  -- «never-delete»
+```
+
+Never-delete список — hard-coded в коде (ADMIN не может ослабить).
+
+**Export:**
+
+- CSV (< 10 000 строк): синхронный download.
+- CSV/JSON (> 10 000): async-job в BullMQ (или Redis queue), возвращает ссылку на temp-файл.
+
+### 5.3 Announcement Banner
+
+**Модель:**
+
+```prisma
+enum AnnouncementType {
+  INFO
+  WARNING
+  ERROR
+}
+
+model Announcement {
+  id          String           @id @default(uuid())
+  type        AnnouncementType @default(INFO)
+  title       String
+  body        String
+  startsAt    DateTime         @map("starts_at")
+  endsAt      DateTime         @map("ends_at")
+  dismissible Boolean          @default(false)  // computed: true только если type=INFO (валидация)
+  priority    Int              @default(0)  // для выбора одного при overlapping schedule
+  createdBy   String           @map("created_by")
+  createdAt   DateTime         @default(now())
+
+  @@index([startsAt, endsAt])
+  @@map("announcements")
+}
+```
+
+**Validation:** если `type != INFO`, форсим `dismissible=false` на сохранении.
+
+**API:**
+
+- `GET /api/announcements/active` — публичный (любой аутентифицированный): возвращает одно сообщение, активное **сейчас** (`startsAt <= NOW() <= endsAt`, `isEnabled=true`), с наивысшим `priority`. Клиент-кеш на 60 сек.
+- `GET /admin/announcements` — админский, все.
+- `POST/PUT/DELETE /admin/announcements/:id` — SUPER_ADMIN only.
+
+**Dismiss per-user:**
+
+Для `type=INFO` при клике X — записываем в `User.preferences.dismissedAnnouncements: string[]` (array of announcement IDs). В `GET /api/announcements/active` исключаем dismissed для текущего юзера.
+
+**Frontend:**
+
+- `AnnouncementBanner.tsx` — fetch `/api/announcements/active` при маунте + refetch каждые 60 сек.
+- Рендер фиксированной полосой сверху (`position: sticky`), цвет по типу.
+- Если dismissible — кнопка X.
+
+### 5.4 Admin UI pages
+
+**AdminPasswordPolicyPage:** форма с полями policy + preview-попытка «Проверить пример пароля» (non-saved).
+
+**AdminAuditLogPage:** таблица с фильтрами сверху, клик по строке → drawer с deep-diff.
+
+**AdminAnnouncementsPage:** таблица (name, type, schedule, isActive-now) + create/edit modal с date-pickers.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: `/admin/security/password-policy` CRUD политики (SUPER_ADMIN only).
+- [ ] FR-2: Login-endpoint применяет текущую политику: lockout после N fails.
+- [ ] FR-3: Lazy-enforcement: пароль не соответствует policy → `mustChangePassword=true` при логине.
+- [ ] FR-4: SUPER_ADMIN не блокируется по email-lockout.
+- [ ] FR-5: `/admin/users/:id/unlock` сбрасывает lockout-counter.
+- [ ] FR-6: `/admin/audit-log` с 6 фильтрами + pagination + full-text search.
+- [ ] FR-7: Detail-drawer показывает deep-diff для update-actions.
+- [ ] FR-8: Export CSV/JSON, > 10k через async-job.
+- [ ] FR-9: Configurable retention через `SystemSetting`; never-delete список захардкожен.
+- [ ] FR-10: `/admin/announcements` CRUD + preview.
+- [ ] FR-11: `GET /api/announcements/active` возвращает текущий активный с учётом dismiss.
+- [ ] FR-12: Banner в шапке, auto-refresh 60 сек.
+
+### Нефункциональные
+- [ ] NFR-1: Audit-log query < 500ms p95 на БД с 1M записей (GIN-индекс на details_tsv).
+- [ ] NFR-2: Password-validate < 5ms.
+- [ ] NFR-3: Banner-fetch не превышает 10 req/мин на одного юзера.
+
+### Безопасность
+- [ ] SEC-1: Password policy — только SUPER_ADMIN.
+- [ ] SEC-2: Audit-log чтение — SUPER_ADMIN + AUDITOR.
+- [ ] SEC-3: Export — только SUPER_ADMIN, audit-logged.
+- [ ] SEC-4: Announcements — SUPER_ADMIN only.
+- [ ] SEC-5: Lockout-counter в Redis защищён от внешнего доступа.
+
+### Тестирование
+- [ ] Unit: `validatePassword`, lockout-counter logic, announcement active-resolver.
+- [ ] Integration: failed logins → lockout → admin-unlock.
+- [ ] Integration: update policy → next login triggers `mustChangePassword`.
+- [ ] Integration: audit-search with full-text (to_tsvector).
+- [ ] E2E: banner появляется/исчезает по расписанию.
+- [ ] Покрытие ≥ 70%.
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: `/admin/security/password-policy` работает, SUPER_ADMIN может менять параметры.
+- [ ] AC-2: 5 failed logins → 6-й получает 403 `ACCOUNT_LOCKED`.
+- [ ] AC-3: SUPER_ADMIN не попадает под lockout.
+- [ ] AC-4: `/admin/users/:id/unlock` сбрасывает lockout.
+- [ ] AC-5: `/admin/audit-log` с фильтрами + deep-diff drawer.
+- [ ] AC-6: Export CSV на 100 строк работает (sync); 50k строк — async-job.
+- [ ] AC-7: Retention cron удаляет старше N дней, never-delete actions остаются.
+- [ ] AC-8: Banner создаётся с расписанием, появляется/исчезает автоматически.
+- [ ] AC-9: INFO-banner — dismissible; WARNING/ERROR — нет.
+- [ ] AC-10: Тесты зелёные.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Password policy: service + validation + lockout (Redis) | 8 |
+| Password policy: admin-UI page | 4 |
+| Audit-log: generated column + GIN migration | 2 |
+| Audit-log: router с фильтрами + full-text | 6 |
+| Audit-log: admin-UI + drawer с diff | 10 |
+| Audit-log: export CSV/JSON + async-job | 6 |
+| Audit-log: retention cron + never-delete list | 3 |
+| Announcements: model + CRUD + active-resolver | 5 |
+| Announcements: banner component + dismiss-logic | 5 |
+| Tests | 10 |
+| Code review | 4 |
+| **Итого** | **63** (~1 спринт) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** нет.
+- **Блокирует:** TTMFA-1 (переиспользует re-auth из password-policy).
+- **Связано:** TTSEC-2 (user management), TTMP-171 (session).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTSEC-4 (TASK) — Password Policy + Audit Log UI + Banner
+  ├─ TTSEC-4.1 — Password policy service + lockout
+  ├─ TTSEC-4.2 — Audit log router + GIN + drawer
+  ├─ TTSEC-4.3 — Audit log export + retention
+  ├─ TTSEC-4.4 — Announcements CRUD + banner
+  └─ TTSEC-4.5 — Tests + review
+```

--- a/docs/tz/MVP2JIRA/TTSSO-1.md
+++ b/docs/tz/MVP2JIRA/TTSSO-1.md
@@ -1,0 +1,360 @@
+# ТЗ: TTSSO-1 — SSO (OpenID Connect)
+
+**Дата:** 2026-04-23
+**Тип:** EPIC | **Приоритет:** P1 | **Статус:** OPEN
+**Проект:** TaskTime MVP (TTMP)
+**Исполнитель:** TBD
+**Автор ТЗ:** Claude Code (auto-generated)
+
+---
+
+## 1. Постановка задачи
+
+Сейчас аутентификация только локальная (email + пароль). Это блокер для корп-заказчиков: требуется интеграция с корпоративным IdP (Keycloak, Azure AD, GitLab, Google Workspace).
+
+Задача вводит **OIDC-based SSO**:
+- Множество одновременно активных провайдеров (список на логин-экране).
+- **JIT-provisioning** — новый SSO-юзер создаётся автоматически.
+- Автоматический **маппинг групп** по claim `groups` (match by name, несуществующие — игнор).
+- **Локальный логин выключается** для всех, кроме SUPER_ADMIN (emergency backdoor).
+- Связывание существующих локальных аккаунтов через **confirm dialog** (ввод старого пароля).
+- **Периодическая sync** из IdP (опционально, требует admin-scope в IdP).
+- **Системные роли — только `USER`** при JIT, `ADMIN`/`SUPER_ADMIN` выдаются админом вручную.
+
+### Пользовательские сценарии
+
+**Первый логин через SSO:**
+1. Юзер на логин-экране видит список: «Войти через Keycloak», «Войти через GitLab».
+2. Кликает «Войти через Keycloak» → редирект на `/realms/corp/.well-known/openid-configuration/auth?...`.
+3. Успешный callback → получены claims `{ sub, email, name, groups: [...] }`.
+4. В БД нет `UserIdentity` с таким `sub` и нет User c таким `email` → JIT: создаётся User с `USER` role + UserIdentity.
+5. Группы из claim мапятся по имени на существующие `UserGroup` — проставляются в `UserGroupMember`.
+
+**Связывание с существующим локальным аккаунтом:**
+1. Alice уже имеет локальный `alice@corp.ru`. Включён SSO.
+2. Alice входит через IdP, claim `email=alice@corp.ru`.
+3. Backend находит существующего User с тем же email → **не создаёт дубль**, возвращает на фронт `requiresLinking=true`.
+4. Фронт показывает экран «Нашли аккаунт с таким email — свяжите ранее созданным паролем».
+5. Alice вводит старый пароль → backend проверяет → создаёт `UserIdentity`, пароль отключает (nullable или флаг).
+
+**Админ настраивает IdP:**
+1. `/admin/sso/providers` → «Добавить провайдера».
+2. Имя `Keycloak`, protocol `OIDC`, issuer `https://keycloak.corp.ru/realms/main`, clientId/clientSecret.
+3. Scopes `openid profile email groups`, claim mapping.
+4. «Сохранить» → иконка появляется на логин-экране.
+
+---
+
+## 2. Текущее состояние
+
+- Аутентификация — локальная через `auth.service.ts` (JWT + bcrypt + mustChangePassword).
+- Session через Redis + sliding session (TTMP-171).
+- `UserSystemRole` enum: SUPER_ADMIN/ADMIN/RELEASE_MANAGER/USER/AUDITOR.
+- `UserGroup` + `UserGroupMember` — есть (TTSEC-2).
+- Библиотеки для OIDC в проекте нет.
+
+---
+
+## 3. Зависимости
+
+### Модули backend (новые)
+- [ ] `modules/sso/sso.service.ts` — OIDC-flow: auth-url, callback, token exchange, userinfo.
+- [ ] `modules/sso/sso.router.ts` — endpoints `/sso/providers`, `/sso/login/:providerId`, `/sso/callback/:providerId`, `/sso/link`.
+- [ ] `modules/sso/providers-admin.router.ts` — CRUD провайдеров.
+- [ ] `modules/sso/sync.worker.ts` — периодический sync пользователей (cron).
+
+### Модули backend (изменённые)
+- [ ] `modules/auth/auth.service.ts` — блокировать локальный логин для не-SUPER_ADMIN при наличии активных IdP.
+- [ ] `modules/auth/auth.router.ts` — добавить `/auth/providers` (возвращает активные провайдеры для login-экрана).
+
+### Frontend
+- [ ] `pages/LoginPage.tsx` — список SSO-кнопок.
+- [ ] `pages/SsoCallbackPage.tsx` — обрабатывает redirect от IdP, показывает loading.
+- [ ] `pages/SsoLinkPage.tsx` — confirm-dialog для линковки существующего аккаунта.
+- [ ] `pages/admin/AdminSsoProvidersPage.tsx` — CRUD провайдеров.
+- [ ] `components/admin/SsoProviderForm.tsx` — форма с полями issuer, clientId, etc.
+
+### Модели данных (Prisma)
+- [ ] `IdentityProvider` — новая таблица.
+- [ ] `UserIdentity` — новая таблица (many-to-one User, UserIdentity).
+- [ ] `User.passwordHash: String` → `String?` (nullable для SSO-only юзеров).
+
+### Внешние зависимости
+- [ ] `openid-client` — OIDC-клиент (Panva Filip, industry standard).
+- [ ] Docker Keycloak — для dev-тестов (опционально).
+
+### Блокеры
+- Нет.
+
+---
+
+## 4. Риски
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | `email` claim от IdP подменён через misconfiguration → account takeover при автолинке | Высокая | Compromise | Автолинк ВЫКЛЮЧЕН, только confirm-dialog с вводом старого пароля |
+| 2 | IdP не возвращает `groups` claim или возвращает под другим именем | Высокая | Пустые группы | Настраиваемый `groupClaim` в IdP-конфиге; null → пропускаем sync |
+| 3 | Периодический sync обращается к IdP с service-account — если прав недостаточно, silent fail | Средняя | Из IdP не приходят disabled-юзеры | `IdentityProvider.syncEnabled` — флаг (default off); если включён и упал — alert в audit-log |
+| 4 | OIDC state/nonce не проверяются → CSRF на callback | Низкая | Compromise | `openid-client` делает это из коробки; явные тесты на подмену state |
+| 5 | SUPER_ADMIN забыл свой пароль, SSO отвалилось — никто не зайдёт | Средняя | Недоступность админки | Emergency-CLI в runbook: `npm run admin:reset-password -- --email=...` |
+| 6 | JIT-юзер получает системную роль через claim (security risk) | — | Privilege escalation | Системные роли **никогда** не мапятся из claims (только USER); ADMIN выдаётся tasktime-админом явно |
+| 7 | clientSecret читается из БД plain | Высокая | Leak | Шифрование AES-256-GCM + `SSO_ENCRYPTION_KEY` из ENV, аналогично SMTP-паролю |
+
+---
+
+## 5. Особенности реализации
+
+### 5.1 Модели
+
+```prisma
+enum SsoProtocol {
+  OIDC
+  // SAML2, LDAP — фазово, не в MVP
+}
+
+model IdentityProvider {
+  id              String      @id @default(uuid())
+  name            String      @unique  // отображаемое имя на логин-экране
+  protocol        SsoProtocol @default(OIDC)
+  issuer          String      // URL discovery, напр. https://keycloak.corp.ru/realms/main
+  clientId        String      @map("client_id")
+  clientSecretEnc String      @map("client_secret_enc")  // AES-GCM encrypted
+  scopes          String[]    @default(["openid", "profile", "email", "groups"])
+  emailClaim      String      @default("email") @map("email_claim")
+  nameClaim       String      @default("name") @map("name_claim")
+  groupClaim      String?     @map("group_claim")  // null → группы не синхронизируются
+  redirectUri     String      @map("redirect_uri")  // должен совпадать c настроенным в IdP
+  iconUrl         String?     @map("icon_url")
+  isEnabled       Boolean     @default(true) @map("is_enabled")
+  syncEnabled     Boolean     @default(false) @map("sync_enabled")
+  syncIntervalMin Int         @default(60) @map("sync_interval_min")
+  lastSyncAt      DateTime?   @map("last_sync_at")
+  createdAt       DateTime    @default(now())
+  updatedAt       DateTime    @updatedAt
+
+  identities      UserIdentity[]
+
+  @@map("identity_providers")
+}
+
+model UserIdentity {
+  id           String   @id @default(uuid())
+  userId       String   @map("user_id")
+  providerId   String   @map("provider_id")
+  externalSub  String   @map("external_sub")  // sub claim
+  lastLoginAt  DateTime? @map("last_login_at")
+  createdAt    DateTime @default(now())
+
+  user     User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  provider IdentityProvider @relation(fields: [providerId], references: [id], onDelete: Restrict)
+
+  @@unique([providerId, externalSub])
+  @@index([userId])
+  @@map("user_identities")
+}
+
+// User.passwordHash: String? — становится nullable (для SSO-only юзеров)
+```
+
+### 5.2 OIDC flow
+
+```typescript
+// GET /api/auth/providers — returns active providers for login page
+// Response: [{ id, name, iconUrl, loginUrl: '/sso/login/:id' }, ...]
+
+// GET /sso/login/:providerId
+// 1. Load provider, build OIDC client via openid-client
+// 2. Generate state + nonce, store in Redis (TTL 10 min): key = state, value = { providerId, nonce }
+// 3. Redirect to provider.authorizationEndpoint with ?state=&nonce=&redirect_uri=&scope=
+
+// GET /sso/callback/:providerId?code=&state=
+// 1. Validate state from Redis, extract nonce
+// 2. tokenSet = await client.callback(redirect_uri, { code, state }, { state, nonce })
+// 3. userInfo = await client.userinfo(tokenSet.access_token)
+// 4. Extract: sub, email, name, groups = userInfo[provider.groupClaim ?? 'groups']
+// 5. Find UserIdentity by (providerId, sub) → existing: login + sync groups
+// 6. Else: find User by email →
+//    a. Found existing User: return { requiresLinking: true, userId, email } → фронт показывает confirm
+//    b. Not found: JIT-create User + UserIdentity + sync groups
+// 7. On login: issue JWT + refresh (same flow as local auth)
+
+// POST /sso/link — body { providerId, externalSub, password }
+// 1. Validate session for the link-request (from step 6a, stored in Redis with TTL 10 min)
+// 2. Verify password against User.passwordHash
+// 3. Create UserIdentity(userId, providerId, externalSub)
+// 4. Optional: User.passwordHash = null (policy; default keep password but pre-empt usage for SSO-only policy)
+// 5. Return JWT
+```
+
+### 5.3 Группы sync
+
+```typescript
+async function syncUserGroups(userId: string, claimGroupNames: string[]): Promise<void> {
+  // 1. Найти существующие UserGroup по name, case-insensitive
+  const groups = await prisma.userGroup.findMany({
+    where: { name: { in: claimGroupNames, mode: 'insensitive' } },
+  });
+  const claimGroupIds = groups.map((g) => g.id);
+
+  // 2. Текущие членства
+  const current = await prisma.userGroupMember.findMany({
+    where: { userId, source: 'SSO_SYNC' },
+    select: { groupId: true },
+  });
+  const currentIds = current.map((m) => m.groupId);
+
+  // 3. Добавить новые, удалить устаревшие — только те, у которых source=SSO_SYNC
+  const toAdd = claimGroupIds.filter((id) => !currentIds.includes(id));
+  const toRemove = currentIds.filter((id) => !claimGroupIds.includes(id));
+
+  await prisma.$transaction([
+    prisma.userGroupMember.deleteMany({
+      where: { userId, groupId: { in: toRemove }, source: 'SSO_SYNC' },
+    }),
+    prisma.userGroupMember.createMany({
+      data: toAdd.map((groupId) => ({ userId, groupId, source: 'SSO_SYNC' })),
+    }),
+  ]);
+}
+```
+
+**Важно:** поле `UserGroupMember.source` — новое (enum `DIRECT | SSO_SYNC`). Мы **не трогаем** manually-added membership'ы. Требуется миграция: добавить колонку со значением `DIRECT` по умолчанию.
+
+### 5.4 Выключение локального логина
+
+```typescript
+// auth.service.ts — login() changes:
+async function login(email: string, password: string): Promise<LoginResult> {
+  const user = await findUserByEmail(email);
+  if (!user || !user.passwordHash) throw new Unauthorized('INVALID_CREDENTIALS');
+
+  const hasActiveSso = await prisma.identityProvider.count({ where: { isEnabled: true } }) > 0;
+  const isSuperAdmin = user.systemRoles.some((r) => r.role === 'SUPER_ADMIN');
+
+  if (hasActiveSso && !isSuperAdmin) {
+    throw new Forbidden('LOCAL_LOGIN_DISABLED_USE_SSO');
+  }
+
+  // ... rest of password validation
+}
+```
+
+Фронт на ответ `LOCAL_LOGIN_DISABLED_USE_SSO` показывает сообщение «Используйте SSO для входа».
+
+### 5.5 Админ-UI провайдеров
+
+- Страница `/admin/sso/providers` — таблица всех IdP.
+- Кнопка «Добавить» → форма:
+  - name, iconUrl
+  - issuer (URL) — при вводе можно делать discovery-test
+  - clientId, clientSecret (masked after save)
+  - scopes (tags-input)
+  - claim mappings (emailClaim, nameClaim, groupClaim)
+  - isEnabled, syncEnabled, syncInterval
+- Кнопка «Test connection» — пробует discovery + показывает полученные endpoints.
+
+### 5.6 Sync worker
+
+- Cron процесс (можно in-process BullMQ job): каждую минуту проверяет все `IdentityProvider` с `syncEnabled=true && (now - lastSyncAt) > syncIntervalMin`.
+- Для каждого: вызывает IdP Admin API (specific для каждого провайдера — Keycloak `/admin/realms/.../users`).
+- Получает список active users, сравнивает с `UserIdentity`:
+  - В IdP disabled, а в TT есть → `User.isActive=false`.
+  - В IdP enabled, а в TT `isActive=false` и последний logon > 30 дней → не активируем (админ решает).
+
+**Оговорка:** sync worker — **не-generic**. Разные IdP имеют разные Admin API. В MVP реализуем адаптер только для **Keycloak** (наиболее используем в on-prem). Для других провайдеров `syncEnabled=false` + ручное управление.
+
+---
+
+## 6. Требования к реализации
+
+### Функциональные
+- [ ] FR-1: CRUD IdentityProvider в `/admin/sso/providers`.
+- [ ] FR-2: На логин-экране динамический список активных провайдеров.
+- [ ] FR-3: OIDC auth flow работает end-to-end (local Keycloak + integration-тест).
+- [ ] FR-4: JIT создаёт User с `USER` role + UserIdentity.
+- [ ] FR-5: Существующий email → confirm-dialog с паролем → линкование.
+- [ ] FR-6: Группы из claim мапятся по имени (case-insensitive).
+- [ ] FR-7: Локальный логин выключен для всех, кроме SUPER_ADMIN, при наличии активного IdP.
+- [ ] FR-8: Периодический sync (Keycloak-адаптер) деактивирует disabled-юзеров.
+- [ ] FR-9: clientSecret шифруется AES-GCM.
+
+### Нефункциональные
+- [ ] NFR-1: OIDC callback + userinfo + DB-writes укладывается в < 2 сек p95.
+- [ ] NFR-2: Sync worker не блокирует основной API — работает в отдельном процессе.
+- [ ] NFR-3: Group-sync на юзера с 50 группами < 500ms.
+
+### Безопасность
+- [ ] SEC-1: State/nonce validated в OIDC callback.
+- [ ] SEC-2: PKCE (S256) включён для всех OIDC-flows.
+- [ ] SEC-3: clientSecret не возвращается в API.
+- [ ] SEC-4: Session после SSO-login ≡ session после локального (sliding session из TTMP-171).
+- [ ] SEC-5: Emergency CLI для сброса пароля SUPER_ADMIN (если оба SSO и пароль утеряны).
+- [ ] SEC-6: Audit-log для: add/remove provider, link account, sync result, disable/enable user.
+
+### Тестирование
+- [ ] Unit: OIDC callback state-validation, group-sync diff logic, link-flow.
+- [ ] Integration: local Keycloak → login → JIT → groups.
+- [ ] Integration: link existing account.
+- [ ] E2E: full auth flow через UI.
+- [ ] Security: invalid state, replayed code, wrong redirect_uri.
+- [ ] Покрытие ≥ 70%.
+
+---
+
+## 7. Критерии приёмки
+
+- [ ] AC-1: Admin добавляет Keycloak provider — появляется на login-экране.
+- [ ] AC-2: Login через Keycloak создаёт нового User (JIT) + UserIdentity + USER role.
+- [ ] AC-3: Повторный login — без JIT, UserIdentity найден.
+- [ ] AC-4: Существующий email → confirm-dialog, вход с правильным паролем создаёт UserIdentity.
+- [ ] AC-5: Группы из IdP синхронизированы на UserGroup (source=SSO_SYNC).
+- [ ] AC-6: Локальный логин отклоняется для не-SUPER_ADMIN при включённом SSO.
+- [ ] AC-7: SUPER_ADMIN логинится локально.
+- [ ] AC-8: Sync worker деактивирует disabled-юзера Keycloak → через минуту User.isActive=false.
+- [ ] AC-9: clientSecret encrypted в БД (проверка — `SELECT client_secret_enc` — не plain).
+- [ ] AC-10: Тесты зелёные.
+
+---
+
+## 8. Оценка трудоёмкости
+
+| Этап | Часы |
+|------|------|
+| Дизайн (models, flows, state diagrams) | 6 |
+| Prisma-миграции + encryption util | 4 |
+| `openid-client` wrapper + redis-state store | 6 |
+| SSO-router (login/callback/link) | 10 |
+| JIT-provisioning + email-matching logic | 6 |
+| Group-sync helper + `UserGroupMember.source` migration | 6 |
+| Keycloak sync-worker adapter | 10 |
+| Admin-UI: providers list + form + test-connection | 14 |
+| Frontend: LoginPage list + callback + link pages | 10 |
+| Emergency CLI script | 2 |
+| Tests (unit + integration + security) | 16 |
+| Docs (architecture/sso.md + runbook) | 4 |
+| Code review + AI review | 8 |
+| **Итого** | **102** (~2 спринта) |
+
+---
+
+## 9. Связанные задачи
+
+- **Зависит от:** нет.
+- **Блокирует:** частично TTMFA-1 (2FA применим только к non-SSO — нужен SUPER_ADMIN-only сценарий).
+- **Связано:** TTSEC-2 (UserGroup — переиспользуем), TTMP-171 (session).
+
+---
+
+## 10. Иерархия задач
+
+```
+TTSSO-1 (EPIC) — SSO / OIDC
+  ├─ TTSSO-1.1 — Prisma models + encryption utility
+  ├─ TTSSO-1.2 — openid-client wrapper + Redis state
+  ├─ TTSSO-1.3 — /sso/login + /sso/callback + /sso/link
+  ├─ TTSSO-1.4 — JIT + email-linking + group-sync
+  ├─ TTSSO-1.5 — Admin-UI (providers CRUD + test)
+  ├─ TTSSO-1.6 — Keycloak sync-worker
+  ├─ TTSSO-1.7 — Frontend LoginPage / CallbackPage / LinkPage
+  └─ TTSSO-1.8 — Tests + security review + docs
+```

--- a/docs/tz/MVP2JIRA/mvp2jira_plan.md
+++ b/docs/tz/MVP2JIRA/mvp2jira_plan.md
@@ -1,0 +1,295 @@
+# MVP2JIRA — План реализации ТЗ
+
+**Дата:** 2026-04-23
+**Источник:** гэп-анализ админки TaskTime vs коробочная Jira ([admin-vs-jira-comparison.html](../../admin-vs-jira-comparison.html))
+**Статус:** OPEN — утверждён список ТЗ и решения по скоупу, реализация не начата
+
+---
+
+## 1. Контекст
+
+Эта папка (`docs/tz/MVP2JIRA/`) содержит 14 отдельных ТЗ, закрывающих разрыв между текущей админкой TaskTime и минимально-приемлемой (MVP-ready) админкой в Jira-стиле. Список ТЗ, их приоритеты и все архитектурные решения — результат пошагового review c владельцем продукта.
+
+**Скоуп MVP2JIRA:** довести админку до состояния, когда систему объективно можно включать в прод для корпоративного заказчика. Всё, что вынесено в P3, — осознанно отложено.
+
+**Что осознанно НЕ делаем (P3 / out-of-scope):**
+- Backup/Restore на уровне приложения — закрывается через DevOps (pg_dump cron, снэпшоты дисков, версионирование кода в Git).
+- Интернационализация (i18n) — переведены UI строки и email-шаблоны останутся на русском.
+- Independent Permission Scheme (текущая Role Scheme с 33 флагами закрывает 95% use-case'ов).
+- Incoming mail handlers, Services cron UI, DB Integrity Checker, Application Links, License management.
+
+---
+
+## 2. Сводная таблица ТЗ
+
+| # | Ключ | Фаза | Объём | Зависит от | Блокирует | Параллельно с |
+|---|------|------|-------|------------|-----------|---------------|
+| 1 | [TTBUS-0](./TTBUS-0.md) | P0-prereq | 54ч (1.5сп) | — | **TTNOTIF-1, TTINTEG-1** | TTRES-1, TTSEC-3 |
+| 2 | [TTNOTIF-1](./TTNOTIF-1.md) | P0 | 110ч (2сп) | **TTBUS-0** | TTINTEG-1 | TTSEC-3 (integrate) |
+| 3 | [TTRES-1](./TTRES-1.md) | P0 | 33ч (0.5сп) | — *(TTCORE-1 желателен)* | — | всё |
+| 4 | [TTSEC-3](./TTSEC-3.md) | P0 | 52ч (1сп) | — | TTNOTIF-1 (recipient filter) | всё |
+| 5 | TTSSO-1 | P1 | 2сп | — | — | всё |
+| 6 | TTSEC-4 | P1 | 1сп | — | TTMFA-1 (re-auth integration) | всё |
+| 7 | TTCORE-1 | P1 | 1сп | — | *(TTRES-1 желает)* | всё |
+| 8 | TTPROJ-1 | P1 | 1сп | — | — | всё |
+| 9 | TTSCR-1 | P1 | 0.5сп | — | — | всё |
+| 10 | TTATTACH-1 | P1 | 1.5сп | — | **TTBRAND-1** | всё |
+| 11 | TTMFA-1 | P2 | 1сп | TTSEC-4 *(рекомендовано)* | — | всё |
+| 12 | TTINTEG-1 | P2 | 1сп | **TTBUS-0, TTNOTIF-1** | — | всё |
+| 13 | TTCFG-1 | P2 | 0.5сп | — | — | всё |
+| 14 | TTBRAND-1 | P2 | 0.5сп | **TTATTACH-1** | — | всё |
+
+**Итого:** ~14.5 спринтов работы (29 недель при full-time работе одной команды без параллелизма).
+
+**Обозначения:**
+- **Жирным** — жёсткие блокеры (без них нельзя начинать зависимое ТЗ).
+- *Курсивом* — рекомендованные, но не блокирующие зависимости.
+
+---
+
+## 3. Граф зависимостей
+
+```
+                        ┌──────────┐
+                        │ TTBUS-0  │ P0 prereq (1.5сп)
+                        └────┬─────┘
+                             │
+                   ┌─────────┴──────────┐
+                   ▼                    ▼
+          ┌──────────────┐      ┌──────────────┐
+          │  TTNOTIF-1   │      │  TTINTEG-1   │ P2 (1сп)
+          │ P0 (2сп)     │──┐   │              │
+          └──────────────┘  │   └──────────────┘
+                            │          ▲
+                            └──────────┘
+                            (TTINTEG-1 также зависит от NOTIF-1
+                             как reference consumer паттерн)
+
+  ┌────────────┐  ┌────────────┐
+  │ TTRES-1    │  │ TTSEC-3    │   P0 — independent, can run any time
+  │ (0.5сп)    │  │ (1сп)      │
+  └────────────┘  └────────────┘
+        │
+        │ (желательно после TTCORE-1 для status category alignment)
+        ▼
+  ┌────────────┐
+  │ TTCORE-1   │   P1 — independent (1сп)
+  └────────────┘
+
+  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐
+  │ TTSEC-4    │  │ TTSSO-1    │  │ TTPROJ-1   │  │ TTSCR-1    │
+  │ (1сп)      │  │ (2сп)      │  │ (1сп)      │  │ (0.5сп)    │
+  └─────┬──────┘  └────────────┘  └────────────┘  └────────────┘
+        │
+        ▼
+  ┌────────────┐
+  │ TTMFA-1    │  P2 (1сп) — reuses re-auth infra from TTSEC-4
+  └────────────┘
+
+  ┌────────────┐
+  │ TTATTACH-1 │  P1 (1.5сп)
+  └─────┬──────┘
+        │ (storage abstraction)
+        ▼
+  ┌────────────┐
+  │ TTBRAND-1  │  P2 (0.5сп)
+  └────────────┘
+
+  ┌────────────┐
+  │ TTCFG-1    │  P2 (0.5сп) — полностью независимое
+  └────────────┘
+```
+
+**Критическая цепочка (самый длинный путь):**
+`TTBUS-0 → TTNOTIF-1 → TTINTEG-1` = 1.5 + 2 + 1 = **4.5 спринта**.
+
+Это нижняя граница времени выполнения при любом уровне параллелизма.
+
+---
+
+## 4. Рекомендованный порядок — Single Team
+
+Для одной команды full-time (4–5 backend + 2 frontend).
+
+### Волна 1 — Фундамент P0 (спринты 1–5)
+
+| Спринт | ТЗ | Причина |
+|--------|-----|---------|
+| 1 | TTBUS-0 | критический путь, без него notifications не работает |
+| 2 | TTBUS-0 (завершение) + TTSEC-3 | TTSEC-3 запускается параллельно (independent) |
+| 3 | TTNOTIF-1 + TTRES-1 | NOTIF — консьюмер поверх BUS; RES — independent короткий |
+| 4 | TTNOTIF-1 (завершение) | |
+| 5 | TTCORE-1 | перед остальными P1 — меняет `Priority`/`Status` модель, влияет на все формы |
+
+**Gate 1 (после спринта 5):** P0 полностью закрыт — MVP запускаем в пилот. Без SSO/MFA/Attachments, но с уведомлениями, resolution'ами, security.
+
+### Волна 2 — P1 (спринты 6–12)
+
+| Спринт | ТЗ | Комментарий |
+|--------|-----|-------------|
+| 6 | TTSEC-4 + TTSCR-1 | P1 security (password policy + audit + banner) + screens (малое) |
+| 7 | TTSSO-1 | большое, приоритет для корп-заказчиков |
+| 8 | TTSSO-1 (завершение) + TTPROJ-1 | components + versions |
+| 9 | TTATTACH-1 | функционал вложений |
+| 10 | TTATTACH-1 (завершение) | |
+| 11 | — резерв на багфиксы P1 — | |
+
+**Gate 2 (после спринта 11):** P1 закрыт — платформа корпоративно-приемлемая.
+
+### Волна 3 — P2 (спринты 12–14)
+
+| Спринт | ТЗ | Комментарий |
+|--------|-----|-------------|
+| 12 | TTMFA-1 + TTCFG-1 | 2FA (после SEC-4) + time-tracking parser |
+| 13 | TTINTEG-1 | webhooks admin UI |
+| 14 | TTBRAND-1 + резерв | look & feel + финальная полировка |
+
+**Gate 3:** Production-ready по всем 14 ТЗ.
+
+**Итого single-team: ~14 спринтов.**
+
+---
+
+## 5. Рекомендованный порядок — Two Parallel Teams
+
+Если есть две команды (или one команда с двумя независимыми треками), можно сжать до **~9 спринтов**.
+
+### Track A — Backend-heavy (Event Bus & Notifications critical path)
+
+| Спринт | ТЗ |
+|--------|-----|
+| 1 | TTBUS-0 |
+| 2 | TTBUS-0 завершение |
+| 3 | TTNOTIF-1 |
+| 4 | TTNOTIF-1 |
+| 5 | TTINTEG-1 (после NOTIF — reuse patterns) |
+| 6 | TTCFG-1 + резерв |
+| 7–9 | баги, доработки, production hardening |
+
+### Track B — Admin & Model changes (parallel)
+
+| Спринт | ТЗ |
+|--------|-----|
+| 1 | TTSEC-3 + TTRES-1 (оба independent) |
+| 2 | TTCORE-1 (priorities + status reconciliation) |
+| 3 | TTSEC-4 + TTSCR-1 |
+| 4 | TTSSO-1 |
+| 5 | TTSSO-1 + TTPROJ-1 |
+| 6 | TTATTACH-1 |
+| 7 | TTATTACH-1 + TTMFA-1 |
+| 8 | TTMFA-1 + TTBRAND-1 |
+| 9 | финализация |
+
+**Точки синхронизации:**
+- Конец спринта 2: Track A должен выдать TTBUS-0 до старта NOTIF в спринте 3.
+- Конец спринта 4: Track B TTSEC-3 к моменту завершения TTNOTIF-1 в Track A для интеграции visibility-фильтра.
+
+**Итого two-team: ~9 спринтов.**
+
+---
+
+## 6. Почему такой порядок — обоснование ключевых решений
+
+### 6.1 Почему TTBUS-0 первый
+- Без шины событий нельзя асинхронно отсылать уведомления.
+- Transactional outbox — инфраструктурный паттерн, который меняет сигнатуру bool-методов (producer'ы должны вызывать `publishInTx`). Ретрофит-делать это потом значительно дороже — придётся переписывать десятки методов.
+- Reference implementation в issues-модуле задаёт паттерн для всех будущих producer'ов (comments, releases, workflow).
+
+### 6.2 Почему TTSEC-3 в параллель с BUS-0
+- Visibility-фильтр нужно ввести **до** TTNOTIF-1 — иначе notifications начнут утекать PRIVATE-задачи в email.
+- Полностью independent от BUS-0 (изолированный RBAC-middleware).
+
+### 6.3 Почему TTCORE-1 перед большинством P1
+- Миграция `IssuePriority` enum → таблица и reconciliation `IssueStatus` затрагивает каждую форму, фильтр, TTQL-компилятор.
+- Если сделать после TTSSO/TTATTACH/TTSCR — придётся дважды трогать UI-формы.
+- Риск: большая миграция данных. Мерж раньше → больше времени на обнаружение багов.
+
+### 6.4 Почему TTSSO-1 до TTMFA-1
+- TTSSO выключает локальные пароли для большинства пользователей (3.1.HH=3 — локальный login только для SUPER_ADMIN).
+- TTMFA только для локального логина релевантен (SSO-провайдер сам делает MFA).
+- Сделав SSO первым, сокращаем surface для TTMFA (применяется только к ~2–5 админам).
+
+### 6.5 Почему TTATTACH-1 до TTBRAND-1
+- TTBRAND-1 (3.4.UUUU=1) переиспользует storage-абстракцию из TTATTACH-1. Иначе придётся писать временную.
+
+### 6.6 Почему TTINTEG-1 последним из критических
+- Webhooks — внешняя интеграция, не блокирует внутренних пользователей.
+- Переиспользует всю инфру TTBUS-0 + pattern'ы TTNOTIF-1 (consumer-dedup, retry, DLQ).
+- Отложив его, мы максимизируем reuse и минимизируем rework.
+
+---
+
+## 7. Gates / точки фиксации
+
+### Gate 0 — Пре-Wave 1 (утверждение ТЗ)
+- [x] Все 14 ТЗ написаны и лежат в `docs/tz/MVP2JIRA/`.
+- [ ] Ревью ТЗ стейкхолдерами (архитектор, SRE, security lead).
+- [ ] Утверждён владелец каждого ТЗ.
+- [ ] Создана Kafka-инфра в dev (TTBUS-0 precondition).
+
+### Gate 1 — После P0 (конец волны 1)
+- [ ] 4 P0-ТЗ замержены и выкачены в staging.
+- [ ] SMTP настроен, Notifications идут.
+- [ ] Issue Security покрыт security-test suite.
+- [ ] Resolution миграция выполнена на копии prod-БД, аномалий нет.
+- [ ] Пилотная группа (1 команда, ~10 чел) работает в staging 2 недели, собран фидбек.
+
+### Gate 2 — После P1
+- [ ] SSO подключён минимум к одному IdP (Keycloak).
+- [ ] Attachments работают, storage pluggable.
+- [ ] Components/Versions в TTQL + UI.
+- [ ] Password policy + audit log UI в админке.
+
+### Gate 3 — После P2 (production-ready)
+- [ ] 2FA опциональна, обязательна для ADMIN/SUPER_ADMIN.
+- [ ] Webhooks admin UI работает, HMAC-signing проверен внешним receiver'ом.
+- [ ] Look & Feel настроен (логотип, цвета, footer, email-logo).
+- [ ] Time tracking парсер `1w 2d` работает.
+
+---
+
+## 8. Риски всего плана
+
+| # | Риск | Вероятность | Влияние | Митигация |
+|---|------|-------------|---------|-----------|
+| 1 | TTBUS-0 затягивается — блокирует TTNOTIF/TTINTEG | Средняя | Сдвиг всех волн на 2+ спринта | Выделить самого опытного backend-инженера; параллельно готовить шаблоны TTNOTIF-1, чтобы сразу после merge BUS-0 стартовать |
+| 2 | Миграция данных TTCORE-1 на prod-БД находит неочевидные edge-cases (NULL, orphaned refs) | Высокая | Downtime / откат релиза | Прогон миграции на снимке prod-БД 2 недели до релиза; dry-run mode в скрипте |
+| 3 | Visibility-фильтр TTSEC-3 пропущен в одном из list-путей — security-leak | Средняя | Компрометация | Единая библиотека `visibilityWhereClause`; security-review обязательный на merge; фаззинг-тесты |
+| 4 | SSO не подключается к конкретному корп-IdP из-за нестандартных claim-mappings | Средняя | Срыв дат у корп-клиента | Ранний POC на pilot-IdP за 1–2 недели до старта TTSSO-1; fallback — локальный логин для SUPER_ADMIN |
+| 5 | Команда перегружена → качество P2-ТЗ страдает (срезают тесты) | Средняя | Прод-баги через неск. месяцев | Каждое ТЗ имеет отдельный «AI review» step в CI; блок merge без green pipeline |
+| 6 | Заказчик требует «сразу всё» без Gate-approach | Низкая | Neverending перекидывание приоритетов | Gate'ы зафиксированы этим документом; изменения scope — через явное PR в этот файл |
+| 7 | Kafka оказывается недостаточна для нагрузки (>5000 events/sec на будущих feature'ах) | Низкая | Перепланирование инфры | В TTBUS-0 partitioning готов; scale — отдельное ТЗ при фактической деградации |
+
+---
+
+## 9. Метрики успеха
+
+После закрытия всех Gate:
+- **Coverage vs Jira vanilla:** целевое 90%+ (против 55% на старте).
+- **Time-to-first-notification:** < 60 сек от события до email (p95).
+- **Authentication methods:** локальный + OIDC, 2FA для SUPER_ADMIN.
+- **API uptime:** 99.5% в staging, 99.9% в prod.
+- **Security audit findings:** 0 critical, ≤ 2 major после penetration-теста.
+
+---
+
+## 10. Что делать после закрытия MVP2JIRA
+
+Roadmap следующей итерации (out-of-scope этого плана):
+- **TTAUTO-1** — Automations (async ScriptRunner аналог). Инфра уже готова (TTBUS-0 + consumer pattern).
+- **TTINTEG-2** — Public Events API (pull-based + WebSocket stream).
+- **TTPERM-1** — Independent Permission Scheme (если потребуется).
+- **TTMAIL-2** — Incoming Mail Handlers (создание issue из email).
+- **TTI18N-1** — Internationalization (RU+EN+...) — если появятся international клиенты.
+- **TTBACKUP-1** — Admin-level backup/restore UI (если DevOps-процесс окажется недостаточным).
+
+---
+
+## Ссылки
+
+- [Гэп-анализ](../../admin-vs-jira-comparison.html) — исходный отчёт.
+- [TTBUS-0](./TTBUS-0.md) — Event Bus.
+- [TTNOTIF-1](./TTNOTIF-1.md) — Notifications.
+- [TTRES-1](./TTRES-1.md) — Resolutions.
+- [TTSEC-3](./TTSEC-3.md) — Issue Security.
+- *(оставшиеся 10 ТЗ появятся в волнах 2 и 3)*


### PR DESCRIPTION
## Summary
- add MVP2JIRA planning index and scoped technical specs
- add admin-vs-Jira comparison artifact
- add Codex-adapted AGENTS workflow notes

## Testing
- not run; documentation-only changes