### PR TITLE
fix(login): убрать placeholder из поля Email

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -291,7 +291,7 @@ function Field({
   type: string;
   value: string;
   onChange: (v: string) => void;
-  placeholder: string;
+  placeholder?: string;
   autoComplete?: string;
   minLength?: number;
   testId?: string;
@@ -483,7 +483,7 @@ export default function LoginPage() {
             )}
             <Field
               label="Email" type="email" value={email} onChange={setEmail}
-              placeholder="p.novak@tasktime.ru" autoComplete="email" testId="login-email" C={CWithFocus}
+              autoComplete="email" testId="login-email" C={CWithFocus}
             />
             <div style={{ marginBottom: 24 }}>
               <Field


### PR DESCRIPTION
Убирает подсказку `p.novak@tasktime.ru` из поля Email на странице входа. Проп `placeholder` компонента Field сделан опциональным (компонент локален для LoginPage, остальные call sites не затронуты).

🤖 Generated with [Claude Code](https://claude.com/claude-code)